### PR TITLE
fix(docs): Incorrect type in Azure Key Vault example

### DIFF
--- a/content/docs/06.enterprise/secrets-manager.md
+++ b/content/docs/06.enterprise/secrets-manager.md
@@ -45,8 +45,7 @@ To configure [Azure Key Vault](https://azure.microsoft.com/products/key-vault/) 
 ```yaml
 kestra:
   secret:
-    type: azure-secret-manager
-    azure-key-vault:
+    type: azure-key-vault
       clientSecret:
         tenantId: "id"
         clientId: "id"

--- a/content/docs/06.enterprise/secrets-manager.md
+++ b/content/docs/06.enterprise/secrets-manager.md
@@ -46,6 +46,7 @@ To configure [Azure Key Vault](https://azure.microsoft.com/products/key-vault/) 
 kestra:
   secret:
     type: azure-key-vault
+    azure-key-vault:
       clientSecret:
         tenantId: "id"
         clientId: "id"


### PR DESCRIPTION
Community report that current example leads to 💥 
```
Caused by: io.kestra.core.exceptions.KestraRuntimeException: No secret interface can be found for 'kestra.secret.type=azure-secret-manager'. Supported types are: [elasticsearch,jdbc,jdbc,jdbc,google-secret- │
│ manager,vault,aws-secret-manager,azure-key-vault] 
```