### PR TITLE
Fix(design): add pointer-event none to background element to allow cl…

### DIFF
--- a/components/use-cases/engineers/ExploreBlueprints.vue
+++ b/components/use-cases/engineers/ExploreBlueprints.vue
@@ -35,6 +35,7 @@
             z-index: 1;
             filter: blur(100px);
             background: linear-gradient(180deg, rgba(98, 24, 255, 0) 0%, #6117FF 100%);
+            pointer-events: none;
         }
 
         .title {


### PR DESCRIPTION
Closes: [3110](https://github.com/kestra-io/docs/issues/3110)

### Summary
Currently the middle resource card link isn't clickable due to the background element overlay. See demo in [issue](https://github.com/kestra-io/docs/issues/3110):

### Fix demo
https://github.com/user-attachments/assets/3902553d-0394-412c-9abf-34e89682d2a1

The fix approach still maintains the original design while making the card clickable through the design element.
