### PR TITLE
docs(expressions): Split uses regex

### DIFF
--- a/content/docs/expressions/index.md
+++ b/content/docs/expressions/index.md
@@ -910,10 +910,11 @@ The `split` filter divides a string into a list based on a delimiter.
 ```
 
 **Arguments**:
-- `delimiter`: the string to split on.
+- `delimiter`: the regex to split on. Escape special characters (e.g. `split('\\.')`)
 - `limit`: limits the number of splits:
   - **Positive**: limits the array size, with the last entry containing the remaining content.
-  - **Zero or negative**: no limit on splits.
+  - **Zero**: no limit on splits, trailing empty strings will be discarded.
+  - **Negative**: no limit on splits, trailing empty strings will be included.
 
 ```twig
 {{ 'apple,banana,cherry,grape' | split(',', 2) }}


### PR DESCRIPTION
The `delimiter` of split is not a string, but a regex. Special characters needs to be escaped. See https://pebbletemplates.io/wiki/filter/split/ and the source code on https://github.com/PebbleTemplates/pebble/blob/master/pebble/src/main/java/io/pebbletemplates/pebble/extension/core/SplitFilter.java It uses [Java.split](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#split-java.lang.String-int-) which is clear on that the delimiter is a regex.

There is also a difference between zero or negative limits, which is clarified a bit.