### PR TITLE
Add Content-Type header for /api/feeds endpoint

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,2 @@
+/api/feeds
+  Content-Type: application/json


### PR DESCRIPTION
## Summary
This change adds HTTP header configuration for the `/api/feeds` endpoint to explicitly set the `Content-Type` response header to `application/json`.

## Key Changes
- Added `public/_headers` configuration file to specify HTTP headers for the `/api/feeds` route
- Set `Content-Type: application/json` header for all responses from the `/api/feeds` endpoint

## Implementation Details
The `_headers` file uses Cloudflare's header configuration format to declare that the `/api/feeds` endpoint should return responses with the `Content-Type: application/json` header. This ensures clients receive proper content-type information and helps with browser handling and API documentation.

https://claude.ai/code/session_01NGfkGhqnpXcYJVDvgLu51p