### PR TITLE
feat: add the Blueprints entry in the menu

### DIFF
--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -384,6 +384,13 @@
                         </NuxtLink>
                     </li>
                     <li class="nav-item">
+                        <NuxtLink class="nav-link" href="/blueprints" role="button" @click="globalClick(true)">
+                            <span>
+                                Blueprints
+                            </span>
+                        </NuxtLink>
+                    </li>
+                    <li class="nav-item">
                         <NuxtLink class="nav-link dropdown-toggle" href="/pricing" role="button" @click="globalClick(true)">
                             <span>
                                 Pricing


### PR DESCRIPTION
Closes #1919 

<img width="1728" alt="Screenshot 2024-10-30 at 2 03 14 PM" src="https://github.com/user-attachments/assets/ed0e0da2-21d9-419f-8224-69694e172d97">

Ensured that clicking on the menu takes me to the appropriate page.