### PR TITLE
fix: use new Response() in feedsContentType middleware to ensure mutable headers

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -262,10 +262,14 @@ const feedsContentType = defineMiddleware(async (context, next) => {
         return next()
     }
 
-    const response = (await next()).clone()
-    response.headers.set("content-type", "application/json")
-
-    return response
+    const response = await next()
+    const headers = new Headers(response.headers)
+    headers.set("content-type", "application/json")
+    return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+    })
 })
 
 export const onRequest = sequence(


### PR DESCRIPTION
In Cloudflare Workers, Response.clone() can return a response with immutable
headers when the response has passed through the runtime, causing headers.set()
to silently fail. Constructing a new Response() always guarantees mutable
headers, ensuring content-type: application/json is reliably set for /api/feeds.

https://claude.ai/code/session_018tgagtF2cR71AKJdc136Cp