### PR TITLE
fix(docs): update mail server config to 0.20+

### DIFF
--- a/content/docs/configuration/index.md
+++ b/content/docs/configuration/index.md
@@ -2203,16 +2203,18 @@ kestra:
 
 ### Configuring a mail server
 
-Kestra can send emails for invitations and forgotten passwords. You can configure the mail server using the `kestra.mail-service` configuration.
+Kestra can send emails for invitations and forgotten passwords. You can configure the mail server using the EE `mail-service` configuration.
 
 ```yaml
-    host: host.smtp.io
-    port: 587
-    username: user
-    password: password
-    from: configurable@mail.com
-    fromName: Kestra
-    auth: true #default
-    starttlsEnable: true #default
-
+kestra:
+  ee:
+    mail-service:
+      host: host.smtp.io
+      port: 587
+      username: user
+      password: password
+      from: configurable@mail.com
+      fromName: Kestra
+      auth: true # default
+      starttlsEnable: true # default
 ```


### PR DESCRIPTION
As the [0.20.0 migration guide](https://kestra.io/docs/migration-guide/0.20.0/server-configuration#email-server-configuration-has-moved-to-a-different-location) mentions the `kestra.mail-service` has become `kestra.ee.mail-service`. The old config simply doesn't work...