### PR TITLE
docs(cloudrun): add more information about cloudrun task runner

### DIFF
--- a/src/contents/docs/task-runners/04.types/07.google-cloudrun-task-runner/index.md
+++ b/src/contents/docs/task-runners/04.types/07.google-cloudrun-task-runner/index.md
@@ -9,22 +9,34 @@ description: Run Kestra tasks as serverless containers on Google Cloud Run for s
 
 Run tasks as containers on Google Cloud Run.
 
-## Run tasks on Google Cloud Run
+## Overview
 
-The Google Cloud Run task runner deploys the container for each task to Google Cloud Run.
+The Google Cloud Run task runner deploys the container for each task as a Cloud Run Job. When no file operations are configured, the container starts in the root directory — use the `{{ workingDir }}` Pebble expression or the `WORKING_DIR` environment variable to reference input files and outputs rather than relying on the current directory.
 
-## How the Google Cloud Run task runner works
+## File handling
 
-To use the `inputFiles`, `outputFiles`, or `namespaceFiles` properties, you must set the `bucket` property. The bucket acts as an intermediary storage layer for the task runner:
+To use the `inputFiles`, `outputFiles`, or `namespaceFiles` properties, set the `bucket` property. The bucket acts as an intermediary storage layer:
 
-- Input and namespace files are uploaded to the Cloud Storage bucket before the task runs.
-- Output files are stored in the same bucket and made available for download and preview in the Kestra UI after execution.
+- Input and namespace files are uploaded to the bucket before the task runs.
+- Output files are stored in the bucket during execution and made available for download and preview in the Kestra UI afterward.
 
-To help track where files are stored, the task runner creates a unique folder for each run. You can access this folder using the `{{ bucketPath }}` Pebble expression or the `BUCKET_PATH` environment variable.
+The task runner creates a unique folder for each run. You can access this folder using the `{{ bucketPath }}` Pebble expression or the `BUCKET_PATH` environment variable.
 
-Because Cloud Run environments are ephemeral, tasks run in the root directory instead of the working directory. Therefore, use the `{{ workingDir }}` Pebble expression or the `WORKING_DIR` environment variable to access your input or namespace files.
+### Syncing the full working directory
 
-## Minimum permissions required
+Set `syncWorkingDirectory: true` to download the entire working directory after task completion, which is useful when tasks produce files dynamically without knowing their names in advance:
+
+```yaml
+taskRunner:
+  type: io.kestra.plugin.ee.gcp.runner.CloudRun
+  projectId: "{{ secret('GCP_PROJECT_ID') }}"
+  region: europe-west2
+  bucket: "{{ secret('GCP_BUCKET') }}"
+  serviceAccount: "{{ secret('GOOGLE_SA') }}"
+  syncWorkingDirectory: true
+```
+
+## IAM permissions
 
 The service account used by Kestra must be able to create Cloud Run jobs, view logs, and access the Cloud Storage bucket used for staging files.
 
@@ -36,20 +48,183 @@ Grant the following IAM roles to the Kestra service account:
 
 If Cloud Run jobs execute as the Compute Engine default service account, also grant the Kestra service account the **Service Account User** role on that service account.
 
-These are the minimum roles required to create and monitor Cloud Run jobs with the task runner.
+## Termination behavior
 
 :::alert{type="warning"}
-### Note on termination behavior
-- If the Kestra Worker running this task is terminated, the Cloud Run job continues to run until completion. This prevents interruptions due to Worker crashes.
-- If you manually stop the execution from the UI, the Cloud Run job is terminated to avoid unnecessary costs.
-_(This behavior is under development; you can track progress [on GitHub](https://github.com/kestra-io/plugin-gcp/issues/381))._
+If the Kestra Worker running this task is terminated, the Cloud Run job continues to run until completion. This prevents interruptions due to Worker crashes.
+
+If you manually stop the execution from the Kestra UI, the Cloud Run job is terminated to avoid unnecessary costs. _(This behavior is under development; track progress [on GitHub](https://github.com/kestra-io/plugin-gcp/issues/381))._
 :::
+
+By default, jobs are deleted after the task completes. When a task is resubmitted, the runner reattaches to an existing job for the same task run rather than creating a new one. Use `delete: false` to keep the job for inspection after completion, or `resume: false` to force a new job on every execution attempt:
+
+```yaml
+taskRunner:
+  type: io.kestra.plugin.ee.gcp.runner.CloudRun
+  projectId: "{{ secret('GCP_PROJECT_ID') }}"
+  region: europe-west2
+  serviceAccount: "{{ secret('GOOGLE_SA') }}"
+  delete: false
+  resume: false
+```
+
+## Container resources
+
+Use the `resources` property to set CPU and memory limits on the Cloud Run container. Both `cpu` and `memory` accept static values or Pebble expressions:
+
+```yaml
+taskRunner:
+  type: io.kestra.plugin.ee.gcp.runner.CloudRun
+  projectId: "{{ secret('GCP_PROJECT_ID') }}"
+  region: europe-west2
+  serviceAccount: "{{ secret('GOOGLE_SA') }}"
+  resources:
+    cpu: "2"
+    memory: "4Gi"
+```
+
+CPU accepts whole vCPUs (`1`, `2`, `4`, `8`) or millicores (`1000m`). Memory accepts standard SI suffixes (`512Mi`, `1Gi`, `2Gi`).
+
+Both fields support Pebble expressions, so you can size containers dynamically from flow inputs:
+
+```yaml
+inputs:
+  - id: cpu_count
+    type: INT
+    defaults: 2
+  - id: memory_gb
+    type: INT
+    defaults: 4
+
+tasks:
+  - id: run
+    type: io.kestra.plugin.scripts.shell.Commands
+    containerImage: ubuntu
+    taskRunner:
+      type: io.kestra.plugin.ee.gcp.runner.CloudRun
+      projectId: "{{ secret('GCP_PROJECT_ID') }}"
+      region: europe-west2
+      serviceAccount: "{{ secret('GOOGLE_SA') }}"
+      resources:
+        cpu: "{{ inputs.cpu_count }}"
+        memory: "{{ inputs.memory_gb }}Gi"
+    commands:
+      - echo "Running with {{ inputs.cpu_count }} vCPUs and {{ inputs.memory_gb }}Gi memory"
+```
+
+## Timeout and polling
+
+Three properties control how long the runner waits and how often it checks job status:
+
+| Property | Default | Description |
+|---|---|---|
+| `waitUntilCompletion` | `PT1H` | Maximum wall-clock time before the job is timed out. The task's own `timeout` takes precedence when set. |
+| `completionCheckInterval` | `PT5S` | How often to poll the Cloud Run API for job status. Lower values reduce latency for short jobs; higher values reduce API calls for long ones. |
+| `waitForLogInterval` | `PT5S` | Extra time to stream late log entries after job completion. |
+
+```yaml
+taskRunner:
+  type: io.kestra.plugin.ee.gcp.runner.CloudRun
+  projectId: "{{ secret('GCP_PROJECT_ID') }}"
+  region: europe-west2
+  serviceAccount: "{{ secret('GOOGLE_SA') }}"
+  waitUntilCompletion: PT4H
+  completionCheckInterval: PT30S
+  waitForLogInterval: PT10S
+```
+
+## Job retries
+
+`maxRetries` controls the number of Cloud Run task-level retries (default `3`). These are retries within the Cloud Run execution itself, not Kestra-level task retries. Set to `0` to disable:
+
+```yaml
+taskRunner:
+  type: io.kestra.plugin.ee.gcp.runner.CloudRun
+  projectId: "{{ secret('GCP_PROJECT_ID') }}"
+  region: europe-west2
+  serviceAccount: "{{ secret('GOOGLE_SA') }}"
+  maxRetries: 0
+```
+
+## VPC networking
+
+### VPC Access Connector
+
+Route job traffic through a Serverless VPC Access Connector to reach private resources such as Cloud SQL or internal services. Both `vpcAccessConnector` and `vpcEgress` must be set together:
+
+```yaml
+taskRunner:
+  type: io.kestra.plugin.ee.gcp.runner.CloudRun
+  projectId: "{{ secret('GCP_PROJECT_ID') }}"
+  region: europe-west1
+  serviceAccount: "{{ secret('GOOGLE_SA') }}"
+  vpcAccessConnector: projects/my-project/locations/europe-west1/connectors/my-connector
+  vpcEgress: PRIVATE_RANGES_ONLY
+```
+
+`vpcEgress` accepts `PRIVATE_RANGES_ONLY` (only private RFC 1918 ranges use the connector) or `ALL_TRAFFIC` (all outbound traffic uses the connector).
+
+### Direct VPC Egress
+
+Direct VPC Egress connects the job to a VPC network without a connector. Set `network` and/or `subnetwork` using full resource paths. `vpcAccessConnector` and Direct VPC Egress are mutually exclusive:
+
+```yaml
+taskRunner:
+  type: io.kestra.plugin.ee.gcp.runner.CloudRun
+  projectId: "{{ secret('GCP_PROJECT_ID') }}"
+  region: europe-west1
+  serviceAccount: "{{ secret('GOOGLE_SA') }}"
+  network: projects/my-project/global/networks/my-vpc
+  subnetwork: projects/my-project/regions/europe-west1/subnetworks/my-subnet
+  vpcEgress: ALL_TRAFFIC
+```
+
+## Mounting GCS buckets as volumes
+
+Use `volumes` to mount one or more GCS buckets directly into the container at specified paths. This is independent of the `bucket` property used for file transfer, and is useful for mounting reference datasets or shared outputs:
+
+```yaml
+taskRunner:
+  type: io.kestra.plugin.ee.gcp.runner.CloudRun
+  projectId: "{{ secret('GCP_PROJECT_ID') }}"
+  region: europe-west1
+  serviceAccount: "{{ secret('GOOGLE_SA') }}"
+  volumes:
+    - bucket: my-reference-data-bucket
+      mountPath: /data
+      readOnly: true
+    - bucket: my-output-bucket
+      mountPath: /output
+```
+
+Each entry requires `bucket` (the GCS bucket name) and `mountPath` (the absolute path inside the container). Set `readOnly: true` for read-only access; the default is read-write.
+
+## Service account configuration
+
+The Cloud Run task runner uses three service account properties with distinct roles:
+
+| Property | Purpose |
+|---|---|
+| `serviceAccount` | JSON key used for Kestra API calls to create and manage Cloud Run jobs. Also used as the job execution identity when `runtimeServiceAccount` is not set. |
+| `runtimeServiceAccount` | Email of the service account that the Cloud Run container runs as (`--service-account` equivalent). Controls what GCP resources the container can access at runtime. When set, takes precedence over `serviceAccount` for job execution identity. |
+| `impersonatedServiceAccount` | Email of a service account to impersonate for API calls (`--impersonate-service-account` equivalent). Applies to job creation and management, not the container runtime. |
+
+Use `runtimeServiceAccount` when the container needs a different identity from the service account Kestra uses to manage jobs:
+
+```yaml
+taskRunner:
+  type: io.kestra.plugin.ee.gcp.runner.CloudRun
+  projectId: "{{ secret('GCP_PROJECT_ID') }}"
+  region: europe-west2
+  serviceAccount: "{{ secret('GOOGLE_SA') }}"
+  runtimeServiceAccount: container-runner@my-project.iam.gserviceaccount.com
+```
 
 ## Example flows
 
 ### Basic example
 
-The following example runs a simple shell command inside a Cloud Run container:
+The following example runs a shell command inside a Cloud Run container:
 
 ```yaml
 id: new-shell
@@ -71,9 +246,9 @@ tasks:
       - echo "Hello World"
 ```
 
-### Example with file inputs
+### Example with file inputs and outputs
 
-This flow runs a shell command and demonstrates how to use file inputs and outputs with Cloud Run:
+The following flow uploads an input file to GCS, runs a shell command, and retrieves the output:
 
 ```yaml
 id: new-shell-with-file
@@ -109,8 +284,6 @@ tasks:
 For a complete list of properties available in the Cloud Run task runner, see the [GCP plugin documentation](/plugins/plugin-gcp/runner/io.kestra.plugin.ee.gcp.runner.CloudRun) or explore the configuration in the built-in Code Editor in the Kestra UI.
 :::
 
----
-
 ## How to run tasks on Google Cloud Run
 
 <div class="video-container">
@@ -119,16 +292,16 @@ For a complete list of properties available in the Cloud Run task runner, see th
 
 ### Before you begin
 
-You’ll need the following:
+Ensure you have the following:
 
 1. A Google Cloud account.
-2. A Kestra instance (version 0.16.0 or later) with Google credentials stored as [secrets](../../../06.concepts/04.secret/index.md) or as environment variables.
+2. A Kestra instance with Google credentials stored as [secrets](../../../06.concepts/04.secret/index.md) or as environment variables.
 
 ### Google Cloud Console setup
 
 #### Create a project
 
-If you don’t already have one, create a new project in the Google Cloud Console.
+If you don't already have one, create a new project in the Google Cloud Console.
 
 ![project](./project.png)
 
@@ -166,27 +339,13 @@ To grant access to the Compute Engine default service account, go to **IAM & Adm
 
 #### Create a storage bucket
 
-Search for “Bucket” in the Cloud Console and create a new GCS bucket. Use default settings unless otherwise required.
+Search for "Bucket" in the Cloud Console and create a new GCS bucket. Use default settings unless otherwise required.
 
 ![bucket](./bucket.png)
 
 ### Create a flow
 
-Below is an example flow that runs a shell script using the Google Cloud Run task runner. The task copies a file under a new name.
-
-```yaml
-containerImage: centos
-taskRunner:
-  type: io.kestra.plugin.ee.gcp.runner.CloudRun
-  projectId: "{{ secret('GCP_PROJECT_ID') }}"
-  region: "{{ vars.region }}"
-  bucket: "{{ secret('GCP_BUCKET') }}"
-  serviceAccount: "{{ secret('GOOGLE_SA') }}"
-```
-
-The `containerImage` property is required because Cloud Run executes each task as a container. You can use any image from a public or private registry. In this example, we use `centos`.
-
-Here’s the complete flow:
+The following flow runs a shell script using the Google Cloud Run task runner and copies a file under a new name:
 
 ```yaml
 id: new-shell-with-file
@@ -218,7 +377,7 @@ tasks:
       - cp {{ workingDir }}/data.txt {{ workingDir }}/out.txt
 ```
 
-When you execute the flow, the logs in Kestra confirm the creation of the Cloud Run task runner:
+When you execute the flow, the Kestra logs confirm that the Cloud Run job was created and started:
 
 ![logs](./logs.png)
 
@@ -226,4 +385,4 @@ You can also verify job creation in the Google Cloud Console:
 
 ![jobs](./jobs.png)
 
-Once the task completes, the Cloud Run container is automatically terminated to free up resources.
+After the task completes, the Cloud Run job is automatically deleted to free up resources.


### PR DESCRIPTION
 ---
  Changes

  Corrections

  - Clarified working directory behaviour: the container only starts in the root directory when no file operations are
  configured; when a bucket is set, the workingDir path is applied to the container automatically
  - Fixed termination description: "container is terminated" → "job is deleted" to match the actual delete: true behaviour
  in code

  Expanded existing sections

  - Termination behavior: added delete: false (keep job for post-failure inspection) and resume: false (force a new job on
  every attempt), with example
  - IAM permissions: already covered; no change

  New sections

  - Syncing the full working directory: documents syncWorkingDirectory: true for downloading the entire working directory
  when output file names are not known in advance
  - Container resources: documents resources.cpu and resources.memory limits, including support for Pebble expressions to
  size containers dynamically from flow inputs
  - Timeout and polling: reference table for waitUntilCompletion (default PT1H), completionCheckInterval (default PT5S),
  and waitForLogInterval (default PT5S)
  - Job retries: documents maxRetries (default 3), clarifying these are Cloud Run task-level retries distinct from
  Kestra-level task retries
  - VPC networking: two subsections — VPC Access Connector (vpcAccessConnector + vpcEgress) and Direct VPC Egress (network
  + subnetwork), with mutual-exclusivity constraint noted
  - Mounting GCS buckets as volumes: documents volumes with bucket, mountPath, and readOnly fields; clarifies this is
  independent of the bucket property used for file transfer
  - Service account configuration: reference table distinguishing serviceAccount (API auth + fallback runtime identity),
  runtimeServiceAccount (container execution identity), and impersonatedServiceAccount (API impersonation), with example

  Removed

  - Empty ## Run tasks on Google Cloud Run H2 that restated the page title with no content
  - Stray --- horizontal rule between the examples section and the setup guide
  - Markdown heading (### Note on termination behavior) inside an alert block
  - Version number from "Before you begin" prose (already captured in frontmatter)