### PR TITLE
fix: correct duplicate get started buttons

### DIFF
--- a/pages/use-cases/stories/index.vue
+++ b/pages/use-cases/stories/index.vue
@@ -13,7 +13,7 @@
                 darkButtonText="Get started"
                 darkButtonHref="/docs/getting-started/quickstart#start-kestra"
                 purpleButtonText="Read the docs"
-                purpleButtonHref="/docs/getting-started"
+                purpleButtonHref="/docs"
             />
         </NuxtLazyHydrate>
     </div>

--- a/pages/use-cases/stories/index.vue
+++ b/pages/use-cases/stories/index.vue
@@ -10,8 +10,10 @@
             <LayoutFooterContact
                 title="Getting started with Kestra"
                 subtitle="Start building with Kestra — Automate Everything Everywhere All at Once."
-                darkButtonText="Get Started"
-                purpleButtonText="Get started!"
+                darkButtonText="Get started"
+                darkButtonHref="/docs/getting-started/quickstart#start-kestra"
+                purpleButtonText="Read the docs"
+                purpleButtonHref="/docs/getting-started"
             />
         </NuxtLazyHydrate>
     </div>


### PR DESCRIPTION
Closes https://github.com/kestra-io/docs/issues/2379

Problem:
![Screenshot 2025-03-28 at 7 30 56 PM](https://github.com/user-attachments/assets/b735a484-a0a5-4292-a79d-291af4dfc64d)

Matched with the button title and links from the home page:
![Screenshot 2025-03-28 at 7 31 43 PM](https://github.com/user-attachments/assets/52ffff3b-3096-4c36-9e75-cae77215d148)
