### PR TITLE
fix: duplicate-serp-titles

### DIFF
--- a/composables/useContentHead.ts
+++ b/composables/useContentHead.ts
@@ -13,10 +13,6 @@ export default function useContentHead(page: Ref<undefined | {title?:string, des
 
     const {origin} = useRequestURL()
 
-    useHead({
-        title: title.value
-    })
-
     useSeoMeta({
         title: title.value,
         description: description.value,

--- a/server/api/sitemap.ts
+++ b/server/api/sitemap.ts
@@ -40,7 +40,8 @@ const generateDefaultSitemap = async () => {
                     }
                     return asSitemapUrl({
                         loc: loc,
-                        _sitemap: sitemapInput.sitemap ?? 'default'
+                        _sitemap: sitemapInput.sitemap ?? 'default',
+                        lastmod: new Date().toISOString()
                     });
                 })
                 .filter(value => value !== null)


### PR DESCRIPTION
closes: #2860

✅ Removed redundant useHead call to prevent duplicate titles