### PR TITLE
SEO: add 3 new resources pages (orchestration complexity, batch vs streaming, event-driven orchestration)

### DIFF
--- a/src/contents/resources/batch-vs-streaming-processing/index.md
+++ b/src/contents/resources/batch-vs-streaming-processing/index.md
@@ -1,0 +1,271 @@
+---
+title: "Batch vs Streaming Processing: Differences, Use Cases & Trade-Offs"
+description: "Understand the real differences between batch and streaming processing, when each one wins, and how modern orchestration lets you run both with the same engine."
+metaTitle: "Batch vs Streaming Processing: Differences, Use Cases & Trade-Offs"
+metaDescription: "Understand the real differences between batch and streaming processing, when each one wins, and how modern orchestration lets you run both with the same engine."
+tag: data
+date: 2026-04-21
+faq:
+  - question: "What is the difference between batch and streaming processing?"
+    answer: "Batch processing operates on bounded datasets — a finite set of records collected over a window (an hour, a day) and processed as one unit. Streaming processing operates on unbounded data — records arriving continuously, processed one at a time or in short windows with low latency. The fundamental difference is not technical, it is about the shape of the data: do you have all the input before you start, or does new input keep arriving?"
+  - question: "When should you use streaming instead of batch processing?"
+    answer: "Use streaming when latency directly affects business outcomes — fraud detection, real-time personalization, monitoring alerts, IoT reactions, or user-facing features that depend on fresh data. Use batch when the data arrives in bulk, the downstream consumer tolerates delay (reports, ML training, historical aggregations), or the cost of running always-on infrastructure outweighs the value of freshness."
+  - question: "Is batch processing still relevant in 2026?"
+    answer: "Yes, batch remains the right answer for a large share of production workloads. Financial reporting, ML training, historical backfills, regulatory exports, and anything where the consumer reads hourly or daily do not benefit from streaming. The shift has not been 'batch to streaming' but 'batch-only to batch plus streaming', with the best platforms handling both."
+  - question: "What is micro-batch processing and when should you use it?"
+    answer: "Micro-batch processes data in small, frequent batches — every few seconds or minutes — rather than as a true continuous stream. It offers most of the freshness benefits of streaming with simpler operational semantics and lower cost. Use micro-batching when you need sub-minute latency but do not need millisecond reactions, or when your team's operational maturity does not yet justify a full streaming stack."
+  - question: "Can the same platform orchestrate batch and streaming workflows?"
+    answer: "Yes, and this is increasingly the default. Modern orchestration engines like Kestra expose schedules, event triggers, and realtime triggers as first-class primitives — the same workflow definition can run on a nightly schedule, on file arrival, or as a realtime Kafka consumer. Unifying the control plane across both paradigms eliminates the coordination gap that plagues teams running separate tools for each."
+  - question: "What is the difference between Lambda and Kappa architecture?"
+    answer: "Lambda architecture runs batch and streaming pipelines in parallel, merging their outputs to get both historical accuracy and real-time freshness. Kappa architecture unifies everything as a stream, replaying historical data through the same pipeline when needed. Lambda is more flexible but doubles the code to maintain. Kappa is simpler but requires a replayable event log as the source of truth. Most teams end up somewhere in between."
+---
+
+Most "batch vs streaming" comparisons treat the choice as binary. In production, it almost never is. Modern data platforms run both, often inside the same business process — a nightly aggregation feeds a real-time dashboard, a streaming fraud detector consults a batch-trained model, a micro-batch ETL bridges the gap between them.
+
+The real question is not "which one should I pick" but "how do I design for both, and orchestrate them consistently". This guide breaks down where the two approaches genuinely differ, when each one wins, and how to handle the hybrid cases that dominate real systems.
+
+## Batch vs streaming processing at a glance
+
+The fundamental distinction is about the shape of the input:
+
+- **Batch processing** operates on **bounded data**: a finite set of records, collected over a time window, processed as one unit. You have all the input before you start. The job runs, produces an output, and exits.
+- **Streaming processing** operates on **unbounded data**: records arrive continuously, with no natural end. The processor is always running, handling records one at a time or in short windows, emitting results as it goes.
+
+Everything else — latency, cost, state management, operational complexity — flows from this distinction. Batch can afford to be slow because the data is already there. Streaming has to be fast because new data keeps coming.
+
+### When latency matters, and when it does not
+
+The biggest mistake in choosing between the two is assuming lower latency is always better. It is not, because latency has a cost. Streaming infrastructure runs 24/7, requires always-on consumers, and usually needs a message broker, schema registry, and state store. Batch infrastructure wakes up, does its work, and goes back to sleep.
+
+If a business process consumes data hourly — a report, a dashboard refresh, an email digest — streaming provides no value over a well-orchestrated batch job. If a business process needs to react in seconds — blocking a fraudulent transaction, personalizing a page — batch is not an option regardless of cost.
+
+### Why most modern systems run both
+
+The mature pattern is hybrid: streaming for the reactive layer, batch for the analytical layer, and shared primitives for state and storage. Trying to force everything into one paradigm creates more complexity than it removes. The interesting engineering question is how to keep the two coordinated without duplicating code, schemas, and operational surface.
+
+## What is batch processing?
+
+Batch processing collects records over a period, then runs a job that reads them, transforms them, and writes an output. The job has a defined start, a defined end, and a known input size.
+
+### Typical architecture and execution model
+
+A batch pipeline usually looks like this: a scheduler triggers the job (cron, or an orchestrator on a schedule), the job reads from a source (object storage, a database, an API), transforms the data, and writes to a destination (warehouse, data lake, another database). Execution is finite, resources are released when the job completes, and observability is retrospective — you look at what happened after it finished.
+
+Tools in this category include Apache Spark (in batch mode), dbt, Apache Airflow for orchestration, and modern engines like Kestra that treat scheduled execution as one primitive among many.
+
+### Strengths
+
+- **Throughput**: processing a large dataset as one unit is computationally efficient. Vectorized operations, parallel reads, and bulk writes all benefit from bounded data.
+- **Cost efficiency**: infrastructure only runs when the job runs. For workloads that execute hourly or daily, this is a fraction of the cost of always-on streaming.
+- **Reproducibility**: the same input and the same code produce the same output. This is essential for financial reporting, regulatory filings, and ML training.
+- **Simplicity**: no state to maintain between runs, no continuous consumer to supervise, no message broker to tune. A batch job is easier to reason about, debug, and replay.
+
+### Weaknesses
+
+- **Latency**: by definition, output is only available after the window completes. An hourly batch adds up to one hour of delay.
+- **Operational windows**: batch jobs running overnight leave a blind spot during the day. If a pipeline fails, you often do not find out until morning.
+- **Staleness**: downstream consumers always see yesterday's — or last hour's — data, which rules out real-time use cases entirely.
+
+## What is streaming processing?
+
+Streaming processing reads records as they arrive, processes each one (or small windows of them), and emits results continuously. The pipeline is always running.
+
+### Typical architecture
+
+A streaming pipeline has three layers: a **producer** that emits events (application, CDC connector, IoT device), a **broker** that buffers and distributes them (Kafka, Pulsar, Kinesis, Pub/Sub), and a **processor** that consumes and transforms them (Flink, Spark Structured Streaming, a consumer application, or a workflow engine with realtime triggers). Outputs go to sinks — databases, other topics, search indexes, caches.
+
+State is first-class: the processor often needs to maintain rolling aggregates, joins across streams, or windowed computations, which means durable state stores and checkpointing to recover from crashes.
+
+### Strengths
+
+- **Low latency**: results are available within milliseconds to seconds of the event occurring.
+- **Continuous insight**: dashboards, monitors, and reactive workflows get a live view of the system rather than periodic snapshots.
+- **Reactive workflows**: streaming enables use cases that are impossible with batch — fraud blocking, dynamic pricing, real-time recommendations, [event-driven orchestration](/resources/event-driven-orchestration) that kicks off downstream work the instant an event lands.
+
+### Weaknesses
+
+- **State complexity**: once you need windowed aggregations, joins, or exactly-once semantics, the engineering effort grows significantly. State stores, checkpoints, watermarks, and reprocessing all become first-order concerns.
+- **Operational overhead**: running a broker, schema registry, dead-letter queues, and always-on consumers is a permanent operational commitment. It is the largest ongoing cost of streaming.
+- **Cost at scale**: always-on infrastructure is more expensive than periodic batch, especially if the event volume is variable.
+- **Debugging**: tracing a bad result through a streaming pipeline is harder than through a batch job. The same input does not always produce the same output if state or timing differs.
+
+## Batch vs streaming: a side-by-side comparison
+
+| Dimension | Batch | Streaming |
+| --- | --- | --- |
+| Data shape | Bounded | Unbounded |
+| Latency | Minutes to hours | Milliseconds to seconds |
+| Throughput | Very high per job | Steady, per-record |
+| Cost profile | Pay when running | Always-on |
+| State management | Usually stateless | Stateful, durable |
+| Fault tolerance | Retry the whole job | Checkpoint and resume |
+| Consistency | Strong, reproducible | Eventual, order-sensitive |
+| Debugging | Retrospective, deterministic | Live, timing-dependent |
+| Typical tools | Spark, dbt, SQL, orchestrators | Kafka, Flink, realtime consumers |
+
+Neither column is universally better. The right choice depends on the use case, and the best production systems use both, routed by the requirements of each workload.
+
+## Choosing between batch and streaming
+
+Five questions decide the right approach. Walk through them in order — the first one that hits a hard constraint usually determines the answer.
+
+### 1. What is the latency SLA?
+
+If the downstream consumer tolerates minutes of delay, batch is almost always cheaper and simpler. If the consumer needs sub-second reactions, streaming is the only option. The middle ground (seconds to a few minutes) is where micro-batching shines.
+
+### 2. What is the data arrival pattern?
+
+If data arrives in bulk (nightly exports, daily dumps, weekly aggregates), batch fits the shape naturally. If data arrives continuously and unpredictably (user events, sensor readings, transactions), streaming or event-driven batch are better matches.
+
+### 3. How complex is the state you need to maintain?
+
+Stateless transformations (filter, enrich, route) work well in both paradigms. Complex stateful operations (multi-stream joins, windowed aggregations, session tracking) are possible in both but significantly easier in batch. If your processing needs a week of rolling context, batch with a proper data warehouse is usually cleaner than a streaming state store.
+
+### 4. What is the cost envelope?
+
+Streaming has a minimum infrastructure cost regardless of volume — the broker, the consumer, the state store all need to be running. For low-volume use cases, this overhead can dwarf the actual processing cost. Batch scales down to zero when idle.
+
+### 5. What is your team's operational maturity?
+
+Streaming stacks demand ongoing investment: schema evolution, broker tuning, consumer lag monitoring, reprocessing strategies. Teams new to data infrastructure often underestimate this and end up with unreliable real-time pipelines they cannot maintain. Batch is more forgiving.
+
+A short checklist: if three or more of these point to batch, pick batch. If three or more point to streaming, pick streaming. If the answers are split, consider a hybrid approach.
+
+## Hybrid approaches: beyond the binary
+
+Most production systems are neither pure batch nor pure streaming. Three patterns dominate.
+
+### Micro-batch processing
+
+Micro-batching runs small, frequent batches — every 10 seconds, every minute, every 5 minutes. It trades the millisecond latency of true streaming for dramatic operational simplification: no always-on consumers, no complex state management, just a very frequent scheduled job.
+
+Spark Structured Streaming in its default mode is micro-batch under the hood. Many "real-time" dashboards are actually micro-batch. For the majority of "we need fresh data" use cases, micro-batching is the right answer — fast enough to feel live, simple enough to operate.
+
+### Lambda architecture
+
+Lambda runs batch and streaming pipelines in parallel over the same input. The batch layer produces the authoritative historical view; the streaming layer produces an approximate real-time view; a serving layer merges them. It was popular in the early 2010s when streaming tools were less mature.
+
+The downside is significant: two pipelines, two codebases, two sources of potential inconsistency, one serving layer responsible for reconciling them. Most teams who adopted Lambda have since moved away from it.
+
+### Kappa architecture
+
+Kappa simplifies Lambda by eliminating the batch layer. All data flows through a streaming pipeline; historical reprocessing happens by replaying the event log through the same code. One pipeline, one codebase, one view of the world.
+
+Kappa requires a durable, replayable event log (Kafka with sufficient retention, for example) and a processor that can keep up with replay speed. It is elegant when it fits, and impractical when the replay volume exceeds what the infrastructure can handle.
+
+### When hybrid is the right answer
+
+Hybrid is the default for any system that serves both analytical and operational workloads. The operational side (real-time dashboards, alerts, user-facing features) gets a streaming or micro-batch feed. The analytical side (reports, ML training, historical comparisons) gets batch pipelines over the warehouse. A unified orchestrator coordinates both.
+
+## Real-world use cases
+
+### Batch-first
+
+- **Financial reporting**: end-of-day, end-of-month, end-of-quarter runs where reproducibility and auditability matter more than latency.
+- **ML training**: most training pipelines run on bounded historical data and do not benefit from streaming input.
+- **Historical backfills**: recomputing a year of aggregates is a batch job by definition, regardless of how the live pipeline is implemented.
+- **Regulatory exports**: formal deliverables to regulators on a fixed schedule.
+- **Classic ETL**: source-to-warehouse pipelines feeding BI tools that refresh hourly or daily — the core of most [data pipeline](/resources/data-pipeline) work.
+
+### Streaming-first
+
+- **Fraud detection**: a fraudulent transaction must be blocked in under a second, not caught in the nightly reconciliation.
+- **Real-time personalization**: content ranking, search suggestions, and product recommendations that must reflect the user's current session.
+- **IoT and sensor data**: continuous telemetry from devices that emit events unpredictably.
+- **Operational alerts**: monitoring systems that must fire within seconds of a threshold breach.
+- **Real-time CDC**: change-data-capture streams that keep derived stores in sync with operational databases.
+
+### Hybrid use cases
+
+- **Customer 360**: batch-built historical profiles enriched with streaming recent-activity updates.
+- **Operational analytics**: dashboards that combine a batch-computed baseline with a streaming overlay of the current day.
+- **ML inference with drift detection**: batch-trained models served in real time, with streaming monitoring of input distributions to trigger retraining.
+- **Fraud rules plus fraud ML**: deterministic streaming rules catching known patterns, batch-trained models catching subtle cases.
+
+## Orchestrating batch and streaming in a single platform
+
+Running separate orchestration tools for batch and streaming is one of the most common sources of operational complexity in data platforms. Different schedulers, different monitoring, different on-call procedures, different secrets management — and the inevitable "is the streaming side or the batch side broken" debugging exercise during incidents.
+
+The alternative is a single orchestration layer that treats schedules, events, and realtime streams as variations on the same primitive: [a declarative definition](/blogs/declarative-from-day-one) of what should run when. This is the approach Kestra takes — and the foundation of Kestra becoming [the first real-time orchestration platform](/blogs/2024-06-25-kestra-become-real-time) to unify scheduled, event-driven, and streaming workloads under one engine.
+
+### Pattern 1: a batch pipeline on a schedule
+
+A classic nightly aggregation, reading from S3 and writing to a warehouse:
+
+```yaml
+id: nightly_aggregate
+namespace: company.analytics
+
+tasks:
+  - id: load_and_aggregate
+    type: io.kestra.plugin.jdbc.duckdb.Query
+    sql: |
+      COPY (
+        SELECT date_trunc('day', event_time) AS day,
+               count(*) AS events
+        FROM read_parquet('s3://events/{{ trigger.date | date("yyyy-MM-dd") }}/*.parquet')
+        GROUP BY 1
+      ) TO 's3://aggregates/{{ trigger.date | date("yyyy-MM-dd") }}.parquet';
+
+triggers:
+  - id: daily
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 2 * * *"
+```
+
+Runs once per day at 2am. Finite input, finite output, predictable cost.
+
+### Pattern 2: a streaming workflow on Kafka
+
+The same engine can run a realtime workflow that creates one execution per message:
+
+```yaml
+id: fraud_check
+namespace: company.payments
+
+tasks:
+  - id: score
+    type: io.kestra.plugin.scripts.python.Script
+    script: |
+      # call fraud model, emit result
+      pass
+
+triggers:
+  - id: realtime
+    type: io.kestra.plugin.kafka.RealtimeTrigger
+    topic: transactions
+    properties:
+      bootstrap.servers: kafka:9092
+    serdeProperties:
+      keyDeserializer: STRING
+      valueDeserializer: JSON
+    groupId: kestra_fraud
+```
+
+Millisecond latency, one execution per transaction, same UI, same observability surface as the batch job.
+
+### Pattern 3: a hybrid workflow
+
+The two paradigms can coexist in the same orchestrator, feeding each other. A batch job trains a model nightly; a streaming job uses it for inference; both report to the same monitoring layer. The orchestrator is not just scheduling tasks — it is [bridging the coordination gap across paradigms](/blogs/orchestration-differences) that used to require two separate tools.
+
+Observability across both is where the unified approach pays off most: a single execution URL per run, the same logs format, the same retry semantics, the same alerting. Debugging a "the dashboard is stale" incident becomes a single investigation instead of a cross-team triage.
+
+## Future of data processing
+
+### Convergence toward event-driven defaults
+
+The historical pattern was batch by default, streaming when forced. The emerging pattern is event-driven by default — work starts when something happens, not when the clock ticks — with schedules as a special case of "periodic events". This does not eliminate batch; it reframes it. A nightly job becomes "an event fires at 2am, trigger the batch workflow".
+
+### The role of declarative orchestration
+
+As the event-driven default takes hold, orchestration becomes the integration layer — the one place where batch, streaming, and hybrid workloads are described, coordinated, and observed. Declarative definitions (YAML, JSON) replace imperative glue code, because integration surfaces scale better as data than as code.
+
+### What to standardize now to stay flexible later
+
+Three decisions matter more than the batch-vs-streaming choice itself:
+
+- **Pick an orchestrator that handles both paradigms natively**, so you never have to migrate workloads between control planes when requirements shift.
+- **Standardize on declarative workflow definitions**, so the same pipeline can be reviewed, versioned, and migrated without rewrites.
+- **Invest in end-to-end observability early**, so that when a hybrid system misbehaves, you can trace the issue through batch and streaming tasks in the same surface.
+
+Batch and streaming are not competing paradigms. They are complementary tools for different data shapes, and the teams that build resilient systems stop treating them as an either-or choice.

--- a/src/contents/resources/event-driven-orchestration/index.md
+++ b/src/contents/resources/event-driven-orchestration/index.md
@@ -1,0 +1,227 @@
+---
+title: "Event-Driven Orchestration: A Practical Guide (with Examples)"
+description: "Learn what event-driven orchestration is, how it compares to choreography and SOA, and how to implement it with real YAML examples you can copy."
+metaTitle: "Event-Driven Orchestration: Definition, Patterns & Examples"
+metaDescription: "Understand event-driven orchestration, how it differs from choreography, SOA, and DDD, and see production YAML examples for webhooks, Kafka, S3, and SQS triggers."
+tag: infrastructure
+date: 2026-04-21
+faq:
+  - question: "What is event-driven orchestration?"
+    answer: "Event-driven orchestration is an architectural pattern where a central orchestrator starts and coordinates a workflow in response to an external event, such as a file arriving in object storage, a message landing on a queue, or an HTTP webhook call. The orchestrator decides the order of steps, handles retries, and owns the end-to-end process, while the events themselves decide when the workflow runs."
+  - question: "What is the difference between event-driven orchestration and choreography?"
+    answer: "In orchestration, a central engine controls the sequence of tasks and knows the full business process. In choreography, there is no central controller, each service independently reacts to events and emits new ones. Orchestration gives you observability, retries, and a single place to debug. Choreography gives you loose coupling but makes the end-to-end flow harder to trace. Event-driven orchestration combines both, event triggers start the process, but a central engine handles the sequencing."
+  - question: "How is event-driven architecture different from SOA?"
+    answer: "Service-Oriented Architecture (SOA) centers on services exposing synchronous interfaces, typically request-response over SOAP or REST. Event-driven architecture (EDA) centers on asynchronous events, producers emit events without knowing who consumes them. SOA tends toward tight coupling through shared contracts, while EDA favors loose coupling through event streams."
+  - question: "What is the difference between EDD and DDD?"
+    answer: "Event-Driven Design (EDD) structures systems around events and asynchronous reactions between loosely coupled components. Domain-Driven Design (DDD) structures systems around business domain concepts, bounded contexts, and the ubiquitous language shared with domain experts. They are not mutually exclusive, many teams use DDD to define bounded contexts and EDD to connect them via events."
+  - question: "What are the drawbacks of event-driven orchestration?"
+    answer: "The main trade-offs are debugging complexity (async flows are harder to trace), eventual consistency (state is not immediately coherent across services), operational overhead (you need to run message brokers, schema registries, and dead-letter queues), and ordering guarantees (events may arrive out of order). A good orchestrator mitigates most of these by giving you a single UI to inspect every execution, its inputs, outputs, and failures."
+  - question: "When should you not use event-driven orchestration?"
+    answer: "Avoid it for simple, strictly sequential workflows that run on a predictable schedule, small applications where a single cron job is enough, or strongly consistent transactions that require synchronous commits across systems. Event-driven patterns pay off when you have multiple upstream systems, unpredictable arrival times, or workloads that need to react in near real time."
+---
+
+Event-driven orchestration has moved from a niche integration pattern to the default way modern teams connect data pipelines, microservices, and infrastructure operations. Files land in object storage, messages arrive on Kafka, webhooks fire from SaaS tools, and workflows need to start immediately, not at the next scheduled run.
+
+This guide defines event-driven orchestration, contrasts it with choreography, SOA, and domain-driven design, walks through an implementation with real YAML examples, and covers the trade-offs you should know before adopting it.
+
+## What is event-driven orchestration?
+
+Event-driven orchestration is an architectural pattern that combines two ideas:
+
+- **Event-driven**: workflows are triggered by events (file arrivals, message queue records, webhooks, database changes) rather than by a fixed schedule.
+- **Orchestration**: a central engine owns the sequence of steps, handles retries and errors, and gives you end-to-end visibility over the process.
+
+The orchestrator listens for events, starts a workflow instance when a relevant event occurs, and coordinates the downstream tasks — calling APIs, running scripts, moving data, triggering subflows. The workflow itself is declarative: you describe the steps and their dependencies, the engine figures out execution.
+
+## How event-driven orchestration works
+
+A typical event-driven orchestration loop looks like this:
+
+1. An **event source** emits an event. This might be an S3 `PutObject`, a Kafka record, an HTTP POST, or a row appearing in a database.
+2. A **trigger** attached to a workflow listens for that event. Triggers can poll on an interval or maintain an always-on connection for real-time reactions.
+3. When the event matches, the **orchestrator** creates a new workflow execution and injects the event payload as context, so downstream tasks can use it.
+4. The **workflow** runs its tasks in the declared order (sequential, parallel, conditional, fan-out), with retries and error handlers at every step.
+5. Every **execution** is recorded, with inputs, outputs, logs, and timings available in a single UI.
+
+The key distinction from a plain scheduler is that the trigger is external and unpredictable, and from plain event streaming that the orchestrator owns the sequencing and state of the process, not the individual services.
+
+### A concrete example
+
+An e-commerce company wants every new order to flow through a coordinated process: validate the payment, reserve inventory, generate a shipping label, send the confirmation email, and update analytics. Each step touches a different system.
+
+With event-driven orchestration, the order creation event (a new message on an `orders` Kafka topic, for instance) triggers a workflow. The workflow calls the payment service, waits for the response, then branches: on success it reserves inventory and ships, on failure it triggers a refund subflow and notifies support. Every order leaves a single execution trace you can open, inspect, and replay if something goes wrong.
+
+## Benefits of event-driven orchestration
+
+### Real-time responsiveness
+
+Schedules are a poor fit when data arrival is unpredictable. An hourly cron that processes files from S3 adds up to an hour of latency on every upload. An event-driven trigger starts the workflow the moment the file lands, keeping end-to-end latency in the seconds.
+
+### Decoupling without losing visibility
+
+Pure event choreography decouples services at the cost of observability — no single system knows the end-to-end flow. Event-driven orchestration keeps components decoupled (they only emit and consume events) while giving you one place to see the whole process, replay failed runs, and debug.
+
+### Resource efficiency
+
+Scheduled pipelines often run unnecessarily, scanning empty buckets or querying tables with no new data. Event-driven workflows only consume compute when there's actual work to do, which matters both for cloud costs and for database load.
+
+### Unified orchestration across domains
+
+The same engine can orchestrate data pipelines, infrastructure automation, and microservice choreography. A single platform handling all three means fewer tools to operate and consistent observability across data, AI, and infra workflows. This is the approach Kestra takes, with event-driven orchestration as a first-class primitive rather than an add-on.
+
+## Event-driven orchestration vs. other approaches
+
+### Orchestration vs. choreography
+
+Orchestration and choreography are the two main ways to coordinate distributed services:
+
+- **Orchestration**: a central component (the orchestrator) tells each service what to do and when. The control flow is centralized and visible.
+- **Choreography**: each service listens to events and decides independently how to react. The control flow is emergent, distributed across services.
+
+Choreography is simpler to set up for small systems but becomes difficult to reason about as the number of services grows. Teams often end up reinventing a coordinator — badly — through layers of event handlers. Orchestration scales better when processes are complex, have branching logic, or need explicit error handling.
+
+Event-driven orchestration isn't a third option so much as a pragmatic combination: events are used for triggering and decoupling (the "choreography" strength), while the orchestrator handles sequencing and observability.
+
+### EDA vs. SOA
+
+Service-Oriented Architecture (SOA) predates event-driven architecture by a decade. The two differ in three main ways:
+
+| Dimension | SOA | Event-Driven Architecture |
+| --- | --- | --- |
+| Communication | Synchronous (request-response) | Asynchronous (publish-subscribe) |
+| Coupling | Tight — consumers know service contracts | Loose — producers don't know consumers |
+| Focus | Services as the central abstraction | Events as the central abstraction |
+
+SOA shines when you need strict contracts and immediate responses. EDA shines when you need to scale producers and consumers independently and tolerate eventual consistency.
+
+### EDD vs. DDD
+
+Event-Driven Design (EDD) and Domain-Driven Design (DDD) address different concerns. EDD is about *how* components communicate — asynchronously, via events. DDD is about *how you model the business* — around bounded contexts, aggregates, and a shared domain language.
+
+Many production systems use both: DDD defines the boundaries (an "Orders" context, a "Shipping" context), and EDD connects them (the Orders context emits an `OrderPlaced` event that Shipping consumes). The orchestrator sits on top, coordinating cross-context workflows without violating the boundaries.
+
+## Building event-driven orchestration with Kestra
+
+Kestra is an open-source, event-driven orchestration platform. Workflows are declarative YAML, triggers are native, and the same engine handles schedules, webhooks, and real-time event streams. Here are three patterns you'll likely need.
+
+### Pattern 1: webhook trigger
+
+The simplest event source is an HTTP call. Any SaaS tool, GitHub, Amazon EventBridge, or internal service can POST to a Kestra webhook URL and start a workflow:
+
+```yaml
+id: webhook_example
+namespace: company.team
+
+tasks:
+  - id: log_payload
+    type: io.kestra.plugin.core.log.Log
+    message: "Received event: {{ trigger.body }}"
+
+triggers:
+  - id: webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: "{{ secret('WEBHOOK_KEY') }}"
+```
+
+The flow exposes a unique URL (`/api/v1/main/executions/webhook/{namespace}/{flowId}/{key}`) that accepts GET, POST, and PUT requests. The request body and headers are available inside the flow as `{{ trigger.body }}` and `{{ trigger.headers }}`.
+
+### Pattern 2: S3 file-arrival trigger
+
+When files land in S3, a polling trigger can detect them and start a workflow per batch:
+
+```yaml
+id: s3_event_driven
+namespace: company.team
+
+tasks:
+  - id: process_files
+    type: io.kestra.plugin.core.flow.ForEach
+    values: "{{ trigger.objects | jq('.[].uri') }}"
+    tasks:
+      - id: handle
+        type: io.kestra.plugin.core.debug.Return
+        format: "Processing file: {{ taskrun.value }}"
+
+triggers:
+  - id: watch_bucket
+    type: io.kestra.plugin.aws.s3.Trigger
+    interval: "PT5M"
+    accessKeyId: "{{ secret('AWS_ACCESS_KEY_ID') }}"
+    secretKeyId: "{{ secret('AWS_SECRET_KEY_ID') }}"
+    region: "eu-central-1"
+    bucket: "my-bucket"
+    prefix: "incoming/"
+    action: MOVE
+    moveTo:
+      key: archive
+      bucket: "archive-bucket"
+```
+
+The trigger polls every five minutes, downloads detected files to Kestra's internal storage (so you don't need a separate download task), and moves them to an archive bucket after processing to prevent re-triggering.
+
+### Pattern 3: real-time Kafka trigger
+
+For low-latency use cases, Kestra offers realtime triggers that maintain an always-on connection to the event source and create one execution per message:
+
+```yaml
+id: kafka_realtime
+namespace: company.team
+
+tasks:
+  - id: log_event
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ trigger.value }}"
+
+triggers:
+  - id: realtime_trigger
+    type: io.kestra.plugin.kafka.RealtimeTrigger
+    topic: orders
+    properties:
+      bootstrap.servers: localhost:9092
+    serdeProperties:
+      keyDeserializer: STRING
+      valueDeserializer: JSON
+    groupId: kestra_orders
+```
+
+Every message published to the `orders` topic starts a new workflow execution with millisecond latency. The same pattern works for SQS, Google Pub/Sub, Pulsar, NATS, MQTT, Redis, AMQP, and Azure Event Hubs — the only thing that changes is the trigger type.
+
+### Combining triggers
+
+A single workflow can define multiple triggers: a webhook for manual testing, a schedule for nightly backfills, and a real-time event trigger for production. All three produce the same execution type, processed by the same logic, visible in the same UI.
+
+## Drawbacks and considerations
+
+Event-driven orchestration is powerful but not free. Before adopting it, weigh these trade-offs.
+
+### Debugging complexity
+
+Async flows are harder to reason about than linear synchronous code. A request that would fail loudly in a monolith can silently wait in a dead-letter queue for hours. The mitigation is end-to-end tracing: every execution should have a single URL where you can see inputs, outputs, logs, and timing for every task. This is one place a good orchestrator earns its keep.
+
+### Eventual consistency
+
+Because services react asynchronously, the system as a whole is eventually consistent. You cannot assume that after emitting an event, all consumers have already processed it. Design workflows to be idempotent, and prefer explicit state checks over "I just sent the event, it must be done."
+
+### Operational overhead
+
+You need to run the event infrastructure: brokers, schema registries, dead-letter queues, monitoring. For a team of three building a small application, a cron job may genuinely be simpler. Event-driven orchestration starts paying off at the scale where you're already running Kafka, RabbitMQ, or cloud pub/sub for other reasons.
+
+### Ordering and duplication
+
+Most event systems offer "at-least-once" delivery, which means occasional duplicates. Some also don't guarantee order across partitions. Build idempotent tasks (deterministic IDs, upserts instead of inserts) and don't assume strict ordering unless your event source guarantees it.
+
+### When not to use it
+
+Skip event-driven orchestration when the workflow is a simple scheduled batch with no dependency on external events, the transaction requires strong consistency across systems (you need a real distributed transaction or saga, not just a workflow), or the system is small enough that adding a broker and an orchestrator is more overhead than the problem justifies.
+
+## Real-world patterns
+
+Event-driven orchestration shows up in three recurring patterns worth recognizing:
+
+**Data pipeline automation.** File lands in S3 or GCS, orchestrator picks it up, runs validation, loads into the warehouse, triggers dbt, and notifies stakeholders. This replaces the classic "scheduled every hour, hope the data is there" pattern.
+
+**Microservice coordination.** An order event triggers a workflow that calls payment, inventory, shipping, and notification services in a defined sequence, with compensating actions on failure. The orchestrator acts as a saga coordinator.
+
+**Infrastructure automation.** A webhook from a monitoring system triggers a remediation workflow: scale a cluster, rotate credentials, run a diagnostic, open an incident. The orchestrator ties together the cloud APIs, scripts, and notifications.
+
+All three patterns share the same shape: an external event, a declarative workflow, and a single place to observe and debug every run.

--- a/src/contents/resources/orchestration-problems-complexity/index.md
+++ b/src/contents/resources/orchestration-problems-complexity/index.md
@@ -1,0 +1,155 @@
+---
+title: "Orchestration Problems and Complexity: How to Solve Them"
+description: "Most orchestration problems come from layers added to fix other layers. Learn how to diagnose complexity, reduce it, and keep systems observable as they scale."
+metaTitle: "Solve Orchestration Problems & Reduce Complexity"
+metaDescription: "Decipher orchestration problems and complexity without adding more to your system. Learn the challenges & solutions for effective orchestration."
+tag: infrastructure
+date: 2026-04-21
+faq:
+  - question: "What is orchestration complexity?"
+    answer: "Orchestration complexity is the operational and cognitive cost of coordinating tasks, services, and data flows across a system. It shows up as hard-to-debug failures, sprawling glue code, duplicate scheduling logic, and tools that each own a slice of the workflow without a unified view. Complexity is not caused by the orchestrator itself but by the accumulation of partial solutions around it."
+  - question: "Why do orchestration problems arise?"
+    answer: "They arise when teams adopt separate tools for each workload type (data pipelines, CI/CD, infra automation, AI agents), each with its own scheduling, secrets, and monitoring. Every new tool adds a coordination surface, and the gaps between tools become the hardest part of the system to operate. Orchestration problems are almost always coordination problems, not capability problems."
+  - question: "What is the orchestration gap in multi-agent AI systems?"
+    answer: "The orchestration gap is the difference between AI agents that work in a demo and AI agents that work at production scale. Individual agents may reason correctly, but once you chain them, you need deterministic sequencing, retry policies, state persistence, and end-to-end observability. Most agent frameworks stop at the reasoning layer and leave orchestration as an exercise for the developer, which is why scaling agents often fails."
+  - question: "How do you reduce orchestration complexity without adding more tools?"
+    answer: "Consolidate onto a single declarative engine that handles data, infrastructure, and AI workflows; replace imperative glue code with YAML or equivalent declarative definitions; standardize triggers, retries, and error handling across all workflow types; and ensure every execution produces the same observability signals. Most complexity reduction comes from deleting tools, not adding them."
+  - question: "What makes container orchestration complex?"
+    answer: "Container orchestration at scale combines scheduling, networking, storage, secrets, and health checks, each with its own failure modes. Complexity grows when workload orchestration (Kubernetes) is separated from business process orchestration (workflow engines) and from data pipeline orchestration, forcing teams to operate three control planes that barely talk to each other."
+  - question: "How do you debug complex orchestration flows?"
+    answer: "Start with a single execution URL that exposes inputs, outputs, logs, and timing for every task. Trace events end-to-end, not per service. Make every task idempotent so replays are safe. Store execution history long enough to correlate issues across systems. The goal is that any failure, anywhere in the system, has a single place to investigate."
+---
+
+Most orchestration problems are not caused by the orchestrator. They are caused by what gets added around it — the scheduler on the side, the monitoring tool bolted on, the custom retry logic written in Python, the second workflow engine the ML team adopted because the first one could not handle agents. Each addition solves one problem and creates two.
+
+This guide breaks down where orchestration complexity actually comes from, how it shows up across data, infrastructure, container, and AI workloads, and how to reduce it without adding yet another layer. The framing throughout: **solve the problem without adding more complexity to the system**.
+
+## Understanding orchestration problems and complexity
+
+### What is orchestration complexity?
+
+Orchestration complexity is the total cost of coordinating work across a system — not the intrinsic difficulty of the work itself, but the overhead of deciding what runs when, what depends on what, and what to do when something breaks.
+
+It is made of three layers:
+
+- **Structural complexity**: the number of distinct scheduling, triggering, and coordination mechanisms in play. One orchestrator plus three cron jobs plus a Kafka consumer plus a CI/CD runner equals four coordination systems, regardless of how simple each one is.
+- **Operational complexity**: the cost of running those systems — secrets management, version upgrades, monitoring, on-call rotations, per-tool dashboards.
+- **Cognitive complexity**: the effort it takes for a new engineer to understand the end-to-end flow. If answering "what runs when an order is placed" requires reading three codebases and two runbooks, the system is complex regardless of its technical elegance.
+
+A system can be technically sophisticated and still have low complexity, and a system can be technically simple and still have very high complexity. The difference is how well the moving parts compose.
+
+### Why do orchestration problems arise?
+
+The dominant pattern: teams adopt a narrow tool to solve a narrow problem, then discover that the problem was never actually narrow. Airflow for data pipelines, then ML workflows need something else, then AI agents need a third thing, then infra automation runs in Ansible on a separate schedule. Five years later, the same business process touches four orchestrators and no single person can draw it on a whiteboard.
+
+The secondary pattern: building custom glue code instead of using primitives. Retry loops wrapped in bash, a cron job that calls another cron job, a Slack notifier scripted into every pipeline. Each shortcut looks cheap at the moment it is written and becomes expensive the first time it fails silently.
+
+### The impact of complexity on system performance
+
+Complexity shows up in measurable ways: longer incident resolution times (more places to look), higher change failure rate (more things to break), slower onboarding (more systems to learn), and lower deployment frequency (more coordination between teams to ship a change that spans multiple orchestrators). The DORA metrics degrade as orchestration complexity grows, not because individual tools are slow but because the cost of crossing boundaries between them dominates.
+
+## Common challenges in modern orchestration
+
+### Multi-agent systems and AI orchestration
+
+AI agent frameworks are strong at individual reasoning and weak at coordination. LangChain, CrewAI, and similar libraries make it easy to compose a few agents in a notebook. Production is a different environment: agents need deterministic retries, persistent state, long-running execution (hours or days), human-in-the-loop approvals, and observability of every tool call.
+
+The industry is converging on a consistent signal here. A recent Docker State of Application Development report found that nearly half of organizations building agents cite orchestration complexity as their number one challenge — not model quality, not cost, not latency. Orchestration.
+
+The reason: agent frameworks optimize for the single-agent local case and treat orchestration as out-of-scope. But production agents are workflows. They have triggers (a user request, a scheduled scan, a webhook), a sequence of tool calls, branching on tool outputs, retries on API failures, and a final output that needs to be persisted. That is exactly what a workflow engine does — and it is why we have positioned Kestra as [the orchestration control plane of the AI era](/blogs/kestra-series-a).
+
+### The orchestration gap: why AI agents struggle at scale
+
+The gap is this: an agent that works in a demo has all state in memory and all calls synchronous. An agent that works in production needs durable state (what if the process crashes halfway through?), asynchronous tool execution (some tools take minutes to respond), parallel fan-out (evaluate 20 candidates simultaneously), and failure isolation (one flaky API must not kill the whole chain).
+
+Teams usually discover this the hard way: the demo runs fine, the production deployment works for a week, then a model provider rate-limits them and 4,000 agent runs die mid-flight with no way to resume. The fix is not a better agent — it is treating agents as tasks inside a proper workflow, with all the retry, state, and observability machinery workflows already have.
+
+### Monitoring and debugging complex orchestration flows
+
+Debugging is the first place complexity hits. If a pipeline spans Airflow, a Kubernetes job, a Lambda function, and a SQS queue, tracing a single failure means correlating logs across four systems, each with its own timestamp format, trace ID convention, and retention window.
+
+The mitigation is end-to-end execution tracing: one URL per run, every task represented, every input and output preserved. If that single surface does not exist, engineers build it themselves — badly, partially, and redundantly across teams. Every hour spent debugging across tools is an hour that could have been spent improving the workflow itself.
+
+### Data orchestration challenges: quality, volume, and complexity
+
+Data orchestration adds a dimension the other workloads do not have: the work is often not deterministic. The same pipeline on the same schedule against the same source can produce different results because the source data changed. This creates three problem classes:
+
+- **Quality regressions** that appear mid-pipeline and must be caught before they reach downstream consumers.
+- **Volume spikes** that break implicit assumptions about task duration and resource usage.
+- **Schema drift** that silently breaks downstream transformations.
+
+Solving these requires the orchestrator to understand not just task dependencies but data dependencies — which table feeds which model, which column a dashboard relies on. This is why the old "orchestrate the code, track the data separately" split is breaking down in favor of engines that handle both.
+
+## Strategies to reduce orchestration complexity
+
+### Simplify orchestration without adding overhead
+
+The principle: every new tool must remove at least two sources of complexity, not just add one more. A new orchestrator is justified if it lets you delete a scheduler, a secrets manager, and two custom Python wrappers. It is not justified if it lives alongside what you already have.
+
+Concretely, this means:
+
+- **Consolidate triggers**. Schedules, events, webhooks, and manual runs should all produce the same execution type, observable in the same UI — the foundation of [event-driven orchestration](/resources/event-driven-orchestration) done right.
+- **Consolidate retries and error handling**. One declaration of retry policy that applies everywhere, not three different libraries' conventions.
+- **Consolidate state**. Execution state — inputs, outputs, logs, timing — should live in one place regardless of task type.
+
+### Effective patterns for AI agent orchestration
+
+Treat the agent as a task, not as a framework. The workflow defines the trigger, the sequence, the retries, and the observability. The agent defines the reasoning inside a single step. This keeps agent logic replaceable (swap the model, swap the framework) without rewriting orchestration.
+
+Two patterns work well in production:
+
+**Agent-as-step**: the workflow calls an agent as one task, provides the context as input, and receives the result as output. The orchestrator owns retry, timeout, and error handling. The agent owns reasoning. Clear boundary.
+
+**Agent-triggered workflow**: the agent decides what workflow to run, and the orchestrator executes it. This is useful when the agent is a planner and the workflow is the executor — the agent can reason about what to do, then delegate to deterministic, observable, retry-safe tasks.
+
+### Leveraging tools to reduce complexity in production
+
+The biggest complexity reduction usually comes from picking a single platform that handles data, infrastructure, and AI workloads with the same primitives. This is the direction Kestra has taken: one declarative engine, one set of triggers, one observability surface, regardless of whether the workflow loads data, deploys a cluster, or orchestrates an agent chain.
+
+The alternative — best-of-breed tools per domain — sounds reasonable until you count the integration surface. Three tools mean three auth systems, three secret stores, three monitoring dashboards, three upgrade cycles, and three places a new hire has to learn. Consolidation is the single highest-leverage complexity reduction available to most teams.
+
+### Best practices for managing evolving use cases
+
+Orchestration systems fail not because they cannot handle today's workload but because they cannot evolve. Three practices help:
+
+- **Declarative definitions**. Workflows described as data (YAML, JSON) rather than as code are easier to version, review, migrate, and regenerate — [the reasoning behind our choice to be declarative from day one](/blogs/declarative-from-day-one).
+- **Reusable components**. Subflows, templates, and namespace-scoped shared logic prevent the same pattern from being re-implemented six times.
+- **Clear versioning**. Every workflow has a history. Changes are auditable. Rollbacks are a one-click operation, not a git archaeology exercise.
+
+## The role of orchestration in different environments
+
+### Container orchestration: solving common problems
+
+Kubernetes solved workload scheduling — which container runs where, how it is networked, how it is scaled. It did not solve business process orchestration. Running `kubectl apply` does not tell you that a nightly ETL depends on a feature pipeline that depends on a data freshness check.
+
+The mature pattern: Kubernetes handles the infrastructure layer (where containers run), and a workflow engine handles the coordination layer (when and why they run). They are complementary, not competitive — a distinction we unpack in depth in [what orchestration actually means across data, software, and infrastructure](/blogs/orchestration-differences). Complexity appears when teams try to do business process orchestration with Kubernetes primitives alone (CronJobs, Jobs, Argo chains) and end up reinventing a workflow engine — badly.
+
+### Orchestration in AI and machine learning workflows
+
+ML workflows have the same needs as data pipelines (triggers, retries, state, lineage) plus a few extras: experiment tracking, model versioning, feature consistency between training and serving. They do not need a separate orchestrator. They need the existing orchestrator to integrate with MLflow, feature stores, and model registries as tasks.
+
+When teams adopt dedicated "ML orchestrators" they usually end up with two systems that do 90% of the same thing, and they spend the rest of the year keeping them in sync. The simpler path is one engine with ML-specific plugins.
+
+### Addressing complexity in enterprise systems
+
+Enterprise orchestration problems compound: more teams, more compliance requirements, more legacy systems, more handoffs between groups who each own part of a process. The complexity is rarely technical — it is organizational, and the orchestration platform either makes it visible or hides it.
+
+A good enterprise orchestration layer exposes a single view of every business process, regardless of which team owns which step. That is what unlocks audit, compliance reporting, incident response, and cross-team optimization. Without it, every complexity reduction effort stops at the team boundary.
+
+## Future outlook: mastering orchestration challenges
+
+### Innovations in managing multi-agent orchestration
+
+The next few years will see agent frameworks stop trying to own orchestration and start integrating with existing workflow engines. The industry has already moved this way for data (dbt delegates execution to Airflow, Kestra, etc.) and will do the same for agents: frameworks will own reasoning, workflow engines will own coordination.
+
+### Anticipating future complexities in system design
+
+As more workloads become event-driven and more systems converge on the same set of primitives (message queues, object storage, HTTP APIs), the orchestration layer becomes the integration layer. This is a good thing — but it raises the stakes on the orchestrator's own complexity. The tools that win will be the ones that scale down to a single YAML file as gracefully as they scale up to thousands of concurrent executions.
+
+### Building resilient and observable orchestration
+
+Resilience comes from three properties: idempotent tasks, durable state, and end-to-end observability. None of them can be bolted on after the fact — they are either built into the orchestration engine or absent. Teams choosing their orchestrator today should treat these as table stakes, not premium features.
+
+The long-term goal is not a more powerful orchestrator. It is a system where orchestration disappears as a visible concern — where engineers describe what should happen, the platform figures out how, and the only time anyone thinks about the orchestrator is when they want to see why something ran.
+
+That is what it means to solve orchestration problems without adding more complexity.


### PR DESCRIPTION
Adds 3 new content pages to the resources hub:

- /resources/orchestration-problems-complexity (tag: infrastructure)
- /resources/batch-vs-streaming-processing (tag: data)
- /resources/event-driven-orchestration (tag: infrastructure)

All three follow the existing frontmatter schema and include FAQ sections that will auto-generate FAQPage JSON-LD via the template.

Targets `resources-page` so it merges into the parent PR #4637 before it goes to main.

cc @MartinRst for review.