### PR TITLE
docs: Update admin password example in CLI documentation

### DIFF
--- a/content/docs/server-cli/index.md
+++ b/content/docs/server-cli/index.md
@@ -521,7 +521,7 @@ Create a user.
 **Options**: `--groups`, `--tenant`, `--admin`, `--superadmin`, `--if-not-exists`
 
 ```bash
-kestra auths users create --superadmin --tenant=default admin admin_password123
+kestra auths users create --superadmin --tenant=default admin Admin_password@123
 ```
 
 ### `kestra auths users create-basic-auth`


### PR DESCRIPTION
The current example password will not work, and it will give an error because it does not match the password policy

<img width="1305" height="337" alt="Screenshot 2025-12-01 at 2 02 48 PM" src="https://github.com/user-attachments/assets/c8617add-b5bd-4206-b61c-5063c1d996d8" />
