### PR TITLE
fix(docs): validate example for gcs + ksa instructions

### DIFF
--- a/content/docs/02.installation/05.kubernetes-gcp-gke.md
+++ b/content/docs/02.installation/05.kubernetes-gcp-gke.md
@@ -152,6 +152,8 @@ By default, internal storage is implemented using the local file system. This se
 8. We will be using the stringified JSON for our configuration. You can use the bash command `% cat <path_to_json_file> | jq '@json'` to generate stringified JSON.
 9. Edit Kestra storage configuration in the [Helm chart's values](https://github.com/kestra-io/helm-charts/blob/master/charts/kestra/values.yaml#L11).
 
+*Note: If you want to use a Kubernetes service account configured as a workload identify, you don't need to provide anything for `serviceAccount` as it will be autodetected for the pod configuration if it's well configured.*
+
 ```yaml
 configuration:
   kestra:
@@ -173,6 +175,22 @@ In order for the changes to take effect, run the `helm upgrade` command as:
 
 ```shell
 helm upgrade my-kestra-cluster kestra/kestra -f values.yaml
+```
+
+You can validate the storage change from minio to Google Cloud Storage by executing the flow example below with a file and then checking it is uploaded to Google Cloud Storage.
+
+```yaml
+id: inputs
+namespace: example
+
+inputs:
+  - id: file
+    type: FILE
+
+tasks:
+  - id: validator
+    type: io.kestra.core.tasks.log.Log
+    message: User {{ inputs.file }}
 ```
 
 ## Next steps


### PR DESCRIPTION
Added instructions for using Kubernetes service accounts for GCS rather than Google service accounts. Also added an example for how to validate that this works.