### PR TITLE
feat: add urls to editions page

### DIFF
--- a/components/enterprise/Editions.vue
+++ b/components/enterprise/Editions.vue
@@ -12,7 +12,7 @@
                             <h4 class="card-title" data-aos="fade-right">Open-Source Edition</h4>
                             <p class="type" data-aos="fade-left">Free</p>
                             <NuxtLink href="/pricing" class="btn btn-animated btn-dark-animated w-100" data-aos="zoom-in">
-                                Get started
+                                Get Started
                             </NuxtLink>
                             <ul>
                                 <li data-aos="fade-right">Apache 2.0 license</li>
@@ -39,16 +39,16 @@
                                 Talk to Us
                             </NuxtLink>
                             <ul>
-                                <li data-aos="fade-left">All features from the Open-Source Edition and more</li>
+                                <li data-aos="fade-left">All features from the Open Source Edition and more</li>
                                 <li data-aos="fade-left" data-aos-delay="100">Scalable architecture with High-Availability</li>
-                                <li data-aos="fade-left" data-aos-delay="150">Multi-tenancy</li>
-                                <li data-aos="fade-left" data-aos-delay="200">Worker groups supporting distributed workers</li>
-                                <li data-aos="fade-left" data-aos-delay="250">Custom secrets backend (AWS Secret Manager, Azure Key Vault, Elasticsearch, Google Secret Manager, Hashicorp Vault)</li>
-                                <li data-aos="fade-left" data-aos-delay="300">Audit logs</li>
-                                <li data-aos="fade-left" data-aos-delay="350">Single Sign-On (SSO)</li>
-                                <li data-aos="fade-left" data-aos-delay="400">Role-Based Access Control (RBAC)</li>
-                                <li data-aos="fade-left" data-aos-delay="450">Custom blueprints</li>
-                                <li data-aos="fade-left" data-aos-delay="500">Namespace-level management</li>
+                                <li data-aos="fade-left" data-aos-delay="150"><a href="/docs/enterprise/tenants">Multi-tenancy</a></li>
+                                <li data-aos="fade-left" data-aos-delay="200"><a href="/docs/enterprise/worker-group">Worker groups supporting distributed workers</a></li>
+                                <li data-aos="fade-left" data-aos-delay="250"><a href="/docs/enterprise/secrets-manager"></a>Custom secrets backend (AWS Secret Manager, Azure Key Vault, Elasticsearch, Google Secret Manager, Hashicorp Vault)</a></li>
+                                <li data-aos="fade-left" data-aos-delay="300"><a href="/docs/enterprise/audit-logs">Audit Logs</a></li>
+                                <li data-aos="fade-left" data-aos-delay="350"><a href="/docs/enterprise/sso">Single Sign-On (SSO)</a></li>
+                                <li data-aos="fade-left" data-aos-delay="400"><a href="/docs/enterprise/rbac">Role-Based Access Control (RBAC)</a></li>
+                                <li data-aos="fade-left" data-aos-delay="450"><a href="/docs/enterprise/custom-blueprints">Custom Blueprints</a></li>
+                                <li data-aos="fade-left" data-aos-delay="500"><a href="/docs/enterprise/namespace-management">Namespace-level Management</a></li>
                                 <li data-aos="fade-left" data-aos-delay="550">Secure credential store</li>
                                 <li data-aos="fade-left" data-aos-delay="600">Built-in variable store</li>
                                 <li data-aos="fade-left" data-aos-delay="650">Centralized governance over task configuration</li>

--- a/components/price/Heading.vue
+++ b/components/price/Heading.vue
@@ -60,25 +60,25 @@
                                 <li data-aos="fade-left">
                                     <span>
                                         <strong>
-                                            All features from the Open-Source Edition and
+                                            All features from the Open Source Edition and
                                             more
                                         </strong>
                                     </span>
                                 </li>
                                 <ul>
                                     <p class="category-title">Security</p>
-                                    <li data-aos="fade-left" data-aos-delay="300"><span>Audit logs</span></li>
-                                    <li data-aos="fade-left" data-aos-delay="400"><span>RBAC</span></li>
-                                    <li data-aos="fade-left" data-aos-delay="400"><span>SSO</span></li>
-                                    <li data-aos="fade-left" data-aos-delay="400"><span>Secrets Manager</span></li>
+                                    <li data-aos="fade-left" data-aos-delay="300"><span><a href="/docs/enterprise/audit-logs">Audit Logs</a></span></li>
+                                    <li data-aos="fade-left" data-aos-delay="400"><span><a href="/docs/enterprise/rbac">Role-Based Access Control (RBAC)</a></span></li>
+                                    <li data-aos="fade-left" data-aos-delay="400"><span><a href="/docs/enterprise/sso">Single Sign-On (SSO)</a></span></li>
+                                    <li data-aos="fade-left" data-aos-delay="400"><span><a href="/docs/enterprise/secrets-manager">Secrets Manager</a></span></li>
                                     <li data-aos="fade-left" data-aos-delay="400"><span>Encryption</span></li>
                                 </ul>
                                 <ul>
                                     <p class="category-title">Governance</p>
-                                    <li data-aos="fade-left" data-aos-delay="300"><span>Multi Tenancy</span></li>
-                                    <li data-aos="fade-left" data-aos-delay="400"><span>Namespace Management</span></li>
-                                    <li data-aos="fade-left" data-aos-delay="400"><span>Custom blueprints</span></li>
-                                    <li data-aos="fade-left" data-aos-delay="400"><span>Task Configuration</span></li>
+                                    <li data-aos="fade-left" data-aos-delay="300"><span><a href="/docs/enterprise/tenants">Multi Tenancy</a></span></li>
+                                    <li data-aos="fade-left" data-aos-delay="400"><span><a href="/docs/enterprise/namespace-management">Namespace Management</a></span></li>
+                                    <li data-aos="fade-left" data-aos-delay="400"><span><a href="/docs/enterprise/custom-blueprints">Custom Blueprints</a></span></li>
+                                    <li data-aos="fade-left" data-aos-delay="400"><span><a href="/docs/enterprise/centralized-task-configuration">Task Configuration</a></span></li>
                                 </ul>
                                 <ul>
                                     <p class="category-title">Scalability</p>

--- a/content/docs/05.enterprise/06.audit-logs.md
+++ b/content/docs/05.enterprise/06.audit-logs.md
@@ -1,5 +1,5 @@
 ---
-title: Audit logs
+title: Audit Logs
 icon: /docs/icons/admin.svg
 ---
 

--- a/content/docs/05.enterprise/07.namespace-management.md
+++ b/content/docs/05.enterprise/07.namespace-management.md
@@ -1,5 +1,5 @@
 ---
-title: Namespace management
+title: Namespace Management
 icon: /docs/icons/admin.svg
 ---
 


### PR DESCRIPTION
URLs for features under the enterprise edition. Some links didn't have dedicated pages (because of what they are).

![Screenshot 2024-04-22 at 14 30 29](https://github.com/kestra-io/docs/assets/34094921/53afe908-589b-4708-ba2e-0504715582ab)
