### PR TITLE
io.kestra.plugin.notifications.slack.SlackIncomingWebhook as prompted by the flow code linting

### DIFF
--- a/src/contents/docs/03.tutorial/06.errors/index.md
+++ b/src/contents/docs/03.tutorial/06.errors/index.md
@@ -42,7 +42,7 @@ tasks:
 
 errors:
   - id: alert_on_failure
-    type: io.kestra.plugin.slack.SlackIncomingWebhook
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
     url: "{{ secret('SLACK_WEBHOOK') }}" # https://hooks.slack.com/services/xyz/xyz/xyz
     messageText: "Failure alert for flow {{ flow.namespace }}.{{ flow.id }} with ID {{ execution.id }}"
 ```
@@ -113,7 +113,7 @@ tasks:
 
 errors:
   - id: alert_on_failure
-    type: io.kestra.plugin.slack.SlackIncomingWebhook
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
     url: "{{ secret('SLACK_WEBHOOK') }}"
     messageText: "Failure alert for flow {{ flow.namespace }}.{{ flow.id }} with ID {{ execution.id }}"
 


### PR DESCRIPTION
In 1.3.0-snapshot, I was prompted to adjust the following by the flow code linting:

`type: io.kestra.plugin.slack.SlackIncomingWebhook`

to

`type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook`