### PR TITLE
Rework the How-To Guide to allow 3 guides in a single row

### DIFF
--- a/components/content/GuidesChildCard.vue
+++ b/components/content/GuidesChildCard.vue
@@ -34,7 +34,7 @@
                 </div>
             </div>
         </div>
-        <NuxtLink :href="item._path" class="col-12 col-md-6 mb-lg-4 mb-2" v-for="item in navigation" :key="item._path">
+        <NuxtLink :href="item._path" class="col-12 col-md-4 mb-lg-4 mb-2" v-for="item in navigation" :key="item._path">
             <div class="card">
                 <div class="card-body">
                     <span class="card-stage" :style="`background-color: ${stages[item.stage]}`">


### PR DESCRIPTION
Fixes #2016

Change the class in `components/content/GuidesChildCard.vue` to display 3 guides in a single row instead of 2.

* Modify the class from `col-12 col-md-6` to `col-12 col-md-4` for each guide in the `NuxtLink` component.
