### PR TITLE
fix(doc): specify Kestra server type CI/CD requirement

### DIFF
--- a/content/docs/05.developer-guide/13.cicd/index.md
+++ b/content/docs/05.developer-guide/13.cicd/index.md
@@ -44,8 +44,8 @@ The `--no-delete` flag is used to preserve existing flows already stored within 
 
 The CLI provides several options to customize your validation and deployment process. CLI options you should be aware of include:
 
-* `--local`: performs the validation locally using the client. By default, Kestra validates flows server-side (a remote API call to your Kestra server).
-* `--server`: allows you to specify the remote server URL. The default URL is [http://localhost:8080](http://localhost:8080).
+* `--local`: performs the validation locally using the client. By default, Kestra validates flows server-side (a remote API call to your Kestra webserver/standalone server).
+* `--server`: allows you to specify the remote Kestra webserver/standalone server URL. The default URL is [http://localhost:8080](http://localhost:8080).
 
 
 For all available CLI options on both `flow validate` and `flow namespace update` commands, use the `-h` or `--help` flag:
@@ -143,7 +143,7 @@ jobs:
         with:
           directory: ./flows/prod
           resource: flow
-          server: ${{secrets.KESTRA_HOST}}
+          server: ${{secrets.KESTRA_WEBSERVER_OR_STANDALONE_HOST}}
           user: ${{secrets.KESTRA_USER}}
           password: ${{secrets.KESTRA_PASSWORD}}
       - name: deploy-prod
@@ -152,7 +152,7 @@ jobs:
           namespace: prod
           directory: ./flows/prod
           resource: flow
-          server: ${{secrets.KESTRA_HOST}}
+          server: ${{secrets.KESTRA_WEBSERVER_OR_STANDALONE_HOST}}
           user: ${{secrets.KESTRA_USER}}
           password: ${{secrets.KESTRA_PASSWORD}}
           delete: false
@@ -162,7 +162,7 @@ jobs:
           namespace: prod.marketing
           directory: ./flows/prod.marketing
           resource: flow
-          server: ${{secrets.KESTRA_HOST}}
+          server: ${{secrets.KESTRA_WEBSERVER_OR_STANDALONE_HOST}}
           user: ${{secrets.KESTRA_USER}}
           password: ${{secrets.KESTRA_PASSWORD}}
           delete: false
@@ -193,7 +193,7 @@ terraform {
 }
 
 provider "kestra" {
-  url = "http://localhost:8080"
+  url = "http://localhost:8080" # Kestra webserver/standalone server URL
 }
 
 resource "kestra_flow" "flows" {


### PR DESCRIPTION
The CI/CD-related API behind the scenes is only the webserver.