### PR TITLE
Update log plugin to `type: io.kestra.plugin.core.log.Log`

### DIFF
--- a/src/contents/docs/05.workflow-components/06.outputs/index.md
+++ b/src/contents/docs/05.workflow-components/06.outputs/index.md
@@ -325,7 +325,7 @@ tasks:
           data: "{{ outputs.first.values.data }}"
 
   - id: log_siblings
-    type: io.kestra.core.tasks.log.Log
+    type: io.kestra.plugin.core.log.Log
     message: "{{ outputs.second.values.data }}"
 ```
 
@@ -353,7 +353,7 @@ tasks:
           data: "{{ outputs.first[taskrun.value].values.data }}"
 
   - id: log_output_from_foreach
-    type: io.kestra.core.tasks.log.Log
+    type: io.kestra.plugin.core.log.Log
     message: "{{ outputs.second['value 1'].values.data }}"
 ```
 


### PR DESCRIPTION
Just did a quick update here based on what the Kestra editor was prompting me to do. Might be worth doing a larger find and replace, although this is a soft warning so you can still save and avoid any yellow squiggles in the editor. 