### PR TITLE
docs(childcards): use sidebarTitle instead of title

### DIFF
--- a/src/components/docs/ChildCard.astro
+++ b/src/components/docs/ChildCard.astro
@@ -63,7 +63,7 @@ const children = await Promise.all(
                     : "")
 
             return {
-                title: doc.data.title,
+                title: doc.data.sidebarTitle ?? doc.data.title,
                 description,
                 path: `/docs/${doc.id}`,
                 release: doc.data.release,


### PR DESCRIPTION
Closes https://github.com/kestra-io/docs/issues/4329

Use sidebarTitle in the Child Card with title as a fallback if not there.

<img width="974" height="737" alt="Screenshot 2026-03-23 at 13 00 15" src="https://github.com/user-attachments/assets/05bb1bd4-4455-49f3-a295-42567e2a116f" />
