### PR TITLE
fix(docs): Getting started CTA should send directly to quickstart guide

### DIFF
--- a/components/company/Platform.vue
+++ b/components/company/Platform.vue
@@ -9,7 +9,7 @@
                             Hundreds of organizations have already experienced significant productivity gains since adopting Kestra in their business-critical production workflows, validating the transformative power of our solution.
                         </p>
                         <p data-aos="fade-right" class="mt-3">
-                            <a href="https://kestra.io/docs/getting-started">Get started</a> today and see how Kestra can help you build reliable workflows.
+                            <a href="https://kestra.io/docs/getting-started/quickstart#start-kestra">Get started</a> today and see how Kestra can help you build reliable workflows.
                         </p>
                     </div>
                 </div>

--- a/components/features/Footer.vue
+++ b/components/features/Footer.vue
@@ -9,7 +9,7 @@
           <div
             class="d-flex gap-2 flex-wrap justify-content-center align-items-center"
           >
-            <NuxtLink href="/docs/getting-started">
+            <NuxtLink href="/docs/getting-started/quickstart#start-kestra">
               <button class="btn btn-dark mx-2 mt-2">Get Started</button>
             </NuxtLink>
             <NuxtLink href="/demo">

--- a/components/features/Header.vue
+++ b/components/features/Header.vue
@@ -21,7 +21,7 @@
               </NuxtLink>
 
               <NuxtLink
-                href="/docs/getting-started"
+                href="/docs/getting-started/quickstart#start-kestra"
                 class="btn btn-animated btn-purple-animated mt-2"
                 data-aos="zoom-in"
               >

--- a/components/features/apifirst/Header.vue
+++ b/components/features/apifirst/Header.vue
@@ -9,7 +9,7 @@
                             Kestra is designed in an API-first way, enabling programmatic access to all actions from managing workflows to user administration.
                         </p>
                         <div class="cta d-flex gap-3">
-                            <NuxtLink href="https://kestra.io/docs/getting-started" class="btn btn-animated btn-purple-animated" data-aos="zoom-in">
+                            <NuxtLink href="https://kestra.io/docs/getting-started/quickstart#start-kestra" class="btn btn-animated btn-purple-animated" data-aos="zoom-in">
                                 Get started
                             </NuxtLink>
                         </div>

--- a/components/features/declaratives/Header.vue
+++ b/components/features/declaratives/Header.vue
@@ -10,7 +10,7 @@
                             <NuxtLink href="https://github.com/kestra-io/kestra" class="btn btn-animated btn-dark-animated" data-aos="zoom-in">
                                 Get started
                             </NuxtLink>
-                            <a href="/docs/getting-started"  class="btn btn-animated btn-purple-animated" data-aos="zoom-in">
+                            <a href="/docs/getting-started/quickstart#start-kestra"  class="btn btn-animated btn-purple-animated" data-aos="zoom-in">
                                 Read the docs
                             </a>
                         </div>

--- a/components/features/declaratives/Header.vue
+++ b/components/features/declaratives/Header.vue
@@ -7,10 +7,10 @@
                         <h1 data-aos="fade-right"><span>Declarative</span> Orchestration with Kestra</h1>
                         <p class="baseline" data-aos="fade-left">Bring Infrastructure as Code Best Practices to All Workflows</p>
                         <div class="cta d-flex gap-3">
-                            <NuxtLink href="https://github.com/kestra-io/kestra" class="btn btn-animated btn-dark-animated" data-aos="zoom-in">
+                            <NuxtLink href="/docs/getting-started/quickstart#start-kestra" class="btn btn-animated btn-dark-animated" data-aos="zoom-in">
                                 Get started
                             </NuxtLink>
-                            <a href="/docs/getting-started/quickstart#start-kestra"  class="btn btn-animated btn-purple-animated" data-aos="zoom-in">
+                            <a href="/docs/getting-started"  class="btn btn-animated btn-purple-animated" data-aos="zoom-in">
                                 Read the docs
                             </a>
                         </div>

--- a/components/features/language/Header.vue
+++ b/components/features/language/Header.vue
@@ -9,7 +9,7 @@
                             Separate your business logic from your orchestration logic with a versatile set of language-agnostic developer tools
                         </p>
                         <div class="cta d-flex gap-3">
-                            <NuxtLink href="/docs/getting-started" class="btn btn-animated btn-purple-animated" data-aos="zoom-in">
+                            <NuxtLink href="/docs/getting-started/quickstart#start-kestra" class="btn btn-animated btn-purple-animated" data-aos="zoom-in">
                                 Get started
                             </NuxtLink>
                         </div>

--- a/components/features/language/sub-pages/Header.vue
+++ b/components/features/language/sub-pages/Header.vue
@@ -15,7 +15,7 @@
 
                         <div class="cta">
                             <NuxtLink
-                                href="/docs/getting-started"
+                                href="/docs/getting-started/quickstart#start-kestra"
                                 class="btn btn-animated btn-purple-animated mt-2"
                                 data-aos="zoom-in"
                             >

--- a/components/home/Header.vue
+++ b/components/home/Header.vue
@@ -9,7 +9,7 @@
                     <br>and Govern them as Code and from the UI.</p>
                 <div class="buttons">
                     <NuxtLink
-                        href="/docs/getting-started"
+                        href="/docs/getting-started/quickstart#start-kestra"
                         class="btn btn-animated btn-purple-animated me-2 mb-2"
                     >
                         <NuxtImg

--- a/components/home/How.vue
+++ b/components/home/How.vue
@@ -140,7 +140,7 @@
                  15,000+ engineers trust Kestra to declartively build their workflows. Be the next!
                 </p>
                 <div class="text-center mt-5 d-flex align-items-center justify-content-center flex-wrap gap-3">
-                    <NuxtLink href="https://github.com/kestra-io/kestra" target="_blank" class="btn btn-animated btn-dark-animated" data-aos="zoom-in">
+                    <NuxtLink href="/docs/getting-started/quickstart#start-kestra" class="btn btn-animated btn-dark-animated" data-aos="zoom-in">
                         Get started
                     </NuxtLink>
                     <NuxtLink href="/docs/getting-started" class="btn btn-animated btn-purple-animated" data-aos="zoom-in">

--- a/components/layout/Footer.vue
+++ b/components/layout/Footer.vue
@@ -52,7 +52,7 @@
                                 <li class="mb-2"><NuxtLink href="/docs">Documentation</NuxtLink></li>
                                 <li class="mb-2"><NuxtLink href="/plugins">Plugins</NuxtLink></li>
                                 <li class="mb-2"><NuxtLink href="/blueprints">Blueprints</NuxtLink></li>
-                                <li class="mb-2"><NuxtLink href="/docs/getting-started">Getting Started</NuxtLink></li>
+                                <li class="mb-2"><NuxtLink href="/docs/getting-started/quickstart#start-kestra">Getting Started</NuxtLink></li>
                                 <li class="mb-2"><NuxtLink href="/docs/administrator-guide">Administrator Guide</NuxtLink></li>
                                 <li class="mb-2"><NuxtLink href="/faq">FAQ</NuxtLink></li>
                             </ul>

--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -396,7 +396,7 @@
 
                         <NuxtLink @click="globalClick(true)"
                             class="d-block d-sm-inline-block mb-1 mn-sm-0 btn btn-animated btn-purple-animated btn-sm get-started"
-                            href="/docs/getting-started">
+                            href="/docs/getting-started/quickstart#start-kestra">
                             <span>
                                 <Flash class="d-none d-xl-inline-flex"/>
                                 Get Started

--- a/components/overview/Header.vue
+++ b/components/overview/Header.vue
@@ -16,7 +16,7 @@
                                 Talk to Us
                             </NuxtLink>
                             <NuxtLink
-                                href="/docs/getting-started"
+                                href="/docs/getting-started/quickstart#start-kestra"
                                 class="btn text-white btn-animated btn-purple-animated mb-2"
                                 data-aos="zoom-in"
                             >

--- a/components/solutions/DetailEmpower.vue
+++ b/components/solutions/DetailEmpower.vue
@@ -14,7 +14,7 @@
                 <h2 data-aos="fade-left">{{ title }}</h2>
                 <p class="text-center" data-aos="fade-right">{{ subtitle }}</p>
                 <div class="text-center cta">
-                    <NuxtLink href="/docs/getting-started" class="btn btn-animated btn-purple-animated" data-aos="zoom-in">
+                    <NuxtLink href="/docs/getting-started/quickstart#start-kestra" class="btn btn-animated btn-purple-animated" data-aos="zoom-in">
                         Get started
                     </NuxtLink>
                 </div>

--- a/components/solutions/DetailHeader.vue
+++ b/components/solutions/DetailHeader.vue
@@ -6,7 +6,7 @@
                     <div>
                         <h1 data-aos="fade-right"><span v-if="titleBefore">{{ titleBefore }}</span> {{ title }} <span v-if="titleAfter">{{ titleAfter }}</span></h1>
                         <p data-aos="fade-left" class="baseline">{{ subtitle }}</p>
-                        <NuxtLink href="/docs/getting-started" class="btn btn-animated btn-purple-animated" data-aos="zoom-in">
+                        <NuxtLink href="/docs/getting-started/quickstart#start-kestra" class="btn btn-animated btn-purple-animated" data-aos="zoom-in">
                             Get started
                         </NuxtLink>
                     </div>

--- a/components/use-cases/deployment/EnterpriseEdition.vue
+++ b/components/use-cases/deployment/EnterpriseEdition.vue
@@ -12,7 +12,7 @@
               </h2>
             </div>
             <div class="text-center rounded">
-              <NuxtLink class="btn btn-animated btn-purple-animated mx-2 mt-2" href="/docs/getting-started">
+              <NuxtLink class="btn btn-animated btn-purple-animated mx-2 mt-2" href="/docs/getting-started/quickstart#start-kestra">
                     Get started
               </NuxtLink>
             </div>

--- a/components/use-cases/deployment/Header.vue
+++ b/components/use-cases/deployment/Header.vue
@@ -15,7 +15,7 @@
                             <NuxtLink href="/docs/getting-started" class="btn btn-animated btn-dark-animated me-3" data-aos="zoom-in">
                                 Talk to Us
                             </NuxtLink>
-                            <NuxtLink href="/docs/getting-started" class="btn btn-animated btn-purple-animated" data-aos="zoom-in">
+                            <NuxtLink href="/docs/getting-started/quickstart#start-kestra" class="btn btn-animated btn-purple-animated" data-aos="zoom-in">
                                 Get started
                             </NuxtLink>
                         </div>

--- a/components/use-cases/engineers/EnterpriseEdition.vue
+++ b/components/use-cases/engineers/EnterpriseEdition.vue
@@ -12,7 +12,7 @@
               </h2>
             </div>
             <div class="text-center rounded">
-              <NuxtLink class="btn btn-animated btn-purple-animated mx-2 mt-2" href="/docs/getting-started">
+              <NuxtLink class="btn btn-animated btn-purple-animated mx-2 mt-2" href="/docs/getting-started/quickstart#start-kestra">
                     Get started
               </NuxtLink>
             </div>

--- a/components/vs/airflow/Header.vue
+++ b/components/vs/airflow/Header.vue
@@ -7,7 +7,7 @@
                         <h1 data-aos="fade-right">The differences between Kestra and Airflow</h1>
                         <p class="baseline" data-aos="fade-left">How to Choose the Right Orchestration Platform</p>
                         <div class="cta">
-                            <NuxtLink href="/docs/getting-started" class="btn btn-animated btn-purple-animated mx-2 mt-2" data-aos="zoom-in">
+                            <NuxtLink href="/docs/getting-started/quickstart#start-kestra" class="btn btn-animated btn-purple-animated mx-2 mt-2" data-aos="zoom-in">
                                 Get started with Kestra
                             </NuxtLink>
                         </div>

--- a/components/vs/dagster/Header.vue
+++ b/components/vs/dagster/Header.vue
@@ -7,7 +7,7 @@
                         <h1 data-aos="fade-right">The differences between Kestra and Dagster</h1>
                         <p class="baseline" data-aos="fade-left">How to Choose the Right Orchestration Platform</p>
                         <div class="cta">
-                            <NuxtLink href="/docs/getting-started" class="btn btn-animated btn-purple-animated mx-2 mt-2" data-aos="zoom-in">
+                            <NuxtLink href="/docs/getting-started/quickstart#start-kestra" class="btn btn-animated btn-purple-animated mx-2 mt-2" data-aos="zoom-in">
                                 Get started with Kestra
                             </NuxtLink>
                         </div>

--- a/components/vs/prefect/Header.vue
+++ b/components/vs/prefect/Header.vue
@@ -7,7 +7,7 @@
                         <h1 data-aos="fade-right">The differences between Kestra and Prefect</h1>
                         <p class="baseline" data-aos="fade-left">How to Choose the Right Orchestration Platform</p>
                         <div class="cta">
-                            <NuxtLink href="/docs/getting-started" class="btn btn-animated btn-purple-animated mx-2 mt-2" data-aos="zoom-in">
+                            <NuxtLink href="/docs/getting-started/quickstart#start-kestra" class="btn btn-animated btn-purple-animated mx-2 mt-2" data-aos="zoom-in">
                                 Get started with Kestra
                             </NuxtLink>
                         </div>

--- a/data/retail.js
+++ b/data/retail.js
@@ -185,7 +185,7 @@ export default {
             },
             {
                 text: "Get started",
-                href: "/docs/getting-started",
+                href: "/docs/getting-started/quickstart#start-kestra",
                 style: "btn-animated btn-purple-animated",
             },
         ],

--- a/pages/blueprints/[_slug]/[id]-[slug].vue
+++ b/pages/blueprints/[_slug]/[id]-[slug].vue
@@ -21,7 +21,7 @@
                 title="New to Kestra?"
                 subtitle="Use blueprints to kickstart your first workflows."
                 purpleButtonText="Get started with Kestra"
-                purpleButtonHref="/docs/getting-started"
+                purpleButtonHref="/docs/getting-started/quickstart#start-kestra"
             />
         </div>
     </div>

--- a/pages/blueprints/index.vue
+++ b/pages/blueprints/index.vue
@@ -13,7 +13,7 @@
             title="New to Kestra?"
             subtitle="Use blueprints to kickstart your first workflows."
             purpleButtonText="Get started with Kestra"
-            purpleButtonHref="/docs/getting-started"
+            purpleButtonHref="/docs/getting-started/quickstart#start-kestra"
         />
     </div>
 </template>

--- a/pages/faq.vue
+++ b/pages/faq.vue
@@ -78,14 +78,14 @@
             <h2 data-aos="zoom-in" class="mt-5">Getting Started</h2>
             <CustomDetails title="How do I get started with Kestra?">
                 <p>To get started with Kestra, follow the
-                    <NuxtLink href="/docs/getting-started">Getting Started Guide</NuxtLink>
+                    <NuxtLink href="/docs/getting-started/quickstart#start-kestra">Getting Started Guide</NuxtLink>
                     on the Kestra website. This guide will walk you through the installation and configuration process,
                     as well as provide an introduction to creating your first flows and tasks.
                 </p>
             </CustomDetails>
             <CustomDetails title="How to install Kestra?">
                 <p>Kestra is designed to be easy to install and set up. The installation process involves following the
-                    <NuxtLink href="/docs/getting-started/">official documentation</NuxtLink>
+                    <NuxtLink href="/docs/getting-started/quickstart#start-kestra">official documentation</NuxtLink>
                     , which provides step-by-step instructions on how to get started with Kestra on various platforms,
                     including Docker, Kubernetes, and Helm. We are also available on our <a target="_blank"
                                                                                             href="/slack">Slack

--- a/pages/features/api-first.vue
+++ b/pages/features/api-first.vue
@@ -2,7 +2,7 @@
     <div>
         <Head>
             <Title>Kestra API First Design</Title>
-            <Meta name="description" content="interact with every aspect of the Kestra programmatically." />
+            <Meta name="description" content="interact with every aspect of Kestra programmatically." />
         </Head>
         <FeaturesApifirstHeader />
         <NuxtLazyHydrate when-visible>
@@ -21,7 +21,7 @@
             <LayoutFooterContact
                 title="Getting Started with Declarative Orchestration"
                 darkButtonText="Get started"
-                darkButtonHref="/docs/getting-started"
+                darkButtonHref="/docs/getting-started/quickstart#start-kestra"
                 purpleButtonText="Talk to us"
                 purpleButtonHref="/demo"
             />

--- a/pages/features/code-in-any-language/index.vue
+++ b/pages/features/code-in-any-language/index.vue
@@ -25,7 +25,7 @@
             <LayoutFooterContact
                 title="Getting Started with  Declarative Orchestration"
                 darkButtonText="Get started"
-                darkButtonHref="docs/getting-started"
+                darkButtonHref="/docs/getting-started/quickstart#start-kestra"
                 purpleButtonText="Talk to us"
                 purpleButtonHref="/demo"
             />

--- a/pages/features/code-in-any-language/julia.vue
+++ b/pages/features/code-in-any-language/julia.vue
@@ -42,7 +42,7 @@
             <LayoutFooterContact
                 title="Getting Started with  Declarative Orchestration"
                 darkButtonText="Get started"
-                darkButtonHref="docs/getting-started"
+                darkButtonHref="/docs/getting-started/quickstart#start-kestra"
                 purpleButtonText="Talk to us"
                 purpleButtonHref="/demo"
             />

--- a/pages/features/code-in-any-language/python.vue
+++ b/pages/features/code-in-any-language/python.vue
@@ -43,7 +43,7 @@
             <LayoutFooterContact
                 title="Getting Started with  Declarative Orchestration"
                 darkButtonText="Get started"
-                darkButtonHref="/docs/getting-started"
+                darkButtonHref="/docs/getting-started/quickstart#start-kestra"
                 purpleButtonText="Talk to us"
                 purpleButtonHref="/demo"
             />

--- a/pages/features/code-in-any-language/r.vue
+++ b/pages/features/code-in-any-language/r.vue
@@ -42,7 +42,7 @@
             <LayoutFooterContact
                 title="Getting Started with  Declarative Orchestration"
                 darkButtonText="Get started"
-                darkButtonHref="docs/getting-started"
+                darkButtonHref="/docs/getting-started/quickstart#start-kestra"
                 purpleButtonText="Talk to us"
                 purpleButtonHref="/demo"
             />

--- a/pages/use-cases/databases-managament.vue
+++ b/pages/use-cases/databases-managament.vue
@@ -38,7 +38,7 @@
             <LayoutFooterContact
                 title="Ready to take your Infrastructure to the next level?"
                 purpleButtonText="Get Started"
-                purpleButtonHref="/docs/getting-started"
+                purpleButtonHref="/docs/getting-started/quickstart#start-kestra"
                 darkButtonText="Talk to Us"
                 darkButtonHref="/demo"
             />


### PR DESCRIPTION
Current CTA sends to https://kestra.io/docs/getting-started where the reader needs to continue finding its way to the quickstart instructions.

Let's make it simpler for reader who engage on 'get started' cta, and send them directly to https://kestra.io/docs/getting-started/quickstart#start-kestra