### PR TITLE
fix(docs): use correct command name

### DIFF
--- a/content/docs/09.administrator-guide/backup-and-restore.md
+++ b/content/docs/09.administrator-guide/backup-and-restore.md
@@ -133,7 +133,7 @@ POST _snapshot/my_snapshot_repository/kestra/_restore
 If you need to start from a fresh Kafka instance, you can reindex Kafka from the data in Elasticsearch using the following Kestra command:
 
 ```shell
-kestra sys restore-queue
+kestra sys-ee restore-queue
 ```
 
 Since some execution information is stored only in Kafka, not all pending executions may be restarted.


### PR DESCRIPTION
The `restore-queue` sub-command is a part of the EE, hence the `sys-ee` parent command.