### PR TITLE
docs(lts): remove specific date from end of support

### DIFF
--- a/src/contents/docs/releases/index.md
+++ b/src/contents/docs/releases/index.md
@@ -15,10 +15,10 @@ Kestra maintains two tracks:
 
 | Type    | Version | Release Date | Supported Until           | Release Notes |
 |---------|---------|--------------|---------------------------|---------------|
-| LTS     | 1.3     | 2026‑03‑03   | 2027‑03‑03 (planned)      | [GitHub Release](https://github.com/kestra-io/kestra/releases/tag/v1.3.0) |
+| LTS     | 1.3     | 2026‑03‑03   | 2027‑03                   | [GitHub Release](https://github.com/kestra-io/kestra/releases/tag/v1.3.0) |
 | Feature | 1.2     | 2026‑13‑01   | Support ended by LTS 1.3  | [GitHub Release](https://github.com/kestra-io/kestra/releases/tag/v1.2.0) |
 | Feature | 1.1     | 2025‑04‑11   | Support ended by LTS 1.3  | [GitHub Release](https://github.com/kestra-io/kestra/releases/tag/v1.1.0) |
-| LTS     | 1.0     | 2025‑09‑09   | 2026‑09‑09 (planned)      | [GitHub Release](https://github.com/kestra-io/kestra/releases/tag/v1.0.0) |
+| LTS     | 1.0     | 2025‑09‑09   | 2026‑09                   | [GitHub Release](https://github.com/kestra-io/kestra/releases/tag/v1.0.0) |
 
 :::alert{type="info"}
 Runtime prerequisite: Kestra 1.3 requires Java 25 or later (Eclipse Temurin recommended). Upgrade Java before adopting a new LTS or feature line to avoid startup/runtime issues.


### PR DESCRIPTION
Instead of being specific about when support will end, change to just show the month and removed the "planned" note.

This is to follow more closely with the Python LTS Policy which just states `year-month` for support: https://devguide.python.org/versions/#supported-versions