### PR TITLE
Document the usage of the JSON Schema to validate flow

### DIFF
--- a/content/docs/01.getting-started/03.tutorial.md
+++ b/content/docs/01.getting-started/03.tutorial.md
@@ -16,5 +16,38 @@ This tutorial will guide you through **key concepts** in Kestra. We'll build upo
 
 We'll then dive into `parallel` task execution, error handling, as well as custom scripts and microservices running in isolated containers. Let's get started!
 
+## Using JSON Schema to Validate a Flow
+
+Kestra provides a JSON Schema to validate your flow definitions. This ensures that your flows are correctly structured and helps catch errors early in the development process.
+
+### JSON Schema in VSCode
+
+To use the JSON Schema in Visual Studio Code (VSCode), follow these steps:
+
+1. Install the [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) by Red Hat.
+2. Open your VSCode settings (`Ctrl+,` or `Cmd+,`).
+3. Search for `YAML: Schemas` and click on `Edit in settings.json`.
+4. Add the following configuration to associate the Kestra JSON Schema with your flow files:
+
+```json
+{
+  "yaml.schemas": {
+    "https://your-kestra-instance.com/api/v1/schemas/flow.json": "/*.yaml"
+  }
+}
+```
+
+Replace `https://your-kestra-instance.com/api/v1/schemas/flow.json` with the actual URL of your Kestra JSON Schema.
+
+### Globally Available Location for JSON Schema
+
+The JSON Schema for Kestra flows is available at the following URL:
+
+```
+https://your-kestra-instance.com/api/v1/schemas/flow.json
+```
+
+Replace `https://your-kestra-instance.com` with the actual URL of your Kestra instance.
+
 ::ChildCard{pageUrl="/docs/tutorial/"}
 ::

--- a/content/docs/08.ui/01.flows.md
+++ b/content/docs/08.ui/01.flows.md
@@ -66,3 +66,51 @@ The Dependencies page allows you to view what other flows depend on the selected
 ::alert{type="info"}
 The Dependencies View on the Namespaces page shows all the flows in the namespace and how they each relate to one another, if at all, whereas the Flow Dependencies view is only for the selected flow.
 ::
+
+## JSON Schema Usage for Flow Validation
+
+Kestra provides a JSON Schema to validate your flow definitions. This ensures that your flows are correctly structured and helps catch errors early in the development process.
+
+### JSON Schema in VSCode
+
+To use the JSON Schema in Visual Studio Code (VSCode), follow these steps:
+
+1. Install the [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) by Red Hat.
+2. Open your VSCode settings (`Ctrl+,` or `Cmd+,`).
+3. Search for `YAML: Schemas` and click on `Edit in settings.json`.
+4. Add the following configuration to associate the Kestra JSON Schema with your flow files:
+
+```json
+{
+  "yaml.schemas": {
+    "https://your-kestra-instance.com/api/v1/schemas/flow.json": "/*.yaml"
+  }
+}
+```
+
+Replace `https://your-kestra-instance.com/api/v1/schemas/flow.json` with the actual URL of your Kestra JSON Schema.
+
+### Example of Using JSON Schema in Flow Editor
+
+Here is an example of how to use the JSON Schema in the flow editor:
+
+```yaml
+id: example_flow
+namespace: example_namespace
+tasks:
+  - id: example_task
+    type: io.kestra.core.tasks.log.Log
+    message: "Hello, World!"
+```
+
+When you open this flow in the editor, the JSON Schema will validate the structure and provide autocompletion and error checking.
+
+### Globally Available Location for JSON Schema
+
+The JSON Schema for Kestra flows is available at the following URL:
+
+```
+https://your-kestra-instance.com/api/v1/schemas/flow.json
+```
+
+Replace `https://your-kestra-instance.com` with the actual URL of your Kestra instance.

--- a/content/docs/plugin-developer-guide/06.document.md
+++ b/content/docs/plugin-developer-guide/06.document.md
@@ -195,3 +195,65 @@ For example, to document two metrics: a **length** metric of type `counter` and 
     }
 )
 ```
+
+## JSON Schema Usage for Flow Validation
+
+Kestra provides a JSON Schema to validate your flow definitions. This ensures that your flows are correctly structured and helps catch errors early in the development process.
+
+### JSON Schema in VSCode
+
+To use the JSON Schema in Visual Studio Code (VSCode), follow these steps:
+
+1. Install the [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) by Red Hat.
+2. Open your VSCode settings (`Ctrl+,` or `Cmd+,`).
+3. Search for `YAML: Schemas` and click on `Edit in settings.json`.
+4. Add the following configuration to associate the Kestra JSON Schema with your flow files:
+
+```json
+{
+  "yaml.schemas": {
+    "https://your-kestra-instance.com/api/v1/schemas/flow.json": "/*.yaml"
+  }
+}
+```
+
+Replace `https://your-kestra-instance.com/api/v1/schemas/flow.json` with the actual URL of your Kestra JSON Schema.
+
+### Example of Using JSON Schema in Flow Editor
+
+Here is an example of how to use the JSON Schema in the flow editor:
+
+```yaml
+id: example_flow
+namespace: example_namespace
+tasks:
+  - id: example_task
+    type: io.kestra.core.tasks.log.Log
+    message: "Hello, World!"
+```
+
+When you open this flow in the editor, the JSON Schema will validate the structure and provide autocompletion and error checking.
+
+### Globally Available Location for JSON Schema
+
+The JSON Schema for Kestra flows is available at the following URL:
+
+```
+https://your-kestra-instance.com/api/v1/schemas/flow.json
+```
+
+Replace `https://your-kestra-instance.com` with the actual URL of your Kestra instance.
+
+### Generating and Using JSON Schema for Plugins
+
+To generate a JSON Schema for your plugin, you can use the `kestra plugins doc` command. This command will generate a JSON Schema file for your plugin, which can be used to validate your plugin's configuration.
+
+Here is an example of how to use the `kestra plugins doc` command:
+
+```sh
+kestra plugins doc --plugin io.kestra.plugin.yourplugin --output yourplugin-schema.json
+```
+
+This will generate a JSON Schema file named `yourplugin-schema.json` for your plugin.
+
+You can then use this JSON Schema file to validate your plugin's configuration in the same way as the flow JSON Schema.


### PR DESCRIPTION
Related to #103

Document the usage of the JSON Schema to validate a flow.

* Add a section in `content/docs/01.getting-started/03.tutorial.md` to document the usage of the JSON Schema to validate a flow, including instructions for using the JSON Schema in VSCode and mentioning the globally available location for the JSON Schema.
* Add a subsection in `content/docs/08.ui/01.flows.md` to explain JSON Schema usage for flow validation, provide an example of how to use the JSON Schema in the flow editor, and mention the globally available location for the JSON Schema.
* Add a section in `content/docs/plugin-developer-guide/06.document.md` to include JSON Schema usage for flow validation, explain how to generate and use the JSON Schema for plugins, and mention the globally available location for the JSON Schema.

