### PR TITLE
(docs): explain uri vs. value in outputs of plugins

### DIFF
--- a/src/contents/docs/14.best-practices/0.flows/index.md
+++ b/src/contents/docs/14.best-practices/0.flows/index.md
@@ -54,6 +54,10 @@ This feature is best suited for small datasets, such as querying a few rows to f
 For large data volumes, use the `stores` property instead. Stored outputs are written to Kestra’s internal storage, and only the file URL is referenced in the execution context.
 :::
 
+Some plugins have outputs that include both a `value` and a `uri`. The `store` property for these plugins is set to `false` by default and should typically only be used with small data volumes. This property should be adjusted for larger data volumes to make file URIs available. 
+
+When `store` is set to `false` or the default value, the output will include a `value`, which is accessible through a Pebble expression like `"{{ outputs.task.value }}"`. When `store` is set to `true`, `value` is not accessible but instead the file URI is accessible through a Pebble expression like `"{{ outputs.task.uri }}"`. `value` and `uri` are not available outputs at the same time. Trying to access `value` when `store: true` will cause an execution error.
+
 ## Parallel tasks
 
 The [Parallel](/plugins/core/tasks/flows/io.kestra.plugin.core.flow.Parallel) task helps reduce overall flow duration by running multiple branches simultaneously.


### PR DESCRIPTION
Since this behavior is expected (URI and value are not available together in outputs), I wanted to put this somewhere we could reference it for several plugins. This was the best place I could find, but I'm open to suggestions of other places.

This was also a bit tricky to explain. The execution error comes across as a user error, which is why I wanted to explicitly mention this in the docs.

In the most simplistic way, if `store: true` then outputs does NOT include `value` and only includes a `uri`. If `store: false` (the default value) then outputs does NOT include `uri` and only includes `value`. 


Related internal conversation - https://kestra-io.slack.com/archives/C07KA8R1K0F/p1769182856745799