### PR TITLE
(website): adjust FooterContact links

### DIFF
--- a/src/components/layout/FooterContact.astro
+++ b/src/components/layout/FooterContact.astro
@@ -15,9 +15,9 @@ const {
     title = "Getting Started",
     subtitle,
     darkButtonText,
-    darkButtonHref = "/docs/terraform",
+    darkButtonHref = "/docs",
     purpleButtonText,
-    purpleButtonHref = "https://github.com/kestra-io/kestra",
+    purpleButtonHref = "/docs/quickstart",
     animation = true,
 } = Astro.props
 

--- a/src/components/layout/FooterContact.vue
+++ b/src/components/layout/FooterContact.vue
@@ -51,7 +51,7 @@
             darkButtonHref: {
                 type: String,
                 required: false,
-                default: () => "/docs/terraform",
+                default: () => "/docs",
             },
             purpleButtonText: {
                 type: String,
@@ -60,7 +60,7 @@
             purpleButtonHref: {
                 type: String,
                 required: false,
-                default: () => "https://github.com/kestra-io/kestra",
+                default: () => "/docs/quickstart",
             },
             animation: {
                 type: Boolean,


### PR DESCRIPTION
The Get Started FooterContact widget's "Read the Docs" button goes to https://kestra.io/docs/terraform for all our vs pages (vs. Airflow, etc.). "Get Started" goes to GitHub. Both of these seem like a mistake, although I'm not sure how broadly they are used.

There are actually two files for the FooterContact, `.vue` and `.astro`. I changed both in this PR for consistency. 

Internal Slack convo - https://kestra-io.slack.com/archives/C04MCSCFWHJ/p1770236199740589