### PR TITLE
docs(process-taskrunner): improve the doc with missing capabilities

### DIFF
--- a/src/contents/docs/task-runners/04.types/01.process-task-runner/index.md
+++ b/src/contents/docs/task-runners/04.types/01.process-task-runner/index.md
@@ -49,10 +49,29 @@ Before each execution, Kestra prepares a working directory on the worker host. T
 
 **Input files** declared with `inputFiles` and **namespace files** are copied into the working directory before the process starts. **Output files** declared with `outputFiles` must be written to the working directory to be captured by Kestra.
 
-The following example passes an input file, processes it, and captures the result:
+Because the Process runner sets the process working directory to Kestra's working directory, **relative paths work without needing the `{{workingDir}}` prefix** in commands.
+
+The following self-contained example writes a file and captures it as an output:
 
 ```yaml
-id: process_with_files
+id: process_output_file
+namespace: company.team
+
+tasks:
+  - id: shell
+    type: io.kestra.plugin.scripts.shell.Commands
+    outputFiles:
+      - out.txt
+    taskRunner:
+      type: io.kestra.plugin.core.runner.Process
+    commands:
+      - echo "Hello from Process runner" > out.txt
+```
+
+You can also pass an input file into the task and capture a transformed result. The input file is placed in the working directory under the key name you specify in `inputFiles`:
+
+```yaml
+id: process_input_output_files
 namespace: company.team
 
 inputs:
@@ -69,7 +88,7 @@ tasks:
     taskRunner:
       type: io.kestra.plugin.core.runner.Process
     commands:
-      - cp {{workingDir}}/data.txt {{workingDir}}/out.txt
+      - cp data.txt out.txt
 ```
 
 ## Installing dependencies with beforeCommands

--- a/src/contents/docs/task-runners/04.types/01.process-task-runner/index.md
+++ b/src/contents/docs/task-runners/04.types/01.process-task-runner/index.md
@@ -30,15 +30,110 @@ tasks:
       - echo "Hello World!"
 ```
 
-The [Process task runner](/plugins/core/task-runners/runner/io.kestra.plugin.core.runner.process) does not require any additional configuration beyond the `type` property.
+The [Process task runner](/plugins/core/task-runners/runner/io.kestra.plugin.core.runner.process) has no additional configuration properties — only the `type` is required.
 
 :::alert{type="info"}
-By default, Python is the only programming language installed in the Kestra Docker image. To use other languages, ensure their dependencies are installed on your local machine if running Kestra manually, or inside your container if running via Docker.
+Script tasks default to the Docker task runner if no `taskRunner` is specified. Set `taskRunner.type` to `io.kestra.plugin.core.runner.Process` explicitly when you want local process execution.
 :::
+
+## Working directory and file handling
+
+Before each execution, Kestra prepares a working directory on the worker host. The following variables give your script access to it:
+
+| Variable | Type | Description |
+|---|---|---|
+| `{{workingDir}}` | Template expression | Absolute path to the working directory |
+| `WORKING_DIR` | Environment variable | Same path, available to any subprocess |
+| `{{outputDir}}` | Template expression | Dedicated output directory (only when `outputDirectoryEnabled` is set on the task) |
+| `OUTPUT_DIR` | Environment variable | Same path as `{{outputDir}}` when available |
+
+**Input files** declared with `inputFiles` and **namespace files** are copied into the working directory before the process starts. **Output files** declared with `outputFiles` must be written to the working directory to be captured by Kestra.
+
+The following example passes an input file, processes it, and captures the result:
+
+```yaml
+id: process_with_files
+namespace: company.team
+
+inputs:
+  - id: file
+    type: FILE
+
+tasks:
+  - id: shell
+    type: io.kestra.plugin.scripts.shell.Commands
+    inputFiles:
+      data.txt: "{{inputs.file}}"
+    outputFiles:
+      - out.txt
+    taskRunner:
+      type: io.kestra.plugin.core.runner.Process
+    commands:
+      - cp {{workingDir}}/data.txt {{workingDir}}/out.txt
+```
+
+## Installing dependencies with beforeCommands
+
+Use `beforeCommands` to install dependencies before the main script runs. When running inside the Kestra Docker image (which manages its own Python environment), pass `--break-system-packages` to avoid conflicts:
+
+```yaml
+id: python_with_deps
+namespace: company.team
+
+inputs:
+  - id: url
+    type: URI
+    defaults: https://jsonplaceholder.typicode.com/todos/1
+
+tasks:
+  - id: transform
+    type: io.kestra.plugin.scripts.python.Script
+    taskRunner:
+      type: io.kestra.plugin.core.runner.Process
+    beforeCommands:
+      - pip install kestra requests --break-system-packages
+    script: |
+      import requests
+      from kestra import Kestra
+
+      url = "{{ inputs.url }}"
+
+      response = requests.get(url)
+      print('Status Code:', response.status_code)
+      Kestra.outputs(response.json())
+```
+
+:::alert{type="info"}
+By default, Python is the only programming language installed in the Kestra Docker image. If you are running Kestra directly on a host machine, whatever is installed on that machine is available to the process. To use other languages, ensure their runtimes are installed in your environment before running Kestra.
+:::
+
+## Logs and exit codes
+
+Both stdout and stderr are captured and streamed to Kestra's task logs in real time. Any non-zero exit code causes the task to fail with a `TaskException` reporting the exit code.
+
+## Behavior on worker interruption
+
+When the Kestra worker is stopped or interrupted:
+
+1. The running process **and all its child processes** are killed immediately.
+2. The task is marked as failed.
+3. When the worker restarts, Kestra re-queues the task execution from the beginning.
+
+There is no process-level resume — the task restarts from scratch on the next attempt.
+
+## Considerations
+
+- **No isolation**: Unlike the Docker task runner, the Process runner provides no container boundary. Subprocesses run with the same OS user and permissions as the Kestra worker JVM, inherit the worker's full environment, and share host CPU, memory, and disk with other running tasks.
+- **Platform support**: Works on Linux, macOS, and Windows.
+- **Dependencies**: Any tool or library used by the script must already be installed on the worker host (or installed via `beforeCommands`).
 
 ## Benefits
 
-The Process task runner is useful when you need to access local files or take advantage of locally configured software libraries and virtual environments.
+The Process task runner is well suited when you need to:
+
+- Access local files or hardware (e.g., GPUs, local databases)
+- Reuse locally configured software libraries or virtual environments
+- Avoid the overhead of container startup
 
 ## Combining task runners with Worker Groups
 


### PR DESCRIPTION
  - Default runner callout: added an info alert clarifying that Docker is the
  default and Process must be set explicitly
  - New "Working directory and file handling" section: reference table for
  {{workingDir}}, WORKING_DIR, {{outputDir}}, OUTPUT_DIR; explains where
  input/namespace files land and where output files must be written; includes
  the inputFiles/outputFiles example from the Java source
  - New "Installing dependencies with beforeCommands" section: added the pip
  install + --break-system-packages example from the Java source, with
  explanation of why the flag is needed
  - Clarified the info alert on language availability — distinguishes Docker
  image deployments from bare-metal
  - New "Logs and exit codes" section: documents stdout/stderr streaming and
  non-zero exit code behavior
  - New "Behavior on worker interruption" section: documents that descendants
  are killed and the task restarts from scratch (mirrors the detail level of
  Docker runner docs)
  - New "Considerations" section: covers no isolation, platform support,
  dependency requirements
  - Reorganized "Benefits" section: tightened to 3 concrete use cases