### PR TITLE
docs: split pressure-tested page updates from skill drafts

### DIFF
--- a/src/contents/docs/01.quickstart/index.md
+++ b/src/contents/docs/01.quickstart/index.md
@@ -7,17 +7,19 @@ description: Get started with Kestra in minutes by launching Kestra locally with
 
 Launch Kestra locally, create a simple flow, and run your first execution in a few minutes.
 
-## Run your first Kestra Workflow with Docker
+## Run your first Kestra workflow with Docker
 
 <div class="video-container">
   <iframe src="https://www.youtube.com/embed/bQNmXge5vSY?si=ueqzWRVVtuGiAwjU" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
 
+## Prerequisites
+
+- Install Docker in your environment. We recommend [Docker Desktop](https://docs.docker.com/get-docker/).
+- If you use Windows, make sure [WSL](https://docs.docker.com/desktop/wsl/) is enabled.
+
 ## Start Kestra
 
-:::alert{type="info"}
-**Prerequisite**: Make sure Docker is installed in your environment. We recommend [Docker Desktop](https://docs.docker.com/get-docker/).
-:::
 Once Docker is running, start Kestra with a single command. If you are using Windows, make sure to use [WSL](https://docs.docker.com/desktop/wsl/):
 
 ```bash

--- a/src/contents/docs/02.installation/03.docker-compose/index.md
+++ b/src/contents/docs/02.installation/03.docker-compose/index.md
@@ -11,13 +11,12 @@ Start Kestra with a PostgreSQL database backend by using a Docker Compose file.
   <iframe src="https://www.youtube.com/embed/SGL8ywf3OJQ?si=Ww-JsVKvceR_n08j" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
 
-## Deploy Kestra with Docker Compose and PostgreSQL
+This guide shows how to start Kestra with Docker Compose and PostgreSQL for a local or server deployment.
 
----
+## Prerequisites
 
-The quickest way to a production-ready, lightweight Kestra installation is to leverage Docker and Docker Compose. This guide helps you get started with Kestra using Docker.
-
-Make sure you have [Docker](https://docs.docker.com/compose/install) installed before you begin.
+- Install [Docker](https://docs.docker.com/compose/install/) before you begin.
+- Make sure Docker Compose is available in your Docker installation.
 
 ## Download the Docker Compose file
 
@@ -61,7 +60,7 @@ Compare editions in [Open Source vs Enterprise](../../oss-vs-paid/index.md) if y
 
 The command from the previous section starts a standalone server, with all architectural components running in one JVM.
 
-The [configuration](../../configuration/01.configuration-basics/index.md) is done inside the `KESTRA_CONFIGURATION` environment variable of the Kestra container. You can update the environment variable inside the Docker Compose file or pass it as a Docker CLI argument.
+The [configuration](../../configuration/01.configuration-basics/index.md) lives in the `KESTRA_CONFIGURATION` environment variable of the Kestra container. You can update that environment variable inside the Docker Compose file or pass it as a Docker CLI argument.
 
 :::alert{type="info"}
 If you want to extend your Docker Compose file, modify container networking, or if you have any other issues using this Docker Compose file, check the [Troubleshooting Guide](../../10.administrator-guide/16.troubleshooting/index.md).
@@ -71,7 +70,7 @@ For running Kestra in Docker Compose with each server component as a separate se
 
 ### Use a configuration file
 
-If you want to use a configuration file instead of the `KESTRA_CONFIGURATION` environment variable to configure Kestra, you can update the default `docker-compose.yml`.
+If you want to use a configuration file instead of the `KESTRA_CONFIGURATION` environment variable, update the default `docker-compose.yml`.
 
 First, create a configuration file containing the `KESTRA_CONFIGURATION` environment variable defined in the `docker-compose.yml` file. You can name it `application.yaml`.
 
@@ -101,13 +100,13 @@ Next, update the `kestra` service in the `docker-compose.yml` file to mount this
 Check out all of our available [Docker image tags](./../02.docker/index.md#docker-image-tags) to see which one is best for your use case.
 :::
 
-### Networking in Docker Compose
+### Configure networking in Docker Compose
 
-The [default docker-compose](https://github.com/kestra-io/kestra/blob/develop/docker-compose.yml) file doesn't configure networking for the Kestra containers. This means that you won't be able to access any services exposed via `localhost` on your local machine (e.g., another Docker container with a mapped port). Your machine and the Docker container operate on different networks. To use a locally exposed service from Kestra container, you can use the `host.docker.internal` hostname or `172.17.0.1`. The  `host.docker.internal` address allows you to reach your host machine's services from Kestra's container.
+The [default Docker Compose file](https://github.com/kestra-io/kestra/blob/develop/docker-compose.yml) does not configure networking for the Kestra containers. This means you cannot access services exposed via `localhost` on your local machine, such as another Docker container with a mapped port. Your machine and the Docker container operate on different networks. To use a locally exposed service from the Kestra container, use the `host.docker.internal` hostname or `172.17.0.1`. The `host.docker.internal` address lets you reach your host machine's services from the container.
 
-Alternatively, you can leverage Docker network. By default, your Kestra container is placed in a `default` network. You can add your custom services to the `docker-compose.yml` file provided by Kestra and use the services' alias (keys from `services`) to reach them.
+Alternatively, you can use a Docker network. By default, your Kestra container is placed in a `default` network. You can add your custom services to the `docker-compose.yml` file provided by Kestra and use the service aliases, which are the keys in `services`, to reach them.
 
-A better approach may be to create a new network (e.g., `kestra_net`) and add your services to it. Then, you can add this network to the `networks` section of the `kestra` service. With this configuration, you have access via `localhost` to all your exposed ports.
+A better approach may be to create a new network such as `kestra_net` and add your services to it. Then add that network to the `networks` section of the `kestra` service. With this configuration, you can access your exposed ports through `localhost`.
 
 The example below shows how you can add `iceberg-rest`, `minio`, and `mc` (i.e., MinIO client) to your Kestra Docker Compose file.
 
@@ -244,7 +243,7 @@ services:
 ```
 :::
 
-Finally, you can also use the `host` network mode for the `kestra` service. This makes your container use your host network, and you are then able to reach all your exposed ports. This means you have to change the `services.kestra.environment.KESTRA_CONFIGURATION.datasources.postgres.url` to `jdbc:postgresql://localhost:5432/kestra`. This is the easiest way reach all ports, but it can be a security risk.
+Finally, you can use `host` network mode for the `kestra` service. This makes the container use your host network, so it can reach all exposed ports. In that case, change `services.kestra.environment.KESTRA_CONFIGURATION.datasources.postgres.url` to `jdbc:postgresql://localhost:5432/kestra`. This is the easiest way to reach all ports, but it can be a security risk.
 
 See the example below using `network_mode: host`.
 

--- a/src/contents/docs/07.enterprise/02.governance/unit-tests/index.md
+++ b/src/contents/docs/07.enterprise/02.governance/unit-tests/index.md
@@ -9,8 +9,6 @@ version: ">= 0.23.0"
 
 Build tests to ensure proper flow behavior.
 
-## Unit tests – validate Flows safely
-
 Tests let you verify that your flow behaves as expected, without cluttering your instance with test executions that run every task. For example, a unit test designed to mock the notification task of a flow ensures the configuration is correct without spamming dummy notifications to the recipient. They also let you isolate testing to specific changes to a task, rather than executing the entire flow.
 
 <div class="video-container">
@@ -25,15 +23,9 @@ Unit tests are configured for and connected to their respective flows. To create
 
 <div style="position: relative; padding-bottom: calc(48.95833333333333% + 41px); height: 0; width: 100%;"><iframe src="https://demo.arcade.software/OXqOYL6Uz47IXDMD3afL?embed&embed_mobile=inline&embed_desktop=inline&show_copy_link=true" title="Unit Test UI | Kestra EE" loading="lazy" webkitallowfullscreen mozallowfullscreen allowfullscreen allow="clipboard-write" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; color-scheme: light;" ></iframe></div>
 
----
-
 Once tests are created, they can all be viewed from the **Tests** tab with their respective Id, Namespace, Tested Flow, and current State listed. Additionally, tests can be run from this view with expandable results.
 
----
-
 ![Tests Interface](./unit-test-interface.png)
-
----
 
 The following diagram illustrates the structure of flows and unit tests together in Kestra:
 
@@ -41,7 +33,7 @@ The following diagram illustrates the structure of flows and unit tests together
 
 ## Configuration
 
-Unit tests are written in YAML like flows, and they are comprised of `testCases` which are then made up of `fixtures` and `assertions`. Fixtures can target **files**, **inputs**, **tasks**, or **triggers** depending on what you need to mock or override. Like flows, you can write Unit Tests as code, No code, or with the [AI Copilot](../../../ai-tools/ai-copilot/index.md).
+Unit tests are written in YAML like flows. A test is made up of `testCases`, and each test case is made up of `fixtures` and `assertions`. Fixtures can target **files**, **inputs**, **tasks**, or **triggers** depending on what you need to mock or override. Like flows, you can write unit tests as code, in No Code, or with the [AI Copilot](../../../ai-tools/ai-copilot/index.md).
 
 - A **fixture** refers to the setup required before a test runs, such as initializing objects or configuring environments, to ensure the test has a consistent starting state.
 - An **assertion** is a statement that checks if a specific condition is true during the test. If the condition is false, the test fails, indicating an issue with the code being tested, while true indicates the expectation is met.
@@ -56,11 +48,12 @@ Common fixture types:
 If you don't specify any fixtures, the test will run the entire flow as in production, executing all tasks and producing outputs as usual.
 :::
 
-For example, take the following flow that does these listed tasks:
-1. Sends a message to Slack to alert a channel that it is running
-2. Extracts data from an API
-3. Transforms the returned data to match a certain format
-4. Loads the transformed data to a BigQuery table
+The following flow:
+
+1. sends a Slack message when it starts
+2. extracts data from an API
+3. transforms the returned data
+4. loads the transformed data into BigQuery
 
 ```yaml
 id: etl_daily_products_bigquery
@@ -94,7 +87,7 @@ tasks:
     format: JSON
 ```
 
-A comprehensive unit test for this flow might look like the following:
+This example test suite shows two common patterns: letting one transformation run normally while mocking side effects, and fully mocking an upstream task to isolate a downstream transformation.
 
 ```yaml
 id: etl_daily_products_bigquery_testsuite
@@ -133,7 +126,7 @@ testCases:
         contains: "MY-PRODUCT-1"
 ```
 
-The `id` is unique to the test suite, and the `namespace` and `flowId` must match the intended flow to be tested against. They will automatically pipe into the test when creating from a flow. The `testCases` property is composed with the aforementioned `fixtures` and `assertions`. You can design multiple tests with their own specific designs.
+The `id` is unique to the test suite, and the `namespace` and `flowId` must match the intended flow. When you create a test from a flow, those values are filled in automatically. The `testCases` property contains the `fixtures` and `assertions` for each test case.
 
 In the first test case, `extract_should_return_data`, the `fixtures` include tasks to replace the Slack alert and BigQuery data load so as to not clutter a Slack channel with test alert messages or a BigQuery table with test data but still test the overall design of the flow.
 
@@ -153,11 +146,11 @@ Execution details are not stored in the Executions page like normally run flows 
 
 ![Test Execution Details](./test-execution.png)
 
-## Unit test with namespace file
+## Unit test with a namespace file
 
-You can also simulate flows with namespace files that are scripts, test data, or any other sort of file content. Taking the previous example, we can include a namespace file that includes sample data from the production API endpoint, so that we do not need to make any API calls simply to test the flow. This prevents accumulating cost for requests or any sort of limit on calls a service might have.
+You can also simulate flows with namespace files that contain scripts, test data, or any other file content. In the previous example, you can add a namespace file that contains sample data from the production API endpoint so you do not need to make any API calls during testing. This avoids extra cost and unnecessary calls to external services.
 
-With the following flow:
+Use the following flow:
 
 ```yaml
 id: etl_download_file
@@ -182,9 +175,9 @@ tasks:
     message: "{{ outputs.transform_to_uppercase.this_task_should_not_be_run }}"
 ```
 
-we can add a namespace file in the `company.team` namespace that mimics the format of the API request's return.
+Then add a namespace file in the `company.team` namespace that mimics the API response format.
 
-`my-namespace-file-with-products.json` to add to the `company.team` namespace:
+For example, add `my-namespace-file-with-products.json` to the `company.team` namespace:
 
 ```json
 {
@@ -229,7 +222,7 @@ we can add a namespace file in the `company.team` namespace that mimics the form
 }
 ```
 
-This way, in our mock test, we can use the following configuration to test the transformation on sample data, rather than making the API request:
+This test uses the namespace file as mocked task output so the transformation runs against sample data instead of making the API request:
 
 ```yaml
 id: etl_mockfile_from_ns
@@ -425,7 +418,7 @@ In this example:
 
 This approach allows you to test the complete flow logic while avoiding the overhead and complexity of executing actual scripts during testing.
 
-## Available assertions operators
+## Available assertion operators
 
 While the above example uses `isNotNull` and `contains` as assertion operators, there are many more that can be used when designing unit tests for your flows. The complete list is as follows:
 
@@ -445,11 +438,11 @@ While the above example uses `isNotNull` and `contains` as assertion operators, 
 | in                   | Asserts the value is in the specified list of values, e.g. `in: [200, 201, 202]`                  |
 | notIn                | Asserts the value is not in the specified list of values, e.g. `notIn: [404, 500]`                |
 
-## Assert on Execution Outputs
+## Assert on execution outputs
 
-Rather than assert with an operator and a set value, you can use execution outputs in your tests. To assert on execution outputs, use the `{{ execution.outputs.your_output_id }}` syntax in your test assertions. This allows you to verify that the outputs of your tasks match the expected values.
+Rather than assert with an operator and a fixed value, you can use execution outputs in your tests. To assert on execution outputs, use the `{{ execution.outputs.your_output_id }}` syntax in your test assertions. This allows you to verify that task outputs match the expected values.
 
-The below example assumes there is a flow that outputs a value:
+The following example assumes there is a flow that outputs a value:
 
 ```yaml
 id: flow_outputs_demo

--- a/src/contents/docs/16.scripts/00.languages/index.md
+++ b/src/contents/docs/16.scripts/00.languages/index.md
@@ -2,107 +2,113 @@
 title: Supported Programming Languages in Kestra
 sidebarTitle: Programming Languages
 icon: /src/contents/docs/icons/dev.svg
-description: Discover the programming languages supported by Kestra, including Python, R, Node.js, Shell, and how to run any language with Docker.
+description: See which languages have dedicated Kestra script plugins and how to run other languages with Shell tasks and Docker.
 ---
 
-Kestra is language agnostic — you can use any programming language inside your workflows.
+Kestra lets you run code in many languages inside your workflows.
 
-## Choose languages and plugins for script tasks
+## Choose the right way to run a language
 
-Kestra works with any programming language, with some having dedicated plugins and libraries that make it easier to send outputs and metrics back to Kestra.
+Use a dedicated script plugin when Kestra provides one for your language. Use the Shell plugin when you need to run another language or compile code inside a container.
 
 <div class="video-container">
   <iframe src="https://www.youtube.com/embed/oZYtLimdKBo?si=w5Tq8qwZQcmjMehf" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
 
-## Dedicated plugins
+## Languages with dedicated plugins
 
-Kestra currently supports the following programming languages with dedicated plugins:
+Kestra provides dedicated script plugins for these languages:
 
-1. [Python](/plugins/plugin-script-python)
-2. [R](/plugins/plugin-script-r)
-3. [Node.js](/plugins/plugin-script-node)
-4. [Shell](/plugins/plugin-script-shell)
-5. [PowerShell](/plugins/plugin-script-powershell)
-6. [Julia](/plugins/plugin-script-julia)
-7. [Ruby](/plugins/plugin-script-ruby)
-8. [Go](/plugins/plugin-script-go)
-9. [Deno](/plugins/plugin-script-deno)
-10. [Lua](/plugins/plugin-script-lua)
-11. [Bun](/plugins/plugin-script-bun)
-12. [PHP](/plugins/plugin-script-php)
-13. [Perl](/plugins/plugin-script-perl)
-14. [Groovy](/plugins/plugin-script-groovy)
+- [Python](/plugins/plugin-script-python)
+- [R](/plugins/plugin-script-r)
+- [Node.js](/plugins/plugin-script-node)
+- [Shell](/plugins/plugin-script-shell)
+- [PowerShell](/plugins/plugin-script-powershell)
+- [Julia](/plugins/plugin-script-julia)
+- [Ruby](/plugins/plugin-script-ruby)
+- [Go](/plugins/plugin-script-go)
+- [Deno](/plugins/plugin-script-deno)
+- [Lua](/plugins/plugin-script-lua)
+- [Bun](/plugins/plugin-script-bun)
+- [PHP](/plugins/plugin-script-php)
+- [Perl](/plugins/plugin-script-perl)
+- [Groovy](/plugins/plugin-script-groovy)
 
 Each of these plugins provides two task types:
-- **Commands**: Execute scripts using a command-line interface (ideal for longer, pre-written files).
-- **Script**: Write your code directly in YAML (best for short inline scripts).
 
-### Script example
+- `Script` for short inline code in your flow definition.
+- `Commands` for code stored in files or split across multiple commands.
 
-An example of an inline Python script:
+Here is a minimal example that uses the Python `Script` task:
 
 ```yaml
-id: myflow
+id: python_script_example
 namespace: company.team
 
 tasks:
-  - id: script
+  - id: run_python
     type: io.kestra.plugin.scripts.python.Script
-    beforeCommands:
-      - pip install requests kestra
+    containerImage: python:3.12-slim
     script: |
-      from kestra import Kestra
-      import requests
-
-      response = requests.get('https://google.com')
-      print(response.status_code)
-
-      Kestra.outputs({'status': response.status_code, 'text': response.text})
+      print("Hello from Python")
 ```
 
-### Commands example
-
-An example using Shell commands, similar to a terminal session:
+Use the `Commands` task when you want to run a file from `namespaceFiles` or execute multiple commands in sequence:
 
 ```yaml
-id: myflow
+id: python_commands_example
 namespace: company.team
 
 tasks:
-  - id: commands
-    type: io.kestra.plugin.scripts.shell.Commands
-    outputFiles:
-      - first.txt
-      - second.txt
+  - id: run_python_file
+    type: io.kestra.plugin.scripts.python.Commands
+    namespaceFiles:
+      enabled: true
+    containerImage: python:3.12-slim
     commands:
-      - echo "1" >> first.txt
-      - echo "2" >> second.txt
+      - python hello.py
 ```
 
-## Run any language using the Shell task
+## Language-specific guides
 
-With the `Commands` task, you can execute arbitrary commands inside a Docker container. This means you can run **any language**, as long as:
-1. Its dependencies can be included in a Docker image.
-2. It can be executed from a Shell command.
+Use these guides for complete examples, outputs, metrics, and dependency management:
 
-For handling outputs and metrics, use the same `::{}::` syntax as the `Shell` task.
-Read more in [Shell outputs and metrics](../06.outputs-metrics/index.md#shell).
+- [Run Python inside your flows](../../15.how-to-guides/python/index.md)
+- [Run R inside your flows](../../15.how-to-guides/r/index.md)
+- [Run JavaScript inside your flows](../../15.how-to-guides/javascript/index.md)
+- [Run Shell scripts inside your flows](../../15.how-to-guides/shell/index.md)
+- [Run PowerShell inside your flows](../../15.how-to-guides/powershell/index.md)
+- [Run Julia inside your flows](../../15.how-to-guides/julia/index.md)
+- [Run Go inside your flows](../../15.how-to-guides/golang/index.md)
+- [Run Perl inside your flows](../../15.how-to-guides/perl/index.md)
+- [Run Rust inside your flows](../../15.how-to-guides/rust/index.md)
 
-### Rust
+## Run other languages with the Shell plugin
 
-Here is an example flow that runs a Rust file inside of a container using a `rust` image:
+Use `io.kestra.plugin.scripts.shell.Commands` when your language does not have a dedicated plugin or when you want to compile and run code in a container.
+
+This approach works best when:
+
+- the language runtime is available in the container image
+- your commands can be executed from a shell
+- you want to use `namespaceFiles` or `inputFiles` for source code
+
+For outputs and metrics, use the same `::{}::` syntax documented for Shell tasks. See [Shell outputs and metrics](../06.outputs-metrics/index.md#shell).
+
+### Rust example
+
+This example compiles and runs a Rust file stored in `namespaceFiles`:
 
 ```yaml
-id: rust
+id: rust_example
 namespace: company.team
 
 tasks:
-  - id: rust
+  - id: run_rust
     type: io.kestra.plugin.scripts.shell.Commands
     taskRunner:
       type: io.kestra.plugin.scripts.runner.docker.Docker
-    containerImage: rust:latest
+    containerImage: rust:1.82
     namespaceFiles:
       enabled: true
     commands:
@@ -110,7 +116,7 @@ tasks:
       - ./hello_world
 ```
 
-The Rust code is saved as a namespace file called `hello_world.rs`:
+The `hello_world.rs` file can contain:
 
 ```rust
 fn main() {
@@ -118,36 +124,28 @@ fn main() {
 }
 ```
 
-When executed, the print statement is displayed in the Kestra logs:
+See the full [Rust guide](../../15.how-to-guides/rust/index.md) for outputs and file handling.
 
-![rust_output](./rust_output.png)
+### Java example
 
-Check out the [full guide](../../15.how-to-guides/rust/index.md) which includes using [outputs and metrics](../06.outputs-metrics/index.md).
-
-### Java
-
-You can build [custom plugins](../../plugin-developer-guide/index.mdx) in Java which enable you to add custom tasks to your workflows. If you're looking to execute something simpler, you can use the `Shell` task with a Docker container.
-
-Here is an example flow that runs a Java file inside of a container using a `eclipse-temurin` image:
+If you need to run Java code without building a custom plugin, you can compile and run it from a container:
 
 ```yaml
-id: java
+id: java_example
 namespace: company.team
 
 tasks:
-  - id: java
+  - id: run_java
     type: io.kestra.plugin.scripts.shell.Commands
     taskRunner:
       type: io.kestra.plugin.scripts.runner.docker.Docker
-    containerImage: eclipse-temurin:latest
+    containerImage: eclipse-temurin:21
     namespaceFiles:
       enabled: true
     commands:
       - javac HelloWorld.java
       - java HelloWorld
 ```
-
-The Java code is saved as a namespace file called `HelloWorld.java`:
 
 ```java
 class HelloWorld {
@@ -157,107 +155,29 @@ class HelloWorld {
 }
 ```
 
-When executed, the print statement is displayed in the Kestra logs:
+### TypeScript example
 
-![java_output](./java_output.png)
-
-### C
-
-Here is an example flow that runs a C file inside of a container using a `gcc` image:
+You can run TypeScript with the Node.js plugin by compiling it to JavaScript first:
 
 ```yaml
-id: c
+id: typescript_example
 namespace: company.team
 
 tasks:
-  - id: c
-    type: io.kestra.plugin.scripts.shell.Commands
-    taskRunner:
-      type: io.kestra.plugin.scripts.runner.docker.Docker
-    containerImage: gcc:latest
-    namespaceFiles:
-      enabled: true
-    commands:
-      - gcc hello_world.c
-      - ./a.out
-```
-
-The C code is saved as a namespace file called `hello_world.c`:
-
-```c
-#include <stdio.h>
-
-int main() {
-   printf("Hello, World!");
-   return 0;
-}
-```
-
-When executed, the print statement is displayed in the Kestra logs:
-
-![c_output](./c_output.png)
-
-### C++
-
-Here is an example flow that runs a C++ file inside of a container using a `gcc` image:
-
-```yaml
-id: cplusplus
-namespace: company.team
-
-tasks:
-  - id: cpp
-    type: io.kestra.plugin.scripts.shell.Commands
-    taskRunner:
-      type: io.kestra.plugin.scripts.runner.docker.Docker
-    containerImage: gcc:latest
-    namespaceFiles:
-      enabled: true
-    commands:
-      - g++ hello_world.cpp
-      - ./a.out
-```
-
-The C++ code is saved as a namespace file called `hello_world.cpp`:
-
-```cpp
-#include <iostream>
-
-int main() {
-    std::cout << "Hello World!";
-    return 0;
-}
-```
-
-When executed, the print statement is displayed in the Kestra logs:
-
-![cpp_output](./cpp_output.png)
-
-### TypeScript
-
-You can execute TypeScript using the NodeJS plugin. To do so, you need to install TypeScript and compile our code to JavaScript using `tsc`.
-
-Once done, you can then execute with NodeJS. However, do note that the file is now a `.js` file.
-
-```yaml
-id: typescript
-namespace: company.team
-
-tasks:
-  - id: ts
+  - id: run_typescript
     type: io.kestra.plugin.scripts.node.Commands
     namespaceFiles:
       enabled: true
+    containerImage: node:22-slim
     commands:
-      - npm i -D typescript
+      - npm install --save-dev typescript
       - npx tsc example.ts
       - node example.js
 ```
 
-This example can be found in the [Node.js docs](https://nodejs.org/en/learn/getting-started/nodejs-with-typescript#examples). The file is saved as `example.ts`.
+The `example.ts` file can contain:
 
 ```typescript
-
 type User = {
   name: string;
   age: number;
@@ -268,195 +188,33 @@ function isAdult(user: User): boolean {
 }
 
 const justine: User = {
-  name: 'Justine',
+  name: "Justine",
   age: 23,
 };
 
-const isJustineAnAdult: boolean = isAdult(justine);
-console.log(isJustineAnAdult)
+console.log(isAdult(justine));
 ```
 
-When executed, the print statement is displayed in the Kestra logs:
+For more background, see the official [Node.js with TypeScript guide](https://nodejs.org/en/learn/getting-started/nodejs-with-typescript).
 
-![ts_output](./ts_output.png)
+## Use a custom Docker image for extra dependencies
 
-For more information, you can read more about [Node.js with TypeScript](https://nodejs.org/en/learn/getting-started/nodejs-with-typescript) on their official site.
+Use a custom Docker image when you need tools or libraries that are not present in the default runtime image.
 
-### PHP
-
-Here is an example flow that runs a PHP file inside of a container using a `php` image:
-
-```yaml
-id: php
-namespace: company.team
-
-tasks:
-  - id: php
-    type: io.kestra.plugin.scripts.shell.Commands
-    taskRunner:
-      type: io.kestra.plugin.scripts.runner.docker.Docker
-    containerImage: php:8.4-rc-alpine
-    namespaceFiles:
-      enabled: true
-    commands:
-      - php hello_world.php
-```
-
-The PHP code is saved as a namespace file called `hello_world.php`:
-
-```php
-<?php
-echo "Hello, World!";
-?>
-```
-
-When executed, the print statement is displayed in the Kestra logs:
-
-![php_output](./php_output.png)
-
-There is a dedicated [PHP plugin](/plugins/plugin-script-php). An example flow might look like the following using a script task:
-
-```yaml
-id: php_script
-namespace: company.team
-
-tasks:
-  - id: script
-    type: io.kestra.plugin.scripts.php.Script
-    script: |
-      #!/usr/bin/php
-      <?php
-      echo "Hello, World!\\n";
-      ?>
-```
-Check out the following example for the commands task:
-
-```yaml
-id: php_commands
-namespace: company.team
-tasks:
-  - id: commands
-    type: io.kestra.plugin.scripts.php.Commands
-    inputFiles:
-      main.php: |
-        #!/usr/bin/php
-        <?php
-        echo "Hello, World!\\n";
-        ?>
-    commands:
-      - php main.php
-```
-
-### Scala
-
-Here is an example flow that runs a Scala file inside of a container using a `sbtscala/scala-sbt` image:
-
-```yaml
-id: scala
-namespace: company.team
-
-tasks:
-  - id: scala
-    type: io.kestra.plugin.scripts.shell.Commands
-    taskRunner:
-      type: io.kestra.plugin.scripts.runner.docker.Docker
-    containerImage: sbtscala/scala-sbt:eclipse-temurin-17.0.4_1.7.1_3.2.0
-    namespaceFiles:
-      enabled: true
-    commands:
-      - scalac HelloWorld.scala
-      - scala HelloWorld
-```
-
-The Scala code is saved as a namespace file called `HelloWorld.scala`:
-
-```scala
-object HelloWorld {
-    def main(args: Array[String]) = {
-        println("Hello, World!")
-    }
-}
-```
-
-When executed, the print statement is displayed in the Kestra logs:
-
-![scala_output](./scala_output.png)
-
-### Perl
-
-Here is an example flow that runs a Perl file inside of a container using a `perl` image:
-
-```yaml
-id: perl
-namespace: company.team
-
-tasks:
-  - id: perl
-    type: io.kestra.plugin.scripts.shell.Commands
-    taskRunner:
-      type: io.kestra.plugin.scripts.runner.docker.Docker
-    containerImage: perl:5.41.2
-    namespaceFiles:
-      enabled: true
-    commands:
-      - perl hello_world.pl
-```
-
-The Perl code is saved as a namespace file called `hello_world.pl`:
-
-```perl
-#!/usr/bin/perl
-use warnings;
-print("Hello, World!\n");
-```
-
-When executed, the print statement is displayed in the Kestra logs:
-
-![perl_output](./perl_output.png)
-
-There is a dedicated [Perl plugin](/plugins/plugin-script-perl). An example flow might look like the following using a script task:
-
-```yaml
-id: perl_inline
-namespace: company.team
-tasks:
-  - id: perl_script
-    type: io.kestra.plugin.scripts.perl.Script
-    script: |
-      my $message = "Hello from an inline Perl script!";
-      print $message . "\\n";
-```
-
-Check out the following example for the commands task:
-
-```yaml
-id: perl_commands
-namespace: company.team
-tasks:
-  - id: perl
-    type: io.kestra.plugin.scripts.perl.Commands
-    commands:
-      - perl -e 'print "Hello from Kestra!
-```
-
-## Run any language using a custom Docker image
-
-You can pre-install any language using a custom Docker image and use the [Process Task Runner](../../task-runners/04.types/01.process-task-runner/index.md) to execute it. Example using Go:
+The Dockerfile below adds Go to a Kestra image:
 
 ```dockerfile
 FROM kestra/kestra:latest
 USER root
 
-## Install Go
 RUN apt-get update -y && apt-get install -y wget && \
     wget -qO- https://go.dev/dl/go1.24.3.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
     echo 'export PATH=$PATH:/usr/local/go/bin' > /etc/profile.d/golang.sh
 
-## Set Go environment variables for Docker
 ENV PATH="/usr/local/go/bin:${PATH}"
 ```
 
-Then, point to that Dockerfile in your [`docker-compose.yml` file](https://github.com/kestra-io/kestra/blob/develop/docker-compose.yml):
+Point your `docker-compose.yml` file to that Dockerfile:
 
 ```yaml
 services:
@@ -467,7 +225,7 @@ services:
     image: kestra-go:latest
 ```
 
-Once you start Kestra using `docker compose up -d`, you can create a flow that directly runs Go tasks with your custom dependencies using the `io.kestra.plugin.core.runner.Process` task runner:
+After you start Kestra with `docker compose up -d`, you can run Go code with the `Process` task runner:
 
 ```yaml
 id: golang_process
@@ -484,19 +242,29 @@ tasks:
       - go mod tidy
     script: |
       package main
+
       import (
           "os"
           "github.com/go-gota/gota/dataframe"
           "github.com/go-gota/gota/series"
       )
+
       func main() {
           names := series.New([]string{"Alice", "Bob", "Charlie"}, series.String, "Name")
           ages := series.New([]int{25, 30, 35}, series.Int, "Age")
           df := dataframe.New(names, ages)
           file, _ := os.Create("output.csv")
-          df.WriteCSV(file)
           defer file.Close()
+          df.WriteCSV(file)
       }
     outputFiles:
       - output.csv
 ```
+
+## Related pages
+
+- [Scripts overview](../index.mdx)
+- [Commands vs. scripts](../01.commands-vs-scripts/index.md)
+- [Task runners](../03.task-runners/index.md)
+- [Installing dependencies](../05.installing-dependencies/index.md)
+- [Outputs and metrics](../06.outputs-metrics/index.md)

--- a/src/contents/docs/plugin-developer-guide/06.unit-tests/index.md
+++ b/src/contents/docs/plugin-developer-guide/06.unit-tests/index.md
@@ -7,13 +7,13 @@ description: Learn how to write unit tests for your Kestra plugins using JUnit a
 
 To avoid regression, we recommend adding unit tests for all your tasks.
 
-## Add unit tests for Kestra plugins
-
-There are two main ways to unit-test your tasks. In both cases, your tests must be annotated with `@KestraTest` to start the needed Kestra components properly.
+There are two main ways to test your tasks. In both cases, annotate your tests with `@KestraTest` so the required Kestra components start correctly.
 
 ## Unit test a RunnableTask
 
 This is the most common way to test a `RunnableTask`. You create your `RunnableTask`, test its `run()` method, and assert on its output or exception.
+
+This example shows a task test that builds the task, creates a `RunContext`, runs the task directly, and asserts on the output:
 
 :::collapse{title="Example"}
 
@@ -40,13 +40,15 @@ class ExampleTest {
 ```
 :::
 
-This is done the same as any Java unit tests. Feel free to use any dependencies, test methods, and start docker containers as you need.
-Kestra tests are Micronaut tests so you can inject any bean in them.
+This works like any other Java unit test. You can use additional dependencies, helper methods, and Docker containers when needed.
+Kestra tests are Micronaut tests, so you can inject any bean into them.
 
 
 ## Unit test with a full flow
 
 If you want to add some unit tests with a full flow (which can be necessary in some rare cases, for example, for a `FlowableTask`), you will use the `@ExecuteFlow` annotation.
+
+This example shows a flow-level test that executes a test flow from `src/test/resources` and asserts on the resulting execution:
 
 :::collapse{title="Example"}
 ```java
@@ -90,5 +92,5 @@ testImplementation group: "io.kestra", name: "runner-memory", version: kestraVer
 testImplementation group: "io.kestra", name: "storage-local", version: kestraVersion
 ```
 
-This will enable the in memory runner and will run your flow without any other dependencies (e.g., kafka).
+This enables the in-memory runner and runs your flow without any other dependencies such as Kafka.
 If you created it from our plugin template, those are usually already included in your project.


### PR DESCRIPTION
## Summary

  This PR splits the page-level docs edits out of the [docs/skill-drafts](https://github.com/kestra-io/docs/pull/4293) work so they can be reviewed and merged independently. We are going to be using Claude Code instead of Codex.

  The changes here come from pressure-testing the draft documentation skills against real pages in the Kestra docs repo and then applying the resulting improvements directly to those pages.

  ## What changed

  Updated pages:

  - Repositories/docs/src/contents/docs/01.quickstart/index.md
  - Repositories/docs/src/contents/docs/02.installation/03.docker-compose/index.md
  - Repositories/docs/src/contents/docs/07.enterprise/02.governance/unit-tests/index.md
  - Repositories/docs/src/contents/docs/16.scripts/00.languages/index.md
  - Repositories/docs/src/contents/docs/plugin-developer-guide/06.unit-tests/index.md

  The updates focus on:

  - improving page structure and scannability
  - removing redundant title-like first H2s
  - normalizing heading style
  - making prerequisites clearer on procedural/setup pages
  - reducing repetitive or overly broad content on overview pages
  - improving example framing and readability
  - fixing small wording and grammar issues found during review

  ## Why this is separate

  These changes are content improvements to existing docs pages, while the skill draft branch also includes .codex/skills work for reusable documentation review workflows. Splitting them allows the page changes to
  be reviewed on their own without mixing them with the new skill definitions.

  ## Notes

  This PR does not include the .codex/skills additions. It only contains the docs-page edits extracted from docs/skill-drafts.