### PR TITLE
feat: use metaTitle from blueprint API for page meta tags

### DIFF
--- a/src/contents/docs/04.contribute-to-kestra/04.docs-contributor-guide/index.mdx
+++ b/src/contents/docs/04.contribute-to-kestra/04.docs-contributor-guide/index.mdx
@@ -468,7 +468,8 @@ extend:
     - SQL
   ee: false
   demo: true
-  meta_description: This flow represents a data engineering use case. It downloads
+  metaTitle: Getting Started - Data Engineering Pipeline
+  metaDescription: This flow represents a data engineering use case. It downloads
     a JSON file, filters the data in Python, and calculates the KPIs in SQL
     using DuckDB.
 ```

--- a/src/pages/blueprints/[id].astro
+++ b/src/pages/blueprints/[id].astro
@@ -50,7 +50,7 @@ if (pageData.tags && pageData.tags.length > 0) {
     }
 }
 
-const title = pageData.title
+const title = pageData.metaTitle || pageData.title
 const description = pageData.metaDescription
 ---
 

--- a/src/type.d.ts
+++ b/src/type.d.ts
@@ -10,6 +10,7 @@ interface Blueprint {
     namespace: string
     name: string
     description: string
+    metaTitle: string
     metaDescription: string
     flow: string
     tasks: Array<{ id: string; type: string }>


### PR DESCRIPTION
## Summary
- Added `metaTitle` to the `Blueprint` TypeScript interface
- Blueprint detail page now uses `metaTitle` (with fallback to `title`) for the page title meta tag
- Companion to kestra-io/api.kestra.io PR that surfaces `metaTitle`/`metaDescription` from the API