### PR TITLE
fix(ui): line height of Heading under Open source page.

### DIFF
--- a/components/features/Header.vue
+++ b/components/features/Header.vue
@@ -61,9 +61,6 @@
   font-size: $font-size-4xl;
   font-weight: 400;
   line-height: 3.7rem;
-  @include media-breakpoint-down(lg) {
-    line-height: calc($font-size-base * 1.625);;
-  }
 }
 
 .baseline {


### PR DESCRIPTION
Closes #2165 

**Now:** 
![image](https://github.com/user-attachments/assets/9e195c04-c9a7-408c-90cf-94bcbbdf7cf8)
