### PR TITLE
docs(ai-copilot): add note on using Docker internal URL for Ollama connection

### DIFF
--- a/content/docs/ai-tools/ai-copilot.md
+++ b/content/docs/ai-tools/ai-copilot.md
@@ -222,9 +222,9 @@ kestra:
       base-url: http://localhost:11434
 ```
 
-:::alert{type="info"}
-Depending on your configuration, if Ollama is running locally on the host machine and Kestra is running inside a container, and if you are encountering an error while connecting, you should use the Docker internal URL instead of localhost to access Ollama from the Kestra instance. For example, use `http://host.docker.internal:11434` as the base URL.
-:::
+::alert{type="info"}
+If Ollama is running locally on your host machine while Kestra is running inside a container, connection errors may occur when using `localhost`. In this case, use the Docker internal network URL instead — for example, set the base URL to `http://host.docker.internal:11434`.
+::
 
 ### OpenAI
 


### PR DESCRIPTION
add note on using Docker internal URL for Ollama connection