### PR TITLE
(docs): flowable tutorial, fix LoopUntil URI to not 404

### DIFF
--- a/src/contents/docs/03.tutorial/05.flowable/index.md
+++ b/src/contents/docs/03.tutorial/05.flowable/index.md
@@ -139,7 +139,7 @@ tasks:
       - id: healthCheck
         type: io.kestra.plugin.core.http.Request
         method: GET
-        uri: https://kestra.io/api/mock
+        uri: https://kestra.io
 ```
 
 This flow checks an HTTP endpoint every 30 seconds and stops either when it returns 200 or after 50 attempts, whichever comes first. You can reference the child task outputs (here `outputs.healthCheck.code`) inside the `condition` expression. See the [LoopUntil task documentation](/plugins/core/tasks/flows/io.kestra.plugin.core.flow.LoopUntil) for additional options.


### PR DESCRIPTION
`https://kestra.io/api/mock` 404s, causing the workflow to fail. I'm not creative enough to find a URI that fails intermittently, so let's set this to `kestra.io`. 