### PR TITLE
fix(docs): Put an icon for developer guide on build custom plugin

### DIFF
--- a/content/docs/08.developer-guide/06.plugins.md
+++ b/content/docs/08.developer-guide/06.plugins.md
@@ -1,5 +1,6 @@
 ---
 title: Build a Custom Plugin
+icon: /docs/icons/dev.svg
 ---
 
 Browse [Kestra's integrations](/plugins) and learn how to create your own plugins.


### PR DESCRIPTION
Closes #1312 