### PR TITLE
docs(timeout): mention unsupported Duration options

### DIFF
--- a/content/docs/04.workflow-components/13.timeout.md
+++ b/content/docs/04.workflow-components/13.timeout.md
@@ -49,4 +49,4 @@ tasks:
 
 ## Flow-level timeout
 
-There is no flow-level timeout. If you want to cancel a workflow execution if it exceeds a certain duration, you can leverage `MAX_DURATION`-type [SLA](./18.sla.md).
+There is no flow-level timeout. If you want to cancel a workflow execution that exceeds a specific duration, you can leverage `MAX_DURATION`-type [SLA](./18.sla.md).


### PR DESCRIPTION
Similar to https://github.com/kestra-io/docs/pull/2754 but I missed that Duration is also mentioned in timeouts. Might be best to keep this consistent.

I don't know why GitHub displays a change on the last line, there shouldn't be an edit there.