### PR TITLE
feat: add FAB close (X) button to video modal (#2783)

### DIFF
--- a/components/home/Header.vue
+++ b/components/home/Header.vue
@@ -65,23 +65,22 @@
             'show.bs.modal': () => (videoVisible = true),
             'hidden.bs.modal': () => (videoVisible = false),
         }"
-        class="modal modal-full fade"
+        class="modal fade"
         id="home-intro"
         tabindex="-1"
         aria-labelledby="home-intro"
         aria-hidden="true"
     >
-        <button 
-        v-if="videoVisible"
-        type="button" 
-        class="floating-close-btn"
-        @click="closeVideoModal"
-        aria-label="Close video"
-        >
-            <Close />
-        </button>
-        <div class="modal-dialog">
+        <div class="modal-dialog modal-xl">
             <div class="modal-content">
+                <div class="modal-header">
+                    <button 
+                        type="button" 
+                        class="btn-close"
+                        data-bs-dismiss="modal" 
+                        aria-label="Close"
+                    ></button>
+                </div>
                 <div class="modal-body">
                     <div class="video-responsive">
                         <iframe
@@ -105,7 +104,6 @@
     import { ref } from "vue";
     import { useMediaQuery, useIntersectionObserver } from "@vueuse/core";
     import PlayCircleOutlineIcon from "vue-material-design-icons/PlayCircleOutline.vue";
-    import Close from "vue-material-design-icons/Close.vue";
 
     const isMobile = useMediaQuery('(max-width: 768px)')
 
@@ -118,22 +116,6 @@
     const riveAnimation = ref()
     const riveLoaded = ref(false)
     const riveDisabled = ref(false)
-
-    function closeVideoModal() {
-        const modal = document.getElementById('home-intro');
-        const modalInstance = (window as any).bootstrap?.Modal?.getInstance(modal);
-        
-        if (modalInstance) {
-            modalInstance.hide();
-        } else {
-            const closeBtn = document.createElement('button');
-            closeBtn.setAttribute('data-bs-dismiss', 'modal');
-            modal?.appendChild(closeBtn);
-            closeBtn.click();
-            modal?.removeChild(closeBtn);
-        }
-        videoVisible.value = false;
-    }
 
     function setupRiveAnimation() {
         const canvas = riveCanvas.value;
@@ -193,39 +175,6 @@
 
 <style lang="scss" scoped>
     @import "../../assets/styles/variable";
-
-    .floating-close-btn {
-        position: absolute;
-        top: 10px;
-        right: 10px;
-        z-index: 99999;
-        width: 30px;
-        height: 30px;
-        border: none;
-        border-radius: 50%;
-        background: white;
-        color: #000;
-        cursor: pointer;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-
-        &:hover {
-            background: rgba(255, 255, 255, 0.9);
-            transform: scale(1.05);
-        }
-
-        @include media-breakpoint-down(md) {
-            width: 25px;
-            height: 25px;
-        }
-    }
-
-    @include media-breakpoint-down(md) {
-        .modal-dialog{
-            top: 28px;
-        }
-    }
 
     .main-header {
         position: relative;
@@ -416,6 +365,17 @@
                     content: none;
                 }
             }
+        }
+    }
+
+    .modal {
+        &-xl {
+            max-width: 90vw;
+        }
+
+        &-header {
+            border: none;
+            padding: 1rem 1rem 0;
         }
     }
 </style>

--- a/components/home/Header.vue
+++ b/components/home/Header.vue
@@ -71,6 +71,17 @@
         aria-labelledby="home-intro"
         aria-hidden="true"
     >
+        <button 
+        v-if="videoVisible"
+        type="button" 
+        class="floating-close-btn"
+        @click="closeVideoModal"
+        aria-label="Close video"
+        >
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+        </button>
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-body">
@@ -108,6 +119,22 @@
     const riveAnimation = ref()
     const riveLoaded = ref(false)
     const riveDisabled = ref(false)
+
+    function closeVideoModal() {
+        const modal = document.getElementById('home-intro');
+        const modalInstance = (window as any).bootstrap?.Modal?.getInstance(modal);
+        
+        if (modalInstance) {
+            modalInstance.hide();
+        } else {
+            const closeBtn = document.createElement('button');
+            closeBtn.setAttribute('data-bs-dismiss', 'modal');
+            modal?.appendChild(closeBtn);
+            closeBtn.click();
+            modal?.removeChild(closeBtn);
+        }
+        videoVisible.value = false;
+    }
 
     function setupRiveAnimation() {
         const canvas = riveCanvas.value;
@@ -167,6 +194,40 @@
 
 <style lang="scss" scoped>
     @import "../../assets/styles/variable";
+
+    .floating-close-btn {
+        position: absolute;
+        top: 20px;
+        right: 20px;
+        z-index: 99999;
+        width: 48px;
+        height: 48px;
+        border: none;
+        border-radius: 50%;
+        background: white;
+        color: #000;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        &:hover {
+            background: rgba(255, 255, 255, 0.9);
+            transform: scale(1.05);
+        }
+
+        @include media-breakpoint-down(md) {
+            width: 35px;
+            height: 35px;
+            top: 5px;
+            right: 10px;
+
+            svg {
+                width: 15px;
+                height: 15px;
+            }
+        }
+    }
 
     .main-header {
         position: relative;

--- a/components/home/Header.vue
+++ b/components/home/Header.vue
@@ -78,9 +78,7 @@
         @click="closeVideoModal"
         aria-label="Close video"
         >
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M18 6L6 18M6 6L18 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
+            <Close />
         </button>
         <div class="modal-dialog">
             <div class="modal-content">
@@ -107,6 +105,7 @@
     import { ref } from "vue";
     import { useMediaQuery, useIntersectionObserver } from "@vueuse/core";
     import PlayCircleOutlineIcon from "vue-material-design-icons/PlayCircleOutline.vue";
+    import Close from "vue-material-design-icons/Close.vue";
 
     const isMobile = useMediaQuery('(max-width: 768px)')
 
@@ -197,11 +196,11 @@
 
     .floating-close-btn {
         position: absolute;
-        top: 20px;
-        right: 20px;
+        top: 10px;
+        right: 10px;
         z-index: 99999;
-        width: 48px;
-        height: 48px;
+        width: 30px;
+        height: 30px;
         border: none;
         border-radius: 50%;
         background: white;
@@ -217,15 +216,14 @@
         }
 
         @include media-breakpoint-down(md) {
-            width: 35px;
-            height: 35px;
-            top: 5px;
-            right: 10px;
+            width: 25px;
+            height: 25px;
+        }
+    }
 
-            svg {
-                width: 15px;
-                height: 15px;
-            }
+    @include media-breakpoint-down(md) {
+        .modal-dialog{
+            top: 28px;
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

- Adds a floating circular close (X) button to the “Kestra in 60 Seconds” video modal
- Improves UX by allowing users to easily close the modal

Closes #2783
Closes https://github.com/kestra-io/docs/issues/2786

### Update

https://github.com/user-attachments/assets/78950500-bcd4-471e-884e-d16610433273


## How to Test

- Run locally with `npm run dev`
- Open homepage
- Click “Kestra in 60 Seconds”
- Verify close button appears top-right
- Click the button and ensure modal closes
