### PR TITLE
fix(plugins): flatten single-subgroup plugins in sidebar and navigation

### DIFF
--- a/src/components/plugins/sidebar/PluginSidebar.vue
+++ b/src/components/plugins/sidebar/PluginSidebar.vue
@@ -17,7 +17,7 @@
         <div class="sidebar-content">
             <h3 v-if="pluginWrapper" class="plugin-title">{{ title }}</h3>
 
-            <div v-if="subGroupWrappers.length > 0" class="subgroups-list">
+            <div v-if="subGroupWrappers.length > 1" class="subgroups-list">
                 <details
                     v-for="sub in subGroupWrappers"
                     :key="sub.subGroup"
@@ -102,9 +102,12 @@
         pluginsWithoutDeprecated.filter((p) => p.subGroup !== undefined),
     )
 
-    const groupedDirectElements = computed(() =>
-        pluginWrapper ? groupPluginElements(pluginWrapper) : {},
-    )
+    const groupedDirectElements = computed(() => {
+        const source = subGroupWrappers.value.length === 1
+            ? subGroupWrappers.value[0]
+            : pluginWrapper
+        return source ? groupPluginElements(source) : {}
+    })
 
     const groupPluginElements = (plugin: Plugin): Record<string, PluginElement[]> =>
         Object.fromEntries(

--- a/src/pages/plugins/[...slug].astro
+++ b/src/pages/plugins/[...slug].astro
@@ -88,6 +88,7 @@ const [page, { blueprintCounts, relatedBlogs }] = await Promise.all([
 ])
 
 const {
+    effectiveSubGroup,
     pluginsWithoutDeprecated,
     rootPlugin,
     rootPluginTitle,
@@ -126,7 +127,7 @@ if (
     page === null ||
     !pluginsWithoutDeprecated.some(
         (p: any) =>
-            subGroup === undefined || slugify(subGroupName(p)) === subGroup,
+            effectiveSubGroup === undefined || slugify(subGroupName(p)) === effectiveSubGroup,
     )
 ) {
     console.warn("Redirecting due to no content")
@@ -178,7 +179,7 @@ if (
                         {pluginsWithoutDeprecated}
                         {subGroupsIcons}
                         {pluginName}
-                        {subGroup}
+                        subGroup={effectiveSubGroup}
                         {pathname}
                         {subgroupBlueprintCounts}
                         {metadataMap}

--- a/src/pages/plugins/[...slug].astro
+++ b/src/pages/plugins/[...slug].astro
@@ -50,6 +50,10 @@ const { githubVersions, allPlugins, allPluginMetadata, pluginsInformations } =
         isEePlugin,
     )
 
+if (subGroup && allPlugins.filter((p) => p.name === pluginName && p.subGroup).length === 1) {
+    return Astro.redirect(`/plugins/${[pluginName, ...splitRouteSlug.slice(2)].join("/")}`, 301)
+}
+
 const navigation = generateNavigationFromSubgroups(allPlugins)
 const aliasMapping = getAliasMapping(allPlugins)
 const pageList = recursivePages(navigation[0])

--- a/src/utils/plugins/buildPluginPageProps.ts
+++ b/src/utils/plugins/buildPluginPageProps.ts
@@ -56,8 +56,12 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
         pluginType ? (sidebarPluginData?.body?.plugins ?? []) : (page?.body?.plugins ?? []),
     )
 
+    const subGroupPlugins = pluginsWithoutDeprecated.filter((p) => p.subGroup !== undefined)
+    const effectiveSubGroup = subGroup
+        ?? (subGroupPlugins.length === 1 ? slugify(subGroupName(subGroupPlugins[0])) : undefined)
+
     const subGroupWrapper = pluginsWithoutDeprecated.find(
-        (p) => slugify(subGroupName(p)) === subGroup,
+        (p) => slugify(subGroupName(p)) === effectiveSubGroup,
     )
 
     const currentPageIcon = `/icons/${pluginType ?? subGroupWrapper?.subGroup ?? page?.body.group}.svg`
@@ -74,7 +78,7 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
     const rootPlugin = pluginsWithoutDeprecated.find((p) => p.subGroup === undefined)
 
     const currentSubgroupPlugin =
-        !subGroup || pluginType
+        !effectiveSubGroup || pluginType
             ? undefined
             : pluginsWithoutDeprecated.find((p) => {
                   const subgroupLastSegment = p.subGroup?.split(".").pop()
@@ -83,7 +87,7 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
                       subgroupLastSegment,
                       slugify(subgroupLastSegment ?? ""),
                   ]
-                  return possibleSubgroupMatches.includes(subGroup)
+                  return possibleSubgroupMatches.includes(effectiveSubGroup)
               })
 
     const currentPluginMetadata = (() => {
@@ -142,7 +146,7 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
     const headingDescription = pluginType
         ? page?.title
         : (combinedDescription ??
-          (subGroup === undefined
+          (effectiveSubGroup === undefined
               ? (rootPlugin?.longDescription ?? combinedDescription)
               : (currentSubgroupPlugin?.longDescription ?? combinedDescription)))
 
@@ -185,12 +189,12 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
             .filter(Boolean)
     })()
 
-    const blueprintsSectionHeading = getBlueprintsHeading(pluginName, rootPlugin, subGroup)
+    const blueprintsSectionHeading = getBlueprintsHeading(pluginName, rootPlugin, effectiveSubGroup)
 
     const currentPluginCategories = (() => {
         const subgroupCats = currentSubgroupPlugin?.categories
         const pluginCats = rootPlugin?.categories
-        return subGroup === undefined
+        return effectiveSubGroup === undefined
             ? (pluginCats ?? [])
             : subgroupCats?.length
               ? subgroupCats
@@ -211,9 +215,9 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
     const makeTOC = (): TocLink[] => {
         const pluginToc = (() => {
             if (!rootPlugin) return []
-            if (subGroup && currentSubgroupPlugin)
+            if (effectiveSubGroup && currentSubgroupPlugin)
                 return generateTocForPluginElements(currentSubgroupPlugin)
-            if (!subGroup && !pluginType) {
+            if (!effectiveSubGroup && !pluginType) {
                 const subGroups = pluginsWithoutDeprecated.filter((p) => p.subGroup)
                 return subGroups.length
                     ? subGroups.map((sub) =>
@@ -232,8 +236,8 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
 
         const hasBlueprints = pluginType
             ? blueprintCounts?.[pluginType] > 0
-            : subGroup
-              ? subgroupBlueprintCounts?.[`${rootPlugin?.group ?? pluginName}-${subGroup}`] > 0
+            : effectiveSubGroup
+              ? subgroupBlueprintCounts?.[`${rootPlugin?.group ?? pluginName}-${effectiveSubGroup}`] > 0
               : blueprintCounts?.[rootPlugin?.group ?? pluginName] > 0
 
         const isRootView = pluginType === undefined
@@ -252,7 +256,7 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
             blueprintsSectionHeading?.text
                 ? [tocEntry(blueprintsSectionHeading.id, blueprintsSectionHeading.text)]
                 : []),
-            ...(isRootView && subGroup === undefined && relatedBlogs.length > 0
+            ...(isRootView && effectiveSubGroup === undefined && relatedBlogs.length > 0
                 ? [tocEntry("latest-blog-posts", "Latest Blog Posts")]
                 : []),
             ...(currentPluginCategories?.length > 0
@@ -275,8 +279,8 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
         ),
     )
 
-    const ogImage = subGroup
-        ? `/meta/plugins/group-${subgroups.find((r) => slugify(r.title) === subGroup)?.subGroup}.svg`
+    const ogImage = effectiveSubGroup
+        ? `/meta/plugins/group-${subgroups.find((r) => slugify(r.title) === effectiveSubGroup)?.subGroup}.svg`
         : `/meta/plugins/${pluginType ?? pluginName}.svg`
 
     const prunedRootPlugin = rootPlugin ? prunePluginsForSidebar([rootPlugin])[0] : undefined
@@ -297,6 +301,7 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
         currentPluginCategories,
         sidebarPluginDataResult: sidebarPluginData,
 
+        effectiveSubGroup,
         pluginsWithoutDeprecated,
         rootPlugin,
         rootPluginTitle,

--- a/src/utils/plugins/generateNavigation.ts
+++ b/src/utils/plugins/generateNavigation.ts
@@ -49,10 +49,10 @@ export function generateNavigationFromSubgroups(pluginsSubGroups: Plugin[]): Nav
             const root = wrappers.find((p) => p.subGroup === undefined)!
             const rootUrl = `/plugins/${slugify(root.name)}`
 
-            const children = wrappers.length > 1
-                ? wrappers
-                    .filter((p) => p.subGroup !== undefined)
-                    .map((p) => {
+            const subGroups = wrappers.filter((p) => p.subGroup !== undefined)
+
+            const children = subGroups.length > 1
+                ? subGroups.map((p) => {
                         const url = `${rootUrl}/${slugify(subGroupName(p))}`
                         return {
                             title: toNavTitle(p.title),
@@ -60,7 +60,7 @@ export function generateNavigationFromSubgroups(pluginsSubGroups: Plugin[]): Nav
                             children: buildElementNav(p, url),
                         }
                     })
-                : buildElementNav(wrappers[0], rootUrl)
+                : buildElementNav(subGroups[0] ?? wrappers[0], rootUrl)
 
             return {
                 title: toNavTitle(root.title),


### PR DESCRIPTION
On [this page](https://kestra.io/plugins/plugin-ee-git) when I joined the page the arbo was hidden

<img width="2404" height="649" alt="image" src="https://github.com/user-attachments/assets/dd9a9cea-4290-4aa8-a218-447534606f97" />


Solution is: flatten the single-subgroup plugins so when opened it would directly show the tasks of it.