### PR TITLE
fix: blog authors css

### DIFF
--- a/components/blogs/BlogDetails.vue
+++ b/components/blogs/BlogDetails.vue
@@ -70,9 +70,9 @@ export default {
 
     .authors {
         margin-top: 1rem;
-        display: grid;
-        grid-template-columns: repeat(2, 1fr);
-        gap: 1rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 2rem;
     }
 
     .author {
@@ -82,14 +82,15 @@ export default {
 
         .name {
             color: $white;
+            line-height: 1.8em;
             font-size: $font-size-md;
             font-weight: 600;
             margin: 0;
         }
 
         .role {
-            color: $white-1;
-            font-size: $font-size-sm;
+            color: $white-3;
+            font-size: $font-size-xs;
             margin-bottom: 0;
         }
     }

--- a/components/blogs/BlogDetails.vue
+++ b/components/blogs/BlogDetails.vue
@@ -90,6 +90,7 @@ export default {
 
         .role {
             color: $white-3;
+            line-height: 1.8em;
             font-size: $font-size-xs;
             margin-bottom: 0;
         }


### PR DESCRIPTION
### Before
<img width="1023" alt="Screenshot 2025-04-24 at 11 05 57" src="https://github.com/user-attachments/assets/107389f5-19f4-42b6-8e2e-1e5cb83446f1" />

### After
<img width="868" alt="Screenshot 2025-04-24 at 11 16 12" src="https://github.com/user-attachments/assets/3c438558-1dec-4fb9-b5b8-6a443ca8d34f" />

