### PR TITLE
feat(docs): mention host HA config parameters

### DIFF
--- a/content/docs/09.administrator-guide/high-availability.md
+++ b/content/docs/09.administrator-guide/high-availability.md
@@ -21,6 +21,7 @@ Note that you need to deploy Kestra using the [Kafka and Elasticsearch architect
 ## Scaling the components
 
 The following components can be scaled horizontally (e.g. by allocating more replicas in your [Helm chart values](https://github.com/kestra-io/helm-charts/blob/master/charts/kestra/values.yaml#L42-L45)):
+
 - Webserver
 - Scheduler
 - Executor
@@ -31,7 +32,10 @@ Additionally, the Elasticsearch and Kafka clusters can be scaled out as needed t
 
 Finally, the internal storage (such as e.g. S3) is highly available and fault-tolerant by design.
 
+::alert{type="info"}
+Ensure that the host system is configured for high availability and fault-tolerance. For instance, you can adjust the Linux kernel `net.ipv4.tcp_retries2` parameter to reduce [TCP retransmission times](https://access.redhat.com/solutions/726753).
+::
+
 ## Load balancing
 
 To ensure high availability, you should use a load balancer to distribute incoming requests across multiple instances of the webserver. This ensures that if one instance fails, the system can continue to operate without interruption.
-


### PR DESCRIPTION
Simply listed the kernel parameter required for handling HA environment, such as AWS OpenSearch cluster upgrades.

Feel free to place the note to a more suitable place.