### PR TITLE
docs(guides): add expressions

### DIFF
--- a/content/docs/15.how-to-guides/golang.md
+++ b/content/docs/15.how-to-guides/golang.md
@@ -16,9 +16,9 @@ Go is a powerful programming language often used for cloud-native development, C
 
 This guide is going to walk you through how to get Go running inside of a workflow, how to manage input and output files, and how you can pass outputs and metrics back to Kestra to use in later tasks.
 
-## Executing Go inside Kestra
+## Commands Task
 
-There is an official Go plugin with an inline `Script` task and `Commands` task. This example executes a Namespace file using `Commands`:
+There is an official Go plugin with a `Commands` task and an inline `Script` task. This example executes a Namespace file using `Commands`:
 
 ```yaml
 id: golang_commands
@@ -45,6 +45,10 @@ func main() {
 
 You'll need to add your Golang code using the built-in Editor or [sync it using Git](../version-control-cicd/04.git.md) so Kestra can see it. You'll also need to set the `enabled` flag for the `namespaceFiles` property to `true` so Kestra can access the file.
 
+You can read more about the Go Commands type in the [Plugin documentation](/plugins/plugin-script-go/io.kestra.plugin.scripts.go.commands).
+
+## Script
+
 You can also add your Golang code inline using the `Script` task.
 
 ```yaml
@@ -63,7 +67,36 @@ tasks:
       }
 ```
 
-You can read more about the Go Commands type in the [Plugin documentation](/plugins/plugin-script-go/io.kestra.plugin.scripts.go.commands).
+You can also use expressions directly inside of your Go code. In this example, inputs are embedded directly into the code:
+
+```yaml
+id: golang_script_expression
+namespace: company.team
+
+inputs:
+  - id: message
+    type: STRING
+    defaults: "Hello, World!"
+
+  - id: number
+    type: INT
+    defaults: 4
+
+tasks:
+  - id: go
+    type: io.kestra.plugin.scripts.go.Script
+    script: |
+      package main
+      import "fmt"
+
+      func main() {
+          fmt.Println("Message: {{ inputs.message }}")
+          fmt.Println("Number: {{ inputs.number }}")
+      }
+```
+
+You can read more about the Go Script type in the [Plugin documentation](/plugins/plugin-script-go/io.kestra.plugin.scripts.go.script).
+
 
 ## Handling Outputs
 

--- a/content/docs/15.how-to-guides/python.md
+++ b/content/docs/15.how-to-guides/python.md
@@ -27,7 +27,7 @@ Managing Python Dependencies can be frustrating. There's 3 ways you can manage y
 
 For more information, check out the [dedicated guide here](./python-dependencies.md).
 
-## Script
+## Script Task
 
 If you want to write a short amount of Python to perform a task, you can use the `io.kestra.plugin.scripts.python.Script` type to write it directly inside of your flow configuration. This allows you to keep everything in one place.
 
@@ -60,7 +60,43 @@ tasks:
       downloads = get_docker_image_downloads()
 ```
 
-## Commands
+You can also include expressions directly inside of your Python code too. In this example, an input is used inside of the Python method:
+
+```yaml
+id: python_scripts_expression_input
+namespace: company.team
+
+description: This flow will install the pip package in a Docker container, and use kestra's Python library to generate outputs (number of downloads of the Kestra Docker image) and metrics (duration of the script).
+
+inputs:
+  - id: image_name
+    type: STRING
+    defaults: kestra/kestra
+
+tasks:
+  - id: outputs_metrics
+    type: io.kestra.plugin.scripts.python.Script
+    beforeCommands:
+      - pip install requests
+    taskRunner:
+      type: io.kestra.plugin.scripts.runner.docker.Docker
+    containerImage: python:slim
+    script: |
+      import requests
+
+      def get_docker_image_downloads():
+          """Queries the Docker Hub API to get the number of downloads for a specific Docker image."""
+          url = f"https://hub.docker.com/v2/repositories/{{ inputs.image_name }}/"
+          response = requests.get(url)
+          data = response.json()
+
+          downloads = data.get('pull_count', 'Not available')
+          return downloads
+
+      downloads = get_docker_image_downloads()
+```
+
+## Commands Task
 
 If you would prefer to put your Python code in a `.py` file (e.g. your code is much longer or spread across multiple files), you can run the previous example using the `io.kestra.plugin.scripts.python.Commands` type:
 

--- a/content/docs/16.scripts/00.languages.md
+++ b/content/docs/16.scripts/00.languages.md
@@ -80,39 +80,6 @@ Below are a number of examples showing how you can do this with different progra
 
 For handling outputs and metrics, you can use the same approach that the `Shell` task uses by using `::{}::` syntax in log messages. Read more about it in [Shell outputs and metrics](./06.outputs-metrics.md#shell).
 
-### Go
-
-There is an official Go plugin with an inline `Script` task and `Commands` task. This example executes a Namespace file using `Commands`:
-
-```yaml
-id: golang_commands
-namespace: company.team
-
-tasks:
-  - id: go
-    type: io.kestra.plugin.scripts.go.Commands
-    namespaceFiles:
-      enabled: true
-    commands:
-      - go run main.go
-```
-
-The Go code is saved as a namespace file called `main.go`:
-
-```go
-package main
-import "fmt"
-func main() {
-    fmt.Println("hello world")
-}
-```
-
-When executed, the print statement is displayed in the Kestra logs:
-
-![golang_output](/docs/developer-guide/scripts/golang_output.png)
-
-Check out the [full guide](../15.how-to-guides/golang.md) which includes using [outputs and metrics](./06.outputs-metrics.md).
-
 ### Rust
 
 Here is an example flow that runs a Rust file inside of a container using a `rust` image:


### PR DESCRIPTION
Few tweaks to the language guides:
- Add expression examples
- Fix Go example in the languages supported as it now has an official plugin