### PR TITLE
feat(docs): mention reserverd plugin property name

### DIFF
--- a/content/docs/plugin-developer-guide/02.task.md
+++ b/content/docs/plugin-developer-guide/02.task.md
@@ -91,6 +91,10 @@ string: "{{ outputs.previousTask.name }}"
 
 You can declare as many properties as you want.
 
+::alert{type="warning"}
+As of Kestra 0.22.0, the `version` property is a core property reserved for [plugin management](../06.enterprise/05.instance/versioned-plugins.md#version-property-in-a-flow). Custom plugins will fail to compile if they use this property, so you must rename it to something else.
+::
+
 You can use any serializable types by [Jackson](https://github.com/FasterXML/jackson) for your properties (ex: Double, boolean, ...). You can create any class as long as the class is Serializable.
 
 #### Properties validation


### PR DESCRIPTION
Let's make `version` property-related compilation failures clear.