### PR TITLE
Document common trigger properties

### DIFF
--- a/content/docs/05.developer-guide/08.triggers/01.schedule.md
+++ b/content/docs/05.developer-guide/08.triggers/01.schedule.md
@@ -86,7 +86,6 @@ The list of core conditions that can be used are:
  - [WeekendCondition](../../../plugins/core/conditions/io.kestra.core.models.conditions.types.WeekendCondition.md)
  - [DayWeekInMonthCondition](../../../plugins/core/conditions/io.kestra.core.models.conditions.types.DayWeekInMonthCondition.md)
 
-
 ## Properties and Outputs
 
-Check the [Schedule task](../../../plugins/core/triggers/io.kestra.core.models.triggers.types.Schedule.md) documentation for the complete list of the task properties and outputs.
+Check the [Schedule task](../../../plugins/core/triggers/io.kestra.core.models.triggers.types.Schedule.md) documentation for the list of the task properties and outputs.

--- a/content/docs/05.developer-guide/08.triggers/02.flow.md
+++ b/content/docs/05.developer-guide/08.triggers/02.flow.md
@@ -72,10 +72,10 @@ triggers:
 
 ## Properties and Outputs
 
-Check the [Flow task](../../../plugins/core/triggers/io.kestra.core.models.triggers.types.Flow.md) documentation for the complete list of the task properties and outputs.
-
+Check the [Flow task](../../../plugins/core/triggers/io.kestra.core.models.triggers.types.Flow.md) documentation for the list of the task properties and outputs.
 
 ## Variables
+
 When another flow triggers the flow, some context variables will be injected to allow flow customization.
 
 | Parameter | Description |

--- a/content/docs/05.developer-guide/08.triggers/03.webhook.md
+++ b/content/docs/05.developer-guide/08.triggers/03.webhook.md
@@ -19,10 +19,9 @@ triggers:
     type: io.kestra.core.models.triggers.types.Webhook
     key: 4wjtkzwVGBM9yKnjm3yv8r
 ```
-> After the trigger is created, the key must be explicitly set in the webhook URL. You can launch the flow using the following URL 
+> After the trigger is created, the key must be explicitly set in the webhook URL. You can launch the flow using the following URL
  `/api/v1/executions/webhook/{namespace}/{flowId}/4wjtkzwVGBM9yKnjm3yv8r`.
 
 ## Properties and Outputs
 
-Check the [Webhook task](../../../plugins/core/triggers/io.kestra.core.models.triggers.types.Webhook.md) documentation for the complete list of the task properties and outputs.
-[]()
+Check the [Webhook task](../../../plugins/core/triggers/io.kestra.core.models.triggers.types.Webhook.md) documentation for the list of the task properties and outputs.

--- a/content/docs/05.developer-guide/08.triggers/index.md
+++ b/content/docs/05.developer-guide/08.triggers/index.md
@@ -10,8 +10,19 @@ Kestra core provides three types of triggers:
 * [Flow trigger](./02.flow.md) allows you to execute your flow when another flow finishes its execution (based on a configurable list of states)
 * [Webhook trigger](./03.webhook.md) allows you to execute your flow based on an HTTP request emitted by a webhook.
 
-
 Many other triggers are available from the plugins, such as triggers based on file detection events, e.g. the [S3 trigger](https://kestra.io/plugins/plugin-aws/triggers/s3/io.kestra.plugin.aws.s3.trigger), or a new message arrival in a message queue, such as the [SQS](https://kestra.io/plugins/plugin-aws/triggers/sqs/io.kestra.plugin.aws.sqs.trigger) or [Kafka trigger](https://kestra.io/plugins/plugin-kafka/triggers/io.kestra.plugin.kafka.trigger).
+
+### Trigger common properties
+
+Following trigger properties can be set.
+
+| Field | Description                                                                                                   |
+| ----- |---------------------------------------------------------------------------------------------------------------|
+|`id`| The flow identifier, must be unique inside a flow.                                                               |
+|`type`| The Java FQCN of the trigger.                                                                                  |
+|`description`| The description of the trigger, more details [here](../01.flow.md#document-your-flow).                  |
+|`disabled`| Set it to `true` to disable execution of the trigger.                                                      |
+|`workerGroup.key`| To execute this trigger on a specific [Worker Group (EE)](../../08.architecture.md#worker-group-ee).|
 
 ---
 
@@ -24,7 +35,6 @@ Note that the above-mentioned **templated variables** are only available when th
 
 Also, note that **you don't need an extra task to consume** the file or message from the event. Kestra downloads those automatically to the **internal storage** and makes those available in your flow using `{{ trigger.uri }}` variable. Therefore, you don't need any additional task to e.g. consume a message from the SQS queue or to download a file from S3 when using those event triggers. The trigger already consumes and downloads those, making them directly available for further processing. Check the documentation of a specific trigger and [Blueprints](../04.user-interface-guide/blueprints.md) with the **Trigger** tag for more details and examples.
 ::
-
 
 Triggers restrict parallel execution for a given trigger ID to one active run. For instance, if an Execution from a flow with a `Schedule` trigger with ID `hourly` is still in a `Running` state, another one will not be started. However, you can still trigger the same flow manually (from the UI or API), and the scheduled Executions will not be affected.
 
@@ -41,14 +51,13 @@ triggers:
     cron: "@hourly"
 ```
 
-
 ## Core triggers
 
 The following triggers are included in Kestra core:
 
-- [Schedule](./01.schedule.md): to trigger a flow based on a schedule.
-- [Flow](./02.flow.md): to trigger a flow after another one.
-- [Webhook](./03.webhook.md): to trigger a flow from an HTTP request.
+* [Schedule](./01.schedule.md): to trigger a flow based on a schedule.
+* [Flow](./02.flow.md): to trigger a flow after another one.
+* [Webhook](./03.webhook.md): to trigger a flow from an HTTP request.
 
 ## Polling triggers
 


### PR DESCRIPTION
Common properties inherited from `AbstractTrigger` were not documented in the main docs nor the generated docs.