### PR TITLE
Update global error handler code example

### DIFF
--- a/content/docs/04.workflow-components/11.errors.md
+++ b/content/docs/04.workflow-components/11.errors.md
@@ -46,7 +46,7 @@ Two kinds of error handlers can be defined:
 ### Global Error Handler
 
 This flow example has a single task that fails immediately.
-The global error handler will then be called so the `2nd` task will run.
+The global error handler will then be called so the `2nd` task will run. Use the `errorLogs()` function to access the task context that failed.
 
 ```yaml
 id: errors
@@ -59,7 +59,7 @@ tasks:
 errors:
   - id: 2nd
     type: io.kestra.plugin.core.log.Log
-    message: I'm failing {{task.id}}
+    message: I'm failing {{ errorLogs()[0]['taskId'] }} # Because errorLogs() is an array, the first taskId to fail is retrieved.
     level: INFO
 ```
 


### PR DESCRIPTION
Update the global error handler example to output the taskId that failed rather than the handler task. From [Slack](https://kestra-io.slack.com/archives/C03FQKXRK3K/p1736412847684019).