### PR TITLE
fix: remove trailing slashes from plugin links

### DIFF
--- a/src/contents/blogs/2022-02-01-kestra-opensource/index.md
+++ b/src/contents/blogs/2022-02-01-kestra-opensource/index.md
@@ -87,7 +87,7 @@ jq -r '.name' /tmp/query.json
 
 Kestra avoids the rigmarole of installing the software on the system, handling dependencies and conflicts, dealing with Python, etc. — just install a plugin (a simple jar) and speak directly with your database.
 
-We have a [number of plugins](/plugins/) and the process of [developing your own](../../docs/plugin-developer-guide/index.mdx) is very simple. We also hope that a community will help us to maintain new plugins/connectors ([contact us](/contact-us) if you require help or support).
+We have a [number of plugins](/plugins) and the process of [developing your own](../../docs/plugin-developer-guide/index.mdx) is very simple. We also hope that a community will help us to maintain new plugins/connectors ([contact us](/contact-us) if you require help or support).
 
 ## First Public Release *and* Production Ready!
 First public release doesn't mean that Kestra is not production ready. In fact, it has been **used in production since August 2020 at Leroy Merlin** — take a deeper look at the [case study](../2022-02-22-leroy-merlin-usage-kestra/index.md) if you want more detail. Here are some figures to give a picture of Kestra’s credentials:

--- a/src/contents/blogs/2022-04-05-debezium-without-kafka-connect/index.md
+++ b/src/contents/blogs/2022-04-05-debezium-without-kafka-connect/index.md
@@ -102,7 +102,7 @@ This code snippet demonstrates how Kestra uses YAML to manage data pipelines. It
 
 ## Broadening the Data Pipeline Possibilities with Kestra ##
 
-Kestra's flexibility and versatility, underlined by its extensive [range of plugins](/plugins/), makes it an ideal tool for creating complex workflows with deep integrations with multiple systems. For systems without existing plugins, Kestra's compatibility with containers such as **Docker** and **Kubernetes** makes integration straightforward.
+Kestra's flexibility and versatility, underlined by its extensive [range of plugins](/plugins), makes it an ideal tool for creating complex workflows with deep integrations with multiple systems. For systems without existing plugins, Kestra's compatibility with containers such as **Docker** and **Kubernetes** makes integration straightforward.
 
 Kestra's Debezium plugins include connectors for Postgres and MySQL, PostgreSQL, Oracle, SQL Server, and more. The ongoing development aims to continually improve and expand the product's capabilities.
 

--- a/src/contents/blogs/2023-04-13-welcome-kestra-0-8-0/index.md
+++ b/src/contents/blogs/2023-04-13-welcome-kestra-0-8-0/index.md
@@ -22,7 +22,7 @@ This new release feature the first iteration of our low-code editor. The previou
 
 ### Task documentation in the editor
 
-Each task has exhaustive documentation in the [plugin documentation](/plugins/) section of our website, but when you create a flow from the UI, switching from the editor to the plugin documentation site is not very convenient.
+Each task has exhaustive documentation in the [plugin documentation](/plugins) section of our website, but when you create a flow from the UI, switching from the editor to the plugin documentation site is not very convenient.
 
 To limit context switching, we added a contextual panel in the flow editor displaying the current task documentation. So now you can keep your flow at hand while developing and still be close to the documentation.
 
@@ -71,7 +71,7 @@ We wrote a new page about flow [tasks](../../docs/05.workflow-components/01.task
 
 We created a [tutorial](../../docs/03.tutorial/index.mdx) to discover the most important features one needs to know to write efficient data pipelines with Kestra.
 
-And we also improved the quality of the [plugin documentation](/plugins/), we hope to find some time to improve it more in the upcoming weeks as we know that plugin documentation is sometimes sparse.
+And we also improved the quality of the [plugin documentation](/plugins), we hope to find some time to improve it more in the upcoming weeks as we know that plugin documentation is sometimes sparse.
 
 
 ## Plugins

--- a/src/contents/blogs/2023-05-22-data-orchestration-choosing-the-right-tool/index.md
+++ b/src/contents/blogs/2023-05-22-data-orchestration-choosing-the-right-tool/index.md
@@ -30,7 +30,7 @@ Kestra's intuitive and user-friendly interface makes the tool accessible to both
 ### 5-Integration & Extension capabilities ###
 ![plugins](./plugins.png)
 
-Kestra's flexibility and versatility, underlined by its extensive [range of plugins](/plugins/), makes it an ideal tool for creating complex workflows with deep integrations with multiple systems. For systems without existing plugins, Kestra's compatibility with containers such as **Docker** and **Kubernetes** makes integration straightforward.
+Kestra's flexibility and versatility, underlined by its extensive [range of plugins](/plugins), makes it an ideal tool for creating complex workflows with deep integrations with multiple systems. For systems without existing plugins, Kestra's compatibility with containers such as **Docker** and **Kubernetes** makes integration straightforward.
 
 ### 6-Monitoring ###
 ![monitoring](./Monitoring.png)

--- a/src/contents/blogs/2023-12-14-orchestration-problems-and-complexity/index.md
+++ b/src/contents/blogs/2023-12-14-orchestration-problems-and-complexity/index.md
@@ -58,7 +58,7 @@ To solve silos without creating new ones, Kestra meets users where they are.
 
 To meet users where they are and remove the need for new silos, Kestra integrates with tools you already know and love. Because each plugin is a single binary file, there’s no package dependency hell, even without relying on Docker (_Docker is supported but not required_). These integrations reduce the complexity of orchestration, and in combination with blueprints, they enable hundreds of use cases out of the box.
 
-Thanks to the open-source contributions, the list of supported plugins keeps growing with every new release. You can check the [list of supported plugins](/plugins/) to see if your favorite tool is already supported. If not, you can [build your own](../../docs/plugin-developer-guide/index.mdx) in minutes.
+Thanks to the open-source contributions, the list of supported plugins keeps growing with every new release. You can check the [list of supported plugins](/plugins) to see if your favorite tool is already supported. If not, you can [build your own](../../docs/plugin-developer-guide/index.mdx) in minutes.
 
 ![ui](./ui.png)
 

--- a/src/contents/docs/07.enterprise/02.governance/logshipper/index.md
+++ b/src/contents/docs/07.enterprise/02.governance/logshipper/index.md
@@ -17,7 +17,7 @@ Manage and distribute logs across your entire infrastructure.
 
 Log Shipper can distribute Kestra logs from across your instance to an external logging platform. Log synchronization fetches logs and batches them into optimized chunks automatically. The batch process is done intelligently through defined synchronization points. Once batched, the Log Shipper delivers consistent and reliable data to your monitoring platform.
 
-Log Shipper is built on top of [Kestra plugins](/plugins/), ensuring it can integrate with popular logging platforms and expand as more plugins are developed. Supported observability platforms include ElasticSearch, Datadog, New Relic, Azure Monitor, Google Operational Suite, AWS Cloudwatch, Splunk, OpenSearch, and OpenTelemetry.
+Log Shipper is built on top of [Kestra plugins](/plugins), ensuring it can integrate with popular logging platforms and expand as more plugins are developed. Supported observability platforms include ElasticSearch, Datadog, New Relic, Azure Monitor, Google Operational Suite, AWS Cloudwatch, Splunk, OpenSearch, and OpenTelemetry.
 
 ## Log shipper properties
 


### PR DESCRIPTION
## Summary

Removes trailing slashes from 6 internal plugin/blog links that were causing redirect issues.

## Changes

- `blogs/2023-12-14-orchestration-problems-and-complexity`
- `blogs/2022-02-01-kestra-opensource`
- `blogs/2023-04-13-welcome-kestra-0-8-0`
- `blogs/2022-04-05-debezium-without-kafka-connect`
- `blogs/2023-05-22-data-orchestration-choosing-the-right-tool`
- `docs/enterprise/governance/logshipper`

These fixes were originally included in PR #4467 and have been extracted into this separate PR for a cleaner history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)