### PR TITLE
fix: add spacing between name and title in homepage testimonials

### DIFF
--- a/src/components/home/EnterpriseQuotesRender.vue
+++ b/src/components/home/EnterpriseQuotesRender.vue
@@ -268,6 +268,8 @@
         }
 
         .quote-author {
+            display: flex;
+            gap: 6px;
             font-size: 1rem;
             white-space: normal;
 


### PR DESCRIPTION
- Fixes missing space between author name and title in the homepage testimonials carousel (e.g. "Ernesto VargasCTO" → "Ernesto Vargas CTO")
- Adds `display: flex` and `gap: 6px` to the `.quote-author` class in `EnterpriseQuotesRender.vue`
- Resolves #4048

### Screenshots

<img width="3836" height="1856" alt="image 2026-02-21 at 10 27 26@2x" src="https://github.com/user-attachments/assets/c6516b63-9500-41b6-b71b-9dbf7462e6c3" />
- Desktop


<img width="1198" height="1182" alt="image 2026-02-21 at 10 27 43@2x" src="https://github.com/user-attachments/assets/f25893be-f995-4176-8855-dbc08297c064" />
- Mobile