### PR TITLE
fix: massive blink on plugins

### DIFF
--- a/pages/plugins/[...slug].vue
+++ b/pages/plugins/[...slug].vue
@@ -1,7 +1,5 @@
 <template>
-    <Suspense>
-        <PluginContainer :prevNext="false" type="plugins" />
-    </Suspense>
+    <PluginContainer :prevNext="false" type="plugins" />
 </template>
 
 <script setup>

--- a/utils/identify.js
+++ b/utils/identify.js
@@ -10,7 +10,7 @@ export default function(email) {
     })
 
     posthog.identify(
-        undefined,
+        posthog.get_distinct_id(),
         {email: email}
     );
 }


### PR DESCRIPTION
remove a suspense tag that made the plugins page load again and again