### PR TITLE
Update doc for the Task Worker with the new command line

### DIFF
--- a/content/docs/task-runners/03.task-runners-vs-worker-groups.md
+++ b/content/docs/task-runners/03.task-runners-vs-worker-groups.md
@@ -46,11 +46,10 @@ Here are common use cases in which **Task Runners** can be beneficial:
 
 ### Worker Groups Usage
 
-First, make sure you start the worker with the `--worker-group myWorkerGroupKey` flag.
+First, make sure you start the worker with the `--worker-group myWorkerGroupKey` flag. It's important for the new worker to have a configuration similar to that of your principal Kestra server and to have access to the same backend database and internal storage. The configuration file will be passed via the `--config` flag, as shown in the example below.
 
 ```shell
-kestra server worker --worker-group=myWorkerGroupKey \
---server=your_ee_host --api-token=your_ee_api_token
+kestra server worker --worker-group=myWorkerGroupKey --config=/path/to/kestra-config.yaml
 ```
 
 To assign a task to the desired worker group, simply add a `workerGroup.key` property. This will ensure that the task or polling trigger is executed on a worker in the specified worker group.


### PR DESCRIPTION
The documentation is inaccurate because --server and --api-token are no longer valid arguments. Replace them with the --config argument.