### PR TITLE
docs(variables): fix FAQ

### DIFF
--- a/content/docs/04.workflow-components/04.variables.md
+++ b/content/docs/04.workflow-components/04.variables.md
@@ -144,7 +144,7 @@ To ensure that a block of code won't be parsed by Pebble, you can use the `{% ra
 
 [Inputs](./05.inputs.md) are resolved first, before the execution starts. If a flow has an invalid input value, the execution will not be created.
 
-Therefore, you can use inputs within variables, but you cannot use variables or Pebble expressions in most contexts (Check out [Dynamic Inputs](../04.workflow-components/05.inputs.md#dynamic-inputs) for more information) within inputs.
+Therefore, you can use inputs within variables, but you cannot use variables or Pebble expressions in most contexts (Check out [Dynamic Inputs](./05.inputs.md#dynamic-inputs) for more information) within inputs.
 
 [Expressions](../expressions/index.md) are rendered recursively: if a variable references another variable, the inner one is resolved first.
 


### PR DESCRIPTION
So Variables can be used in Triggers. Inputs cannot be used in a Trigger without a default value. A variable can be used in a trigger to set an input.

Hard to follow Slack thread: https://kestra-io.slack.com/archives/C04HTFM3VL6/p1765962037837089