### PR TITLE
fix: subgroup showing group icon

### DIFF
--- a/src/pages/plugins/[...slug].astro
+++ b/src/pages/plugins/[...slug].astro
@@ -330,7 +330,7 @@ const subGroupWrapper = pluginsForDisplay.find(
 const currentPageIcon = `/icons/${pluginType ?? subGroupWrapper?.subGroup ?? page?.body.group}.svg`
 const subGroupsIcons = page?.body?.plugins
     ? Object.fromEntries(
-          page.body.plugins.map((p) => [p.group, `/icons/${p.group}.svg`]),
+          page.body.plugins.map((p) => [p.subGroup ?? p.group, `/icons/${p.subGroup ?? p.group}.svg`]),
       )
     : {}
 


### PR DESCRIPTION
Fix this

<img width="2366" height="1764" alt="image" src="https://github.com/user-attachments/assets/ceb89212-20f9-4964-b0e7-3df39c212793" />


**AFTER:**

<img width="2366" height="1764" alt="image" src="https://github.com/user-attachments/assets/f15d9a58-b8f8-41d4-a1a4-98a2110f4d0e" />:

