### PR TITLE
docs(redirects): fixes for 404s in getting started refactor

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -386,7 +386,10 @@ export default defineNuxtConfig({
         '/docs/getting-started/community-guidelines': {redirect: '/docs/contribute-to-kestra/community-guidelines'},
         '/docs/getting-started/': {redirect: '/docs/quickstart'},
         '/docs/getting-started/selected-plugin-installation': {redirect: '/docs/how-to-guides/selected-plugin-installation'},
-        '/docs/getting-started/plugins': {redirect: '/plugins'}
+        '/docs/getting-started/plugins': {redirect: '/plugins'},
+        '/docs/getting-started/workflow-components': {redirect: '/docs/workflow-components'},
+        '/docs/getting-started/migration-guide': {redirect: '/docs/migration-guide'},
+        '/docs/getting-started/installation': {redirect: '/docs/installation'}
     },
 
     build: {


### PR DESCRIPTION
Came up on a Google Search Console report, but this only includes fixes for the 404s from the getting started refactor work. 

I think these will 301 by default, but we should manually validate the fix with GSC. 