### PR TITLE
fix: add-full-text-search

### DIFF
--- a/components/blueprints/Lists.vue
+++ b/components/blueprints/Lists.vue
@@ -5,7 +5,7 @@
             <h1 data-aos="fade-left">Blueprints</h1>
             <h4 data-aos="fade-right">The first step is always the hardest. Explore blueprints to kick-start your next flow.</h4>
             <div class="col-12 search-input position-relative">
-                <input type="text" class="form-control form-control-lg" placeholder="Search across 250+ of blueprints" v-model="searchQuery">
+                <input type="text" class="form-control form-control-lg" placeholder="Search across 250+ blueprints by title or content" v-model="searchQuery">
                 <Magnify class="search-icon" />
             </div>
         </div>
@@ -141,7 +141,7 @@ watch([currentPage, itemsPerPage, searchQuery, activeTags], ([pageVal, itemVal, 
         clearTimeout(timer)
       }
   timer = setTimeout(async () => {
-      const { data } = await useFetch(`${config.public.apiUrl}/blueprints/versions/latest?page=${(itemVal != oldItemVal) ? 1 : pageVal}&size=${itemVal}${!!activeTagsVal.map(item => item.id).join(',') ? `&tags=${activeTagsVal.map(item => item.id).join(',')}` : ''}${searchVal.length ? `&q=${searchVal}` : ''}`)
+      const { data } = await useFetch(`${config.public.apiUrl}/blueprints/versions/latest?page=${(itemVal != oldItemVal) ? 1 : pageVal}&size=${itemVal}${!!activeTagsVal.map(item => item.id).join(',') ? `&tags=${activeTagsVal.map(item => item.id).join(',')}` : ''}${searchVal.length ? `&q=${searchVal}&searchContent=true` : ''}&includeContent=true`)
       setBlueprints(data.value.results, data.value.total)
 
         function getQuery() {

--- a/components/home/Blueprints.vue
+++ b/components/home/Blueprints.vue
@@ -15,7 +15,7 @@
 import { useBlueprintsList } from '~/composables/useBlueprintsList.js'
 const { data: blueprintsData } = await useAsyncData(
   `blueprints`,
-  () => useBlueprintsList({ page: 1, size: 20 })
+  () => useBlueprintsList({ page: 1, size: 20, includeContent: true })
 )
 const blueprints = computed(() => blueprintsData.value?.results ?? [])
 </script>

--- a/composables/useBlueprintsList.js
+++ b/composables/useBlueprintsList.js
@@ -1,11 +1,11 @@
 export async function useBlueprintsList({ page = 1, size = 24, tags = '', q = '' } = {}) {
     const config = useRuntimeConfig();
-    let apiUrl = `${config.public.apiUrl}/blueprints/versions/latest?page=${page}&size=${size}`;
+    let apiUrl = `${config.public.apiUrl}/blueprints/versions/latest?page=${page}&size=${size}&includeContent=true`;
     if (tags) {
         apiUrl += `&tags=${tags}`;
     }
     if (q) {
-        apiUrl += `&q=${q}`;
+        apiUrl += `&q=${q}&searchContent=true`;
     }
     const data = await $fetch(apiUrl);
     const shuffledResults = [...data.results].sort(() => Math.random() - 0.5);

--- a/pages/blueprints/index.vue
+++ b/pages/blueprints/index.vue
@@ -23,4 +23,7 @@
     const {data: tags} = await useAsyncData('blueprints-tags', () => {
         return $fetch(`${config.public.apiUrl}/blueprints/versions/latest/tags`)
     })
+    await useAsyncData('blueprints-preload', () => {
+        return $fetch(`${config.public.apiUrl}/blueprints/versions/latest?includeContent=true&size=24`)
+    })
 </script>

--- a/server/api/blueprint.js
+++ b/server/api/blueprint.js
@@ -17,8 +17,7 @@ export default defineEventHandler(async (event) => {
             return {message: "Not Found"};
         }
         
-        if (pageData.tags && pageData.tags.length > 0) {
-            const data = await $fetch(`${config.public.apiUrl}/blueprints/versions/latest?tags=${pageData.tags}`)
+        if (pageData.tags && pageData.tags.length > 0) {const data = await $fetch(`${config.public.apiUrl}/blueprints/versions/latest?tags=${pageData.tags}&includeContent=true`)
             if (data) {
                 const shuffleBlueprints = arr => arr.sort(() => Math.random() - 0.5);
                 relatedBlueprints = shuffleBlueprints(data.results.filter(b => b.id !== pageData.id)).slice(0, 3);


### PR DESCRIPTION
closes: #1623

✅ Added `includeContent=true` parameter when fetching related blueprints in the API endpoint.
✅ Updated the Blueprints list composable to include content in search queries.
✅ Updated search placeholder text and API calls in the Blueprints list component.
✅ Added pre-fetching of blueprints with content for search in the index page.
✅ Ensured the home page blueprints component includes content for search.