### PR TITLE
fixed header image

### DIFF
--- a/components/home/Header.vue
+++ b/components/home/Header.vue
@@ -49,7 +49,7 @@
                     width="600"
                     height="480"
                     lazy
-                    placeholder="blur"
+                    :placeholder="[600, 480]"
                 />
             </div>
             <div class="companies-background">

--- a/components/home/Header.vue
+++ b/components/home/Header.vue
@@ -46,7 +46,10 @@
                 <NuxtImg
                     class="img-fluid headerimg"
                     src="/landing/home/header.svg"
-                    alt="Smarter Not Harder"
+                    width="600"
+                    height="480"
+                    lazy
+                    placeholder="blur"
                 />
             </div>
             <div class="companies-background">


### PR DESCRIPTION
something with the new homepage, during the loading, I often see this for few seconds, anything to have a proper layout during the loading ?
![image](https://github.com/user-attachments/assets/11efe7ca-a87e-48fd-bd90-c8a403428acf)
