### PR TITLE
Add space between menu item icon and item's border highlight

### DIFF
--- a/components/docs/RecursiveNavSidebar.vue
+++ b/components/docs/RecursiveNavSidebar.vue
@@ -195,7 +195,7 @@
 
             &.depth-1 {
                 a {
-                    padding-left: 0;
+                    padding-left: 0.25rem;
                     border-left: 0;
                 }
             }


### PR DESCRIPTION
Hopefully, this made the icon vs border interaction look a bit cleaner 😌