### PR TITLE
feat(docs): specify Syslog tag

### DIFF
--- a/content/docs/02.installation/12.standalone-server.md
+++ b/content/docs/02.installation/12.standalone-server.md
@@ -47,6 +47,8 @@ KillMode=mixed
 TimeoutStopSec=150
 # Treat received SIGTERM as 'inactive'
 SuccessExitStatus=143
+# The syslog tag
+SyslogIdentifier=kestra
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Overrode the default `sh` tag inherited from `/bin/sh`.