### PR TITLE
Make the Docker section more logically structured

### DIFF
--- a/content/docs/09.administrator-guide/02.deployment/01.docker.md
+++ b/content/docs/09.administrator-guide/02.deployment/01.docker.md
@@ -4,9 +4,10 @@ title: Deployment with Docker
 
 The quickest way to install Kestra is to use *Docker Compose*. This will start a production-ready lightweight Kestra installation.
 
-
 ## Before you begin
+
 Make sure you have already installed:
+
 - [Docker](https://docs.docker.com/engine/install/)
 - [Docker Compose](https://docs.docker.com/compose/install/)
 
@@ -21,29 +22,32 @@ This will start all the dependencies with a pre-configured Kestra that is connec
 Kestra will start a *Standalone* server (all the different [servers](../../08.architecture.md) in one JVM).
 This is clearly not meant for **production** workloads, but is certainly sufficient to test on a local computer.
 
-The [configuration](../01.configuration/index.md) will be done inside the `KESTRA_CONFIGURATION` environment variable of the Kestra container. You can update the environment variable inside the Docker compose file, or pass it via the docker command line argument.
-If you pass it via the docker command line argument, don't forget to add existing configuration or nothing will work anymore.
-
+The [configuration](../01.configuration/index.md) will be done inside the `KESTRA_CONFIGURATION` environment variable of the Kestra container. You can update the environment variable inside the Docker compose file, or pass it via the Docker command line argument.
+If you pass it via the Docker command line argument, don't forget to add existing configuration or nothing will work anymore.
 
 ## Docker Image
 
 ### Use official images
 
-The official Kestra docker images are available in [Docker hub](https://hub.docker.com/r/kestra/kestra).
+The official Kestra Docker images are available in [Docker hub](https://hub.docker.com/r/kestra/kestra).
 
 We provide two images:
-* `kestra/kestra:latest`
-* `kestra/kestra:latest-full`
 
-These docker images are based on the `eclipse-temurin:17-jre` docker image.
+- `kestra/kestra:latest`
+- `kestra/kestra:latest-full`
+
+These Docker images are based on the `eclipse-temurin:17-jre` Docker image.
 
 #### `kestra/kestra:latest`
+
 This image:
+
 - does not contain any Kestra plugins.
 - does not contain a lot of binaries to work with your [Bash tasks](../../../plugins/core/tasks/scripts/io.kestra.core.tasks.scripts.Bash.md).
 - does not contain some binaries for [Python tasks](../../../plugins/core/tasks/scripts/io.kestra.core.tasks.scripts.Python.md) or [Node tasks](../../../plugins/core/tasks/scripts/io.kestra.core.tasks.scripts.Node.md).
 
 #### `kestra/kestra:latest-full`
+
 This image contains all the Kestra plugins and all the binaries for [Python tasks](../../../plugins/core/tasks/scripts/io.kestra.core.tasks.scripts.Python.md) or [Node tasks](../../../plugins/core/tasks/scripts/io.kestra.core.tasks.scripts.Node.md).
 Take care that this image will always contain the latest version of all plugins that can have some breaking changes.
 
@@ -67,7 +71,7 @@ RUN mkdir -p /app/plugins && \
 
 ### Create a new image with more plugins
 
-By default, the Kestra base docker image does not contain any plugins, you can create a new image from the Kestra base image and add the needed plugins.
+By default, the Kestra base Docker image does not contain any plugins, you can create a new image from the Kestra base image and add the needed plugins.
 
 The following `Dockerfile` creates an image from the Kestra base image and adds the `plugin-notifications`, `storage-gcs` and `plugin-gcp` plugins using the command `kestra plugins install`:
 
@@ -88,7 +92,7 @@ FROM openjdk:17-slim as stage-build
 WORKDIR /
 USER root
 
-RUN apt-get update -y 
+RUN apt-get update -y
 RUN apt-get install git -y && \
     git clone https://github.com/kestra-io/plugin-aws.git
 
@@ -110,12 +114,12 @@ RUN rm -rf /app/plugins/plugin-aws-*.jar
 COPY --from=stage-build /plugin-aws/build/libs/plugin-aws-*.jar /app/plugins
 ```
 
-This multi-stage Docker build allows you to overwrite a plugin that has already been installed. In this example, the AWS plugin is by default already included in the `kestra/kestra:latest-full` image. However, it's overritten by a plugin built in the first Docker build stage. 
-
+This multi-stage Docker build allows you to overwrite a plugin that has already been installed. In this example, the AWS plugin is by default already included in the `kestra/kestra:latest-full` image. However, it's overwritten by a plugin built in the first Docker build stage.
 
 ### Docker image tags
 
-We provide three tags for each docker image:
+We provide three tags for each Docker image:
+
 - `latest`: the latest default image along with its full variant `latest-full`.
 - `release`: the preview of the next release along with its full variant `release-full`.
 - `develop`: an experimental image based on the `develop` branch that will change every day and contains all **unstable** features we are working on, along with its full variant `develop-full`.

--- a/content/docs/09.administrator-guide/02.deployment/01.docker.md
+++ b/content/docs/09.administrator-guide/02.deployment/01.docker.md
@@ -121,5 +121,6 @@ This multi-stage Docker build allows you to overwrite a plugin that has already 
 We provide three tags for each Docker image:
 
 - `latest`: the latest default image along with its full variant `latest-full`.
+- `v<release-version>`: official Kestra release with its full variant `v<release-version>-full`.
 - `release`: the preview of the next release along with its full variant `release-full`.
 - `develop`: an experimental image based on the `develop` branch that will change every day and contains all **unstable** features we are working on, along with its full variant `develop-full`.

--- a/content/docs/09.administrator-guide/02.deployment/01.docker.md
+++ b/content/docs/09.administrator-guide/02.deployment/01.docker.md
@@ -29,27 +29,36 @@ If you pass it via the Docker command line argument, don't forget to add existin
 
 ### Use official images
 
-The official Kestra Docker images are available in [Docker hub](https://hub.docker.com/r/kestra/kestra).
+The official Kestra Docker images are available in [Docker hub](https://hub.docker.com/r/kestra/kestra) for both `linux/amd64` and `linux/arm64` platforms.
 
-We provide two images:
+We provide two image variants:
 
-- `kestra/kestra:latest`
-- `kestra/kestra:latest-full`
+- `kestra/kestra:*`
+- `kestra/kestra:*-full`
 
-These Docker images are based on the `eclipse-temurin:17-jre` Docker image.
+Both variants are based on the [`eclipse-temurin:17-jre`](https://hub.docker.com/_/eclipse-temurin) Docker image.
 
-#### `kestra/kestra:latest`
+#### `kestra/kestra:*-full`
 
-This image:
+These images contain all the Kestra [plugins](../../../plugins/index.md) and all the binaries for [Python tasks](../../../plugins/plugin-script-python/tasks/io.kestra.plugin.scripts.python.Commands.md) or [Node tasks](../../../plugins/plugin-script-node/tasks/io.kestra.plugin.scripts.node.Commands.md).
+Take care that these images will always contain the latest version of all plugins that can have some breaking changes.
 
-- does not contain any Kestra plugins.
-- does not contain a lot of binaries to work with your [Bash tasks](../../../plugins/core/tasks/scripts/io.kestra.core.tasks.scripts.Bash.md).
-- does not contain some binaries for [Python tasks](../../../plugins/core/tasks/scripts/io.kestra.core.tasks.scripts.Python.md) or [Node tasks](../../../plugins/core/tasks/scripts/io.kestra.core.tasks.scripts.Node.md).
+#### `kestra/kestra:*`
 
-#### `kestra/kestra:latest-full`
+These images:
 
-This image contains all the Kestra plugins and all the binaries for [Python tasks](../../../plugins/core/tasks/scripts/io.kestra.core.tasks.scripts.Python.md) or [Node tasks](../../../plugins/core/tasks/scripts/io.kestra.core.tasks.scripts.Node.md).
-Take care that this image will always contain the latest version of all plugins that can have some breaking changes.
+- do not contain any Kestra [plugins](../../../plugins/index.md).
+- do not contain a lot of binaries to work with your [Shell tasks](../../../plugins/plugin-script-shell/tasks/io.kestra.plugin.scripts.shell.Commands.md).
+- do not contain binaries for [Python tasks](./../../plugins/plugin-script-python/tasks/io.kestra.plugin.scripts.python.Commands.md) or [Node tasks](../../../plugins/plugin-script-node/tasks/io.kestra.plugin.scripts.node.Commands.md).
+
+### Docker image tags
+
+We provide three tags for each Docker image:
+
+- `latest`: the latest default image along with its full variant `latest-full`.
+- `v<release-version>`: official Kestra release with its full variant `v<release-version>-full`.
+- `release`: the preview of the next release along with its full variant `release-full`.
+- `develop`: an experimental image based on the `develop` branch that will change every day and contains all **unstable** features we are working on, along with its full variant `develop-full`.
 
 ### Create a new image with more binaries
 
@@ -115,12 +124,3 @@ COPY --from=stage-build /plugin-aws/build/libs/plugin-aws-*.jar /app/plugins
 ```
 
 This multi-stage Docker build allows you to overwrite a plugin that has already been installed. In this example, the AWS plugin is by default already included in the `kestra/kestra:latest-full` image. However, it's overwritten by a plugin built in the first Docker build stage.
-
-### Docker image tags
-
-We provide three tags for each Docker image:
-
-- `latest`: the latest default image along with its full variant `latest-full`.
-- `v<release-version>`: official Kestra release with its full variant `v<release-version>-full`.
-- `release`: the preview of the next release along with its full variant `release-full`.
-- `develop`: an experimental image based on the `develop` branch that will change every day and contains all **unstable** features we are working on, along with its full variant `develop-full`.


### PR DESCRIPTION
* The official release tag `v<release>` was omitted.
* The full/non-full is more distinct now.
* Migrated away from deprecated `plugins/core/tasks/scripts`.