### PR TITLE
docs(agent-skills): use skills.sh for installation

### DIFF
--- a/src/contents/docs/ai-tools/agent-skills/index.md
+++ b/src/contents/docs/ai-tools/agent-skills/index.md
@@ -74,17 +74,19 @@ Use kestra-ops to validate and deploy all flows in ./flows to prod.namespace wit
 
 ## Setup
 
-Pick the skills you need from the [kestra-io/agent-skills](https://github.com/kestra-io/agent-skills) repository — each skill is a `SKILL.md` file under `skills/<skill-name>/`. Download only the skills relevant to your workflow.
+The easiest way to install Kestra agent skills is with [skills.sh](https://skills.sh) — it auto-detects your AI coding agent and places the skill files in the right location:
 
-The base URL for raw skill files is:
-
-```text
-https://raw.githubusercontent.com/kestra-io/agent-skills/main/skills/<skill-name>/SKILL.md
+```bash
+npx skills add kestra-io/agent-skills
 ```
 
-### Claude Code
+This works with Claude Code, Cursor, Windsurf, OpenAI Codex, and other agents that support skill files. The CLI detects which agent you’re using and installs the `SKILL.md` files into the correct directory (e.g. `.claude/skills/` for Claude Code, `.cursor/rules/` for Cursor).
 
-Download a skill into your project’s `.claude/skills/` directory. For example, to add `kestra-ops`:
+### Manual installation
+
+You can also manually download skill files from the [kestra-io/agent-skills](https://github.com/kestra-io/agent-skills) repository. Each skill is a `SKILL.md` file under `skills/<skill-name>/`.
+
+For example, to add the `kestra-ops` skill to Claude Code:
 
 ```bash
 mkdir -p .claude/skills/kestra-ops
@@ -92,41 +94,7 @@ curl -sL https://raw.githubusercontent.com/kestra-io/agent-skills/main/skills/ke
   -o .claude/skills/kestra-ops/SKILL.md
 ```
 
-Repeat for any other skill you need (e.g. `kestra-flow`). To make skills available across all your projects, use `~/.claude/skills/` instead.
-
-See the [Claude Code Skills documentation](https://code.claude.com/docs/en/skills) for more details.
-
-### Cursor
-
-Copy the skill file into `.cursor/rules/`. For example, to add `kestra-ops`:
-
-```bash
-mkdir -p .cursor/rules
-curl -sL https://raw.githubusercontent.com/kestra-io/agent-skills/main/skills/kestra-ops/SKILL.md \
-  -o .cursor/rules/kestra-ops.md
-```
-
-### OpenAI Codex
-
-Download a skill into your project’s `.agents/skills/` directory. For example, to add `kestra-ops`:
-
-```bash
-mkdir -p .agents/skills/kestra-ops
-curl -sL https://raw.githubusercontent.com/kestra-io/agent-skills/main/skills/kestra-ops/SKILL.md \
-  -o .agents/skills/kestra-ops/SKILL.md
-```
-
-For personal skills available across all projects, use `~/.agents/skills/` instead. See the [Codex Skills documentation](https://developers.openai.com/codex/skills) for more details.
-
-### Other agents
-
-Clone the repository and point your agent to the skill files you need:
-
-```bash
-git clone https://github.com/kestra-io/agent-skills.git
-```
-
-Then reference `agent-skills/skills/kestra-ops/SKILL.md` or any other skill in your agent’s context or configuration.
+Repeat for any other skill you need (e.g. `kestra-flow`). Adjust the target directory for your agent — `.cursor/rules/` for Cursor, `.agents/skills/` for OpenAI Codex, etc.
 
 ## Example Workflows
 


### PR DESCRIPTION
## Summary
- Add `npx skills add kestra-io/agent-skills` via [skills.sh](https://skills.sh) as the primary install method
- Keep a manual curl/mkdir fallback section for users who prefer it
- Simplifies setup from per-agent sections to one command + one manual example

## Test plan
- [ ] Verify the Setup section renders correctly
- [ ] Confirm `npx skills add kestra-io/agent-skills` works with Claude Code and Cursor