### PR TITLE
doc: explicit default values used by HikariCP

### DIFF
--- a/content/docs/09.administrator-guide/01.configuration/01.databases.md
+++ b/content/docs/09.administrator-guide/01.configuration/01.databases.md
@@ -104,7 +104,7 @@ Since Kestra is built with [Micronaut](https://micronaut.io) and [HikariCP](http
 | `validation-timeout`          | Long   | The maximum number of milliseconds that the pool will wait for a connection to be validated as alive.                                            |
 
 
-Here is the default HikariCP configuration,:
+Here is the default HikariCP configuration:
 
 ```yaml
 transaction-isolation: default
@@ -121,7 +121,7 @@ max-lifetime: 1800000
 validation-timeout: 5000
 ```
 
-Implementation details are accessible [here](https://github.com/brettwooldridge/HikariCP/blob/master/src/main/java/com/zaxxer/hikari/HikariConfig.java)
+Implementation details are accessible [here](https://github.com/brettwooldridge/HikariCP/blob/master/src/main/java/com/zaxxer/hikari/HikariConfig.java).
 
 ## Queues configuration
 

--- a/content/docs/09.administrator-guide/01.configuration/01.databases.md
+++ b/content/docs/09.administrator-guide/01.configuration/01.databases.md
@@ -103,6 +103,26 @@ Since Kestra is built with [Micronaut](https://micronaut.io) and [HikariCP](http
 | `max-lifetime`                | Long   | The maximum lifetime of a connection in the pool.                                                                              |
 | `validation-timeout`          | Long   | The maximum number of milliseconds that the pool will wait for a connection to be validated as alive.                                            |
 
+
+Here is the default HikariCP configuration,:
+
+```yaml
+transaction-isolation: default
+pool-name: HikariPool-<Generated>
+connection-init-sql: null
+connection-test-query: null
+connection-timeout: 30000
+idle-timeout: 600000
+minimum-idle: 10
+initialization-fail-timeout: 1
+leak-detection-threshold: 0
+maximum-pool-size: 10 # Generates 40 connections
+max-lifetime: 1800000
+validation-timeout: 5000
+```
+
+Implementation details are accessible [here](https://github.com/brettwooldridge/HikariCP/blob/master/src/main/java/com/zaxxer/hikari/HikariConfig.java)
+
 ## Queues configuration
 
 ### `kestra.jdbc.queues`


### PR DESCRIPTION
Following same doc structure as for queues configuration, give default values used by HikariCP.

<img width="804" alt="image" src="https://github.com/kestra-io/kestra.io/assets/25565600/91ee2819-fcc2-40a6-a7a5-e3e40b2c2835">
