### PR TITLE
seo: allow all /_astro/ assets in robots.txt

### DIFF
--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -12,7 +12,7 @@ Disallow: ${disabled ? "*" : "/slack"}
 ${disabled ? "" : `# Block the /blueprints pagination bug (critical - 501 errors)
 Disallow: /blueprints?*clid=*
 Disallow: /blueprints?*size=*
-# Build assets — CSS, JS, fonts accessible pour le rendu
+# Build assets — CSS, JS, fonts accessible for robots rendering
 Allow: /_astro/
 Disallow: /_nuxt/
 Disallow: /__nuxt_content/

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -12,14 +12,8 @@ Disallow: ${disabled ? "*" : "/slack"}
 ${disabled ? "" : `# Block the /blueprints pagination bug (critical - 501 errors)
 Disallow: /blueprints?*clid=*
 Disallow: /blueprints?*size=*
-# Build assets (keep images indexable)
-Allow: /_astro/*.jpg
-Allow: /_astro/*.jpeg
-Allow: /_astro/*.png
-Allow: /_astro/*.webp
-Allow: /_astro/*.svg
-Allow: /_astro/*.gif
-Disallow: /_astro/
+# Build assets — CSS, JS, fonts accessible pour le rendu
+Allow: /_astro/
 Disallow: /_nuxt/
 Disallow: /__nuxt_content/
 # Cloudflare image optimization (keep indexable)


### PR DESCRIPTION
## Summary

- Replace 6 per-extension `Allow` rules (`*.jpg`, `*.jpeg`, `*.png`, `*.webp`, `*.svg`, `*.gif`) under `/_astro/` with a single `Allow: /_astro/`
- This ensures CSS, JS, and fonts are also accessible to crawlers for rendering, not just images
- Update section comment from `# Build assets (keep images indexable)` → `# Build assets — CSS, JS, fonts accessible pour le rendu`
- No change to the disabled/preview mode logic

## Test plan

- [ ] Verify `robots.txt` in production returns the new `Allow: /_astro/` rule
- [ ] Confirm no `Disallow: /_astro/` line appears after the `Allow`
- [ ] Verify dev/preview mode still disallows everything (`Disallow: *`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)