### PR TITLE
fix(docs): correct typo in the community guidelines

### DIFF
--- a/components/community/Guidelines.vue
+++ b/components/community/Guidelines.vue
@@ -58,10 +58,10 @@
 
           title: "Make it easy to help you",
           descriptionHtml: "<ul>\n" +
-            "                   <li>Please share relevant flows(YAML), logs and stack traces <a target='_blank' href='https://slack.com/intl/en-gb/help/articles/202288908-Format-your-messages'>formatted</a> in code blocks (no screenshots, please).</li><br/>\n" +
+            "                   <li>Please share relevant flows (YAML), logs and stack traces <a target='_blank' href='https://slack.com/intl/en-gb/help/articles/202288908-Format-your-messages'>formatted</a> in code blocks (no screenshots, please).</li><br/>\n" +
             "                   <li>Please share how you have deployed Kestra:\n" +
             "                   <ol type='a'>\n" +
-            "                       <li>Deployment choice (Standalone, Docker, Kubernetes etc).</li>\n" +
+            "                       <li>Deployment choices (Standalone, Docker, Kubernetes, etc.).</li>\n" +
             "                       <li>The version of Kestra.</li>\n" +
             "                       <li>Your OS and its version.</li>\n" +
             "                       </ul>\n" +

--- a/content/docs/01.getting-started/04.community-guidelines.md
+++ b/content/docs/01.getting-started/04.community-guidelines.md
@@ -9,9 +9,9 @@ The Kestra community is a friendly and welcoming place for everyone.
     1. Be respectful towards other members of this Slack Community. Do not harass others.
     2. Assume positive intent.
 2. **Make it easy to help you**
-    1. Please share relevant flows(YAML), logs and stack traces [formatted](https://slack.com/intl/en-gb/help/articles/202288908-Format-your-messages) in code blocks (no screenshots, please).
+    1. Please share relevant flows (YAML), logs and stack traces [formatted](https://slack.com/intl/en-gb/help/articles/202288908-Format-your-messages) in code blocks (no screenshots, please).
     2. Please share how you have deployed Kestra:
-        1. Deployment choice (Standalone, Docker, Kubernetes etc)
+        1. Deployment choices (Standalone, Docker, Kubernetes, etc.)
         2. The version of Kestra
         3. Your OS and its version
 3. **Use relevant channels**


### PR DESCRIPTION
This PR fixes minor grammar and punctuation issues in the community guidelines:

Changed "**Deployment choice**" to "**Deployment choices**" for correctness.

Added a missing space and comma in "**(Kubernetes, etc.)**".

Fixed spacing in "**flows (YAML)**".