### PR TITLE
Update realtime-triggers.md, use the URL from "aws sqs list-queues --region XX-XXXX-XX", not long url.

### DIFF
--- a/content/docs/15.how-to-guides/realtime-triggers.md
+++ b/content/docs/15.how-to-guides/realtime-triggers.md
@@ -126,7 +126,7 @@ triggers:
     accessKeyId: "{{ secret('AWS_ACCESS_KEY_ID') }}"
     secretKeyId: "{{ secret('AWS_SECRET_KEY_ID') }}"
     region: "eu-central-1"
-    queueUrl: "https://sqs.eu-central-1.amazonaws.com/000000000000/logs"
+    queueUrl: "https:///queue.amazonaws.com/000000000000/logs"
 ```
 
 When any message is pushed into the `logs` SQS queue, this flow will get triggered immediately.


### PR DESCRIPTION
The "long" url with region in it for SQS will cause errors, as the Java SDK will not be able to connect with the long version.  Since you need to give a region anyhow, you do NOT want the long version of the queue URL. You should use the version of the url that is returned by * aws sqs list-queues --region XX-XXXX-XX", which does NOT have the region in the url.