### PR TITLE
feat(docs): provide systemd service guidance

### DIFF
--- a/content/docs/02.installation/12.standalone-server.md
+++ b/content/docs/02.installation/12.standalone-server.md
@@ -23,6 +23,28 @@ Running the jar version will come without any [plugins](/plugins). You need to i
 directory_with_plugins/` command. Alternatively, point to a directory with the plugins in the configuration file or an environment variable `KESTRA_PLUGINS_PATH` e.g. `KESTRA_PLUGINS_PATH=/Users/anna/dev/plugins`.
 ::
 
+## systemd
+
+On [systemd](https://systemd.io/)-based systems, Kestra can be deployed as a systemd service. Here is a basic unit file template:
+
+```systemd
+[Unit]
+Description=Kestra Event-Driven Declarative Orchestrator
+Documentation=https://kestra.io/docs/
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/bin/sh <PATH_TO_YOUR_KESTRA_JAR>/kestra-<VERSION> server standalone
+User=<KESTRA_UNIX_USER>
+Group=<KESTRA_UNIX_GROUP>
+RestartSec=5
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
 ## Install plugins from a Docker image
 
 To copy the plugins from a Docker container to your local machine, you can use the following commands:

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -62,6 +62,7 @@ export default defineNuxtConfig({
               'sql',
               'java',
               'dockerfile',
+              'systemd',
               'hcl',
               'python',
               'twig',


### PR DESCRIPTION
Systemd is the most common way to run services on standalone Linux servers.

Kestra requires a slightly unusual exec command, so this PR provides a basic systemd unit file.