### PR TITLE
docs(subflow): add scheduleDate

### DIFF
--- a/content/docs/04.workflow-components/10.subflows.md
+++ b/content/docs/04.workflow-components/10.subflows.md
@@ -84,8 +84,10 @@ Below is a full list of all properties of the `io.kestra.plugin.core.flow.Subflo
 | `labels`               | Labels assigned to the subflow                                             |
 | `outputs` (deprecated) | Allows passing outputs from the subflow execution to the parent flow.       |
 | `revision`             | The subflow revision to execute (defaults to the latest)                   |
-| `wait`                 | If true, parent flow waits for subflow completion (default: false).         |
+| `scheduleDate`         | Schedule subflow execution on a specific date rather than immediately.      |
 | `transmitFailed`       | If true, parent flow fails on subflow failure (requires `wait` to be true). |
+| `wait`                 | If true, parent flow waits for subflow completion (default: false).         |
+
 
 ## Passing data between parent and child flows
 


### PR DESCRIPTION
This must've been missed in a previous release. Part of https://github.com/kestra-io/kestra-ee/issues/3632