### PR TITLE
fix(updateletter): handle responses for FAQ section email subscription form (#2807)

### DIFF
--- a/components/layout/Updateletter.vue
+++ b/components/layout/Updateletter.vue
@@ -16,24 +16,16 @@
     </div>
 </template>
 
-<script>
-    import Twitter from "vue-material-design-icons/Twitter.vue";
-    import Youtube from "vue-material-design-icons/Youtube.vue";
+<script setup>
+
     import newsletterSubmit from "../../utils/newsletterSubmit.js";
 
-    export default {
-        components: {Twitter, Youtube},
-        data() {
-            return {
-                valid: undefined,
-                message: undefined,
-            };
-        },
-        methods: {
-            checkForm: function (e) {
-                newsletterSubmit(this, e);
-            }
-        }
+    const valid = ref(false);
+    const message = ref(null);
+    const newsletter = ref(null);
+
+    function checkForm(e) {
+        newsletterSubmit({ newsletter, valid, message }, e);
     }
 </script>
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes the email subscription form on the FAQ page, addressing [#2807](https://github.com/kestra-io/kestra.io/issues/2807)

Previously, submitting the FAQ section newsletter form could not work. 


## Updated


https://github.com/user-attachments/assets/4b6794b7-e769-44c6-8268-c47ca277429f



## How to test

1. Go to the FAQ page
2. Enter a valid email in the newsletter form
3. Click Subscribe
4. You should see a success message or validation message as per need.

## Related Issue

Closes #2807
