### PR TITLE
docs(retries): mention unsupported Duration options

### DIFF
--- a/content/docs/04.workflow-components/12.retries.md
+++ b/content/docs/04.workflow-components/12.retries.md
@@ -87,7 +87,7 @@ Consider a task with a `timeout` of 10 minutes and a `retry.maxDuration` of 30 m
 ### Duration
 
 Some options above have to be filled with a duration notation.
-Durations are expressed in the [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) format; here are some examples:
+Durations are expressed in the [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) format, although the week, month and year designator are not supported. Here are some examples:
 
 | name     | description              |
 |----------|--------------------------|
@@ -95,6 +95,7 @@ Durations are expressed in the [ISO 8601 Durations](https://en.wikipedia.org/wik
 | PT2S     | 2 seconds delay          |
 | PT1M     | 1 minute delay           |
 | PT3.5H   | 3 hours and a half delay |
+| P6DT4H   | 6 days and 4 hours delay |
 
 ---
 


### PR DESCRIPTION
`java.time.Duration.parse()` doesn't support weeks (W), months (M) nor year (Y) notation. This can also be seen in the regex used by Java
![Screenshot 2025-07-01 at 15 09 41](https://github.com/user-attachments/assets/de6c91f8-6c5b-497a-9a00-e52a246a6104)

The editor will give a `ConstraintViolationException` when trying to use it, but I think it's good to mention it in the docs as well.