### PR TITLE
fix(ui): make edition badges clickable with proper navigation links

### DIFF
--- a/assets/styles/docs.scss
+++ b/assets/styles/docs.scss
@@ -266,6 +266,11 @@ $bd-gutter-x: 3rem;
         vertical-align: baseline;
         margin-left: 1px;
     }
+
+    a.badge[target="_blank"]::after {
+        display: none;
+        content: none;
+    }
 }
 
 

--- a/components/content/Badge.vue
+++ b/components/content/Badge.vue
@@ -3,12 +3,13 @@
         <p class="mb-0">Available on:</p>
         <span v-if="version" class="badge d-flex align-items-center bg-body-tertiary">{{version}}</span>
     <component
-        :is="editionInfo(edition).link ? 'a' : 'span'"
-        v-for="edition in editions.split(',').filter(edition => edition.trim())"
-        :key="edition"
-        :href="editionInfo(edition).link"
-        class="badge d-flex align-items-center text-decoration-none"
-        :class="`bg-${editionInfo(edition).color}`"
+      :is="editionInfo(edition).link ? 'a' : 'span'"
+      v-for="edition in editions.split(',').filter(edition => edition.trim())"
+      :key="edition"
+      :href="editionInfo(edition).link"
+      :target="editionInfo(edition).link ? '_blank' : undefined"
+      class="badge d-flex align-items-center text-decoration-none"
+      :class="`bg-${editionInfo(edition).color}`"
     >
         {{ editionInfo(edition).label }}
     </component>

--- a/components/docs/FeatureScopeMarker.vue
+++ b/components/docs/FeatureScopeMarker.vue
@@ -7,6 +7,7 @@
                 :key="edition"
                 v-if="edition"
                 :href="editionInfo(edition).link"
+                :target="editionInfo(edition).link ? '_blank' : undefined"
                 class="badge d-flex align-items-center text-decoration-none"
                 :class="`bg-${editionInfo(edition).color}`"
             >


### PR DESCRIPTION
closes #3482 

Changes: 

- Badge and FeatureScopeMarker components now render as clickable links
- Added link properties for all edition types:
  - OSS: https://kestra.io/features
  - EE: https://kestra.io/enterprise
  - Cloud: https://kestra.io/cloud
- Updated components to dynamically render as 'a' or 'span' based on link availability
- Added TypeScript type support for optional link property
- Maintains backward compatibility with badges that have no link defined

Fixes: Fixes non-clickable edition badges by adding proper navigation links.

Screen Recording:

https://github.com/user-attachments/assets/571572df-2af9-4e16-a37c-b58afd2a8056

