### PR TITLE
fix(examples) - kestra header line in the KESTRA_CONFIGURATION section

### DIFF
--- a/content/docs/15.how-to-guides/ssl-configuration.md
+++ b/content/docs/15.how-to-guides/ssl-configuration.md
@@ -127,6 +127,7 @@ Ensure that you expose the secure port of the connection if different from the d
             driverClassName: org.postgresql.Driver
             username: kestra
             password: k3str4
+        kestra:
           server:
             basic-auth:
               enabled: false


### PR DESCRIPTION
Fixed missed `kestra` header line in the `KESTRA_CONFIGURATION` section.