### PR TITLE
docs: correct Docker run command in Quickstart

### DIFF
--- a/content/docs/01.getting-started/01.quickstart.md
+++ b/content/docs/01.getting-started/01.quickstart.md
@@ -23,9 +23,7 @@ Start Kestra in a Docker container and create your first flow.
 Make sure that Docker is running. Then, you can start Kestra in a single command using Docker (*if you run it on Windows, make sure to use [WSL](https://docs.docker.com/desktop/wsl/)*):
 
 ```bash
-docker run --pull=always --rm -it -p 8080:8080 --user=root \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -v /tmp:/tmp kestra/kestra:latest server local
+docker run --pull=always --rm -it -p 8080:8080 --user=root -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp kestra/kestra:latest server local
 ```
 
 Open `http://localhost:8080` in your browser to launch the UI and start building your first flows.


### PR DESCRIPTION
The Docker command in 'docs/content/docs/01.getting-started/01.quickstart.md' contained invalid line breaks, causing an 'invalid reference format' error. This update removes the unnecessary spaces and ensures proper execution.