### PR TITLE
Fix more info Flow Link 01.fundamentals.md

### DIFF
--- a/content/docs/03.tutorial/01.fundamentals.md
+++ b/content/docs/03.tutorial/01.fundamentals.md
@@ -80,7 +80,7 @@ tasks:
       This task will print "Hello World!" to the logs.
 ```
 
-Learn more about flows in the [Flows section](/workflow-components/flow).
+Learn more about flows in the [Flows section](/docs/workflow-components/flow).
 
 ---
 


### PR DESCRIPTION
Hello!

The current link for More Flows Content is taking me to 404 page, this adds the missing `/docs` prefix to the URL.