### PR TITLE
fix(docs): fix Use Cases breadcrumb parent link and hide sidebar entry

### DIFF
--- a/src/components/docs/RecursiveNavSidebar.vue
+++ b/src/components/docs/RecursiveNavSidebar.vue
@@ -157,9 +157,7 @@
     }
 
     const filteredChildren = computed(() => {
-        return (props.item.children ?? []).filter(
-            (r: any) => props.item.path !== r.path && !r.hideSidebar,
-        )
+        return (props.item.children ?? []).filter((r: any) => props.item.path !== r.path)
     })
 
     const isActiveOrExpanded = (item: NavigationItem) => {

--- a/src/components/docs/RecursiveNavSidebar.vue
+++ b/src/components/docs/RecursiveNavSidebar.vue
@@ -157,7 +157,9 @@
     }
 
     const filteredChildren = computed(() => {
-        return (props.item.children ?? []).filter((r: any) => props.item.path !== r.path)
+        return (props.item.children ?? []).filter(
+            (r: any) => props.item.path !== r.path && !r.hideSidebar,
+        )
     })
 
     const isActiveOrExpanded = (item: NavigationItem) => {

--- a/src/utils/getNavigationTree.ts
+++ b/src/utils/getNavigationTree.ts
@@ -68,8 +68,7 @@ export function getNavigationTree(
                               path: `/docs/${page.id}`,
                               children: recursivelyBuildChildren(page.id, docsPages),
                               hideSubMenus: Boolean(page.data.hideSubMenus),
-                              hideSidebar:
-                                  title === "Use Cases" || Boolean(page.data.hideSidebar),
+                              hideSidebar: Boolean(page.data.hideSidebar),
                           }
                         : undefined
                 })

--- a/src/utils/getNavigationTree.ts
+++ b/src/utils/getNavigationTree.ts
@@ -20,6 +20,7 @@ const navigationTree = {
         "No-Code",
         "Version Control & CI/CD",
         "Plugin Developer Guide",
+        "Use Cases",
         "How-to Guides",
     ],
     "Scale with Kestra": [
@@ -67,7 +68,8 @@ export function getNavigationTree(
                               path: `/docs/${page.id}`,
                               children: recursivelyBuildChildren(page.id, docsPages),
                               hideSubMenus: Boolean(page.data.hideSubMenus),
-                              hideSidebar: Boolean(page.data.hideSidebar),
+                              hideSidebar:
+                                  title === "Use Cases" || Boolean(page.data.hideSidebar),
                           }
                         : undefined
                 })


### PR DESCRIPTION
fixes: https://github.com/kestra-io/docs/issues/4334

---

Video reference for the patch, 

https://github.com/user-attachments/assets/dcedf18b-4d0f-47bf-ac58-81693c530104

