### PR TITLE
docs(config): link examples to queue section

### DIFF
--- a/content/docs/configuration/index.md
+++ b/content/docs/configuration/index.md
@@ -110,6 +110,8 @@ kestra:
     type: postgres
 ```
 
+See [database](#database) for details.
+
 ### Repository configuration
 
 Repositories must match the queue type:


### PR DESCRIPTION
Wasn't sure on what to put in my config but later found this example. It's linked for the repository, but not for queue so thought I'd link it there too.