### PR TITLE
fix(docs): Update outputs tutorial to use `outputFiles` instead of `outputDir`

### DIFF
--- a/content/docs/03.tutorial/03.outputs.md
+++ b/content/docs/03.tutorial/03.outputs.md
@@ -5,7 +5,7 @@ icon: /docs/icons/tutorial.svg
 
 Outputs allow you to pass data between tasks and flows.
 
-Tasks and flows can generate outputs, which can be passed to downstream processes. These outputs can be variables or files stored in the [internal storage](/docs/architecture/internal-storage).
+Tasks and flows can generate outputs, which can be passed to downstream processes. These outputs can be variables or files stored in the [internal storage](../07.architecture/09.internal-storage.md).
 
 <div class="video-container">
   <iframe src="https://www.youtube.com/embed/QgP_atMXk-c?si=0fUlb4ty7xrvCmPc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
@@ -43,7 +43,7 @@ inputs:
 
 tasks:
   - id: api
-    type: io.kestra.plugin.fs.http.Request
+    type: io.kestra.plugin.core.http.Request
     uri: "{{ inputs.api_url }}"
 
   - id: python
@@ -53,12 +53,14 @@ tasks:
     beforeCommands:
       - pip install polars
     warningOnStdErr: false
+    outputFiles:
+      - "products.csv"
     script: |
       import polars as pl
       data = {{outputs.api.body | jq('.products') | first}}
       df = pl.from_dicts(data)
       df.glimpse()
-      df.select(["brand", "price"]).write_csv("{{outputDir}}/products.csv")
+      df.select(["brand", "price"]).write_csv("products.csv")
 ```
 
 This flow processes data using Polars and stores the result as a CSV file.
@@ -87,7 +89,7 @@ namespace: dev
 
 tasks:
   - id: api
-    type: io.kestra.plugin.fs.http.Request
+    type: io.kestra.plugin.core.http.Request
     uri: https://dummyjson.com/products
 
   - id: python
@@ -97,12 +99,14 @@ tasks:
     beforeCommands:
       - pip install polars
     warningOnStdErr: false
+    outputFiles:
+      - "products.csv"
     script: |
       import polars as pl
       data = {{ outputs.api.body | jq('.products') | first }}
       df = pl.from_dicts(data)
       df.glimpse()
-      df.select(["brand", "price"]).write_csv("{{ outputDir }}/products.csv")
+      df.select(["brand", "price"]).write_csv("products.csv")
 
   - id: sqlQuery
     type: io.kestra.plugin.jdbc.duckdb.Query
@@ -138,7 +142,7 @@ inputs:
 
 tasks:
   - id: api
-    type: io.kestra.plugin.fs.http.Request
+    type: io.kestra.plugin.core.http.Request
     uri: "{{ inputs.api_url }}"
 
   - id: python
@@ -147,12 +151,14 @@ tasks:
     beforeCommands:
       - pip install polars
     warningOnStdErr: false
+    outputFiles:
+      - "products.csv"
     script: |
       import polars as pl
       data = {{ outputs.api.body | jq('.products') | first }}
       df = pl.from_dicts(data)
       df.glimpse()
-      df.select(["brand", "price"]).write_csv("{{ outputDir }}/products.csv")
+      df.select(["brand", "price"]).write_csv("products.csv")
 
   - id: sqlQuery
     type: io.kestra.plugin.jdbc.duckdb.Query
@@ -166,9 +172,9 @@ tasks:
     store: true
 ```
 
-To learn more about outputs, check out the full [outputs documentation](/docs/workflow-components/outputs). 
+To learn more about outputs, check out the full [outputs documentation](../04.workflow-components/06.outputs.md). 
 
 ::next-link
-[Next, let's cover `triggers` to schedule the flow](/docs/tutorial/triggers)
+[Next, let's cover `triggers` to schedule the flow](04.triggers.md)
 ::
 


### PR DESCRIPTION
Updated the 3 examples to use `outputFiles` instead of `outputDir`. Also updated the http plugin type to use `core`