### PR TITLE
fix(seo): expand /pricing title tag

### DIFF
--- a/src/pages/pricing/index.astro
+++ b/src/pages/pricing/index.astro
@@ -7,7 +7,7 @@ import PriceBottom from "~/components/price/PriceBottom.astro"
 import PlanTable from "~/components/price/PlanTable.astro"
 import PriceQuote from "~/components/price/PriceQuote.vue"
 
-const title = "Pricing"
+const title = "Kestra Pricing: Open Source, Cloud & Enterprise Plans"
 const description =
     "Choose the right plan for your needs. Start with the Open Source version and scale with the Enterprise Edition of Kestra."
 ---


### PR DESCRIPTION
## Summary

- `/pricing` title was `Pricing | Kestra` (16 chars) — too short, wastes SERP space on a high-intent commercial page
- Updated to `Kestra Pricing: Open Source, Cloud & Enterprise Plans | Kestra` (rendered with suffix)

## Verification checklist

- [ ] `/pricing` → View Source → `<title>` contains "Kestra Pricing: Open Source, Cloud & Enterprise Plans"
- [ ] Homepage title unchanged
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)