### PR TITLE
doc(local-flow): fix info block

### DIFF
--- a/content/docs/15.how-to-guides/local-flow-sync.md
+++ b/content/docs/15.how-to-guides/local-flow-sync.md
@@ -42,7 +42,7 @@ File created locally should use `<namespace>.<flow_id>.yml` or `<namespace>_<flo
 Flow created inside the UI will be created at the root of the first path supplied in the configuration.
 
 
-::alert{type="note"}
+::alert{type="info"}
 If you are using the docker-compose installation, you will need to mount a volume so Kestra container can access your local folder.
 
 ```yaml

--- a/content/docs/15.how-to-guides/local-flow-sync.md
+++ b/content/docs/15.how-to-guides/local-flow-sync.md
@@ -48,7 +48,7 @@ If you are using the docker-compose installation, you will need to mount a volum
 ```yaml
     volumes:
       # ... other volumes
-      - ./local_folder:/local_folder
+      - ./local_folder:/docker_folder
     environment:
       KESTRA_CONFIGURATION: |
         micronaut:
@@ -56,7 +56,7 @@ If you are using the docker-compose installation, you will need to mount a volum
             watch:
               enabled: true
               paths:
-                - /local_folder
+                - /docker_folder
 ```
 ::
 


### PR DESCRIPTION
Change from note to info. Also make the paths clearer by using different names.

Currently unreadable:
![Screenshot 2025-04-16 at 11 19 17](https://github.com/user-attachments/assets/621d2eaa-d86f-4ec3-8e46-bc0650061e0c)
