### PR TITLE
docs(config): add link

### DIFF
--- a/content/blogs/release-0-20.md
+++ b/content/blogs/release-0-20.md
@@ -93,7 +93,7 @@ Announcements appear as banners of the chosen type (`Info`, `Warning`, `Error`) 
 
 [System Labels](https://kestra.io/docs/concepts/system-labels) provide a powerful way to add extra metadata to manage executions. For example, they allow you to disable edits from the UI by making workflows read-only or track cross-execution dependencies using correlation IDs.
 
-Labels prefixed with `system.` are hidden in the UI unless you explicitly filter for them. If you prefer to display them by default, remove the `system.` prefix from the list of hidden prefixes in your Kestra configuration.
+Labels prefixed with `system.` are hidden in the UI unless you explicitly filter for them. If you prefer to display them by default, remove the `system.` prefix from the list of hidden prefixes in your [Kestra configuration](../docs/configuration/index.md).
 
 
 ## Flow-Level SLA (Beta)

--- a/content/blogs/release-0-22.md
+++ b/content/blogs/release-0-22.md
@@ -372,8 +372,8 @@ Kestra 0.22.0 introduces several new Pebble functions that enhance your workflow
 - **fileSize**: `{{ fileSize(outputs.download.uri) }}` — Returns the size of the file present at the given URI location.
 - **fileExists**: `{{ fileExists(outputs.download.uri) }}` — Returns true if file is present at the given URI location.
 - **fileEmpty**: `{{ isFileEmpty(outputs.download.uri) }}` — Returns true if file present at the given URI location is empty.
-- **Environment Name**: `{{ kestra.environment.name }}` — Returns the name given to your environment. This value should be configured in the Kestra configuration.
-- **Environment URL**: `{{ kestra.url }}` — Returns the environment's configured URL. This value should be configured in the Kestra configuration.
+- **Environment Name**: `{{ kestra.environment.name }}` — Returns the name given to your environment. This value should be configured in the [Kestra configuration](../docs/configuration/index.md).
+- **Environment URL**: `{{ kestra.url }}` — Returns the environment's configured URL. This value should be configured in the [Kestra configuration](../docs/configuration/index.md).
 
 
 ## Thanks to Our Contributors

--- a/content/docs/02.installation/02.docker.md
+++ b/content/docs/02.installation/02.docker.md
@@ -73,7 +73,7 @@ docker run --pull=always --rm -it -p 8080:8080 --user=root \
 
 ### Using the `KESTRA_CONFIGURATION` environment variable
 
-You can adjust the Kestra configuration by passing the `KESTRA_CONFIGURATION` variable to the Docker container via the `-e` option.
+You can adjust the [Kestra configuration](../configuration/index.md) by passing the `KESTRA_CONFIGURATION` variable to the Docker container via the `-e` option.
 This environment variable must be a valid YAML string.
 
 Managing a large configuration via a single YAML string can be tedious. To simplify this, consider using a configuration file instead.

--- a/content/docs/02.installation/03.kubernetes.md
+++ b/content/docs/02.installation/03.kubernetes.md
@@ -168,11 +168,11 @@ There are multiple ways to configure and access secrets in a Kubernetes installa
 
 ## Configuration
 
-There are two methods to adjust the Kestra configuration:
+There are two methods to adjust the [Kestra configuration](../configuration/index.md):
 - Using a Kubernetes `ConfigMap` via the `configurations` Helm value
 - Using a Kubernetes `Secret` via the `secrets` Helm value
 
-Both must be valid YAML that is merged as the Kestra configuration file.
+Both must be valid YAML that is merged as the [Kestra configuration](../configuration/index.md) file.
 
 Below is an example that shows how to enable Kafka as the queue implementation and configure its server property using a secret:
 

--- a/content/docs/02.installation/04.kubernetes-aws-eks.md
+++ b/content/docs/02.installation/04.kubernetes-aws-eks.md
@@ -29,7 +29,7 @@ kubectl get svc
 Navigate to the RDS console to create a PostgreSQL database. Once your database is created, configure the settings, ensuring the database is accessible from your EKS cluster. Make note of the database endpoint and port after creation for later use.
 
 ## Prepare an AWS S3 Bucket
-Create a private S3 bucket (i.e., with public access blocked). Keep a record of the bucket name as this is needed for the Kestra configuration.
+Create a private S3 bucket (i.e., with public access blocked). Keep a record of the bucket name as this is needed for the [Kestra configuration](../configuration/index.md).
 
 
 ## Install Kestra on AWS EKS

--- a/content/docs/02.installation/08.aws-ec2.md
+++ b/content/docs/02.installation/08.aws-ec2.md
@@ -121,7 +121,7 @@ Before attaching your Kestra server to the new database backend, initialize the 
 
 **Update Kestra configuration**
 
-In the docker-compose configuration, edit the `datasources` property of the Kestra service in the following way:
+In the Docker compose configuration, edit the `datasources` property of the Kestra service in the following way:
 
 ```yaml
 datasources:

--- a/content/docs/02.installation/09.gcp-vm.md
+++ b/content/docs/02.installation/09.gcp-vm.md
@@ -152,7 +152,7 @@ If you are just testing or would like to be able to delete your instance and all
 
 **Update Kestra configuration**
 
-In the docker-compose configuration, edit the `datasources` property of the Kestra service in the following way:
+In the Docker compose configuration, edit the `datasources` property of the Kestra service in the following way:
 
 ```yaml
 datasources:

--- a/content/docs/06.enterprise/02.governance/allowed-plugins.md
+++ b/content/docs/06.enterprise/02.governance/allowed-plugins.md
@@ -11,7 +11,7 @@ How to configure Kestra to allow or restrict specific plugins.
 
 Kestra comes with the full library of official plugins by default. However, in some cases you may want to restrict which plugins are available to specific teams or users. For example, you might allow a team to use only BigQuery tasks while blocking script execution. Kestra enables this by letting you define allowlists (`includes`) and blocklists (`excludes`) using plugin names or regular expressions.
 
-To allow specific plugins, add the `includes` attribute in your Kestra configuration file and list the approved plugins or use a regular expression. Below is an example that `includes` all plugins from the `io.kestra` package using a regular expression.
+To allow specific plugins, add the `includes` attribute in your [Kestra configuration](../../configuration/index.md) file and list the approved plugins or use a regular expression. Below is an example that `includes` all plugins from the `io.kestra` package using a regular expression.
 
 ```yaml
 kestra:
@@ -23,7 +23,7 @@ kestra:
 
 ## Restricted plugins
 
-To restrict certain plugins, add the `excludes` attribute in your Kestra configuration file and list the disallowed plugins or use a regular expression. Below is the previous example with `excludes` added to disallow the `io.kestra.plugin.core.debug.Echo` plugin.
+To restrict certain plugins, add the `excludes` attribute in your [Kestra configuration](../../configuration/index.md) file and list the disallowed plugins or use a regular expression. Below is the previous example with `excludes` added to disallow the `io.kestra.plugin.core.debug.Echo` plugin.
 
 ```yaml
 kestra:

--- a/content/docs/06.enterprise/02.governance/worker-isolation.md
+++ b/content/docs/06.enterprise/02.governance/worker-isolation.md
@@ -29,7 +29,7 @@ To only limit access to certain plugins on a Worker without requiring file path 
 
 ### `kestra.ee.java-security.forbidden-paths`
 
-This is a list of paths on the file system that the Kestra Worker will be forbidden to read or write to. This can help to protect Kestra configuration files and ensure security for audits and compliance. With this property configured, you can reduce the amount of directories that a Worker can access such as protecting access to the folders where global Kestra configuration or `~/.aws/credentials` are stored.
+This is a list of paths on the file system that the Kestra Worker will be forbidden to read or write to. This can help to protect [Kestra configuration](../../configuration/index.md) files and ensure security for audits and compliance. With this property configured, you can reduce the amount of directories that a Worker can access such as protecting access to the folders where global Kestra configuration or `~/.aws/credentials` are stored.
 
 ### `kestra.ee.java-security.authorized-class-prefix`
 

--- a/content/docs/06.enterprise/03.auth/04.authentication.md
+++ b/content/docs/06.enterprise/03.auth/04.authentication.md
@@ -17,7 +17,7 @@ Kestra provides two authentication methods:
 - Basic Auth – enabled by default
 - OpenID Connect (OIDC)
 
-By default, JWT token security is configured to use the default Kestra encryption key. If you haven't already configured it, generate a secret that is at least 256 bits and add it to your kestra configuration as follows:
+By default, JWT token security is configured to use the default Kestra encryption key. If you haven't already configured it, generate a secret that is at least 256 bits and add it to your [Kestra configuration](../../configuration/index.md) as follows:
 
 ```yaml
 kestra:

--- a/content/docs/06.enterprise/03.auth/sso/google-oidc.md
+++ b/content/docs/06.enterprise/03.auth/sso/google-oidc.md
@@ -59,7 +59,7 @@ Refer to the [Google OIDC setup documentation](https://cloud.google.com/identity
 Now that Google is set up as an OIDC provider, we need to link it to Kestra.
 
 1. **Navigate to the Kestra Configuration File**:
-   - Locate Kestra’s `yaml` configuration file.
+   - Locate Kestra’s `yaml` [configuration](../../../configuration/index.md) file.
 
 2. **Add the OIDC Settings**:
    - Add the following configuration to enable Google as an OIDC provider for Kestra:

--- a/content/docs/06.enterprise/03.auth/sso/ldap.md
+++ b/content/docs/06.enterprise/03.auth/sso/ldap.md
@@ -19,7 +19,7 @@ With Kestra, you can use an existing LDAP directory to authenticate users and sy
 
 ## Configuration
 
-LDAP is configured under the security context of your Kestra configuration file. Below is an example configuration with Kestra-specific properties on top of the Micronaut configuration.
+LDAP is configured under the security context of your [Kestra configuration](../../../configuration/index.md) file. Below is an example configuration with Kestra-specific properties on top of the Micronaut configuration.
 
 ```yaml
 micronaut:

--- a/content/docs/06.enterprise/03.auth/sso/microsoft-oidc.md
+++ b/content/docs/06.enterprise/03.auth/sso/microsoft-oidc.md
@@ -39,7 +39,7 @@ To get your `client-id` and `client-secret`, refer to the [Microsoft Documentati
 
 1. Go to **Certificates & secrets**.
 2. Under **Client secrets**, click on **New client secret**.
-3. Copy the generated secret and use it in the `{{ clientSecret }}` field in your configuration.
+3. Copy the generated secret and use it in the `{{ clientSecret }}` field in your [configuration](../../../configuration/index.md).
 
 ### Kestra Configuration
 

--- a/content/docs/06.enterprise/03.auth/sso/okta.md
+++ b/content/docs/06.enterprise/03.auth/sso/okta.md
@@ -59,7 +59,7 @@ Now that Okta is set up as an OIDC provider, we need to link it to Kestra. After
 
 ![okta-5](/docs/enterprise/sso/okta-5.png)
 
-After copying your **Client ID** and **Client Secret**, switch from the **General** tab to the **Sign On** tab. Here, you can configure your **OpenID Connect ID Token**. For this example, we will edit the issuer from Dynamic to our Okta URL. Click **Save** and copy the URL to be used in our Kestra configuration along with the Client Id and Client Secret.
+After copying your **Client ID** and **Client Secret**, switch from the **General** tab to the **Sign On** tab. Here, you can configure your **OpenID Connect ID Token**. For this example, we will edit the issuer from Dynamic to our Okta URL. Click **Save** and copy the URL to be used in our [Kestra configuration](../../../configuration/index.md) along with the Client Id and Client Secret.
 
 ![okta-6](/docs/enterprise/sso/okta-6.png)
 

--- a/content/docs/06.enterprise/06.ee-faq/index.md
+++ b/content/docs/06.enterprise/06.ee-faq/index.md
@@ -8,7 +8,7 @@ Frequently asked questions about the Cloud and Enterprise Edition of Kestra.
 
 ## My session expires too quickly. Is there a way to change the session expiration time?
 
-Yes, there is! Add the following Micronaut setting to your Kestra configuration to change the session expiration time to 10 hours:
+Yes, there is! Add the following Micronaut setting to your [Kestra configuration](../../configuration/index.md) to change the session expiration time to 10 hours:
 
 ```yaml
     environment:

--- a/content/docs/09.administrator-guide/open-telemetry.md
+++ b/content/docs/09.administrator-guide/open-telemetry.md
@@ -23,7 +23,7 @@ Starting with version 0.21, Kestra supports all three kinds of telemetry data th
 Exporting trace data in Kestra is currently a Beta feature.
 :::
 
-The first step is to enable distributed traces inside the Kestra configuration file:
+The first step is to enable distributed traces inside the [Kestra configuration](../configuration/index.md) file:
 
 ```yaml
 kestra:

--- a/content/docs/11.migration-guide/0.24.0/basic-authentication.md
+++ b/content/docs/11.migration-guide/0.24.0/basic-authentication.md
@@ -9,7 +9,7 @@ editions: ["OSS"]
 
 Basic authentication (`username` and `password`) is now required to enhance security on open-source instances. All users must log in to access the Kestra UI and API, even if they are running Kestra locally or in a development environment. This change is designed to prevent unauthorized access to your Kestra instance and ensure that only authenticated users can view and manage flows.
 
-The credentials can be configured from the Setup Page in the UI (http://localhost:8080/ui/main/setup) or you can set them manually in the Kestra configuration file under `basic-auth` (recommended for production):
+The credentials can be configured from the Setup Page in the UI (http://localhost:8080/ui/main/setup) or you can set them manually in the [Kestra configuration](../../configuration/index.md) file under `basic-auth` (recommended for production):
 
 ```yaml
 kestra:

--- a/content/docs/15.how-to-guides/keycloak.md
+++ b/content/docs/15.how-to-guides/keycloak.md
@@ -50,7 +50,7 @@ You can retrieve `clientId` and `clientSecret` via KeyCloak user interface
 ![alt text](/docs/how-to-guides/keycloak/clientSecret.png)
 
 
-Don't forget to set a default role in your Kestra configuration to streamline the process of adding new users.
+Don't forget to set a default role in your [Kestra configuration](../configuration/index.md) to streamline the process of adding new users.
 
 ```
 kestra:

--- a/content/docs/16.scripts/bind-mount.md
+++ b/content/docs/16.scripts/bind-mount.md
@@ -11,7 +11,7 @@ To run a script stored locally, you can bind-mount it to your Kestra container.
 
 Bind-mounting local scripts to the Kestra server can also make the local scripts available to the Docker containers running the script tasks. This is useful when you want to test a script and you don't want to use Namespace Files.
 
-First, make sure that your Kestra configuration in the [Docker Compose file](https://github.com/kestra-io/kestra/blob/develop/docker-compose.yml) allows volume mounting. Below is an example with the intended setting in the final line:
+First, make sure that your [Kestra configuration](../configuration/index.md) in the [Docker Compose file](https://github.com/kestra-io/kestra/blob/develop/docker-compose.yml) allows volume mounting. Below is an example with the intended setting in the final line:
 
 ```yaml
   kestra:

--- a/content/docs/ai-tools/ai-copilot.md
+++ b/content/docs/ai-tools/ai-copilot.md
@@ -19,7 +19,7 @@ The AI Copilot is designed to help build and modify flows directly from natural 
 
 ## Configuration
 
-To add Copilot to your flow editor, add the following to your Kestra configuration:
+To add Copilot to your flow editor, add the following to your [Kestra configuration](../configuration/index.md):
 
 ```yaml
 kestra:


### PR DESCRIPTION
After a comment on YouTube about not knowing where to add something to the Kestra configuration for AI Copilot, I’ve gone through and added links to mentions of it so it’s easier for new people to figure out where it is so they can modify it.

Checking all links have been added before merging.