### PR TITLE
fix(docs): remove extra space in API docs

### DIFF
--- a/components/content/ApiDocee.vue
+++ b/components/content/ApiDocee.vue
@@ -11,11 +11,6 @@
             allow-try="false"
             regular-font="Public Sans"
             mono-font="Source Code Pro"
-            style="
-                --textarea-height: auto;
-                --textarea-min-height: 100px;
-                --code-block-max-height: 600px;
-            "
         />
     </ClientOnly>
 </template>
@@ -30,6 +25,9 @@
     rapi-doc {
         background: transparent;
         width: 100%;
+        --textarea-height: auto;
+        --textarea-min-height: 100px;
+        --code-block-max-height: 600px;
 
         &::part(section-endpoint) {
             white-space: nowrap;


### PR DESCRIPTION
**Before**

<img width="865" height="764" alt="image" src="https://github.com/user-attachments/assets/b1e047aa-1a0c-429c-bc1b-8c15cc384233" />

**After**

<img width="865" height="764" alt="image" src="https://github.com/user-attachments/assets/d3002a49-1742-43d8-b185-4fa77d09102f" />

fixes #3210 