### PR TITLE
fix(docs): add python execute example

### DIFF
--- a/content/docs/15.how-to-guides/python.md
+++ b/content/docs/15.how-to-guides/python.md
@@ -88,4 +88,4 @@ flow = Flow()
 flow.execute('example', 'python_scripts', {'greeting': 'hello from Python'})
 ```
 
-Read more about it on the [execution page](/docs/workflow-components/executions).
+Read more about it on the [execution page](/docs/workflow-components/execution).

--- a/content/docs/15.how-to-guides/python.md
+++ b/content/docs/15.how-to-guides/python.md
@@ -75,3 +75,17 @@ You can also get [metrics](../08.developer-guide/07.scripts/outputs-metrics.md#o
 
 Once this has executed, `duration` will be viewable under **Metrics**.
 ![metrics](/docs/how-to-guides/python/metrics.png)
+
+## Execute Flows in Python
+
+Inside of your Python code, you can execute flows. This is useful if you want to manage your orchestration directly in Python rather than using the Kestra flow editor.
+
+You can trigger a flow execution by calling the `execute()` method. Here is an example for the same `python_scripts` flow in the namespace `example` as above:
+
+```python
+from kestra import Flow
+flow = Flow()
+flow.execute('example', 'python_scripts', {'greeting': 'hello from Python'})
+```
+
+Read more about it on the [execution page](/docs/workflow-components/executions).

--- a/public/examples/commands_python.yml
+++ b/public/examples/commands_python.yml
@@ -4,7 +4,7 @@ namespace: example
 description: This flow will install the pip package in a Docker container, and use kestra's Python library to generate outputs (number of downloads of the Kestra Docker image) and metrics (duration of the script).
 
 tasks:
-- id: outputs_metrics
+  - id: outputs_metrics
     type: io.kestra.plugin.scripts.python.Commands
     namespaceFiles:
       enabled: true


### PR DESCRIPTION
Add how to execute flows directly from Python to the Python How-to Guide