### PR TITLE
feat(docs): add release context to migrations

### DIFF
--- a/components/content/ChildReleases.vue
+++ b/components/content/ChildReleases.vue
@@ -1,0 +1,44 @@
+<template>
+    <div class="row card-group card-centered mb-2">
+        <NuxtLink :href="item._path" class="col-12 col-md-10 mb-4" v-for="item in navigation" :key="item._path">
+            <div class="card">
+                <div class="card-body">
+                    <div>
+                        <h4>{{ item.release }}</h4>
+                        <h4 class="card-title">{{ item.title }}</h4>
+                    </div>
+                    <p class="card-text">{{ item.description }}</p>
+                </div>
+            </div>
+        </NuxtLink>
+    </div>
+</template>
+
+<script setup>
+    import {hash} from "ohash";
+    import {useAsyncData} from "#imports";
+
+    const props = defineProps({
+        pageUrl: {
+            type: String,
+            default: undefined
+        },
+    });
+
+    const route = useRoute()
+
+    let currentPage = null;
+
+    if (props.pageUrl) {
+        currentPage = props.pageUrl;
+    } else {
+        currentPage = route.path;
+    }
+
+    currentPage = currentPage.endsWith("/") ? currentPage.slice(0, -1) : currentPage;
+
+    const {data: navigation} = await useAsyncData(
+        `ChildReleases-${hash(currentPage)}`,
+        () => queryContent(`${currentPage}/`).where({ release: { $exists: true } }).sort({ release: 1 }).find()
+    );
+</script>

--- a/content/docs/12.migrations/core-script-tasks.md
+++ b/content/docs/12.migrations/core-script-tasks.md
@@ -1,6 +1,7 @@
 ---
 title: Deprecation of core Script tasks
 icon: /docs/icons/migrations.svg
+release: 0.11.0
 ---
 
 Script tasks included in the core plugin have been deprecated in 0.11.0 and moved to dedicated plugins.

--- a/content/docs/12.migrations/index.md
+++ b/content/docs/12.migrations/index.md
@@ -4,5 +4,5 @@ title: Migrations
 
 Upgrades and migrations are sometimes necessary. This section covers what's being phased out and what you can use instead.
 
-::ChildCard
+::ChildReleases
 ::

--- a/content/docs/12.migrations/listeners.md
+++ b/content/docs/12.migrations/listeners.md
@@ -1,6 +1,7 @@
 ---
 title: Deprecation of Listeners
 icon: /docs/icons/migrations.svg
+release: 0.12.0
 ---
 
 Listeners are deprecated and disabled by default starting from the 0.12.0 release. Please use [Flow triggers](../06.workflow-components/05.triggers/flow-trigger.md) instead.
@@ -11,7 +12,6 @@ Listeners are deprecated and disabled by default starting from the 0.12.0 releas
 2. It is an extra concept that you, as a user, would need to learn even though you may not have to if you already know Flow triggers.
 3. It's a hard-to-grasp concept — listeners can launch tasks *outside* of the flow, i.e., tasks that will not be considered part of the flow but are defined *within* it. Additionally, the results of listeners will not change the execution status of the flow, so having them defined within the flow has caused some confusion in the past.
 4. Currently, listeners are mainly used to send failure (or success) notifications, and Kestra already has two concepts allowing you to do that: `triggers` and `errors`. Having **three** choices for such a standard use case has led to confusion about when to use which of them.
-
 
 If you are using listeners and you are not ready to migrate to Flow triggers yet, add the following Kestra configuration option to still be able to use listeners:
 
@@ -45,7 +45,6 @@ kestra:
 ```
 
 Due to listeners' deprecation, we changed the default behavior of various `io.kestra.core.models.conditions`-type conditions to use the `{{trigger.date}}` as default value for the `date` property instead of using `"{{ now(format='iso_local_date') }}"`. To ensure that your conditions are working properly after the upgrade to any version after 0.12.0, you need to add the above task defaults to your Kestra configuration.
-
 
 ---
 
@@ -90,7 +89,6 @@ The next section shows how you can accomplish the same using Flow triggers.
 To migrate from a listener to a Flow trigger, create a new flow. Add a trigger of type `io.kestra.core.models.triggers.types.Flow` and move the condition e.g. `ExecutionStatusCondition` to the trigger conditions. Finally, move the list of tasks from listeners to `tasks` in the flow.
 
 The example below will explain it better than words:
-
 
 ```yaml
 id: alert_to_slack
@@ -140,7 +138,6 @@ Anytime you execute that `demo` flow, the Slack notification will be sent, thank
 
 You can look at both a flow with a listener and a flow with a Flow trigger side by side to see the syntax difference:
 
-
 ![listeners-vs-flow-triggers](/docs/migrations/listeners-vs-flow-triggers.png)
 
 If you still have questions about migrating from listeners to flow triggers, reach out via our [Community Slack](https://kestra.io/slack).
@@ -172,6 +169,7 @@ listeners:
 ### Properties
 
 **`conditions`**
+
 * **Type:** ==array==
 * **SubType:** ==Condition==
 * **Required:** ❌
@@ -179,6 +177,7 @@ listeners:
 > A list of Conditions that must be validated in order to execute the listener `tasks`. If you don't provide any conditions, the listeners will always be executed.
 
 **`tasks`**
+
 * **Type:** ==array==
 * **SubType:** ==Task==
 * **Required:** ❌
@@ -188,8 +187,8 @@ listeners:
 > You can use every tasks you need here, even Flowable.
 > All task `id` must be unique for the whole flow even for main `tasks` and `errors`.
 
-
 **`description`**
+
 * **Type:** ==string==
 * **Required:** ❌
 

--- a/content/docs/12.migrations/recursive-rendering.md
+++ b/content/docs/12.migrations/recursive-rendering.md
@@ -1,11 +1,13 @@
 ---
 title: Recursive rendering of Pebble expressions
 icon: /docs/icons/migrations.svg
+release: 0.14.0
 ---
 
 Since the release 0.14.0, kestra's templating engine has changed the default rendering behavior to **not recursive**.
 
 ## Why the change?
+
 Before the release 0.14, kestra's templating engine has been rendering all expressions **recursively**. While recursive rendering enabled many flexible usage patterns, it also opened up the door to some unintended behavior. For example, if you wanted to parse JSON elements of a webhook payload that contained a templated string from other applications (such as GitHub Actions or dbt core), the recursive rendering would attempt to parse those expressions, resulting in an error.
 
 The release 0.14.0 has changed the default rendering behavior to **not recursive** and introduced a new `render()` function that gives you more control over which expressions should be rendered and how.
@@ -57,4 +59,3 @@ kestra:
 ```
 
 This is an instance-level configuration, so you don't need any changes in your code. We recommend that you migrate your flows to the new rendering behavior as soon as you can, as we believe this more explicit rendering behavior will be more intuitive and less error-prone in the long run.
-

--- a/content/docs/12.migrations/templates.md
+++ b/content/docs/12.migrations/templates.md
@@ -1,18 +1,17 @@
 ---
 title: Deprecation of Templates
 icon: /docs/icons/migrations.svg
+release: 0.11.0
 ---
 
 Since the release 0.11.0, Templates are deprecated and disabled by default. Please use subflows instead.
 
 If you still rely on templates, you can re-enable them in your [configuration](../10.administrator-guide/01.configuration/04.others.md).
 
-
 ## Why templates are deprecated
 
 1. Subflows are more powerful — subflows provide the same functionality as templates while simultaneously being more flexible than templates. For instance, `inputs` are not allowed in a template because a template is only a list of tasks that get copied to another flow that references it. In contrast, when invoking a subflow, you can parametrize it with custom parameters. This way, subflows allow you to define workflow logic once and invoke it in other flows with custom parameters.
 2. Subflows are more transparently reflected in the topology view and don't require copying tasks.
-
 
 If you are using templates and you are not ready to migrate to subflows yet, add the following Kestra configuration option to still be able to use them:
 
@@ -94,6 +93,7 @@ To migrate from a template to a subflow, you can create a flow that is a 1:1 cop
 In our example, we can create a new flow called `mytemplate` in a namespace `dev`. This flow will be invoked from a parent flow as a subflow.
 
 Then, to create a child flow (a subflow), you only need to change the following values in the `templatedFlow`:
+
 - Change the `io.kestra.core.tasks.flows.Template` task type to `io.kestra.core.tasks.flows.Subflow`
 - Change the `templateId` to `flowId`.
 
@@ -160,9 +160,7 @@ tasks:
 
 You can look at both a flow with a template task and a flow with a subflow task side by side to see the difference in syntax:
 
-
 ![template-vs-subflow](/docs/migrations/template-vs-subflow.png)
-
 
 If you still have questions about migrating from templates to subflows, reach out via our [Community Slack](https://kestra.io/slack).
 


### PR DESCRIPTION
Migrations are intended to be applied on a release basis - the release info should be clearly conveyed.

Feel free to redo the look & feel!