### PR TITLE
fix(docs): shorten titles and descriptions for Configuration Section

### DIFF
--- a/content/docs/10.configuration-guide/01.database.md
+++ b/content/docs/10.configuration-guide/01.database.md
@@ -1,9 +1,9 @@
 ---
-title: Database Configuration
+title: Database
 icon: /docs/icons/admin.svg
 ---
 
-This section describes how to configure Kestra to use a database for its Queue and Repository.
+How to configure Kestra to use a database for its Queue and Repository.
 
 
 First, you need to configure Kestra to use a database for its Queue and Repository. Here is an example for PostgreSQL:

--- a/content/docs/10.configuration-guide/02.storage.md
+++ b/content/docs/10.configuration-guide/02.storage.md
@@ -1,9 +1,9 @@
 ---
-title: Storage Configuration
+title: Storage
 icon: /docs/icons/admin.svg
 ---
 
-This page describes the different storage options available in Kestra.
+Different storage options available in Kestra.
 
 Kestra uses [internal storage](/docs/architecture/internal-storage) to store data processed by tasks. This includes files from flow inputs and data stored as task outputs.
 

--- a/content/docs/10.configuration-guide/03.enterprise-edition.md
+++ b/content/docs/10.configuration-guide/03.enterprise-edition.md
@@ -1,5 +1,5 @@
 ---
-title: Enterprise Edition Configuration
+title: Enterprise Edition
 icon: /docs/icons/kestra.svg
 editions: ["EE"]
 ---

--- a/content/docs/10.configuration-guide/api-retries.md
+++ b/content/docs/10.configuration-guide/api-retries.md
@@ -1,9 +1,9 @@
 ---
-title: API Retries Configuration
+title: API Retries
 icon: /docs/icons/admin.svg
 ---
 
-This page describes how you can configure retries for internal storage and secrets API calls.
+How you can configure retries for internal storage and secrets API calls.
 
 Kestra uses external storage and secrets so that your private data and secrets are stored in a secure way in your private infrastructure. These external systems communicate with Kestra through APIs. Those API calls, however, might eperience transient failures. To handle these transient failures, Kestra allows you to configure retries.
 

--- a/content/docs/10.configuration-guide/elasticsearch.md
+++ b/content/docs/10.configuration-guide/elasticsearch.md
@@ -1,5 +1,5 @@
 ---
-title: Elasticsearch Configuration
+title: Elasticsearch
 icon: /docs/icons/admin.svg
 editions: ["EE"]
 ---

--- a/content/docs/10.configuration-guide/enabled.md
+++ b/content/docs/10.configuration-guide/enabled.md
@@ -1,7 +1,9 @@
 ---
-title: Enabled Configuration
+title: Enabled
 icon: /docs/icons/admin.svg
 ---
+
+How to manage deprecated or disabled features.
 
 Often, some features get deprecated or disabled by default in Kestra. This page describes how you can enable them.
 

--- a/content/docs/10.configuration-guide/encryption.md
+++ b/content/docs/10.configuration-guide/encryption.md
@@ -1,6 +1,7 @@
 ---
-title: Encryption Configuration
+title: Encryption
 icon: /docs/icons/admin.svg
+version: ">= 0.15.0"
 ---
 
 Kestra 0.15.0 and later supports encryption of sensitive data.

--- a/content/docs/10.configuration-guide/endpoints.md
+++ b/content/docs/10.configuration-guide/endpoints.md
@@ -1,9 +1,9 @@
 ---
-title: Endpoints Configuration
+title: Endpoints
 icon: /docs/icons/admin.svg
 ---
 
-This page describes how you can configure the Micronaut management endpoints in Kestra.
+How you can configure the Micronaut management endpoints in Kestra.
 
 Management endpoints can be set up from the [Micronaut endpoint configuration](https://docs.micronaut.io/latest/guide/index.html#endpointConfiguration). You can also secure all endpoints with basic authentication using this additional configuration:
 

--- a/content/docs/10.configuration-guide/environment.md
+++ b/content/docs/10.configuration-guide/environment.md
@@ -1,7 +1,9 @@
 ---
-title: Environment Configuration
+title: Environment
 icon: /docs/icons/admin.svg
 ---
+
+How to configure the environment UI display.
 
 Here are the configuration options for the environment UI display.
 

--- a/content/docs/10.configuration-guide/jvm.md
+++ b/content/docs/10.configuration-guide/jvm.md
@@ -1,9 +1,9 @@
 ---
-title: JVM Configuration
+title: JVM
 icon: /docs/icons/admin.svg
 ---
 
-This section describes the configuration options for the JVM.
+How to configure options for the JVM.
 
 All JVM options can be passed in an environment variable named `JAVA_OPTS`. You can use it to change all JVM options available, such as memory, encoding, etc.
 

--- a/content/docs/10.configuration-guide/kafka.md
+++ b/content/docs/10.configuration-guide/kafka.md
@@ -1,5 +1,5 @@
 ---
-title: Kafka Configuration
+title: Kafka
 icon: /docs/icons/admin.svg
 editions: ["EE"]
 ---

--- a/content/docs/10.configuration-guide/logging.md
+++ b/content/docs/10.configuration-guide/logging.md
@@ -1,9 +1,9 @@
 ---
-title: Logging Configuration
+title: Logging
 icon: /docs/icons/admin.svg
 ---
 
-Here you will find the necessary information for configuring the logging of your Kestra cluster.
+Configure the logging of your Kestra cluster.
 
 You can change the log behavior in Kestra by adjusting the following configuration parameters:
 

--- a/content/docs/10.configuration-guide/metrics.md
+++ b/content/docs/10.configuration-guide/metrics.md
@@ -1,9 +1,9 @@
 ---
-title: Metrics Configuration
+title: Metrics
 icon: /docs/icons/admin.svg
 ---
 
-This short page describes how you can configure metrics in Kestra.
+How to configure metrics in Kestra.
 
 You can set the prefix for all Kestra metrics using the following configuration:
 

--- a/content/docs/10.configuration-guide/micronaut.md
+++ b/content/docs/10.configuration-guide/micronaut.md
@@ -1,9 +1,9 @@
 ---
-title: Micronaut Configuration
+title: Micronaut
 icon: /docs/icons/admin.svg
 ---
 
-This page describes Micronaut configuration options for Kestra.
+How to configure Micronaut options for Kestra.
 
 As Kestra is a Java-based application built with Micronaut, you can configure any Micronaut configuration options.
 We will not explain all the possible configuration options, these are available [here](https://docs.micronaut.io/latest/guide/index.html). However, we will provide some tips on the most useful options:

--- a/content/docs/10.configuration-guide/plugins.md
+++ b/content/docs/10.configuration-guide/plugins.md
@@ -1,9 +1,9 @@
 ---
-title: Plugins Configuration
+title: Plugins
 icon: /docs/icons/admin.svg
 ---
 
-This page describes how you can configure plugins in Kestra.
+How to configure plugins in Kestra.
 
 Configuration of Maven repositories used by the command `kestra plugins install`.
 

--- a/content/docs/10.configuration-guide/server.md
+++ b/content/docs/10.configuration-guide/server.md
@@ -1,9 +1,9 @@
 ---
-title: Server Configuration
+title: Server
 icon: /docs/icons/admin.svg
 ---
 
-This section describes the configuration options for the Kestra Server.
+How to configure options for the Kestra Server.
 
 ## HTTP Basic Authentication
 

--- a/content/docs/10.configuration-guide/system-flows.md
+++ b/content/docs/10.configuration-guide/system-flows.md
@@ -1,9 +1,9 @@
 ---
-title: System Flows Configuration
+title: System Flows
 icon: /docs/icons/admin.svg
 ---
 
-This page describes how you can overwrite the default namespace for system flows.
+How to overwrite the default namespace for system flows.
 
 By default, the `system` namespace is reserved for background workflows — a feature we [plan to implement](https://github.com/kestra-io/kestra/issues/3003) in the near future (not yet available as of Kestra 0.15.0). These background workflows are intended to perform routine tasks such as sending alerts and purging old logs. If you want to use the `system` namespace for your regular flows, you can specify which namespace should be used for background workflows with this configuration:
 

--- a/content/docs/10.configuration-guide/tasks.md
+++ b/content/docs/10.configuration-guide/tasks.md
@@ -1,9 +1,9 @@
 ---
-title: Tasks Configuration
+title: Tasks
 icon: /docs/icons/admin.svg
 ---
 
-This section eplains various configuration options for tasks in Kestra.
+How to configuration various options for tasks in Kestra.
 
 ## Task Defaults
 

--- a/content/docs/10.configuration-guide/url.md
+++ b/content/docs/10.configuration-guide/url.md
@@ -1,9 +1,9 @@
 ---
-title: URL Configuration
+title: URL
 icon: /docs/icons/admin.svg
 ---
 
-This page describes how you can configure the URL of your Kestra webserver.
+How to configure the URL of your Kestra webserver.
 
 ## URL Configuration
 Some notification services require a URL configuration defined in order to add links from the alert message. Use a full URI here with a trailing `/` (without ui or api).

--- a/content/docs/10.configuration-guide/usage.md
+++ b/content/docs/10.configuration-guide/usage.md
@@ -1,5 +1,5 @@
 ---
-title: Usage Configuration
+title: Usage
 icon: /docs/icons/admin.svg
 ---
 

--- a/content/docs/10.configuration-guide/variables.md
+++ b/content/docs/10.configuration-guide/variables.md
@@ -1,9 +1,9 @@
 ---
-title: Variables Configuration
+title: Variables
 icon: /docs/icons/admin.svg
 ---
 
-This section lists how you can configure variables usage in Kestra.
+How to configure variables usage in Kestra.
 
 ## `kestra.variables.env-vars-prefix`
 

--- a/content/docs/10.configuration-guide/webserver.md
+++ b/content/docs/10.configuration-guide/webserver.md
@@ -1,9 +1,9 @@
 ---
-title: Webserver Configuration
+title: Webserver
 icon: /docs/icons/admin.svg
 ---
 
-This section describes the configuration options for the webserver.
+How to configure options for the webserver.
 
 
 ## `kestra.webserver.google-analytics`: Google Analytics ID


### PR DESCRIPTION
Similar to How-to Guides, remove the repetition from the side menu. Also clean up some of the descriptions so they display better on the cards.

![image](https://github.com/kestra-io/docs/assets/34094921/ef816fec-a1a8-4020-992d-cd4f36377204)
