### PR TITLE
fix: remove Airflow reference from Apple quote on ai-automation page

### DIFF
--- a/src/pages/ai-automation.astro
+++ b/src/pages/ai-automation.astro
@@ -70,7 +70,7 @@ const items = [
 
 const AppleQuotes = [
     {
-        quote: "We switched from Airflow because we want engineers solving problems, not coding orchestration. Kestra delivers end-to-end automation with the robustness we need at our scale. Few companies operate at this level, especially in AI/ML.",
+        quote: "Kestra delivers end-to-end automation with the robustness we need at our scale. Few companies operate at this level, especially in AI/ML.",
         author: "Senior Engineering Manager (ML Team)",
         smallLogoSvg: AppleLogo,
     },


### PR DESCRIPTION
Tiny edit to remove the mention of Airflow from the quote, since it is not specific to AI. The rest of the quote is correct. 