### PR TITLE
fix: reduce top space in menu dropdown

### DIFF
--- a/src/assets/styles/components/header.scss
+++ b/src/assets/styles/components/header.scss
@@ -531,7 +531,7 @@ nav {
                         position: absolute;
                         top: 0;
                         bottom: 0;
-                        padding: $rem-2 $rem-1;
+                        padding: $rem-1;
 
                         &.opacity-100 {
                             transition: opacity 700ms ease;

--- a/src/utils/menu-sizes.ts
+++ b/src/utils/menu-sizes.ts
@@ -3,19 +3,19 @@ type MenuSize = { width: string; height: string }
 const menuSizes: Record<string, MenuSize> = {
     product:   {
         width: "305px",
-        height: "260px"
+        height: "228px"
     },
     solutions: {
         width: "782px",
-        height: "240px"
+        height: "208px"
     },
     resources: {
         width: "285px",
-        height: "260px"
+        height: "228px"
     },
     company: {
         width: "305px",
-        height: "260px"
+        height: "228px"
     },
 }
 


### PR DESCRIPTION
For Feedback from Manu to align the spacing to right and left one.

<img width="1162" height="656" alt="image" src="https://github.com/user-attachments/assets/d95c3e19-f2a2-41cb-bc08-3249dd1738b4" />
