### PR TITLE
Fix typo in 01.getting-started.md

### DIFF
--- a/content/docs/01.getting-started.md
+++ b/content/docs/01.getting-started.md
@@ -41,7 +41,7 @@ If you don't have `curl` installed, you can download the [Docker Compose file](h
 Then, use the following command to start Kestra server:
 
 ```bash
-docker compose up -d
+docker-compose up -d
 ```
 
 Open [http://localhost:8080](http://localhost:8080) in your browser to launch the UI.


### PR DESCRIPTION
Should be using `docker-compose` 