### PR TITLE
fix(plugins): enhance  search with task class matching and relevance ranking

### DIFF
--- a/src/components/plugins/PluginsLists.vue
+++ b/src/components/plugins/PluginsLists.vue
@@ -124,10 +124,20 @@
         props.categories.map((c) => ({ id: c, label: formatCategoryName(c) })),
     )
 
-    const SEARCHABLE_FIELDS: (keyof CardPlugin)[] = ["title", "description", "name"]
+    const SEARCHABLE_FIELDS: (keyof CardPlugin)[] = ["title", "description", "name", "classes"]
 
-    const sortPlugins = (plugins: CardPlugin[], ascending: boolean) =>
-        [...plugins].sort((a, b) => {
+    const sortPlugins = (plugins: CardPlugin[], ascending: boolean, query: string) => {
+        const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
+        const matchesAll = (value: string | undefined) =>
+            tokens.length > 0 && tokens.every((t) => value?.toLowerCase().includes(t))
+
+        return [...plugins].sort((a, b) => {
+            if (query) {
+                const aStrong = matchesAll(a.name) || matchesAll(a.title)
+                const bStrong = matchesAll(b.name) || matchesAll(b.title)
+                if (aStrong !== bStrong) return aStrong ? -1 : 1
+            }
+
             const aCore = a.group === "io.kestra.plugin.core" && !a.subGroup
             const bCore = b.group === "io.kestra.plugin.core" && !b.subGroup
             if (aCore !== bCore) return aCore ? -1 : 1
@@ -135,15 +145,22 @@
             const comparison = a.title.toLowerCase().localeCompare(b.title.toLowerCase())
             return ascending ? comparison : -comparison
         })
+    }
 
     const filterBySearch = (plugins: CardPlugin[], query: string) => {
         if (!query) return plugins
         const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
-        return plugins.filter((plugin) =>
-            SEARCHABLE_FIELDS.some((field) =>
-                tokens.every((t) => (plugin[field] as string)?.toLowerCase().includes(t)),
-            ),
-        )
+        const matchesAll = (value: string | undefined) =>
+            tokens.every((t) => value?.toLowerCase().includes(t))
+
+        return plugins
+            .filter((p) => SEARCHABLE_FIELDS.some((f) => matchesAll(p[f] as string)))
+            .sort((a, b) => {
+                const aStrong = matchesAll(a.name) || matchesAll(a.title)
+                const bStrong = matchesAll(b.name) || matchesAll(b.title)
+                if (aStrong !== bStrong) return aStrong ? -1 : 1
+                return 0
+            })
     }
 
     const searchFilteredPlugins = computed(() =>
@@ -159,7 +176,7 @@
     )
 
     const pluginsSlice = computed(() =>
-        sortPlugins(categoryFilteredPlugins.value, sortBy.value === "A-Z").slice(
+        sortPlugins(categoryFilteredPlugins.value, sortBy.value === "A-Z", searchQuery.value).slice(
             (currentPage.value - 1) * itemsPerPage.value,
             currentPage.value * itemsPerPage.value,
         ),

--- a/src/utils/plugins/pruneForClient.ts
+++ b/src/utils/plugins/pruneForClient.ts
@@ -13,16 +13,24 @@ export type CardPlugin = {
     elementCounts?: number
     blueprints?: number
     isEnterprise?: boolean
+    classes?: string
 }
 
 export function prunePluginsForCards(
-    plugins: Plugin[], 
+    plugins: Plugin[],
     pluginsData: Record<string, any>
 ): CardPlugin[] {
     return plugins.map(p => {
         const key = p.subGroup ?? p.group ?? p.name
         const info = pluginsData[key] ?? {}
         const groupInfo = pluginsData[p.group]
+
+        const classes = Object.entries(p)
+            .filter(([k, v]) => isEntryAPluginElementPredicate(k, v))
+            .flatMap(([, v]) => (v as PluginElement[]).map((el) => el.cls))
+            .join(" ")
+            .replace(/io\.kestra\.plugin\./g, "")
+
         return {
             name: p.name,
             title: info.title ?? p.title ?? p.name,
@@ -35,6 +43,7 @@ export function prunePluginsForCards(
             elementCounts: info.elementCounts,
             blueprints: info.blueprints,
             isEnterprise: p.group?.includes('.ee.') ?? false,
+            classes,
         }
     })
 }


### PR DESCRIPTION
Closes https://github.com/kestra-io/docs/issues/4123

- title — e.g., "HTTP"
- description — e.g., "Tasks that make HTTP requests..."
- name — e.g., "plugin-kestra"
-
Try searching:

core http download → HTTP plugin
kestra → Kestra-named plugins (ranked first, description matches after)
s3 upload → AWS S3 plugin