### PR TITLE
feat(seo): make linkedin required for blog authors

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -49,7 +49,7 @@ export const collections = {
                         name: z.string(),
                         image: z.string(),
                         twitter: z.string().optional(),
-                        linkedin: z.string().optional(),
+                        linkedin: z.string(),
                         role: z.string().nullable().optional(),
                     })
                     .optional(),
@@ -59,7 +59,7 @@ export const collections = {
                             name: z.string(),
                             image: z.string(),
                             twitter: z.string().optional(),
-                            linkedin: z.string().optional(),
+                            linkedin: z.string(),
                             role: z.string().nullable().optional(),
                         }),
                     )

--- a/src/contents/blogs/2023-10-09-kestra-surrealdb/index.md
+++ b/src/contents/blogs/2023-10-09-kestra-surrealdb/index.md
@@ -5,6 +5,7 @@ date: 2023-10-09T08:00:00
 category: Solutions
 author:
   name: Dario Radecic
+  linkedin: ""
   image: "dradecic"
 image: ./main.jpg
 ---

--- a/src/contents/blogs/2023-10-30-top-data-orchestration-platforms/index.md
+++ b/src/contents/blogs/2023-10-30-top-data-orchestration-platforms/index.md
@@ -5,6 +5,7 @@ date: 2023-10-30T12:00:00
 category: Solutions
 author:
   name: Dario Radecic
+  linkedin: ""
   image: "dradecic"
 image: ./main.png
 ---

--- a/src/contents/blogs/2023-10-31-kestra-weaviate/index.md
+++ b/src/contents/blogs/2023-10-31-kestra-weaviate/index.md
@@ -5,6 +5,7 @@ date: 2023-10-31T08:00:00
 category: Solutions
 author:
   name: Dario Radecic
+  linkedin: ""
   image: "dradecic"
 image: ./main.jpg
 ---

--- a/src/contents/blogs/2023-11-20-advanced-python-scripts/index.md
+++ b/src/contents/blogs/2023-11-20-advanced-python-scripts/index.md
@@ -5,6 +5,7 @@ date: 2023-11-20T12:00:00
 category: Solutions
 author:
   name: Dario Radecic
+  linkedin: ""
   image: "dradecic"
 image: ./main.jpg
 ---

--- a/src/contents/blogs/2023-12-04-dlt-kestra-usage/index.md
+++ b/src/contents/blogs/2023-12-04-dlt-kestra-usage/index.md
@@ -5,6 +5,7 @@ date: 2023-12-04T13:00:00
 category: Solutions
 author:
   name: Anuun Chinbat
+  linkedin: ""
   image: "achinbat"
 image: ./main.jpg
 ---

--- a/src/contents/blogs/2024-01-08-sentry-plugin/index.md
+++ b/src/contents/blogs/2024-01-08-sentry-plugin/index.md
@@ -5,6 +5,7 @@ date: 2024-01-08T08:00:00
 category: Solutions
 author:
   name: Kevin Fleming
+  linkedin: ""
   image: "kfleming"
 image: ./main.jpg
 ---

--- a/src/contents/blogs/2024-03-06-guide-integration-ingestion/index.md
+++ b/src/contents/blogs/2024-03-06-guide-integration-ingestion/index.md
@@ -5,6 +5,7 @@ date: 2024-03-06T12:00:00
 category: Solution
 author:
   name: Kevin Fleming
+  linkedin: ""
   image: "kfleming"
 image: ./main.jpg
 ---

--- a/src/contents/blogs/2024-03-12-kestra-databricks/index.md
+++ b/src/contents/blogs/2024-03-12-kestra-databricks/index.md
@@ -5,6 +5,7 @@ date: 2024-03-12T10:00:00
 category: Solutions
 author:
   name: Shruti Mantri
+  linkedin: https://www.linkedin.com/in/shruti-mantri-88527a67/
   image: "smantri"
 image: ./main.jpg
 ---

--- a/src/contents/blogs/2024-03-18-guide-vector-databases/index.md
+++ b/src/contents/blogs/2024-03-18-guide-vector-databases/index.md
@@ -5,6 +5,7 @@ date: 2024-03-18T12:00:00
 category: Solution
 author:
   name: Kevin Fleming
+  linkedin: ""
   image: "kfleming"
 image: ./main.jpg
 ---

--- a/src/contents/blogs/2024-03-19-oltp-databases-guide/index.md
+++ b/src/contents/blogs/2024-03-19-oltp-databases-guide/index.md
@@ -5,6 +5,7 @@ date: 2024-03-19T12:00:00
 category: Solution
 author:
   name: Kevin Fleming
+  linkedin: ""
   image: "kfleming"
 image: ./main.jpg
 ---

--- a/src/contents/blogs/2024-03-20-kestra-airbyte/index.md
+++ b/src/contents/blogs/2024-03-20-kestra-airbyte/index.md
@@ -5,6 +5,7 @@ date: 2024-03-20T10:00:00
 category: Solutions
 author:
   name: Shruti Mantri
+  linkedin: https://www.linkedin.com/in/shruti-mantri-88527a67/
   image: "smantri"
 image: ./main.jpg
 ---

--- a/src/contents/blogs/2024-04-04-top-10-cool-features-I-love-about-kestra/index.md
+++ b/src/contents/blogs/2024-04-04-top-10-cool-features-I-love-about-kestra/index.md
@@ -5,6 +5,7 @@ date: 2024-04-04T10:00:00
 category: Solutions
 author:
   name: Shruti Mantri
+  linkedin: https://www.linkedin.com/in/shruti-mantri-88527a67/
   image: "smantri"
 image: ./main.jpg
 ---

--- a/src/contents/blogs/2024-04-09-aws-data-pipeline/index.md
+++ b/src/contents/blogs/2024-04-09-aws-data-pipeline/index.md
@@ -5,6 +5,7 @@ date: 2024-04-09T10:00:00
 category: Solutions
 author:
   name: Shruti Mantri
+  linkedin: https://www.linkedin.com/in/shruti-mantri-88527a67/
   image: "smantri"
 image: ./main.jpg
 ---
@@ -59,6 +60,7 @@ tasks:
     item:
       id: "{{ read(outputs.json.uri) | jq('.product_id') | first | number }}"
       name: "{{ read(outputs.json.uri) | jq('.product_name') | first }}"
+      linkedin: ""
       category: "{{ read(outputs.json.uri) | jq('.product_category') | first }}"
       brand: "{{ read(outputs.json.uri) | jq('.brand') | first }}"
 ```

--- a/src/contents/blogs/2024-04-16-infrastructure-orchestration-using-kestra/index.md
+++ b/src/contents/blogs/2024-04-16-infrastructure-orchestration-using-kestra/index.md
@@ -5,6 +5,7 @@ date: 2024-04-16T17:00:00
 category: Solutions
 author:
   name: Shruti Mantri
+  linkedin: https://www.linkedin.com/in/shruti-mantri-88527a67/
   image: "smantri"
 image: ./main.jpg
 
@@ -44,6 +45,7 @@ tasks:
           - name: create a simple s3 bucket
             amazon.aws.s3_bucket:
               name: <bucket-name>
+              linkedin: ""
               state: present
               region: eu-central-1
               access_key: "{{ secret('AWS_ACCESS_KEY_ID') | trim }}"

--- a/src/contents/blogs/2024-06-27-realtime-triggers/index.md
+++ b/src/contents/blogs/2024-06-27-realtime-triggers/index.md
@@ -5,6 +5,7 @@ date: 2024-06-27T08:00:00
 category: Solutions
 author:
   name: Shruti Mantri
+  linkedin: https://www.linkedin.com/in/shruti-mantri-88527a67/
   image: "smantri"
 image: ./main.jpg
 ---

--- a/src/contents/blogs/2024-09-18-what-is-an-orchestrator/index.md
+++ b/src/contents/blogs/2024-09-18-what-is-an-orchestrator/index.md
@@ -5,6 +5,7 @@ date: 2024-09-17T15:00:00
 category: Solutions
 author:
   name: Federico Trotta
+  linkedin: https://www.linkedin.com/in/federico-trotta/
   image: "ftrotta"
 image: ./main.jpg
 ---
@@ -141,6 +142,7 @@ The `analyze_csv.yml` could be something like that:
 
 ```yaml
 name: Analyze CSV with Python
+linkedin: ""
 
 on:
   workflow_dispatch:

--- a/src/contents/blogs/2024-10-17-cd-cd-kestra-comparison/index.md
+++ b/src/contents/blogs/2024-10-17-cd-cd-kestra-comparison/index.md
@@ -5,6 +5,7 @@ date: 2024-10-17T15:00:00
 category: Solutions
 author:
   name: Federico Trotta
+  linkedin: https://www.linkedin.com/in/federico-trotta/
   image: "ftrotta"
 image: ./main.jpg
 ---

--- a/src/contents/blogs/2024-10-22-credit-agricole-case-study/index.md
+++ b/src/contents/blogs/2024-10-22-credit-agricole-case-study/index.md
@@ -5,6 +5,7 @@ date:  2024-10-22T17:00:00
 category: Solutions
 author:
   name: Julien Legrand
+  linkedin: ""
   image: jlegrand
   role: Data & AI Product Owner
 image: ./main.jpg

--- a/src/contents/blogs/2024-11-19-kestra-ion/index.md
+++ b/src/contents/blogs/2024-11-19-kestra-ion/index.md
@@ -5,6 +5,7 @@ date: 2024-11-19T16:00:00
 category: Solutions
 author:
   name: Shruti Mantri
+  linkedin: https://www.linkedin.com/in/shruti-mantri-88527a67/
   image: smantri
 image: ./main.jpg
 ---

--- a/src/contents/blogs/2025-03-27-using-amazon-s3-tables-with-kestra/index.md
+++ b/src/contents/blogs/2025-03-27-using-amazon-s3-tables-with-kestra/index.md
@@ -5,6 +5,7 @@ date: 2025-03-27T17:00:00
 category: Solutions
 author:
   name: Shruti Mantri
+  linkedin: https://www.linkedin.com/in/shruti-mantri-88527a67/
   image: smantri
   role:
 image: ./main.jpg

--- a/src/contents/blogs/2026-01-26-data-assets-use-cases/index.md
+++ b/src/contents/blogs/2026-01-26-data-assets-use-cases/index.md
@@ -5,6 +5,7 @@ date: 2026-01-26T13:00:00
 category: Solutions
 author: 
   name: "Parham Parvizi"
+  linkedin: https://www.linkedin.com/in/xdatanomad/
   image: pparvizi
   role: Solutions Engineer
 image: ./main.png

--- a/src/contents/blogs/2026-03-26-using-dbt-cloud-with-kestra/index.md
+++ b/src/contents/blogs/2026-03-26-using-dbt-cloud-with-kestra/index.md
@@ -5,6 +5,7 @@ date: 2026-03-26T13:00:00
 category: Solutions
 author:
   name: Elliot Gunn
+  linkedin: https://www.linkedin.com/in/elliotgunn/
   image: egunn
   role: Product Marketing Manager
 image: ./main.png

--- a/src/contents/blogs/2026-04-06-airflow-2-end-of-life/index.md
+++ b/src/contents/blogs/2026-04-06-airflow-2-end-of-life/index.md
@@ -5,6 +5,7 @@ date: 2026-04-06T09:00:00
 category: Solutions
 author:
   name: Elliot Gunn
+  linkedin: https://www.linkedin.com/in/elliotgunn/
   image: egunn
   role: Product Marketing Manager
 image: ./main.png
@@ -14,26 +15,31 @@ schema:
   mainEntity:
     - "@type": "Question"
       name: "When does Airflow 2 reach end of life?"
+      linkedin: ""
       acceptedAnswer:
         "@type": "Answer"
         text: "Apache Airflow 2 reaches end of life on April 22, 2026. After this date, no security patches, bug fixes, or provider updates will be released for the 2.x line."
     - "@type": "Question"
       name: "Is it safe to keep running Airflow 2 after EOL?"
+      linkedin: ""
       acceptedAnswer:
         "@type": "Answer"
         text: "Running unsupported software in production introduces security and compliance risks. Any CVEs discovered in Airflow 2 or its dependencies after EOL won't receive patches. Organizations with compliance requirements (SOC 2, HIPAA, PCI-DSS) will likely need to migrate to a supported version or platform."
     - "@type": "Question"
       name: "What are the main breaking changes in Airflow 3?"
+      linkedin: ""
       acceptedAnswer:
         "@type": "Answer"
         text: "The biggest breaking changes include: SubDAGs removed entirely (must convert to Task Groups), deprecated context variables removed (execution_date, prev_ds, next_ds), provider packages moved from apache-airflow to apache-airflow-providers-standard, and the webserver split into an API server and DAG processor."
     - "@type": "Question"
       name: "Should I upgrade to Airflow 3 or switch to a different platform?"
+      linkedin: ""
       acceptedAnswer:
         "@type": "Answer"
         text: "If your team is Python-native and invested in the Airflow ecosystem, upgrading to Airflow 3 is probably the right call. If you've been constrained by Airflow's Python-only model or need to orchestrate beyond data pipelines, the EOL window is a natural point to evaluate declarative alternatives like Kestra."
     - "@type": "Question"
       name: "How long does a typical Airflow migration take?"
+      linkedin: ""
       acceptedAnswer:
         "@type": "Answer"
         text: "Both upgrading to Airflow 3 and migrating to an alternative typically take 4 to 8 weeks for a mid-size deployment (50-200 DAGs), depending on the number of custom operators, undocumented workarounds, and integration complexity."

--- a/src/contents/blogs/kestra-2-0-engineering/index.md
+++ b/src/contents/blogs/kestra-2-0-engineering/index.md
@@ -5,6 +5,7 @@ date: 2026-04-01T10:00:00
 category: Engineering
 author:
   name: Ludovic Dehon
+  linkedin: https://www.linkedin.com/in/ludovic-dehon/
   image: ldehon
   role: CTO & Co-founder
 image: ./main.png

--- a/src/contents/blogs/kestra-series-a/index.md
+++ b/src/contents/blogs/kestra-series-a/index.md
@@ -5,6 +5,7 @@ date: 2026-03-31T08:00:00
 category: Company News
 author:
   name: Emmanuel Darras
+  linkedin: https://www.linkedin.com/in/emmanuel-darras/
   image: edarras
   role: CEO & Co-founder
 image: ./series-a-header.png


### PR DESCRIPTION
## Summary

Completes the work started in #4469 by ensuring **every** blog post has the `linkedin` field and making it **required** in the Zod schema so future posts fail at build time without it.

- **15 posts** backfilled with real LinkedIn URLs (Shruti Mantri, Elliot Gunn, Federico Trotta, Parham Parvizi, Ludovic Dehon, Emmanuel Darras)
- **10 posts** backfilled with empty string `""` (external contributors: Dario Radecic, Kevin Fleming, Anuun Chinbat, Julien Legrand — LinkedIn URLs unconfirmed)
- **`content.config.ts`**: `linkedin` changed from `z.string().optional()` to `z.string()` in both `author` and `authors` schemas

### Why this matters

Without this change, new blog posts can be published without a `linkedin` field, which means the JSON-LD `author.sameAs` property (added in #4469) would silently be missing. Making it required ensures:
- Every future post must declare the field
- Build fails immediately if forgotten
- Empty string `""` is valid for external authors (the Astro template already handles falsy values gracefully)

## Test plan

- [ ] Changes verified in dev/preprod
- [ ] No unrelated files modified
- [ ] YAML validated (for blueprint PRs)
- [ ] `astro sync` passes with no content collection errors
- [ ] Verify JSON-LD output includes `sameAs` for posts with real URLs
- [ ] Verify JSON-LD output omits `sameAs` for posts with `linkedin: ""`

🤖 Generated with [Claude Code](https://claude.com/claude-code)