### PR TITLE
docs(triggers): note about webhook triggers not displaying in the UI or API

### DIFF
--- a/content/docs/04.workflow-components/07.triggers/index.md
+++ b/content/docs/04.workflow-components/07.triggers/index.md
@@ -148,6 +148,10 @@ If your trigger is locked due to an execution in progress, you can unlock it by 
 
 The **Unlock trigger** functionality is useful for troubleshooting, e.g. if a process is stuck due to infrastructure issues. Note that manually unlocking triggers may result in multiple concurrent (potentially duplicated) executions — use it with caution.
 
+::alert{type="info"}
+Only scheduled-based triggers (triggers handled by the Scheduler) will be visible in the UI. Triggers handled by the Executor and Webserver will not be displayed. This also applies when fetching triggers from the API.
+::
+
 ### Toggle or unlock triggers from the Administation page
 
 You can also disable, re-enable, or unlock triggers from the Administration page. Here is how you can do it:


### PR DESCRIPTION
Check that this is correct, but noticed we don't talk about the changes made [here](https://github.com/kestra-io/docs/issues/2497) in the triggers page.

We had a user who was trying to fetch triggers from the API and didn't get their webhook one which I assume is related to this. Also doesn't display in UI.