### PR TITLE
feat(docs): improve property default example

### DIFF
--- a/content/docs/plugin-developer-guide/02.task.md
+++ b/content/docs/plugin-developer-guide/02.task.md
@@ -77,7 +77,7 @@ public class ReverseString extends Task implements RunnableTask<ReverseString.Ou
 
 ### Properties
 ```java
-    private Property<String> string;
+private Property<String> string;
 ```
 All task properties must be declared as task class attributes. They will be passed to the task by the flow at execution time.
 If you want your attribute to be dynamic, you need to wrap the type of your attribute into the `Property` type. Dynamic properties are explained [later](#dynamic-properties-rendering).
@@ -205,6 +205,7 @@ public Output run(RunContext runContext) throws Exception {
 You can provide a default value at property definition time via `Property.of()`:
 
 ```java
+@Builder.Default
 private Property<Duration> duration = Property.of(Duration.ofSeconds(10));
 ```
 
@@ -287,8 +288,8 @@ data:
 Alternatively to using the `Property` carrier type, if you don't want or can't use dynamic properties using the `Property` carrier type, you can define you task property like this:
 
 ```java
-    @PluginProperty
-    private String string;
+@PluginProperty
+private String string;
 ```
 
 Always use the `@PluginProperty` if you don't use the `Property` carrier type for the task JSON Schema and documentation to be property generated. You can even use `@PluginProperty(dynamic = true)` and render the property __in other ways__ that I will not explain here, this was the old way to deal with dynamic properties, but it's now strongly dis-encouraged.


### PR DESCRIPTION
Add `@Builder.Default` to the defaulted property since the guide explicitly mentions `@SuperBuilder`. Also nuke whitespace prefixes.