### PR TITLE
docs(worker-groups): add notes on relevant pages for worker groups

### DIFF
--- a/content/docs/06.enterprise/04.scalability/worker-group.md
+++ b/content/docs/06.enterprise/04.scalability/worker-group.md
@@ -7,8 +7,11 @@ version: ">= 0.10.0"
 
 How to configure Worker Groups in Kestra Enterprise Edition.
 
-
 A Worker Group is a set of workers that can be explicitly targeted for task execution or polling trigger evaluation. For example, tasks that require heavy resources can be isolated to a Worker Group designed to handle that load, and tasks that perform best on a specific Operating System can be optimized to run on a Worker Group designed for them.
+
+::alert{type="info"}
+Please note that Worker Groups are not yet available in Kestra Cloud, only in Kestra Enterprise Edition.
+::
 
 <div class="video-container">
   <iframe src="https://www.youtube.com/embed/C-539c3UVJM?si=3USIb1F7OiW9AQVp" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/content/docs/07.architecture/02.server-components.md
+++ b/content/docs/07.architecture/02.server-components.md
@@ -29,6 +29,10 @@ In the [Enterprise Edition](../06.enterprise/01.overview/01.enterprise-edition.m
 
 To specify a worker group for a task, use the `workerGroup.key` property in the task definition to point the task to a specific worker group key. If no worker group is specified, the task will be executed on the default worker group.
 
+::alert{type="info"}
+Please note that Worker Groups are not yet available in Kestra Cloud, only in Kestra Enterprise Edition.
+::
+
 ## Scheduler
 
 The [Scheduler](./06.scheduler.md) manages all [triggers](../04.workflow-components/07.triggers/index.md) except for [Flow triggers](../04.workflow-components/07.triggers/02.flow-trigger.md) handled by the [Executor](#executor). It determines when to start a flow based on trigger conditions.

--- a/content/docs/14.best-practices/8.business-unit-separation.md
+++ b/content/docs/14.best-practices/8.business-unit-separation.md
@@ -20,6 +20,10 @@ You can configure dedicated resources per tenant:
 - dedicated worker groups (e.g. special pool of workers intended to be used by a given tenant)
 - flows, executions, and logs are by default **isolated** between tenants.
 
+::alert{type="info"}
+Please note that Worker Groups are not yet available in Kestra Cloud, only in Kestra Enterprise Edition.
+::
+
 ### Use cases for tenants
 
 - **Customer separation**: If you operate a multi-tenant SaaS on top of Kestra and you need strict isolation between customers, each customer should have its own tenant, not just a dedicated namespace.

--- a/content/docs/oss-vs-paid.md
+++ b/content/docs/oss-vs-paid.md
@@ -38,6 +38,10 @@ The Open-Source Edition runs by default on a single server, which can become a b
 
 [Worker Groups](06.enterprise/04.scalability/worker-group.md) let you assign tasks to specialized infrastructure. For example, GPU-heavy machine learning workflows can target a worker group with NVIDIA GPUs, while ETL jobs run on cost-optimized spot instances. [Task Runners](06.enterprise/04.scalability/task-runners.md) offload compute-intensive scripts on-demand to Kubernetes or cloud batch services such as Azure Batch, Google Cloud Run or AWS ECS Fargate to prevent resource contention and making it easy to scale in a cost-effective way.
 
+::alert{type="info"}
+Please note that Worker Groups are not yet available in Kestra Cloud, only in Kestra Enterprise Edition.
+::
+
 [Maintenance Mode](06.enterprise/05.instance/maintenance-mode.md) allows safe upgrades: new executions queue while in-progress tasks complete gracefully, avoiding abrupt workflow termination. [Cluster monitoring](06.enterprise/05.instance/index.md) provides real-time visibility into resource usage, helping teams proactively address infrastructure bottlenecks. Additionally, using **Custom Dashboards**, you can create custom views to track specific metrics, logs, or executions. The [Backup and Restore](09.administrator-guide/backup-and-restore.md) eliminates the risk of data loss or corruption during upgrades, allowing you to recover from accidental deletions or system failures.
 
 ---

--- a/content/docs/task-runners/03.task-runners-vs-worker-groups.md
+++ b/content/docs/task-runners/03.task-runners-vs-worker-groups.md
@@ -29,6 +29,9 @@ The table below summarizes the differences between task runners and worker group
 | **Latency**           | High latency (seconds, up to minutes) | Low latency (milliseconds)                  |
 | **Cost Efficiency**   | Suitable for infrequent tasks         | Suitable for frequent or long-running tasks |
 
+::alert{type="info"}
+Please note that Worker Groups are not yet available in Kestra Cloud, only in Kestra Enterprise Edition.
+::
 
 ## Use cases
 


### PR DESCRIPTION
Worker Groups are currently only an EE feature. This PR denotes in strategic doc places that they are unavailable on the Cloud.