### PR TITLE
Update 13.timeout.md with runnable task limitation

### DIFF
--- a/content/docs/04.workflow-components/13.timeout.md
+++ b/content/docs/04.workflow-components/13.timeout.md
@@ -3,7 +3,7 @@ title: Task timeout
 icon: /docs/icons/flow.svg
 ---
 
-Timeout allows you to set a maximum duration for a task run.
+Timeout allows you to set a maximum duration for a [runnable task](./01.tasks/01.runnable-tasks.md).
 
 <div class="video-container">
   <iframe src="https://www.youtube.com/embed/vvD3Jg5huiE?si=M7BX8vwp7JsdUrL1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>


### PR DESCRIPTION
As long as https://github.com/kestra-io/kestra/issues/6739 is open, it might be good to mention the limitation that timeout doesn't work for flowable tasks.