### PR TITLE
Fix: Sort version numbers in descending order in Migration Guide

### DIFF
--- a/components/content/ChildCard.vue
+++ b/components/content/ChildCard.vue
@@ -50,6 +50,29 @@
             .where('path', 'LIKE', `${currentPageSlug}/%`)
             .where('path', 'NOT LIKE', `${currentPageSlug}/%/%`)
             .all()
+            .then(items => {
+                // Sort items by title in descending order for version numbers
+                return items.sort((a, b) => {
+                    // Extract version numbers from titles (e.g., "0.23.0" from "0.23.0")
+                    const versionA = a.title;
+                    const versionB = b.title;
+                    
+                    // Compare versions using semantic versioning
+                    const partsA = versionA.split('.').map(Number);
+                    const partsB = versionB.split('.').map(Number);
+                    
+                    for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
+                        const partA = partsA[i] || 0;
+                        const partB = partsB[i] || 0;
+                        
+                        if (partA !== partB) {
+                            return partB - partA; // Descending order (newest first)
+                        }
+                    }
+                    
+                    return 0;
+                });
+            })
     );
 
     const {data: currentPage} = await useAsyncData(

--- a/components/content/ChildCard.vue
+++ b/components/content/ChildCard.vue
@@ -49,30 +49,8 @@
         () => queryCollection(CollectionNames.docs)
             .where('path', 'LIKE', `${currentPageSlug}/%`)
             .where('path', 'NOT LIKE', `${currentPageSlug}/%/%`)
+            .order('release', 'DESC')
             .all()
-            .then(items => {
-                // Sort items by title in descending order for version numbers
-                return items.sort((a, b) => {
-                    // Extract version numbers from titles (e.g., "0.23.0" from "0.23.0")
-                    const versionA = a.title;
-                    const versionB = b.title;
-                    
-                    // Compare versions using semantic versioning
-                    const partsA = versionA.split('.').map(Number);
-                    const partsB = versionB.split('.').map(Number);
-                    
-                    for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
-                        const partA = partsA[i] || 0;
-                        const partB = partsB[i] || 0;
-                        
-                        if (partA !== partB) {
-                            return partB - partA; // Descending order (newest first)
-                        }
-                    }
-                    
-                    return 0;
-                });
-            })
     );
 
     const {data: currentPage} = await useAsyncData(


### PR DESCRIPTION
Closes #2872 

## Description:
This PR fixes the sorting order of version numbers in the Migration Guide component https://github.com/kestra-io/docs/issues/2872 .
Previously, versions were displayed in ascending order, which made it harder to see the latest changes first.
Now, the versions are sorted in descending order so that the most recent version appears at the top.

Before vs After:

<img width="1340" height="1000" alt="image" src="https://github.com/user-attachments/assets/ef393a71-4669-452c-9fbf-9ad2ad78e61a" />

<img width="1418" height="883" alt="Migration Guide" src="https://github.com/user-attachments/assets/23eb0341-f1ed-46ed-861f-e90a975288d9" />
