### PR TITLE
Clean up comment/uncomment keyboard shortcut note

### DIFF
--- a/src/contents/docs/03.tutorial/01.fundamentals/index.md
+++ b/src/contents/docs/03.tutorial/01.fundamentals/index.md
@@ -148,7 +148,7 @@ When you want to tweak a flow step by step without rerunning everything, use the
 Kestra supports [hundreds of tasks](/plugins) integrating with various external systems. It's not necessary nor possible to memorize all potential tasks or properties (maybe one day) Use the shortcut `CTRL + SPACE` on Windows/Linux or `fn + control + SPACE` on macOS to trigger autocompletion to list available tasks or properties of a given task. Kestra also has built-in documentation accessible through the UI for Flow, Task, and Trigger properties, so you don't have to context switch between building a flow and learning the ins and outs of a component.
 
 :::alert{type="info"}
-If you want to comment out part of your code, use `CTRL + K + C` on Windows/Linux or `⌘ + fn + K + C` on macOS. To uncomment, use `CTRL + K + U` on Windows/Linux or `⌘ + fn + K + U` on macOS. All available keyboard shortcuts are listed in the code editor context menu.
+If you want to comment or uncomment out part of your code, use `CTRL + /` on Windows/Linux or `⌘ + /` on macOS. All available keyboard shortcuts are listed in the code editor context menu.
 :::
 
 ---


### PR DESCRIPTION
We have 3 different ways to comment/uncomment with keyboard shortcuts, so I'd like to clean this up a bit to just have the one method mentioned. 