### PR TITLE
website: remove period from menu item

### DIFF
--- a/utils/menu-items.ts
+++ b/utils/menu-items.ts
@@ -234,7 +234,7 @@ export const menuItems: MenuItems = {
             },
             {
                 icon: Flare,
-                title: "Quickstart installation guide.",
+                title: "Quickstart installation guide",
                 description: "Trust kestra as your unified orchestration tool",
                 link: "/docs/installation"
             }


### PR DESCRIPTION
Hovering over "Learn" I see one of the options ends in a period. I assume this was just a typo so I removed it.

Since it links into the docs, I added docs reviewers.