### PR TITLE
docs(deployment): add configuration tip for manual deployment

### DIFF
--- a/content/docs/09.administrator-guide/02.deployment/03.manual.md
+++ b/content/docs/09.administrator-guide/02.deployment/03.manual.md
@@ -23,5 +23,8 @@ More information on Kestra commands can be found in [Kestra servers](../04.serve
 
 ## Configuration
 
-You must [configure](../01.configuration/index.md) Kestra inside the default `~/.kestra/config.yml` YAML file or use the `-c` or `--config` option to point to another file. You can find the default `config.yml` file [here on GitHub](https://github.com/kestra-io/kestra/blob/develop/cli/src/main/resources/application.yml).
+You can either your whole configuration through the environment variable `KESTRA_CONFIGURATION` or you can specify a configuration file to read through `--config` (or `-c`) option. If neither of these option is used, Kestra will read from `${HOME}/.kestra/config.yml`.
 
+If you are using `KESTRA_CONFIGURATION` environment variable, you'll need to have a directory called `confs` in the directory where you run Kestra.
+
+Configuration options are available [here](../01.configuration/index.md), you can also see the default configuration loaded on  [GitHub](https://github.com/kestra-io/kestra/blob/develop/cli/src/main/resources/application.yml).

--- a/content/docs/09.administrator-guide/02.deployment/03.manual.md
+++ b/content/docs/09.administrator-guide/02.deployment/03.manual.md
@@ -23,7 +23,7 @@ More information on Kestra commands can be found in [Kestra servers](../04.serve
 
 ## Configuration
 
-You can either your whole configuration through the environment variable `KESTRA_CONFIGURATION` or you can specify a configuration file to read through `--config` (or `-c`) option. If neither of these option is used, Kestra will read from `${HOME}/.kestra/config.yml`.
+You can either put your whole configuration in the environment variable `KESTRA_CONFIGURATION` or you can specify a configuration file to read through `--config` (or `-c`) option. If neither of these option is used, Kestra will read from `${HOME}/.kestra/config.yml`.
 
 If you are using `KESTRA_CONFIGURATION` environment variable, you'll need to have a directory called `confs` in the directory where you run Kestra.
 


### PR DESCRIPTION
Hello :wave: 

I've been working with manual deployment, and I encountered an issue which wasn't documented. The problem is that i needed to have `./confs` directory where my kestra is running, else, it would crash because couldn't find the file `confs/application.yml`.