### PR TITLE
Custom Plugin build step updated in the documentation

### DIFF
--- a/content/docs/08.developer-guide/06.plugins.md
+++ b/content/docs/08.developer-guide/06.plugins.md
@@ -821,7 +821,7 @@ To use this plugin in your Kestra instance, add this JAR to the [Kestra plugins 
 #### Use a custom docker image with your plugin
 Adding this `Dockerfile` to the root of your plugin project:
 ```
-FROM kestra/kestra:latest-full
+FROM kestra/kestra:develop-full
 
 COPY build/libs/* /app/plugins/
 ```


### PR DESCRIPTION
Updated the plugin build step to use kestra:develop-full instead of kestra:latest-full docker as base docker image tag