### PR TITLE
fix(core): tags casing should match API response

### DIFF
--- a/components/home/BlueprintsCarousel.vue
+++ b/components/home/BlueprintsCarousel.vue
@@ -3,7 +3,7 @@
         <button class="navigation navigation-left" @click="scrollLeft"><ArrowLeftIcon/></button>
         <button class="navigation navigation-right" @click="scrollRight"><ArrowRightIcon/></button>
         <div class="blueprints-carousel" ref="wrapper">
-            <BlueprintsListCard v-for="blueprint in blueprints" :key="blueprint.id" :blueprint="blueprint" :tags="tagsList" :href="`/blueprints/${blueprint.id}`"/>
+            <BlueprintsListCard v-for="blueprint in blueprints" :key="blueprint.id" :blueprint="blueprint" :tags :href="`/blueprints/${blueprint.id}`"/>
         </div>
     </div>
 </template>
@@ -12,16 +12,11 @@
 import ArrowLeftIcon from "vue-material-design-icons/ArrowLeft.vue"
 import ArrowRightIcon from "vue-material-design-icons/ArrowRight.vue"
 
+const config = useRuntimeConfig();
+
 defineProps<{
     blueprints: {id: string}[]
 }>()
-
-// Fetch tags API
-const config = useRuntimeConfig();
-const { data: tags } = await useAsyncData<Array<{id: string, name: string}>>('blueprints-tags-carousel', () => {
-    return $fetch(`${config.public.apiUrl}/blueprints/versions/latest/tags`)
-});
-const tagsList = computed(() => tags.value ?? []);
 
 const wrapper = ref<HTMLElement | null>(null)
 
@@ -36,6 +31,11 @@ const scrollRight = () => {
         wrapper.value.scrollTo({left:wrapper.value.scrollLeft + 400, behavior: 'smooth'})
     }
 }
+
+const { data: tags } = await useAsyncData<Array<{id: string, name: string}>>('blueprints-tags', () => {
+    return $fetch(`${config.public.apiUrl}/blueprints/versions/latest/tags`)
+});
+
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
Closes https://github.com/kestra-io/docs/issues/3548.

## Background

Fix for tags casing which should match API response.

### References

- https://github.com/kestra-io/docs/issues/3548

## Changes

- Fetch tags from API in _BlueprintsCarousel_ component and pass them as props 
to _BlueprintsListCard_ to ensure tags display with correct casing (matching 
API response) instead of lowercase.

## Areas of Impact

- _components/home/BlueprintsCarousel.vue_

## Screenshot

- **Before Fix:** tags in lowercase 
<img width="1916" height="1052" alt="Screenshot 2025-12-29 at 7 38 35 PM" src="https://github.com/user-attachments/assets/1ae2e55f-66e3-4ab3-8b40-87c632aaeb9f" /> 

<br>

- **After Fix:** tags as per API Response
<img width="1916" height="1052" alt="Screenshot 2025-12-29 at 7 39 03 PM" src="https://github.com/user-attachments/assets/12de52de-c34c-4efe-912b-6dd5b2159759" />
