### PR TITLE
fix(exmaples): Replace examples using `exit 1` with `io.kestra.plugin.core.execution.Fail`

### DIFF
--- a/content/blogs/2024-01-08-sentry-plugin.md
+++ b/content/blogs/2024-01-08-sentry-plugin.md
@@ -326,11 +326,8 @@ tasks:
   - id: say_hello
     type: io.kestra.plugin.core.log.Log
     message: This should have triggered the sentry_execution_example flow.
-  - id: bash_will_fail
-    type: io.kestra.plugin.scripts.shell.Commands
-    runner: PROCESS
-    commands:
-    - "exit 1"
+  - id: task_will_fail
+    type: io.kestra.plugin.core.execution.Fail
 ```
 
 ### A flow using SentryExecution

--- a/content/docs/03.tutorial/06.errors.md
+++ b/content/docs/03.tutorial/06.errors.md
@@ -37,11 +37,7 @@ namespace: company.team
 
 tasks:
   - id: fail
-    type: io.kestra.plugin.scripts.shell.Commands
-    taskRunner:
-      type: io.kestra.plugin.core.runner.Process
-    commands:
-      - exit 1
+    type: io.kestra.plugin.core.execution.Fail
 
 errors:
   - id: alert_on_failure

--- a/content/docs/04.workflow-components/01.tasks/00.flowable-tasks.md
+++ b/content/docs/04.workflow-components/01.tasks/00.flowable-tasks.md
@@ -341,18 +341,14 @@ tasks:
     type: io.kestra.plugin.core.flow.AllowFailure
     tasks:
       - id: ko
-        type: io.kestra.plugin.scripts.shell.Commands
-        taskRunner:
-          type: io.kestra.plugin.core.runner.Process
-        commands:
-          - exit 1
+        type: io.kestra.plugin.core.execution.Fail
       - id: next
         type: io.kestra.plugin.core.debug.Return
-        format: "{{task.id}} > {{taskrun.startDate}}"
+        format: "{{ task.id }} > {{ taskrun.startDate }}"
 
   - id: end
     type: io.kestra.plugin.core.debug.Return
-    format: "{{task.id}} > {{taskrun.startDate}}"
+    format: "{{ task.id }} > {{ taskrun.startDate }}"
 ```
 
 ::next-link

--- a/content/docs/04.workflow-components/11.errors.md
+++ b/content/docs/04.workflow-components/11.errors.md
@@ -26,11 +26,7 @@ description: This will always fail
 
 tasks:
   - id: failed_task
-    type: io.kestra.plugin.scripts.shell.Commands
-    taskRunner:
-      type: io.kestra.plugin.core.runner.Process
-    commands:
-      - "exit 1"
+    type: io.kestra.plugin.core.execution.Fail
 
 errors:
   - id: alert_on_failure
@@ -49,7 +45,7 @@ Two kinds of error handlers can be defined:
 
 ### Global Error Handler
 
-This flow example has a single Shell task that fails immediately.
+This flow example has a single task that fails immediately.
 The global error handler will then be called so the `2nd` task will run.
 
 ```yaml
@@ -58,11 +54,8 @@ namespace: company.team
 
 tasks:
   - id: failed
-    type: io.kestra.plugin.scripts.shell.Commands
-    taskRunner:
-      type: io.kestra.plugin.core.runner.Process
-    commands:
-      - exit 1
+    type: io.kestra.plugin.core.execution.Fail
+
 errors:
   - id: 2nd
     type: io.kestra.plugin.core.log.Log
@@ -92,11 +85,7 @@ tasks:
         type: io.kestra.plugin.core.flow.Sequential
         tasks:
           - id: t2-t1
-            type: io.kestra.plugin.scripts.shell.Commands
-            taskRunner:
-              type: io.kestra.plugin.core.runner.Process
-            commands:
-              - 'exit 1'
+            type: io.kestra.plugin.core.execution.Fail
         errors:
           - id: error-t1
             type: io.kestra.plugin.core.debug.Return

--- a/content/docs/09.administrator-guide/03.monitoring.md
+++ b/content/docs/09.administrator-guide/03.monitoring.md
@@ -21,11 +21,7 @@ namespace: company.team
 
 tasks:
   - id: fail
-    type: io.kestra.plugin.scripts.shell.Commands
-    taskRunner:
-      type: io.kestra.plugin.core.runner.Process
-    commands:
-      - exit 1
+    type: io.kestra.plugin.core.execution.Fail
 
 errors:
   - id: slack

--- a/content/docs/11.migration-guide/0.12.0/listeners.md
+++ b/content/docs/11.migration-guide/0.12.0/listeners.md
@@ -58,11 +58,7 @@ namespace: prod.monitoring
 
 tasks:
   - id: fail
-    type: io.kestra.plugin.scripts.shell.Commands
-    taskRunner:
-      type: io.kestra.plugin.core.runner.Process
-    commands:
-      - exit 1
+    type: io.kestra.plugin.core.execution.Fail
 
 
 listeners:
@@ -125,11 +121,7 @@ namespace: prod
 
 tasks:
   - id: fail
-    type: io.kestra.plugin.scripts.shell.Commands
-    taskRunner:
-      type: io.kestra.plugin.core.runner.Process
-    commands:
-      - exit 1
+    type: io.kestra.plugin.core.execution.Fail
 ```
 
 Anytime you execute that `demo` flow, the Slack notification will be sent, thanks to the Flow trigger. Additionally, the **Dependencies** tab of both flows will make it clear that they depend on each other.

--- a/content/docs/15.how-to-guides/conditional-branching.md
+++ b/content/docs/15.how-to-guides/conditional-branching.md
@@ -53,11 +53,7 @@ tasks:
           type: io.kestra.plugin.core.flow.Sequential
           tasks:
             - id: failed
-              type: io.kestra.plugin.scripts.shell.Commands
-              taskRunner:
-                type: io.kestra.plugin.core.runner.Process
-              commands:
-                - 'exit 1'
+              type: io.kestra.plugin.core.execution.Fail
           errors:
             - id: error1
               type: io.kestra.plugin.core.debug.Return


### PR DESCRIPTION
Closes #1852 