### PR TITLE
fix(blueprints): clarify filtering options for tags in Blueprints documentation

### DIFF
--- a/content/docs/05.concepts/07.blueprints.md
+++ b/content/docs/05.concepts/07.blueprints.md
@@ -44,7 +44,7 @@ Blueprints are accessible from two places in the UI:
 Once you are on the Blueprints page, you can:
 
 - **Search** Blueprints for a specific use case or integration, e.g., Snowflake, BigQuery, DuckDB, Slack, ETL, ELT, Pandas, GPU, Git, Python, Docker, Redis, MongoDB, dbt, Airbyte, Fivetran, etc.
-- **Filter** by a tag, e.g., filter for Docker, to see various ways to run containers in your flow. Or filter for Notifications to see several options for configuring alerts on success or failure.
+- **Filter** by one or multiple tags, e.g., filter for Docker to see various ways to run containers in your flow, or filter for Notifications to see several options for configuring alerts on success or failure.
 
 ## Custom Blueprints
 


### PR DESCRIPTION
Clarify filtering options for tags in Blueprints documentation, as now we select multiple filters at the same time.