### PR TITLE
docs(keycloak): fix guide

### DIFF
--- a/content/docs/06.enterprise/03.auth/sso/keycloak.md
+++ b/content/docs/06.enterprise/03.auth/sso/keycloak.md
@@ -37,7 +37,7 @@ micronaut:
           client-id: "{{clientId}}"
           client-secret: "{{clientSecret}}"
           openid:
-            issuer: "https://{{keyCloakServer}}/auth/realms/{{yourRealm}}"
+            issuer: "https://{{keyCloakServer}}/realms/{{yourRealm}}"
     endpoints:
       logout:
         get-allowed: true
@@ -51,7 +51,7 @@ You can retrieve `clientId` and `clientSecret` via KeyCloak user interface
 
 Don't forget to set a default role in your Kestra configuration to streamline the process of adding new users.
 
-```
+```yaml
 kestra:
   security:
     defaultRole:


### PR DESCRIPTION
- [x] correct issuer should be https://{{keyCloakServer}}/realms/{{yourRealm}}  without /auth in it.
- [ ] The screenshot contains localhost:8081 which is not the default port as Kestra uses 8080 by default
- [x] no syntax highlighting on bottom code block