### PR TITLE
feat(docs): add product overview video

### DIFF
--- a/content/docs/09.administrator-guide/upgrades.md
+++ b/content/docs/09.administrator-guide/upgrades.md
@@ -17,19 +17,6 @@ Next to all bug fixes and enhancements, you can find a dedicated section called 
 ⚠️ Note that `Breaking Changes` are **always** included as the last section of the [release notes](https://github.com/kestra-io/kestra/releases). Make sure to inspect that part of the release notes before upgrading to a new version.
 ::
 
-## How to minimise downtime when updating Kestra
-
-If running Kestra in separate components you should:
-- Stop the executors and the scheduler
-- Stop the workers - there is a graceful shutdown (which can be configured but I'm not sure we already document how to configure this) and automatic task resubmission.
-- Stop the webserver (and the indexer using EE and Kafka)
-
-Normally, there is a graceful shutdown on all components so you will not lose anything. Once this is done, you can update and restart everything in the opposite order (or any order as all components are independent).
-
-::alert{type="info"}
-The webserver host the API so it's the one that must be stopped then started immediately to avoid potential downtime. Once this has been done, you can restart the other components so flow executions can start again.
-::
-
 ## How to stick to a specific Kestra version
 
 If you want to stick to a specific Kestra version, you can pin the [Docker image tag](https://hub.docker.com/r/kestra/kestra/tags) to a specific release. Here are some examples:

--- a/content/docs/09.administrator-guide/upgrades.md
+++ b/content/docs/09.administrator-guide/upgrades.md
@@ -17,6 +17,19 @@ Next to all bug fixes and enhancements, you can find a dedicated section called 
 ⚠️ Note that `Breaking Changes` are **always** included as the last section of the [release notes](https://github.com/kestra-io/kestra/releases). Make sure to inspect that part of the release notes before upgrading to a new version.
 ::
 
+## How to minimise downtime when updating Kestra
+
+If running Kestra in separate components you should:
+- Stop the executors and the scheduler
+- Stop the workers - there is a graceful shutdown (which can be configured but I'm not sure we already document how to configure this) and automatic task resubmission.
+- Stop the webserver (and the indexer using EE and Kafka)
+
+Normally, there is a graceful shutdown on all components so you will not lose anything. Once this is done, you can update and restart everything in the opposite order (or any order as all components are independent).
+
+::alert{type="info"}
+The webserver host the API so it's the one that must be stopped then started immediately to avoid potential downtime. Once this has been done, you can restart the other components so flow executions can start again.
+::
+
 ## How to stick to a specific Kestra version
 
 If you want to stick to a specific Kestra version, you can pin the [Docker image tag](https://hub.docker.com/r/kestra/kestra/tags) to a specific release. Here are some examples:

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -6,7 +6,7 @@ Kestra is an open-source **infinitely-scalable orchestration platform** enabling
 
 Thanks to hundreds of [built-in plugins](/plugins) and embedded Code editor with Git and Terraform integrations, Kestra makes scheduled and event-driven data pipelines effortless.
 
-Follow the [Quickstart Guide](/docs/getting-started) to install Kestra and start orchestrating your first workflows.
+Follow the [Quickstart Guide](./01.getting-started/01.quickstart.md) to install Kestra and start orchestrating your first workflows.
 
 Then, explore the following pages to start building more advanced workflows:
 - [Tutorial](/docs/tutorial)
@@ -14,9 +14,8 @@ Then, explore the following pages to start building more advanced workflows:
 - [Concepts](/docs/concepts)
 - [Blueprints](/blueprints)
 
-
 <div class="video-container">
-<iframe width="100%" height="100%" src="https://www.youtube.com/embed/a2BZ7vOihjg?si=4vEZy7hekHoP4PD8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+    <iframe src="https://www.youtube.com/embed/feC6-KQLYyA?si=BTVeAthx3ZxE2e3c" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
 
 ---


### PR DESCRIPTION
Replacing the 15 minute tutorial on the homepage with the product overview. Moving 15 minute tutorial to quickstart and tutorial pages 