### PR TITLE
fix: fixed a bug where see more button on blueprint details page  shows see more after expanding.

### DIFF
--- a/components/blueprints/Detail.vue
+++ b/components/blueprints/Detail.vue
@@ -9,7 +9,7 @@
                 />
                 <div class="show-more" :class="{ hide: !hideCode }">
                     <a href="" @click.prevent="hideCode = !hideCode">
-                        See more
+                        {{ hideCode ? 'See more' : 'See less' }}
                         <ChevronDown v-if="hideCode"/>
                         <ChevronUp v-else/>
                     </a>


### PR DESCRIPTION
closes #2744 

After the fix:

<img width="1636" alt="Screenshot 2025-06-30 at 5 27 05 PM" src="https://github.com/user-attachments/assets/08808697-eb5a-492a-b32c-098dd7a98c37" />
