### PR TITLE
refactor(seo): merge SchemaFAQ into Faq component

### DIFF
--- a/src/components/common/Faq.astro
+++ b/src/components/common/Faq.astro
@@ -1,0 +1,37 @@
+---
+import FaqVue from "~/components/common/Faq.vue"
+
+interface FaqItem {
+    question: string
+    answer: string
+}
+
+interface Props {
+    items: FaqItem[]
+    title?: string
+    subtitle?: string
+    showHeader?: boolean
+}
+
+const { items, ...rest } = Astro.props
+
+function stripHtml(html: string): string {
+    return html.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim()
+}
+
+const schema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: items.map((item) => ({
+        "@type": "Question",
+        name: item.question,
+        acceptedAnswer: {
+            "@type": "Answer",
+            text: stripHtml(item.answer),
+        },
+    })),
+}
+---
+
+{items.length > 0 && <script type="application/ld+json" set:html={JSON.stringify(schema)} />}
+<FaqVue {items} {...rest} client:visible />

--- a/src/components/price/PriceBottom.astro
+++ b/src/components/price/PriceBottom.astro
@@ -1,6 +1,6 @@
 ---
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 const SELF_HOSTED_FAQ = [
     {
@@ -57,11 +57,11 @@ const CLOUD_HOSTED_FAQ = [
 </div>
 
 <div class="price-faq" data-host="self-hosted" data-usal="fade-u delay-20">
-    <Faq items={SELF_HOSTED_FAQ} client:visible />
+    <Faq items={SELF_HOSTED_FAQ} />
 </div>
 
 <div class="price-faq d-none" data-host="cloud-hosted" data-usal="fade-u delay-20">
-    <Faq items={CLOUD_HOSTED_FAQ} client:visible />
+    <Faq items={CLOUD_HOSTED_FAQ} />
 </div>
 
 <style lang="scss">

--- a/src/pages/ai-automation.astro
+++ b/src/pages/ai-automation.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from "~/components/layout.astro"
 
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 import Link from "~/components/common/Link.astro"
 import Quotes from "~/components/common/Quotes.vue"
 import SeeHow from "~/components/common/SeeHow.astro"
@@ -111,7 +111,7 @@ const AppleQuotes = [
             </Link>
         </SeeHow>
     </div>
-    <Faq {items} client:visible />
+    <Faq {items} />
 </Layout>
 
 <style lang="scss">

--- a/src/pages/blueprints/index.astro
+++ b/src/pages/blueprints/index.astro
@@ -3,7 +3,7 @@ export const prerender = false
 
 import { $fetchApiCached } from "~/utils/fetch"
 import Layout from "~/components/layout.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 import BlueprintCard from "~/components/layout/BlueprintCard.astro"
 import BlueprintLists from "~/components/blueprints/BlueprintLists.vue"
 import BlueprintSearch from "~/components/blueprints/BlueprintSearch.vue"
@@ -111,7 +111,7 @@ const description = "Get started with our library of workflows ready to use"
             }
         </div>
     </BlueprintLists>
-    <Faq items={ITEMS} client:visible />
+    <Faq items={ITEMS} />
 </Layout>
 
 <style lang="scss">

--- a/src/pages/data.astro
+++ b/src/pages/data.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from "~/components/layout.astro"
 
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 import Intro from "~/components/data/Intro.astro"
 import Solves from "~/components/data/Solves.astro"
 import Actual from "~/components/data/Actual.astro"
@@ -91,7 +91,7 @@ const items = [
         </Fragment>
         Join 500+ data teams who’ve modernized their orchestration with Kestra.
     </SeeHow>
-    <Faq {items} client:visible />
+    <Faq {items} />
 </Layout>
 
 <style lang="scss">

--- a/src/pages/features/index.astro
+++ b/src/pages/features/index.astro
@@ -1,5 +1,5 @@
 ---
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 import Layout from "~/components/layout.astro"
 import Run from "~/components/features/core/Run.astro"
 import Stacked from "~/components/common/Stacked.astro"

--- a/src/pages/vs/airflow.astro
+++ b/src/pages/vs/airflow.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import airflowLogo from "~/components/versus/assets/airflow.svg?raw"
 import airflowMonogram from "~/components/versus/assets/airflow-monograme.svg?raw"
@@ -119,7 +119,7 @@ const {
             logo: airflowLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Getting Started with Declarative Orchestration

--- a/src/pages/vs/ansible-automation-platform.astro
+++ b/src/pages/vs/ansible-automation-platform.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import competitorLogo from "~/components/versus/assets/ansible.svg?raw"
 import competitorMonogram from "~/components/versus/assets/ansible-monograme.svg?raw"
@@ -122,7 +122,7 @@ const {
             logo: competitorLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Getting Started with Ansible Orchestration

--- a/src/pages/vs/apache-nifi.astro
+++ b/src/pages/vs/apache-nifi.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import nifiLogo from "~/components/versus/assets/apache-nifi.svg?raw"
 import nifiMonogram from "~/components/versus/assets/apache-nifi-monograme.svg?raw"
@@ -119,7 +119,7 @@ const {
             logo: nifiLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Getting Started with Declarative Orchestration

--- a/src/pages/vs/aws-step-functions.astro
+++ b/src/pages/vs/aws-step-functions.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import awsStepFunctionsLogo from "~/components/versus/assets/aws-step-functions.svg?raw"
 import awsStepFunctionsMonogram from "~/components/versus/assets/aws-step-functions-monograme.svg?raw"
@@ -120,7 +120,7 @@ const {
             logo: awsStepFunctionsLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Getting Started with Multi-Cloud Orchestration

--- a/src/pages/vs/azure-data-factory.astro
+++ b/src/pages/vs/azure-data-factory.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import adfLogo from "~/components/versus/assets/azure-data-factory.svg?raw"
 import adfMonogram from "~/components/versus/assets/azure-data-factory-monograme.svg?raw"
@@ -120,7 +120,7 @@ const {
             logo: adfLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Getting Started with Declarative Orchestration

--- a/src/pages/vs/broadcom.astro
+++ b/src/pages/vs/broadcom.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import broadcomLogo from "~/components/versus/assets/broadcom.svg?raw"
 import broadcomMonogram from "~/components/versus/assets/broadcom-monograme.svg?raw"
@@ -119,7 +119,7 @@ const {
             logo: broadcomLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Modernize Beyond Legacy Batch Scheduling

--- a/src/pages/vs/chef.astro
+++ b/src/pages/vs/chef.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import competitorLogo from "~/components/versus/assets/chef.svg?raw"
 import competitorMonogram from "~/components/versus/assets/chef-monograme.svg?raw"
@@ -119,7 +119,7 @@ const {
             logo: competitorLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             From Configuration Management to Workflow Orchestration

--- a/src/pages/vs/control-m.astro
+++ b/src/pages/vs/control-m.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import bmcLogo from "~/components/versus/assets/control-m.svg?raw"
 import controlMMonogram from "~/components/versus/assets/control-m-monograme.svg?raw"
@@ -119,7 +119,7 @@ const {
             logo: bmcLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Getting Started with Declarative Orchestration

--- a/src/pages/vs/dagster.astro
+++ b/src/pages/vs/dagster.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import dagsterLogo from "~/components/versus/assets/dagster.svg?raw"
 import dagsterMonogram from "~/components/versus/assets/dagster-monograme.svg?raw"
@@ -119,7 +119,7 @@ const {
             logo: dagsterLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Getting Started with Declarative Orchestration

--- a/src/pages/vs/google-workflows.astro
+++ b/src/pages/vs/google-workflows.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import googleWorkflowsLogo from "~/components/versus/assets/google-workflows.svg?raw"
 import googleWorkflowsMonogram from "~/components/versus/assets/google-workflows-monograme.svg?raw"
@@ -120,7 +120,7 @@ const {
             logo: googleWorkflowsLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Orchestrate Beyond GCP Service Coordination

--- a/src/pages/vs/hp-operations-orchestrator.astro
+++ b/src/pages/vs/hp-operations-orchestrator.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import competitorLogo from "~/components/versus/assets/hp-operations-orchestrator.svg?raw"
 import competitorMonogram from "~/components/versus/assets/hp-operations-orchestrator-monograme.svg?raw"
@@ -122,7 +122,7 @@ const {
             logo: competitorLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Modernizing Legacy IT Automation with Kestra

--- a/src/pages/vs/ibm-workload-automation.astro
+++ b/src/pages/vs/ibm-workload-automation.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import competitorLogo from "~/components/versus/assets/ibm-workload-automation.svg?raw"
 import competitorMonogram from "~/components/versus/assets/ibm-workload-automation-monograme.svg?raw"
@@ -122,7 +122,7 @@ const {
             logo: competitorLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Getting Started with Declarative Orchestration

--- a/src/pages/vs/index.astro
+++ b/src/pages/vs/index.astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection } from "astro:content"
 import Layout from "~/components/layout.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 import GetStarted from "~/components/common/GetStarted.astro"
 import kestraIcon from "~/components/versus/assets/ks-icon.svg?raw"
 import vsBadgeSvg from "~/components/versus/assets/vs-badge.svg?raw"
@@ -155,7 +155,6 @@ const faqItems = [
     <Faq
         items={faqItems}
         title="Frequently Asked Questions"
-        client:visible
     />
 </Layout>
 

--- a/src/pages/vs/morpheus.astro
+++ b/src/pages/vs/morpheus.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import competitorLogo from "~/components/versus/assets/morpheus.svg?raw"
 import competitorMonogram from "~/components/versus/assets/morpheus-monograme.svg?raw"
@@ -119,7 +119,7 @@ const {
             logo: competitorLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Getting Started with Declarative Orchestration

--- a/src/pages/vs/n8n.astro
+++ b/src/pages/vs/n8n.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import n8nLogo from "~/components/versus/assets/n8n.svg?raw"
 import n8nMonogram from "~/components/versus/assets/n8n-monograme.svg?raw"
@@ -119,7 +119,7 @@ const {
             logo: n8nLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Getting Started with Declarative Orchestration

--- a/src/pages/vs/pagerduty.astro
+++ b/src/pages/vs/pagerduty.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import competitorLogo from "~/components/versus/assets/pagerduty.svg?raw"
 import competitorMonogram from "~/components/versus/assets/pagerduty-monograme.svg?raw"
@@ -119,7 +119,7 @@ const {
             logo: competitorLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Getting Started with Modern Incident Orchestration

--- a/src/pages/vs/prefect.astro
+++ b/src/pages/vs/prefect.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import prefectLogo from "~/components/versus/assets/prefect.svg?raw"
 import prefectMonogram from "~/components/versus/assets/prefect-monograme.svg?raw"
@@ -119,7 +119,7 @@ const {
             logo: prefectLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Getting Started with Declarative Orchestration

--- a/src/pages/vs/puppet.astro
+++ b/src/pages/vs/puppet.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import competitorLogo from "~/components/versus/assets/puppet.svg?raw"
 import competitorMonogram from "~/components/versus/assets/puppet-monograme.svg?raw"
@@ -119,7 +119,7 @@ const {
             logo: competitorLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             From Configuration Management to Workflow Orchestration

--- a/src/pages/vs/redwood.astro
+++ b/src/pages/vs/redwood.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import competitorLogo from "~/components/versus/assets/redwood.svg?raw"
 import competitorMonogram from "~/components/versus/assets/redwood-monograme.svg?raw"
@@ -119,7 +119,7 @@ const {
             logo: competitorLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Getting Started with Declarative Orchestration

--- a/src/pages/vs/rundeck.astro
+++ b/src/pages/vs/rundeck.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import competitorLogo from "~/components/versus/assets/rundeck-full.svg?raw"
 import competitorMonogram from "~/components/versus/assets/rundeck-full-monograme.svg?raw"
@@ -119,7 +119,7 @@ const {
             logo: competitorLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Getting Started with Modern Runbook Orchestration

--- a/src/pages/vs/stonebranch.astro
+++ b/src/pages/vs/stonebranch.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import competitorLogo from "~/components/versus/assets/stonebranch.svg?raw"
 import competitorMonogram from "~/components/versus/assets/stonebranch-monograme.svg?raw"
@@ -119,7 +119,7 @@ const {
             logo: competitorLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Getting Started with Declarative Orchestration

--- a/src/pages/vs/vmware-cloud-foundation.astro
+++ b/src/pages/vs/vmware-cloud-foundation.astro
@@ -12,7 +12,7 @@ import SocialProof from "~/components/common/SocialProof.astro"
 import PlatformStrengths from "~/components/common/PlatformStrengths.astro"
 import DecisionGuide from "~/components/versus/DecisionGuide.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 
 import competitorLogo from "~/components/versus/assets/vmware-cloud-foundation.svg?raw"
 import competitorMonogram from "~/components/versus/assets/vmware-cloud-foundation-monograme.svg?raw"
@@ -119,7 +119,7 @@ const {
             logo: competitorLogo,
         }}
     />
-    <Faq items={commonQuestions} client:visible />
+    <Faq items={commonQuestions} />
     <SeeHow>
         <Fragment slot="title">
             Getting Started with Modern Infrastructure Orchestration

--- a/src/pages/write-for-us.astro
+++ b/src/pages/write-for-us.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from "~/components/layout.astro"
-import Faq from "~/components/common/Faq.vue"
+import Faq from "~/components/common/Faq.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
 import CardGrid from "~/components/card/CardGrid.astro"
 
@@ -67,7 +67,7 @@ const FAQS = [
         />
         <WriteSection />
         <Process />
-        <Faq items={FAQS} client:visible />
+        <Faq items={FAQS} />
         <SeeHow imgSrc={seeHowImg}>
             <Fragment slot="title">Start Writing For Kestra</Fragment>
             Ready to share your technical knowledge? Join our community of writers


### PR DESCRIPTION
## Summary

- Created `Faq.astro` that combines the Vue UI (`Faq.vue`) and the FAQPage JSON-LD schema in a single component
- Deleted `SchemaFAQ.astro` — its logic is now inlined in `Faq.astro`
- Updated all 28 `.astro` pages/components to import `Faq.astro` instead of separately importing `Faq.vue` + `SchemaFAQ.astro`

## Test plan

- [ ] Verify FAQ sections render correctly on a few `/vs/*` pages
- [ ] Check JSON-LD output in page source (`<script type="application/ld+json">`) is present and valid
- [ ] Validate with Google Rich Results Test on a page with FAQ content