### PR TITLE
style(pricing): add margin-top to container for improved layout

### DIFF
--- a/pages/pricing/index.vue
+++ b/pages/pricing/index.vue
@@ -68,6 +68,7 @@
     .cont {
         overflow: clip;
         background: #121217;
+        margin-top: 62px;
 
         @include media-breakpoint-down(md) {
             background-image: url(/public/landing/pricing/visual-bg.png);


### PR DESCRIPTION
Closes https://github.com/kestra-io/docs/issues/3098
Added 62px between the header and top pricing content, suggested by @Nico-Kestra 