### PR TITLE
fix(docs) default true for wait in Subflow

### DIFF
--- a/content/docs/04.workflow-components/10.subflows.md
+++ b/content/docs/04.workflow-components/10.subflows.md
@@ -86,7 +86,7 @@ Below is a full list of all properties of the `io.kestra.plugin.core.flow.Subflo
 | `revision`             | The subflow revision to execute (defaults to the latest)                   |
 | `scheduleDate`         | Schedule subflow execution on a specific date rather than immediately.      |
 | `transmitFailed`       | If true, parent flow fails on subflow failure (requires `wait` to be true). |
-| `wait`                 | If true, parent flow waits for subflow completion (default: false).         |
+| `wait`                 | If true, parent flow waits for subflow completion (default: true).         |
 
 
 ## Passing data between parent and child flows


### PR DESCRIPTION
Field `wait` of Subflow is default true, according to https://kestra.io/plugins/core/flow/io.kestra.plugin.core.flow.subflow#properties_wait-body