### PR TITLE
feat(docs): mention worker job metrics

### DIFF
--- a/content/docs/09.administrator-guide/03.monitoring.md
+++ b/content/docs/09.administrator-guide/03.monitoring.md
@@ -207,6 +207,13 @@ Each task type can expose custom metrics that will be also exposed on Prometheus
 |worker.retried.count|`COUNTER`|Count of tasks retried|
 |worker.ended.count|`COUNTER`|Count of tasks ended|
 |worker.ended.duration|`TIMER`|Duration of tasks ended|
+|worker.job.running|`GAUGE`|Count of currently running worker jobs|
+|worker.job.pending|`GAUGE`|Count of currently pending worker jobs|
+|worker.job.thread|`GAUGE`|Total worker job thread count|
+
+::alert{type="info"}
+The `worker.job.pending`, `worker.job.running`, and `worker.job.thread` metrics are intended for autoscaling [worker servers](/docs/architecture/worker).
+::
 
 #### Executor
 


### PR DESCRIPTION
These metrics were [added](https://github.com/kestra-io/kestra/commit/dc4c78aaf2ebb38390bdf63760fff15ae004ac3a) in v0.18.