### PR TITLE
fix(core) improve contrast of search field on focus

### DIFF
--- a/components/content/GuidesChildCard.vue
+++ b/components/content/GuidesChildCard.vue
@@ -265,6 +265,10 @@
                     color: $white-3;
                     font-size: $font-size-sm !important;
                 }
+                &:focus {
+                    background-color: $black-2 !important;
+                    color: $white;
+                }
             }
         }
     }


### PR DESCRIPTION
### Problem
When the search field on the How To page receives focus in dark mode, the background turns white while the text remains white, making the input unreadable.

### What I Changed
Updated GuidesChildCard.vue to apply proper dark-mode styling to the focused input search bar.

closes #3424 

### Screenshots
Before:
<img width="929" height="188" alt="Screenshot 2025-12-07 215346" src="https://github.com/user-attachments/assets/4f130540-3a51-4484-a037-c92af35b640f" />

After:
<img width="929" height="187" alt="Screenshot 2025-12-07 215246" src="https://github.com/user-attachments/assets/0bd452cf-b1c6-40cd-9220-5438004a6218" />