### PR TITLE
fix(doc): Logs do not reveal secrets

### DIFF
--- a/content/docs/05.concepts/04.secret.md
+++ b/content/docs/05.concepts/04.secret.md
@@ -73,7 +73,7 @@ If you would add the environment variable to the `kestra` container section in a
       SECRET_MYPASSWORD: bXlQcml2YXRlQ29kZQ==
 ```
 
-This secret can then be used in a flow using the `{{ secret('SECRET_MYPASSWORD') }}` syntax, and it will base64-decoded during flow execution. Make sure to not include the prefix `SECRET_` when calling the `secret('MYPASSWORD')` function, as this prefix is only there in the environment variable definition to prevent Kestra from treating other system variables as secrets (for better performance and increased security).
+This secret can then be used in a flow using the `{{ secret('MYPASSWORD') }}` syntax, and it will base64-decoded during flow execution. Make sure to not include the prefix `SECRET_` when calling the `secret('MYPASSWORD')` function, as this prefix is only there in the environment variable definition to prevent Kestra from treating other system variables as secrets (for better performance and increased security).
 
 Lastly, shall you wish to reference any non_encoded environment variables in your flows definition, you can always use the syntax `{{envs.lowercase_environment_variable_key}}`.
 

--- a/content/docs/05.concepts/04.secret.md
+++ b/content/docs/05.concepts/04.secret.md
@@ -28,7 +28,7 @@ Here, we add a new secret with a key `MY_SECRET`:
 
 
 ### Using Secrets in your flows
-For a concrete example of using secrets in flows, check out our dedicated ![How-To Guide on Secrets](/how-to-guides/secrets)
+For a concrete example of using secrets in flows, check out our dedicated [How-To Guide on Secrets](/how-to-guides/secrets)
 
 ### Secret Management backends
 
@@ -37,7 +37,7 @@ Kestra [Enterprise Edition](/enterprise) provides additional secret management b
 
 ---
 
-how-to-guides/secrets
+
 ## Secrets in the Open-Source version
 
 When using the open-source version, sensitive variables can be managed using base64-encoded environment variables. The section below demonstrates several ways to encode those values and use them in your Kestra instance.
@@ -73,15 +73,13 @@ If you would add the environment variable to the `kestra` container section in a
       SECRET_MYPASSWORD: bXlQcml2YXRlQ29kZQ==
 ```
 
-This secret can then be used in a flow using the `{{ secret('SECRET_MYPASSWORD') }}` syntax, and it will base64-decoded during flow execution. Note that to reference any non_encoded environment variables, you can always use the syntax `{{envs.lowercase_environment_variable_key}}` instead.
+This secret can then be used in a flow using the `{{ secret('SECRET_MYPASSWORD') }}` syntax, and it will base64-decoded during flow execution. Make sure to not not include the prefix `SECRET_` when calling the `secret('MYPASSWORD')` function, this prefix is only there in the environment variable definition to prevent Kestra from treating unnecessary system variables as secrets (for better performance and increased security).
+
+Lastly, shall you wish to reference any non_encoded environment variables in your flows definition, you can always use the syntax `{{envs.lowercase_environment_variable_key}}`.
 
 ::alert{type="warning"}
 Note that Kestra has built-in protection to prevent logs from revealing any encoded secret you would have defined and passed to it.
 ::
-
-> Make sure to add your custom environment variables *before* starting Kestra. Environment variables are loaded at the JVM startup, so adding new variables or modifying existing ones requires restarting your instance. To manage such changes without downtime, you can either try the [Enterprise Edition](/enterprise) or restart your server during a planned maintenance window.
-
-> **Note** that we do not include the prefix `SECRET_` when calling the `secret('MYPASSWORD')` function. The prefix is only required as a name of the environment variable to ensure that Kestra is only looking for the relevant environment variables without loading unnecessary system variables. This improves both performance and security as it ensures that Kestra only reads environment variables that are needed.
 
 ### Convert all variables in an `.env` file
 

--- a/content/docs/05.concepts/04.secret.md
+++ b/content/docs/05.concepts/04.secret.md
@@ -28,7 +28,7 @@ Here, we add a new secret with a key `MY_SECRET`:
 
 
 ### Using Secrets in your flows
-For a concrete example of using secrets in flows, check out our dedicated [How-To Guide on Secrets](/docs/how-to-guides/secrets)
+For a concrete example of using secrets in flows, check out our dedicated [How-To Guide on Secrets](/docs/how-to-guides/secrets).
 
 ### Secret Management backends
 

--- a/content/docs/05.concepts/04.secret.md
+++ b/content/docs/05.concepts/04.secret.md
@@ -28,7 +28,7 @@ Here, we add a new secret with a key `MY_SECRET`:
 
 
 ### Using Secrets in your flows
-For a concrete example of using secrets in flows, check out our dedicated [How-To Guide on Secrets](/how-to-guides/secrets)
+For a concrete example of using secrets in flows, check out our dedicated [How-To Guide on Secrets](/docs/how-to-guides/secrets)
 
 ### Secret Management backends
 
@@ -56,7 +56,7 @@ Here is how you can encode the sensitive value of that environment variable:
 echo -n "myPrivateCode" | base64
 ```
 
-This should output the value: `bXlQcml2YXRlQ29kZQ==`.
+This should output the value: `bXlQcml2YXRlQ29kZQ==`
 
 To use that value as a Secret in your Kestra instance, you would need to add a prefix `SECRET_` to the variable key (here: `SECRET_MYPASSWORD`) and set that key to the encoded value:
 
@@ -73,12 +73,12 @@ If you would add the environment variable to the `kestra` container section in a
       SECRET_MYPASSWORD: bXlQcml2YXRlQ29kZQ==
 ```
 
-This secret can then be used in a flow using the `{{ secret('SECRET_MYPASSWORD') }}` syntax, and it will base64-decoded during flow execution. Make sure to not not include the prefix `SECRET_` when calling the `secret('MYPASSWORD')` function, this prefix is only there in the environment variable definition to prevent Kestra from treating unnecessary system variables as secrets (for better performance and increased security).
+This secret can then be used in a flow using the `{{ secret('SECRET_MYPASSWORD') }}` syntax, and it will base64-decoded during flow execution. Make sure to not include the prefix `SECRET_` when calling the `secret('MYPASSWORD')` function, as this prefix is only there in the environment variable definition to prevent Kestra from treating other system variables as secrets (for better performance and increased security).
 
 Lastly, shall you wish to reference any non_encoded environment variables in your flows definition, you can always use the syntax `{{envs.lowercase_environment_variable_key}}`.
 
 ::alert{type="warning"}
-Note that Kestra has built-in protection to prevent logs from revealing any encoded secret you would have defined and passed to it.
+Note that Kestra has built-in protection to prevent its logs from revealing any encoded secret you would have defined.
 ::
 
 ### Convert all variables in an `.env` file

--- a/content/docs/05.concepts/04.secret.md
+++ b/content/docs/05.concepts/04.secret.md
@@ -9,7 +9,7 @@ Secret is a mechanism that allows you to securely store sensitive information, s
 
 To retrieve secrets in a flow, use the `secret()` function, e.g. `"{{ secret('API_TOKEN'') }}"`. You can leverage your existing secrets manager as a secrets backend.
 
-Your flows often need to interact with external systems. To do that, they need to programmatically authenticate using passwords or API keys.  Secrets help you securely store such variables and avoid hard-coding sensitive information within your workflow code.
+Your flows often need to interact with external systems. To do that, they need to programmatically authenticate using passwords or API keys. Secrets help you securely store such variables and avoid hard-coding sensitive information within your workflow code.
 
 You can leverage the `secret()` function, described in the [function section](/docs/concepts/expression/function#secret), to retrieve sensitive variables within your flow code.
 
@@ -28,22 +28,7 @@ Here, we add a new secret with a key `MY_SECRET`:
 
 
 ### Using Secrets in your flows
-Here is a simple example showing how to retrieve that new secret in a flow:
-
-```yaml
-id: secretTest
-namespace: company.team
-tasks:
-  - id: hello
-    type: io.kestra.plugin.core.log.Log
-    message: "{{ secret('MY_SECRET') }}"
-```
-
-When you execute that flow, you should see `mysecretvalue` in the logs output.
-
-::alert{type="warning"}
-The purpose of this example is to show how to use secrets in your flows. In practice, you should **avoid logging sensitive information**.
-::
+For a concrete example of using secrets in flows, check out our dedicated ![How-To Guide on Secrets](/how-to-guides/secrets)
 
 ### Secret Management backends
 
@@ -52,7 +37,7 @@ Kestra [Enterprise Edition](/enterprise) provides additional secret management b
 
 ---
 
-
+how-to-guides/secrets
 ## Secrets in the Open-Source version
 
 When using the open-source version, sensitive variables can be managed using base64-encoded environment variables. The section below demonstrates several ways to encode those values and use them in your Kestra instance.
@@ -62,21 +47,21 @@ When using the open-source version, sensitive variables can be managed using bas
 Imagine that so far, you were setting the following environment variable:
 
 ```bash
-export MYPASSWORD=password
+export MYPASSWORD=myPrivateCode
 ```
 
 Here is how you can encode the sensitive value of that environment variable:
 
 ```bash
-echo -n "password" | base64
+echo -n "myPrivateCode" | base64
 ```
 
-This should output the value: `cGFzc3dvcmQ=`.
+This should output the value: `bXlQcml2YXRlQ29kZQ==`.
 
 To use that value as a Secret in your Kestra instance, you would need to add a prefix `SECRET_` to the variable key (here: `SECRET_MYPASSWORD`) and set that key to the encoded value:
 
 ```bash
-export SECRET_MYPASSWORD=cGFzc3dvcmQ=
+export SECRET_MYPASSWORD=bXlQcml2YXRlQ29kZQ==
 ```
 
 If you would add the environment variable to the `kestra` container section in a [Docker Compose file](https://github.com/kestra-io/kestra/blob/develop/docker-compose.yml#L22), it would look as follows:
@@ -85,25 +70,18 @@ If you would add the environment variable to the `kestra` container section in a
   kestra:
     image: kestra/kestra:latest
     environment:
-      SECRET_MYPASSWORD: cGFzc3dvcmQ=
+      SECRET_MYPASSWORD: bXlQcml2YXRlQ29kZQ==
 ```
 
-This variable can then be used in a flow using the `{{ secret('secret_key_name') }}` syntax:
+This secret can then be used in a flow using the `{{ secret('SECRET_MYPASSWORD') }}` syntax, and it will base64-decoded during flow execution. Note that to reference any non_encoded environment variables, you can always use the syntax `{{envs.lowercase_environment_variable_key}}` instead.
 
-```yaml
-id: secretTest
-namespace: company.team
-tasks:
-  - id: hello
-    type: io.kestra.plugin.core.log.Log
-    message: "{{ secret('MYPASSWORD') }}"
-```
-
-When executing that flow, you should see the output `password` in your logs. Why `password` rather than the encoded value `cGFzc3dvcmQ=`? Because each secret is base64-decoded during a flow's execution. This means that only base64-encoded environment variables can be used with the `secret()` function. To reference not-e_ncoded environment variables, use the syntax `{{envs.lowercase_environment_variable_key}}` instead.
-
+::alert{type="warning"}
+Note that Kestra has built-in protection to prevent logs from revealing any encoded secret you would have defined and passed to it.
+::
 
 > Make sure to add your custom environment variables *before* starting Kestra. Environment variables are loaded at the JVM startup, so adding new variables or modifying existing ones requires restarting your instance. To manage such changes without downtime, you can either try the [Enterprise Edition](/enterprise) or restart your server during a planned maintenance window.
 
+> **Note** that we do not include the prefix `SECRET_` when calling the `secret('MYPASSWORD')` function. The prefix is only required as a name of the environment variable to ensure that Kestra is only looking for the relevant environment variables without loading unnecessary system variables. This improves both performance and security as it ensures that Kestra only reads environment variables that are needed.
 
 ### Convert all variables in an `.env` file
 
@@ -158,23 +136,6 @@ with the encoded version of the file:
     env_file:
       - .env_encoded
 ```
-
-After you've started Kestra using `docker compose up -d`, you should be able to run the flow shown below and see decoded secret values in the logs output:
-
-```yaml
-id: secretTest
-namespace: company.team
-tasks:
-  - id: hello
-    type: io.kestra.plugin.core.log.Log
-    message: |
-      {{ secret('MYPASSWORD') }}
-      {{ secret('GITHUB_ACCESS_TOKEN') }}
-      {{ secret('AWS_ACCESS_KEY_ID') }}
-      {{ secret('AWS_SECRET_ACCESS_KEY') }}
-```
-
-> **Note** that we didn't include the prefix `SECRET_` when calling the `secret('MYPASSWORD')` function. The prefix is only required as a name of the environment variable to ensure that Kestra is only looking for the relevant environment variables without loading unnecessary system variables. This improves both performance and security as it ensures that Kestra only reads environment variables that are needed.
 
 
 ### Use a macro within your `.env` file


### PR DESCRIPTION
Removed examples that are trying to log secrets. Those are de-facto broken since #3018 .

Also, changed 'password' example to 'myPrivateCode' to avoid user confusion (between variable name and value) since a lot of the content is already about passwords. :)