### PR TITLE
Handled repositioning of the plugin icons in a temporary way

### DIFF
--- a/components/content/ProseImg.vue
+++ b/components/content/ProseImg.vue
@@ -1,10 +1,10 @@
 <template>
-    <span class="text-center d-block">
+    <span class="image-margin" :class="defaultClasses">
         <NuxtImg
             :src="refinedSrc"
             :alt="alt"
-            :width="width"
-            :height="height"
+            :width="`${width}px`"
+            :height="`${height}px`"
             :class="classWithZoom"
             loading="lazy"
             format="webp"
@@ -35,6 +35,10 @@
             type: [String, Number],
             default: undefined
         },
+        defaultClasses: {
+            type: String,
+            default: 'text-center d-block'
+        },
         class: {
             type: String,
             default: ''
@@ -52,3 +56,9 @@
         return "zoom " + props.class
     })
 </script>
+
+<style lang="scss">
+.image-margin {
+    margin-right: 10px;
+}
+</style>

--- a/server/api/plugins.js
+++ b/server/api/plugins.js
@@ -78,7 +78,18 @@ export default defineEventHandler(async (event) => {
         if (type === 'plugin') {
             let pageData = await $fetch(`${config.public.apiUrl}/plugins/${page}`);
 
-            const parsedMarkdown = await parseMarkdown(pageData.body);
+            let parsedMarkdown = await parseMarkdown(pageData.body);
+
+            // Start of temporary solution for plugins
+            // TODO: Handle response structure on the BE part differently (description and image parameters need to be subchildren of the the same child)
+            let elementToMove = parsedMarkdown.body.children?.splice(2, 1)?.[0]?.children?.[0];
+
+            if(elementToMove) {
+                elementToMove.props.defaultClasses = '';
+                elementToMove.props.width = 60;
+                parsedMarkdown.body.children?.[1]?.children?.unshift(elementToMove);
+            }
+            // End of temporary solution for plugins
 
             return toNuxtContent(parsedMarkdown);
         }


### PR DESCRIPTION
This is far, faaar away from a perfect solution, because the structure of the response seemingly needs a bit of tweaking, but as a temporary tweak it might be beneficial.

![image](https://github.com/kestra-io/docs/assets/62475782/4f41d113-12c9-4165-977f-2f42e3838776)

Resolves #981, #966.