### PR TITLE
DO NOT MERGE! docs(sitemap): add docs sitemap

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -60,6 +60,9 @@ export default defineNuxtConfig({
                 includeAppSources: true,
                 sources: ['/api/sitemap']
             },
+            docs: {
+                sources: ['/api/sitemap']
+            },
             plugins: {
                 sources: ['/api/sitemap']
             },


### PR DESCRIPTION
**DO NOT MERGE!**

We have several sitemaps, but none of them include docs content. This seems to follow the same pattern as plugins and blueprints to add a sitemap, but may not be how we want to ultimately resolve this.

- https://kestra.io/sitemap_index.xml
  - https://kestra.io/__sitemap__/default.xml
  - https://kestra.io/__sitemap__/plugins.xml
  - https://kestra.io/__sitemap__/blueprints.xml

**DO NOT MERGE!**