### PR TITLE
feat(docs): add validation example

### DIFF
--- a/content/docs/plugin-developer-guide/02.task.md
+++ b/content/docs/plugin-developer-guide/02.task.md
@@ -115,6 +115,12 @@ The default available annotations are:
 - `@Future`
 - `@FutureOrPresent`
 
+The validation must be added to the inner type:
+
+```java
+private Property<@Min(1) @Max(30) Integer> integer;
+```
+
 You can also create your own custom validation.
 To do so, first define the annotation as follows:
 


### PR DESCRIPTION
Property validation must be performed at its inner type.