### PR TITLE
docs(triggers): add note on default UTC scheduling and timezone property

### DIFF
--- a/content/docs/03.tutorial/04.triggers.md
+++ b/content/docs/03.tutorial/04.triggers.md
@@ -19,6 +19,10 @@ The `trigger` definition is similar to a task definition — it contains an `id`
 
 The workflow below is triggered automatically every day at 10 AM and whenever `first_flow` finishes its execution. Both triggers are independent of each other.
 
+::::alert{type="info"}
+Schedules default to UTC. To use a different time zone, set the `timezone` property on the `Schedule` trigger (for example, `America/New_York`).
+::::
+
 ```yaml
 id: getting_started
 namespace: company.team


### PR DESCRIPTION
Add a note on the default UTC scheduling and timezone property