### PR TITLE
feats(docs): add endsWith and flatten filter to pebble string filter doc

### DIFF
--- a/content/docs/05.concepts/expression/03.filter/numeric.md
+++ b/content/docs/05.concepts/expression/03.filter/numeric.md
@@ -56,19 +56,3 @@ The above example will output the following:
 
 **Arguments**
 - format
-
-## replace
-
-The `replace` filter formats a given string by replacing the placeholders (placeholders are free-form) or using regular expression:
-```twig
-{{ "I like %this% and %that%." | replace({'%this%': foo, '%that%': "bar"}) }}
-```
-
-```twig
-{{ 'aa1bb2cc3dd4ee5' | replace({'(\d)': '-$1-'}, regexp=true) }}
-```
-
-**Arguments**
-- `replace_pairs`: an object with key the search string and value the replace string
-- `regexp`: use regexp for search and replace pattern (default is `false`)
-

--- a/content/docs/05.concepts/expression/03.filter/object.md
+++ b/content/docs/05.concepts/expression/03.filter/object.md
@@ -10,6 +10,7 @@ Each section below represents a built-in filter.
 - [chunk](#chunk)
 - [className](#classname)
 - [first](#first)
+- [flatten](#flatten)
 - [join](#join)
 - [keys](#keys)
 - [last](#last)
@@ -19,6 +20,7 @@ Each section below represents a built-in filter.
 - [slice](#slice)
 - [sort](#sort)
 - [split](#split)
+- [toIon](#toIon)
 
 ## chunk
 
@@ -50,6 +52,43 @@ The `first` filter will return the first item of a collection, or the first lett
 
 {{ 'Mitch' | first }}
 {# will output 'M' #}
+```
+
+## flatten
+
+The `flatten()` filter flattens the nested list. Note that this filter only applies on the list.
+
+```yaml
+id: flatten
+namespace: company.team
+
+inputs:
+  - id: json
+    type: JSON
+    defaults: |
+      [
+        "First String", 
+        [
+          "Second String 1",
+          "Second String 2"
+        ],
+        "Third String",
+        [
+          "Fourth String 1",
+          "Fourth String 2",
+          "Fourth String 3"
+        ]
+      ]
+
+tasks:
+  - id: flatten_list
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ inputs.json | flatten }}"
+```
+
+The above flow will output the following:
+```
+["First String","Second String 1","Second String 2","Third String","Fourth String 1","Fourth String 2","Fourth String 3"]
 ```
 
 ## join
@@ -194,3 +233,14 @@ You can also pass a limit argument:
 **Arguments**
 - delimiter: The delimiter
 - limit: The limit argument
+
+## toIon
+
+The `toIon` filter will convert any object to an Ion value.
+
+The following expression `{{ {"name": "John"} | toIon  }}` will result in an ion  `{name: "John"}`.
+
+Similarly:
+
+- `{{ {"nullValue": null} | toIon }}` will result in `{nullValue: null}`
+- `{{ {"amount": 10.5} | toIon }}` will result in `{amount: 10.5e0}`

--- a/content/docs/05.concepts/expression/03.filter/string.md
+++ b/content/docs/05.concepts/expression/03.filter/string.md
@@ -12,12 +12,13 @@ Each section below represents a built-in filter.
 - [base64encode](#base64encode)
 - [capitalize](#capitalize)
 - [default](#default)
+- [endsWith](#endsWith)
 - [escapeChar](#escapechar)
 - [lower](#lower)
 - [replace](#replace)
 - [sha256](#sha256)
-- [startsWith](#startswith)
 - [slugify](#slugify)
+- [startsWith](#startswith)
 - [substringAfter](#substringafter)
 - [substringAfterLast](#substringafterlast)
 - [substringBefore](#substringbefore)
@@ -130,6 +131,29 @@ Note that the default filter will suppress any `AttributeNotFoundException` exce
 **Arguments**
 - default
 
+## endsWith
+
+The `endsWith()` filter returns `true` if the input string ends with the specified suffix. This filter is useful for string comparisons and conditional logic in your workflows.
+
+```yaml
+id: compare_strings
+namespace: company.team
+
+inputs:
+  - id: myvalue
+    type: STRING
+    defaults: "hello world!"
+
+tasks:
+  - id: log_true
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ inputs.myvalue | endsWith('world!') }}"
+
+  - id: log_false
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ inputs.myvalue | endsWith('World!') }}"
+```
+
 ## escapeChar
 
 The `escapeChar` filter sanitizes given string using a selected string escape sequence.
@@ -201,6 +225,15 @@ The above example will output the following:
 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
 ```
 
+## slugify
+
+The `slugify` filter removes non-word characters (alphanumerics and underscores) and converts spaces to hyphen. Also strips leading and trailing whitespace.
+
+```twig
+{{ "Joel is a slug" | slugify }}
+{# will output 'joel-is-a-slug' #}
+```
+
 ## startsWith
 
 The `startsWith()` filter returns `true` if the input string starts with the specified prefix. This filter is useful for string comparisons and conditional logic in your workflows.
@@ -222,15 +255,6 @@ tasks:
   - id: log_false
     type: io.kestra.plugin.core.log.Log
     message: "{{ inputs.myvalue | startsWith('Hello') }}"
-```
-
-## slugify
-
-The `slugify` filter removes non-word characters (alphanumerics and underscores) and converts spaces to hyphen. Also strips leading and trailing whitespace.
-
-```twig
-{{ "Joel is a slug" | slugify }}
-{# will output 'joel-is-a-slug' #}
 ```
 
 ## substringAfter


### PR DESCRIPTION
Updates #1843 

Add filters:
1. `endsWith` in string filters
2. `toIon` in object filters
3. `flatten` in object filters

Removed `replace` from numeric filters. It is already correctly present under string filters.