### PR TITLE
(docs): remove mermaid source, pngs used instead

### DIFF
--- a/src/contents/docs/05.workflow-components/17.states/index.md
+++ b/src/contents/docs/05.workflow-components/17.states/index.md
@@ -40,44 +40,6 @@ Here is a brief description of each state:
 12. **KILLING**: This transient state indicates that the user has issued a command to kill the execution, e.g., via a task or by clicking on the `Kill` button in the UI. The system is terminating (killing) any task runs still in progress. As soon as all task runs are terminated, the execution will transition to the `KILLED` state.
 13. **KILLED**: This terminal state indicates that the execution has been killed upon request by the user. No more tasks will be able to run, and the execution is considered terminated.
 
-:::collapse{title="Mermaid source code for the Execution States diagram"}
-
-```mermaid
-graph LR;
-    classDef transient fill:#0ff,stroke:#333,stroke-width:2px;
-    classDef terminal fill:#f9f,stroke:#333,stroke-width:2px;
-
-    subgraph Legend
-        direction TB
-        L1[Transient State]:::transient
-        L2[Terminal State]:::terminal
-    end
-
-    A[CREATED] -->|Wait for free slot| B[QUEUED]
-    A -->|Start execution| C[RUNNING]
-    B -->|Slot available| C[RUNNING]
-    C -->|Execution completed without errors| D[SUCCESS]
-    C -->|Tasks emitted warnings| E[WARNING]
-    C -->|One or more tasks failed| F[FAILED]
-    F -->|Retry failed tasks| G[RETRYING]
-    G -->|Retry succeeded| D[SUCCESS]
-    G -->|Retry exhausted| F[FAILED]
-    F -->|Retry by creating a new execution| H[RETRIED]
-    C -->|Manual approval or pause| I[PAUSED]
-    I -->|Resume execution| C[RUNNING]
-    F -->|Restart execution| J[RESTARTED]
-    J -->|Restart processed| C[RUNNING]
-    A -->|System cancelled execution| K[CANCELLED]
-    C -->|User  killed execution| L[KILLING]
-    L -->|Tasks terminated| M[KILLED]
-
-    class A,B,C,G,I,J,L transient;
-    class D,E,F,H,K,M terminal;
-
-    linkStyle 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16 stroke:#2a9d8f, stroke-width:3px;
-```
-:::
-
 ## What is the difference between the `CANCELLED` and `KILLED` states?
 
 1. The `CANCELLED` state is used when the **system** automatically cancels an execution due to the `concurrency` limit being reached.
@@ -103,36 +65,3 @@ Each task run can be in one of the following states:
 10. **KILLED**: The task run has been killed upon request by the user.
 
 Note how there is no `QUEUED`, `CANCELLED`, or `PAUSED` states for task runs.
-
-:::collapse{title="Mermaid source code for the Task Run States diagram"}
-
-```mermaid
-graph LR;
-    classDef transient fill:#0ff,stroke:#333,stroke-width:2px;
-    classDef terminal fill:#f9f,stroke:#333,stroke-width:2px;
-
-    subgraph Legend
-        direction TB
-        L1[Transient State]:::transient
-        L2[Terminal State]:::terminal
-    end
-
-    A[CREATED] -->| Start task run | B[RUNNING]
-    B -->| Completed without errors | C[SUCCESS]
-    B -->| Completed with warnings | D[WARNING]
-    B -->| Completed with errors | E[FAILED]
-    E -->| Retry task run | F[RETRYING]
-    F -->| Retry succeeded | C[SUCCESS]
-    F -->| Retry exhausted | E[FAILED]
-    E -->| Retry by creating new task run | G[RETRIED]
-    B -->| Requested to be killed | H[KILLING]
-    H -->| Task run terminated | I[KILLED]
-    E -->| Restart/replay | J[RESTARTED]
-    J -->| Restart processed | B[RUNNING]
-
-    class A,B,F,H,J transient;
-    class C,D,E,G,I terminal;
-
-    linkStyle 0,1,2,3,4,5,6,7,8,9,10,11 stroke:#2a9d8f, stroke-width:3px;
-```
-:::


### PR DESCRIPTION
<img width="3248" height="1996" alt="image" src="https://github.com/user-attachments/assets/d92e1b31-70a4-4bdc-b79c-64048fabdb87" />

Mermaid source is in a collapsed element on the page, but the page itself uses PNGs. We don't think people would want or need the mermaid source, so let's remove it. 