### PR TITLE
docs(child-cards): fix weird clipping issue on child card titles

### DIFF
--- a/src/components/docs/ChildCard.astro
+++ b/src/components/docs/ChildCard.astro
@@ -131,7 +131,7 @@ const children = await Promise.all(
                     overflow: hidden;
                     text-overflow: ellipsis;
                     white-space: nowrap;
-                    padding-bottom: 0.15em;
+                    padding: 0.15em 0;
                 }
             }
 


### PR DESCRIPTION
Child card titles have this clipping issue:
<img width="974" height="737" alt="Screenshot 2026-03-23 at 14 21 15" src="https://github.com/user-attachments/assets/c0e4e7c4-3393-4715-8701-166ac3ab9e67" />


This should solve that:
<img width="974" height="737" alt="Screenshot 2026-03-23 at 14 22 02" src="https://github.com/user-attachments/assets/c0acb3d7-1031-4175-8fc9-5d3a1acbd91e" />
