### PR TITLE
fix(docs): amend property path

### DIFF
--- a/content/docs/06.enterprise/03.auth/rbac.md
+++ b/content/docs/06.enterprise/03.auth/rbac.md
@@ -253,16 +253,19 @@ There is no limit to the number of Roles that can be bound to an entity. They ca
 By default, Kestra >= 0.22 will lock the user for the `lock-duration` period after a `threshold` number of failed attempts performed within the `monitoring-window` duration. The snippet below lists the default values for those properties — you can adjust them based on your preferences:
 
 ```yaml
-security:
-  login:
-    failed-attempts:
-      threshold: 10
-      monitoring-window: PT5M
-      lock-duration: PT30M
+kestra:
+  security:
+    login:
+      failed-attempts:
+        threshold: 10
+        monitoring-window: PT5M
+        lock-duration: PT30M
 ```
+
 The key attributes are:
+
 - `threshold`: Sets the number of allowed failed attempts before a user is locked out.
-- `monitoring-window`: Defines the period during which failed login attempts are counted before triggering a lock. Superadmin can unlock the user manually by resetting their password from the user's detail page.
+- `monitoring-window`: Defines the period during which failed login attempts are counted before triggering a lock. Super Admin can unlock the user manually by resetting their password from the user's detail page.
 - `lock-duration`: Defines how long the account remains locked.
 
 In the above configuration, a user is allotted 10 failed login attempts in a 5-minute window before they are locked out. They must wait 30 minutes to try again, be unlocked by an Admin, or reset their password by clicking on the "Forgot password" link and following the instructions in the email.

--- a/content/docs/11.migration-guide/0.22.0/failed-attempts-lockout.md
+++ b/content/docs/11.migration-guide/0.22.0/failed-attempts-lockout.md
@@ -12,14 +12,17 @@ Too many failed login attempts now lock user's account
 To improve the security of your Enterprise Edition instance, we now automatically lock user accounts after a `threshold` number of failed login attempts made within `monitoring-window`. The number of failed attempts, the monitoring window to track the failed attempts and the duration of how long the user remains locked are configurable.
 
 ```yaml
-security:
-  login:
-    failed-attempts:
-      threshold: 10           # the number of failed attempts before lockout
-      monitoring-window: PT5M # period to count failed attempts
-      lock-duration: PT30M    # period the account remains locked
+kestra:
+  security:
+    login:
+      failed-attempts:
+        threshold: 10           # the number of failed attempts before lockout
+        monitoring-window: PT5M # period to count failed attempts
+        lock-duration: PT30M    # period the account remains locked
 ```
 
+::alert{type="info"}
 Note that this change is only relevant for users who leverage LDAP or basic authentication (not relevant for SSO-users).
+::
 
-Superadmin can unlock the user manually by resetting their password from the user's detail page. The user can also unlock their account by resetting their password using the "Forgot password" link on the login page and following the instructions in the email.
+Super Admin can unlock the user manually by resetting their password from the user's detail page. The user can also unlock their account by resetting their password using the "Forgot password" link on the login page and following the instructions in the email.


### PR DESCRIPTION
AFAIK the `security` block should be a child of `kestra`.