### PR TITLE
fix(pebble): correct return value of timestampMicro in docs

### DIFF
--- a/content/docs/expressions/index.md
+++ b/content/docs/expressions/index.md
@@ -1247,11 +1247,15 @@ The `timestamp` filter converts a date to a Unix timestamp in seconds.
 
 ### timestampMicro
 
+::alert{type="warn"}
+Previously, this expression has wrongly returned a nano-precision timestamp.
+::
+
 The `timestampMicro` filter converts a date to a Unix timestamp in microseconds.
 
 ```twig
 {{ now() | timestampMicro(timeZone="Asia/Kolkata") }}
-# output: 1720505821000180275
+# output: 1720505821182413
 ```
 
 **Arguments**:

--- a/content/docs/expressions/index.md
+++ b/content/docs/expressions/index.md
@@ -1247,7 +1247,7 @@ The `timestamp` filter converts a date to a Unix timestamp in seconds.
 
 ### timestampMicro
 
-::alert{type="warn"}
+::alert{type="warning"}
 Previously, this expression has wrongly returned a nano-precision timestamp.
 ::
 


### PR DESCRIPTION
Doc change in line with https://github.com/kestra-io/kestra/pull/11546

Closes #3125 