### PR TITLE
refactor(docs): Rename how to titles

### DIFF
--- a/content/docs/18.how-to-guides/index.md
+++ b/content/docs/18.how-to-guides/index.md
@@ -3,7 +3,7 @@ title: How-to guides
 icon: /docs/icons/tutorial.svg
 ---
 
-Tutorials covering various use cases step by step.
+Guides covering various use cases step by step.
 
 ::ChildCard
 ::

--- a/content/docs/18.how-to-guides/inputs.md
+++ b/content/docs/18.how-to-guides/inputs.md
@@ -1,9 +1,9 @@
 ---
-title: Using Inputs
+title: How to Use Inputs in Kestra
 icon: /docs/icons/tutorial.svg
 ---
 
-This page provides a deep dive into how you can use inputs in various use cases.
+Deep dive into how you can use inputs in various use cases.
 
 ## What are inputs
 

--- a/content/docs/18.how-to-guides/monitoring.md
+++ b/content/docs/18.how-to-guides/monitoring.md
@@ -1,7 +1,9 @@
 ---
-title: Setup Monitoring
+title: How to Setup Monitoring in Kestra
 icon: /docs/icons/tutorial.svg
 ---
+
+Setup monitoring dashboards for Kestra.
 
 We will look in detail at setting up monitoring dashboards for Kestra.
 

--- a/content/docs/18.how-to-guides/pause-resume.md
+++ b/content/docs/18.how-to-guides/pause-resume.md
@@ -1,9 +1,9 @@
 ---
-title: Pause and Resume
+title: How to use the Pause and Resume in Kestra
 icon: /docs/icons/tutorial.svg
 ---
 
-How to use the Pause and Resume functionality in Kestra.
+Pause and Resume flows in Kestra.
 
 ## The use cases for pausing and resuming workflows
 

--- a/content/docs/18.how-to-guides/pause-resume.md
+++ b/content/docs/18.how-to-guides/pause-resume.md
@@ -1,5 +1,5 @@
 ---
-title: How to use the Pause and Resume in Kestra
+title: How to Use Pause and Resume in Kestra
 icon: /docs/icons/tutorial.svg
 ---
 

--- a/content/docs/18.how-to-guides/python.md
+++ b/content/docs/18.how-to-guides/python.md
@@ -1,9 +1,9 @@
 ---
-title: Using Python
+title: How to Use Python in Kestra
 icon: /docs/icons/tutorial.svg
 ---
 
-How to run Python code inside of your flow.
+Run Python code inside of your flow.
 
 You can execute Python code inside of a flow by either writing your Python inline or by executing a `.py` file. You can also get outputs and metrics from your Python code too.
 

--- a/content/docs/18.how-to-guides/rollback-and-revision-history.md
+++ b/content/docs/18.how-to-guides/rollback-and-revision-history.md
@@ -1,9 +1,9 @@
 ---
-title: Rollback & Revision History
+title: How to Use Revision History & Rollback in Kestra
 icon: /docs/icons/tutorial.svg
 ---
 
-This page describes how you can use revision history to rollback to an older version of a flow.
+Use revision history to rollback to an older version of a flow.
 
 ## What is Revision History
 

--- a/content/docs/18.how-to-guides/secrets.md
+++ b/content/docs/18.how-to-guides/secrets.md
@@ -1,9 +1,9 @@
 ---
-title: Using Secrets
+title: How to Use Secrets in Kestra
 icon: /docs/icons/tutorial.svg
 ---
 
-This page provides a deep dive into how you can use secrets in various Kestra use cases.
+A deep dive into how you can use secrets in various Kestra use cases.
 
 ## What are Secrets
 

--- a/content/docs/18.how-to-guides/slack-webhook.md
+++ b/content/docs/18.how-to-guides/slack-webhook.md
@@ -1,9 +1,9 @@
 ---
-title: Slack Events API
+title: How to Use the Slack Events API in Kestra
 icon: /docs/icons/tutorial.svg
 ---
 
-This page describes how you can trigger Kestra flows based on Slack events.
+Trigger Kestra flows based on Slack events.
 
 The Slack Events API allows you to build apps that respond to events from Slack. For example, you can trigger a custom action anytime a user joins a channel or when someone reacts to a message with a specific emoji.
 

--- a/content/docs/18.how-to-guides/webhooks.md
+++ b/content/docs/18.how-to-guides/webhooks.md
@@ -1,5 +1,5 @@
 ---
-title: Using Webhook
+title: How to Use Webhooks in Kestra
 icon: /docs/icons/tutorial.svg
 ---
 


### PR DESCRIPTION
How to titles are now "How to Use..." for consistency


![Screenshot 2024-04-15 at 15 08 35](https://github.com/kestra-io/docs/assets/34094921/c127f26b-00ce-4b87-b0fd-58364a6d974e)
