### PR TITLE
Annotate ServiceAccount in Helm chart and add commented-out examples in values.yaml

### DIFF
--- a/content/docs/02.installation/05.kubernetes-gcp-gke.md
+++ b/content/docs/02.installation/05.kubernetes-gcp-gke.md
@@ -59,7 +59,7 @@ helm repo add kestra https://helm.kestra.io/
 helm install my-kestra kestra/kestra
 ```
 
-**Workload Identity Setup(Optional)**
+## Workload Identity Setup
 
 If you are using Google Cloud Workload Identity, you can annotate your Kubernetes service account in the Helm chart configuration. This will allow Kestra to automatically use the associated GCP service account for authentication.
 

--- a/content/docs/02.installation/05.kubernetes-gcp-gke.md
+++ b/content/docs/02.installation/05.kubernetes-gcp-gke.md
@@ -59,6 +59,29 @@ helm repo add kestra https://helm.kestra.io/
 helm install my-kestra kestra/kestra
 ```
 
+**Workload Identity Setup(Optional)**
+
+If you are using Google Cloud Workload Identity, you can annotate your Kubernetes service account in the Helm chart configuration. This will allow Kestra to automatically use the associated GCP service account for authentication.
+
+To configure this, you can add the following to your "values.yaml" file:
+```yaml
+serviceAccount:
+  create: true
+  name: <your-service-account-name>
+  annotations:
+    iam.gke.io/gcp-service-account: "<gcp-service-account>@<gcp-project-id>.iam.gserviceaccount.com"
+
+```
+
+Alternatively, you can apply the annotation directly when you install Kestra using Helm:
+
+```shell
+helm install my-kestra kestra/kestra \
+  --set serviceAccount.annotations.iam.gke.io/gcp-service-account=<gcp-service-account>@<gcp-project-id>.iam.gserviceaccount.com
+```
+
+This configuration links your Kubernetes service account to the GCP service account, enabling Workload Identity for secure access to Google Cloud resources.
+
 ## Launch CloudSQL
 
 1. Go to the [Cloud SQL console](https://console.cloud.google.com/sql/instances).
@@ -190,6 +213,56 @@ tasks:
     type: io.kestra.plugin.core.log.Log
     message: User {{ inputs.file }}
 ```
+
+## Commented-out Examples in values.yaml
+To provide users with clear guidance on configuring the values.yaml file, we have included some commented-out examples in the configuration. These examples can be used to set up various aspects of Kestra, such as secrets, database configurations, and other key parameters. You can uncomment and modify them as needed.
+
+Here’s an example of how you can define secrets and other configurations in the values.yaml file:
+
+```yaml
+# Example configuration for secrets:
+configuration:
+  kestra:
+    # Configure this section to set secrets for your Kestra instance.
+    # secret:
+    #   - name: "MY_SECRET_KEY"
+    #     value: "my-secret-value"
+    #   - name: "ANOTHER_SECRET"
+    #     valueFrom:
+    #       secretKeyRef:
+    #         name: "my-k8s-secret"
+    #         key: "my-secret-key"
+
+    # Configure this section to use PostgreSQL as the queue and repository backend.
+    # queue:
+    #   type: postgres
+    # repository:
+    #   type: postgres
+
+    # Example of connecting to a PostgreSQL database:
+    # datasources:
+    #   postgres:
+    #     url: jdbc:postgresql://<your-db-endpoint>:5432/<db-name>
+    #     driverClassName: org.postgresql.Driver
+    #     username: <your-username>
+    #     password: <your-password>
+
+# Example to disable default services like MinIO and PostgreSQL if you're using external services:
+minio:
+  # enabled: false
+postgresql:
+  # enabled: false
+```
+
+In this example:
+
+-**Secrets**: You can configure sensitive values as secrets, either hardcoding them or referencing existing Kubernetes secrets.  
+-**Queue and Repository**: By default, these can use PostgreSQL or any other supported type. Uncomment the relevant lines to use them.  
+-**PostgreSQL Configuration**: Set the datasources section to provide details for connecting to a PostgreSQL database.  
+-**Disabling Services**: If you're using external services like CloudSQL or Google Cloud Storage, you can disable the built-in services (MinIO and PostgreSQL).  
+
+
+Feel free to uncomment and modify these examples based on your setup needs. This provides flexibility while keeping your values.yaml well-structured.
 
 ## Next steps
 


### PR DESCRIPTION
With reference to issue #958 

1) it would be nice if you could annotate the serviceaccount via the helm chart rather than creating a seperate service account for workload identity
![Screenshot 2024-10-25 215611](https://github.com/user-attachments/assets/8274826d-8aa1-4aec-b41f-e54e8a18783b)

2) also, it would be nice if the values.yaml in git had some commented-out examples for configuration: secret: etc
![Screenshot 2024-10-25 215625](https://github.com/user-attachments/assets/a7b8814b-de64-44bd-beea-19762049525a)
![Screenshot 2024-10-25 215639](https://github.com/user-attachments/assets/cccd0314-77bf-4e55-af86-2ce1b0acd297)

@anna-geller Please have a look