### PR TITLE
docs(kv-secrets-metadata-migration): fix missing "s" in command

### DIFF
--- a/content/docs/11.migration-guide/1.1.0/kv-secrets-metadata-migration.md
+++ b/content/docs/11.migration-guide/1.1.0/kv-secrets-metadata-migration.md
@@ -34,7 +34,7 @@ and then do the same with
 ```yaml
 kestra:
   image: registry.kestra.io/docker/kestra:latest
-  command:  migrate metadata secret
+  command:  migrate metadata secrets
 ```
 
 Once the migration is complete, the container will stop automatically. You can then move back to the usual command to run the server:


### PR DESCRIPTION
`migrate metadata secret` to `migrate metadata secret**s**`