### PR TITLE
fix(#3331): unify list and paragraph font size for consistency

### DIFF
--- a/assets/styles/docs.scss
+++ b/assets/styles/docs.scss
@@ -274,7 +274,7 @@ $bd-gutter-x: 3rem;
     p, li {
         color: $white;
         line-height: 1.75rem;
-        font-size: $font-size-md;
+        font-size: $h6-font-size;
 
         a {
             color: $purple-36;


### PR DESCRIPTION
### Summary
This PR addresses an inconsistency where list items were rendered at `1rem` while normal text was `1.125rem`, creating a visual imbalance when used together.

Fixes #3331 

### What Changed
Updated the relevant SCSS rule to ensure list items use the same font size as normal text for visual consistency - `1.125rem` using the variable `h6-font-size`.

### Before
<img width="941" height="603" alt="1 125 rem" src="https://github.com/user-attachments/assets/cac09fcb-c822-4866-b132-7daea0d59754" />


### After
<img width="942" height="646" alt="1 125 rem (1)" src="https://github.com/user-attachments/assets/b845821c-65bf-4024-a906-87ff7a06aee9" />
