### PR TITLE
Updated the Minio naming standards

### DIFF
--- a/content/docs/02.installation/03.docker-compose.md
+++ b/content/docs/02.installation/03.docker-compose.md
@@ -204,7 +204,7 @@ services:
                 accessKey: admin
                 secretKey: password
                 region: us-east-1
-                bucket: minio/warehouse
+                bucket: minio-warehouse
             queue:
               type: postgres
             tasks:

--- a/content/docs/02.installation/03.docker-compose.md
+++ b/content/docs/02.installation/03.docker-compose.md
@@ -204,7 +204,7 @@ services:
                 accessKey: admin
                 secretKey: password
                 region: us-east-1
-                bucket: minio-warehouse
+                bucket: warehouse
             queue:
               type: postgres
             tasks:


### PR DESCRIPTION
Wrong naming standards for the Minio object storage resulted in an Internal server error.

```bash
Internal server error
Internal server error: java.lang.IllegalArgumentException: bucket name ‘minio/warehouse’ does not follow Amazon S3 standards. For more information refer https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
```


![internal_server_error](https://github.com/user-attachments/assets/74c32d8e-c6b4-4ede-9133-c8054be045c4)
 I update it to a compatible naming standard.

From
bucket: minio/warehouse

To
bucket: warehouse