### PR TITLE
fix(core): ensure bootstrap is available before initializing collapse.

### DIFF
--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -395,8 +395,12 @@ if (process.client) {
 
 onMounted(() => {
     if (process.client) {
-        collapse = new nuxtApp.$bootstrap.Collapse('#main-header', {
-            toggle: false
+        // Wait for bootstrap to be available
+        nextTick(() => {
+            const bootstrap = nuxtApp.$bootstrap as any;
+            collapse = bootstrap?.Collapse 
+                ? new bootstrap.Collapse('#main-header', { toggle: false })
+                : undefined;
         });
 
         document.documentElement.style.setProperty("--top-bar-height", navbar.value?.offsetHeight + "px");


### PR DESCRIPTION
This will the solve the issue with multiple authors blog. Closes #2829 

was getting error - 

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'Collapse')
    at Header.vue:398:43

```