### PR TITLE
fix naming on k8s cluster and kestra deployment

### DIFF
--- a/content/docs/02.installation/05.kubernetes-gcp-gke.md
+++ b/content/docs/02.installation/05.kubernetes-gcp-gke.md
@@ -41,7 +41,7 @@ gcloud components install gke-gcloud-auth-plugin
 Run the following command to have your kubecontext point to the newly created cluster:
 
 ```shell
-gcloud container clusters get-credentials my-kestra --region=europe-west3
+gcloud container clusters get-credentials my-kestra-cluster --region=europe-west3
 ```
 
 You can now confirm that your kubecontext points to the GKE cluster using:
@@ -132,7 +132,7 @@ postgres:
 In order for the changes to take effect, run the `helm upgrade` command as:
 
 ```shell
-helm upgrade my-kestra-cluster kestra/kestra -f values.yaml
+helm upgrade my-kestra kestra/kestra -f values.yaml
 ```
 
 ## Prepare a GCS bucket
@@ -173,7 +173,7 @@ minio:
 In order for the changes to take effect, run the `helm upgrade` command as:
 
 ```shell
-helm upgrade my-kestra-cluster kestra/kestra -f values.yaml
+helm upgrade my-kestra kestra/kestra -f values.yaml
 ```
 
 You can validate the storage change from minio to Google Cloud Storage by executing the flow example below with a file and then checking it is uploaded to Google Cloud Storage.


### PR DESCRIPTION
k8s cluster was named incorrectly on line 44. Also modifying name of deployment to `my-kestra` from `my-kestra-cluster` to distinguish from k8s cluster 