### PR TITLE
updating source to be dot activated in python/pandas cache example

### DIFF
--- a/content/docs/14.best-practices/managing-pip-dependencies.md
+++ b/content/docs/14.best-practices/managing-pip-dependencies.md
@@ -48,7 +48,7 @@ tasks:
         warningOnStdErr: false
         beforeCommands:
           - python -m venv venv
-          - source venv/bin/activate
+          - . venv/bin/activate
           - pip install pandas
         script: |
           import pandas as pd


### PR DESCRIPTION
- fails currently with:
```
2024-10-21T18:45:16.860Z DEBUG Using task runner 'io.kestra.plugin.core.runner.Process'
2024-10-21T18:45:16.861Z TRACE Provided 0 input(s).
2024-10-21T18:45:16.873Z TRACE Provided 1 input(s).
2024-10-21T18:45:16.894Z DEBUG Starting command with pid 483 [/bin/sh -c set -e
python -m venv venv
source venv/bin/activate
pip install panda
python /tmp/kestra-wd/tmp/7gJaCiIimNEijTVQ6VqlB7/467293932332219461.py]
2024-10-21T18:45:23.086Z WARN /bin/sh: 3: source: not found
2024-10-21T18:45:23.087Z TRACE io.kestra.core.models.tasks.runners.TaskException: Command failed with code 127
    at io.kestra.plugin.core.runner.Process.run(Process.java:155)
    at io.kestra.plugin.scripts.exec.scripts.runners.CommandsWrapper.run(CommandsWrapper.java:157)
    at io.kestra.plugin.scripts.python.Script.run(Script.java:207)
    at io.kestra.plugin.scripts.python.Script.run(Script.java:24)
    at io.kestra.core.runners.WorkerTaskThread.doRun(WorkerTaskThread.java:76)
    at io.kestra.core.runners.AbstractWorkerThread.run(AbstractWorkerThread.java:57)
2024-10-21T18:45:23.087Z ERROR Command failed with code 127
```

- with `.` instead of `source` it succeeds and appears to use the cache.
![Screenshot 2024-10-21 at 1 11 57 PM](https://github.com/user-attachments/assets/119acff8-69e6-45ba-a4ec-8fde81244e6e)
