### PR TITLE
Fix: Replace Azure with GCP vocabulary

### DIFF
--- a/content/docs/02.installation/05.kubernetes-gcp-gke.md
+++ b/content/docs/02.installation/05.kubernetes-gcp-gke.md
@@ -45,7 +45,7 @@ Run the following command to have your kubecontext point to the newly created cl
 gcloud container clusters get-credentials my-kestra --region=europe-west3
 ```
 
-You can now confirm that your kubecontext points to the AKS cluster using:
+You can now confirm that your kubecontext points to the GKE cluster using:
 
 ```shell
 kubectl get svc
@@ -107,7 +107,7 @@ helm install my-kestra kestra/kestra
 
 **Update Kestra configuration**
 
-Here is how you can configure Azure Database in the [Helm chart's values](https://github.com/kestra-io/helm-charts/blob/master/charts/kestra/values.yaml#L11):
+Here is how you can configure CloudSQL Database in the [Helm chart's values](https://github.com/kestra-io/helm-charts/blob/master/charts/kestra/values.yaml#L11):
 
 ```yaml
 configuration:


### PR DESCRIPTION
Hi,
I noticed a few Azure related words in the [Kubernetes on GCP GKE installation guide](https://kestra.io/docs/installation/kubernetes-gcp-gke).
Here is a quick fix. 