### PR TITLE
seo: decouple H1 from SEO title (5-page sample)

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -14,6 +14,7 @@ export const collections = {
         schema: () =>
             z.object({
                 title: z.string(),
+                h1: z.string().optional(),
                 sidebarTitle: z.string().optional(),
                 description: z.string().optional(),
                 icon: z.string().optional(),

--- a/src/contents/docs/02.installation/02.docker/index.md
+++ b/src/contents/docs/02.installation/02.docker/index.md
@@ -1,5 +1,6 @@
 ---
 title: Run Kestra with Docker – Single-Container Setup
+h1: Get Started with Kestra Using a Single Docker Container
 sidebarTitle: Docker
 icon: /src/contents/docs/icons/docker.svg
 description: Run Kestra in a single Docker container for quick testing and development, with options for custom configuration.

--- a/src/contents/docs/05.workflow-components/01.flow/index.md
+++ b/src/contents/docs/05.workflow-components/01.flow/index.md
@@ -1,5 +1,6 @@
 ---
 title: Flows in Kestra – Define Orchestration Units
+h1: "Understand Flows: The Core Units of Kestra Orchestration"
 description: Understand Kestra Flows, the fundamental units of orchestration. Learn to define tasks, inputs, outputs, and logic to automate your business processes.
 sidebarTitle: Flow
 icon: /src/contents/docs/icons/flow.svg

--- a/src/contents/docs/05.workflow-components/01.flow/index.md
+++ b/src/contents/docs/05.workflow-components/01.flow/index.md
@@ -1,6 +1,6 @@
 ---
 title: Flows in Kestra – Define Orchestration Units
-h1: "Understand Flows: The Core Units of Kestra Orchestration"
+h1: Understand Flows: The Core Units of Kestra Orchestration
 description: Understand Kestra Flows, the fundamental units of orchestration. Learn to define tasks, inputs, outputs, and logic to automate your business processes.
 sidebarTitle: Flow
 icon: /src/contents/docs/icons/flow.svg

--- a/src/contents/docs/05.workflow-components/07.triggers/01.schedule-trigger/index.md
+++ b/src/contents/docs/05.workflow-components/07.triggers/01.schedule-trigger/index.md
@@ -1,5 +1,6 @@
 ---
 title: Schedule Trigger in Kestra – Cron-Based Scheduling
+h1: Run Flows on a Cron Schedule with Backfills and Conditions
 description: Schedule Kestra workflows with the Schedule Trigger. Learn to use cron expressions, backfills, and conditions to run flows at precise times.
 sidebarTitle: Schedule Trigger
 icon: /src/contents/docs/icons/flow.svg

--- a/src/contents/docs/06.concepts/05.kv-store/index.md
+++ b/src/contents/docs/06.concepts/05.kv-store/index.md
@@ -1,6 +1,7 @@
 ---
-title: KV Store in Kestra – Persist Shared State
-description: Build stateful workflows with the KV Store.
+title: "KV Store in Kestra: Persist Shared State"
+h1: Build Stateful Workflows with the KV Store
+description: Build stateful workflows with the Kestra KV Store. Persist and share key-value pairs across flows and executions for dynamic configuration and shared state.
 sidebarTitle: Key Value (KV) Store
 icon: /src/contents/docs/icons/concepts.svg
 version: ">= 0.18.0"

--- a/src/contents/docs/15.how-to-guides/alerting/index.md
+++ b/src/contents/docs/15.how-to-guides/alerting/index.md
@@ -1,5 +1,6 @@
 ---
 title: Configure Alerts in Kestra
+h1: Set Up Workflow Failure Alerts via Slack and PagerDuty
 icon: /src/contents/docs/icons/tutorial.svg
 stage: Getting Started
 topics:

--- a/src/pages/docs/[...docsPath].astro
+++ b/src/pages/docs/[...docsPath].astro
@@ -70,7 +70,7 @@ const icon = doc.data?.icon ? (await images[doc.data.icon]()).default.src : null
     image={image.toString()}
 >
     <h1 class="title" slot="title">
-        {doc.data?.title}
+        {doc.data?.h1 ?? doc.data?.title}
     </h1>
     <div class="bd-content">
         <Content />

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -15,7 +15,7 @@ const editUrl = doc.filePath
 ---
 
 <LayoutDocs activeStem="/docs" isHomePage>
-    <h1 slot="title" class="py-0 title">{doc.data?.title}</h1>
+    <h1 slot="title" class="py-0 title">{doc.data?.h1 ?? doc.data?.title}</h1>
 
     <NavToc
         client:visible


### PR DESCRIPTION
## Context

The SEO audit identified that `<title>` and `<h1>` are currently identical on every docs page. Best practice is to keep the SEO title optimised for SERP click-through while the H1 is written for the reader landing on the page.

## What this PR does

- **Adds an `h1` optional field** to the docs Zod schema (`content.config.ts`)
- **Updates both doc page templates** (`[...docsPath].astro` and `docs/index.astro`) to render `h1 ?? title` as the visible heading — zero behaviour change for pages that don't set the field
- **Updates 5 pages as a sample** for review before rolling out the full batch (~470 pages)

## Pages updated

| Page | Change |
|------|--------|
| `docs/workflow-components/flow` | H1 added |
| `docs/workflow-components/triggers/schedule-trigger` | H1 added |
| `docs/how-to-guides/alerting` | H1 added |
| `docs/concepts/kv-store` | title colon style + description expanded + H1 added |
| `docs/installation/docker` | H1 added |

## How to review

- Check that the rendered H1 differs from the browser tab title on the 5 pages above
- Confirm no visual regression on pages that don't have the `h1` field (fallback to `title`)
- If approved, the remaining ~464 pages will be applied in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)