### PR TITLE
Fix listing lang

### DIFF
--- a/content/docs/05.developer-guide/03.scripts.md
+++ b/content/docs/05.developer-guide/03.scripts.md
@@ -351,7 +351,7 @@ tasks:
 
 You can bake all dependencies needed for your script tasks directly into the Kestra's base image. Here is an example for Python tasks:
 
-```Dockerfile
+```dockerfile
 FROM kestra/kestra:latest-full
 
 USER root


### PR DESCRIPTION
shiki supports `docker` and `dockerfile`