### PR TITLE
feat(docs): recreate podman vm to run kestra

### DIFF
--- a/content/docs/02.installation/14.podman-compose.md
+++ b/content/docs/02.installation/14.podman-compose.md
@@ -37,7 +37,9 @@ podman compose up -d
 ```
 
 ::alert{type="info"}
-Podman executes containers through a VM on your local machine. In order to access local volumes from your container you need to ensure you mount these to the podman VM, hence the `-v /tmp:/tmp -v $PWD:$PWD` arguments.  
+Podman executes containers through a VM on your local machine. In order to access local volumes from your container you need to ensure you mount these to the podman VM, hence the `-v /tmp:/tmp -v $PWD:$PWD` arguments.
+
+Note: Check if you have an existing podman VM on your local machine by navigating to the 'Resources' tab in podman desktop or running the command `podman machine list` in your terminal. If you have an existing VM, ensure the required volumes are mounted as expected. If that does not work, you can [recreate the podman VM](https://stackoverflow.com/questions/69298356/how-to-mount-a-volume-from-a-local-machine-on-podman) with volumes mounted and then run Kestra.
 ::
 
 Open the URL `http://localhost:8080` in your browser to launch the UI.


### PR DESCRIPTION
The `note` addition is based on a discussion happened on [slack](https://kestra-io.slack.com/archives/C03FEC452NQ/p1721037692544139). 

Changes have been locally tested (Snapshot below). 

<img width="1509" alt="Screenshot 2024-07-17 at 5 45 44 PM" src="https://github.com/user-attachments/assets/872afad3-7a14-432f-83c0-78533c81cb4b">
