### PR TITLE
(faq): add general orchestration questions

### DIFF
--- a/src/components/plugins/Faq.vue
+++ b/src/components/plugins/Faq.vue
@@ -5,6 +5,8 @@
 <script setup lang="ts">
     import Faq from "~/components/price/Faq.vue"
 
+    // update to be more plugin focused? Are these references anywhere else? 
+
     const faqItems = [
         {
             question: "Is it easy to upgrade from Open Source edition to Kestra Enterprise?",

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -30,6 +30,14 @@ const description = "Get responses on all your common questions about Kestra"
                     integration with various tools and services.
                 </p>
             </CustomDetails>
+            <CustomDetails title="What is an orchestrator?">
+                <p>An orchestrator is a system that coordinates multiple interconnected steps and dependencies into a single,
+                    automated workflow. Effective orchestration handles triggers, manages dependencies, maintains state, 
+                    and provides visibility—all without requiring teams to rebuild processes from scratch every time.</p>
+
+                <p>Some orchestrators are general, while others, like data orchestrators, are more purpose built. Kestra
+                    can handle a variety of orchestration use cases. You can read more about orchestration on our <a target="_blank" href="/blog/orchestration-differences">blog.</a></p>
+            </CustomDetails>
             <CustomDetails
                 title="What is a declarative orchestrator?"
                 client:visible
@@ -82,6 +90,11 @@ const description = "Get responses on all your common questions about Kestra"
                         refactoring.
                     </li>
                 </ol>
+            </CustomDetails>
+            <CustomDetails title="When should you consider an orchestrator?">
+                <p>You should consider an orchestrator when you have a growing complexity in automating tasks, managing
+                    dependencies, or coordinating multiple systems across different teams. Put more basically, you should
+                    consider an orchestrator when you are looking to scale.</p>
             </CustomDetails>
             <CustomDetails
                 title="Who can benefit from using Kestra?"


### PR DESCRIPTION
I closed the [original PR](https://github.com/kestra-io/docs/pull/3593) since it was opened before the Astro migration. 

I added several questions on general orchestration topics, and linked to a general orchestration blog.