### PR TITLE
feat(resources): add 5 infrastructure and data resource pages

### DIFF
--- a/src/contents/resources/automation/index.md
+++ b/src/contents/resources/automation/index.md
@@ -1,0 +1,192 @@
+---
+title: "What Is Infrastructure Automation? Definition, Tools, and Benefits"
+description: "Infrastructure automation replaces slow, manual operations with fast, consistent machine execution. Learn what it is, how it works, the core tools (Terraform, Ansible, Kubernetes), and how to adopt it successfully."
+metaTitle: "What Is Infrastructure Automation? Full Guide"
+metaDescription: "Infrastructure automation codifies provisioning, configuration, and operations into repeatable workflows. Learn the principles, tools, and benefits."
+tag: infrastructure
+date: 2026-04-22
+faq:
+  - question: "What does infrastructure automation mean?"
+    answer: "Infrastructure automation is the use of technology to perform infrastructure tasks with reduced human assistance. It lets IT teams control hardware, software, networking, and data storage components with less manual oversight — turning provisioning, configuration, patching, and decommissioning into repeatable workflows that run consistently every time."
+  - question: "What are the top 5 IaC tools?"
+    answer: "The top IaC tools in 2026 are Terraform (cloud-agnostic, HCL-based, the de facto standard), AWS CloudFormation (AWS-native), Ansible (agentless configuration management with lightweight provisioning), Pulumi (IaC in general-purpose languages like Python and TypeScript), and Azure Resource Manager / Bicep (Azure-native). Puppet and Chef remain widely used for configuration management."
+  - question: "What are the 4 components of infrastructure?"
+    answer: "IT infrastructure is typically categorized into hardware (servers, storage, network equipment), software (operating systems, applications, databases), networking (routers, switches, load balancers, DNS), and security (identity, encryption, monitoring, compliance tooling). Infrastructure automation covers all four layers, though specific tools differ by layer."
+  - question: "What are the four types of automation?"
+    answer: "The four types are fixed automation (single-purpose, high-volume), programmable automation (reconfigurable but slow to switch), flexible automation (switches between tasks with minimal reconfiguration), and integrated automation (multiple systems coordinated as one, with minimal human intervention). Modern IT infrastructure automation most closely resembles integrated automation."
+  - question: "What is the difference between infrastructure automation and orchestration?"
+    answer: "Infrastructure automation codifies individual tasks — provisioning a VM, applying a patch, rotating a credential. Orchestration coordinates many tasks into end-to-end workflows with triggers, dependencies, retries, and audit trails. Automation is the building block; orchestration is the system that runs automation reliably in production."
+  - question: "What is infrastructure automation in DevOps?"
+    answer: "In DevOps, infrastructure automation is the foundation that lets application teams ship fast without waiting on ops. Infrastructure as Code enables self-service environments. CI/CD pipelines trigger infrastructure workflows alongside application deploys. Configuration management enforces consistency. All three are typically tied together by an orchestration layer that spans the full stack."
+---
+
+Managing infrastructure by hand doesn't scale. A decade ago, an ops team might have manually provisioned a dozen servers per quarter. Today, that same team is expected to manage thousands of ephemeral workloads across multiple clouds, apply security patches within hours of disclosure, and guarantee audit trails for every change. Infrastructure automation is the only way to meet these expectations without drowning in toil.
+
+This guide covers what infrastructure automation is, the principles that make it work, the core tools (IaC, configuration management, orchestration), the benefits it unlocks, and the steps organizations take to adopt it successfully.
+
+## What Is Infrastructure Automation?
+
+Infrastructure automation is the use of technology to perform infrastructure tasks with reduced human assistance. It lets IT teams control hardware, software, networking, and data storage components with less manual oversight — turning provisioning, configuration, patching, and decommissioning into repeatable workflows that run consistently every time.
+
+What separates infrastructure automation from a pile of scripts is **repeatability and governance**. An automated workflow runs the same way every time, handles failures predictably, logs every action, and produces an audit trail. The scripts in the corner of a runbook repo are not infrastructure automation — they're technical debt waiting to become an outage.
+
+## Why Infrastructure Automation Matters
+
+The value is straightforward: infrastructure automation replaces slow, error-prone human effort with fast, consistent machine execution. The secondary benefits — scalability, auditability, faster recovery from failures — all flow from that core shift.
+
+Organizations that don't automate infrastructure end up with operations teams spending most of their time firefighting and replicating manual steps, rather than improving reliability or enabling developer velocity. The opportunity cost compounds fast: competitors who automated years ago ship features faster, recover from incidents faster, and spend less on infrastructure per dollar of revenue.
+
+## How Infrastructure Automation Works — The Three Principles
+
+Three principles anchor effective infrastructure automation:
+
+- **Declarative definition** — describe the desired end state rather than the steps to get there. "I want three load-balanced web servers" is declarative. "SSH in, run this, then run that" is imperative. Declarative scales; imperative doesn't.
+- **Idempotency** — the same workflow produces the same result whether run once or ten times. Non-idempotent automation fails in subtle ways the first time something needs to be re-run.
+- **Version control** — every configuration change is tracked in Git, reviewable like application code. Pull requests, code review, rollback on failure. Infrastructure becomes software.
+
+When all three are in place, infrastructure behaves like software — with the same development practices, review processes, and quality guarantees.
+
+## Infrastructure as Code (IaC) — The Foundation
+
+Infrastructure as Code is the practice of defining infrastructure through machine-readable configuration files rather than through manual console clicks. The configuration files live in version control alongside application code. When deployed, the IaC tool reconciles the declared state with the live environment, creating, updating, or destroying resources as needed.
+
+IaC is the foundation most infrastructure automation builds on. Without it, automation is a collection of brittle scripts. With it, automation becomes a reproducible, auditable system that any engineer can read on day one.
+
+### Top 5 IaC Tools
+
+The most widely adopted IaC tools in 2026:
+
+| Tool | Language | Cloud scope | Best for |
+| --- | --- | --- | --- |
+| **Terraform** | HCL | Multi-cloud | De facto standard for cloud-agnostic infrastructure |
+| **AWS CloudFormation** | YAML / JSON | AWS-only | Deep AWS integration, native service coverage |
+| **Ansible** | YAML | Multi-cloud | Agentless config + lightweight provisioning |
+| **Pulumi** | Python / TypeScript / Go | Multi-cloud | Teams preferring general-purpose languages over HCL |
+| **Azure Resource Manager / Bicep** | Bicep / JSON | Azure-only | Azure-native, integrated with Azure Policy |
+
+Puppet and Chef remain in use for configuration management, particularly in mature enterprise environments. Most modern stacks combine two or three of these tools rather than relying on a single one.
+
+## Benefits of Infrastructure Automation
+
+### Increased Efficiency and Speed
+
+Automated provisioning collapses timelines that used to span days or weeks into minutes. A new environment — VPC, subnets, databases, load balancers, monitoring — can be stood up from a single workflow run. Teams stop waiting on infrastructure to start building.
+
+### Reduced Human Error and Improved Reliability
+
+Manual infrastructure changes are the leading cause of production incidents. Every manual step is an opportunity for typos, forgotten flags, inconsistent naming, or missed dependencies. Automation codifies the right way to do each operation, so every execution follows the same path.
+
+### Cost Savings and Scalability
+
+Automation makes cost discipline possible. Idle environments can be automatically shut down overnight. Over-provisioned resources can be right-sized based on actual utilization. Burst workloads can scale up and tear down without leaving expensive remnants behind. None of this is practical manually at scale.
+
+### Audit and Compliance
+
+Every change is logged with who, what, when, and why. Compliance reports (SOC 2, ISO 27001, PCI, HIPAA) are generated from workflow execution history rather than reconstructed after the fact. Audit prep shifts from a quarterly scramble to a continuous property of the system.
+
+## The Four Components of Infrastructure Automation
+
+Infrastructure automation in IT typically covers four layers:
+
+- **Hardware** — physical servers, storage devices, networking equipment. Automation here means API-driven provisioning (cloud VMs) or software-defined infrastructure (Nutanix, VMware).
+- **Software** — operating systems, middleware, applications, databases. Configuration management (Ansible, Puppet, Chef) enforces desired state.
+- **Networking** — routers, switches, load balancers, firewalls, VPNs, DNS. Network-as-Code tools (Terraform providers for Cloudflare, AWS, Cisco ACI) codify network configuration.
+- **Security** — identity and access management, encryption, monitoring, compliance tooling. Policy-as-Code tools (OPA, Sentinel, Kyverno) enforce security at deploy time.
+
+A mature automation stack covers all four layers. Automating only one (say, VM provisioning) while leaving the others manual just moves the bottleneck.
+
+## The Four Types of Automation
+
+The four-type classification of automation is more relevant to manufacturing than to IT, but it helps contextualize where infrastructure automation fits:
+
+- **Fixed automation** — single-purpose, high-volume, rigid. Think assembly lines.
+- **Programmable automation** — reconfigurable but slow to switch between tasks.
+- **Flexible automation** — switches between tasks with minimal reconfiguration.
+- **Integrated automation** — multiple systems coordinated as one, with minimal human intervention.
+
+Modern IT infrastructure automation most closely resembles **integrated automation** — multiple tools and environments coordinated through a single orchestration layer.
+
+## A Concrete Example — Provisioning and Configuring in One Workflow
+
+Here's what integrated infrastructure automation looks like in Kestra: provision with Terraform, configure with Ansible, register the new service in a CMDB, and notify the team — all in one declarative workflow.
+
+```yaml
+id: provision_and_configure
+namespace: company.platform
+
+inputs:
+  - id: environment
+    type: STRING
+    defaults: dev
+
+tasks:
+  - id: provision_infra
+    type: io.kestra.plugin.terraform.cli.TerraformCLI
+    beforeCommands:
+      - terraform init
+    commands:
+      - terraform apply -auto-approve -var="env={{ inputs.environment }}"
+
+  - id: configure_with_ansible
+    type: io.kestra.plugin.ansible.cli.AnsibleCLI
+    inventories:
+      - inventory-{{ inputs.environment }}.yml
+    playbooks:
+      - site.yml
+
+  - id: register_in_cmdb
+    type: io.kestra.plugin.core.http.Request
+    uri: "https://cmdb.example.com/api/servers"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ secret('CMDB_TOKEN') }}"
+    body: '{"env":"{{ inputs.environment }}","provisioned_by":"kestra"}'
+
+  - id: notify_ops
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK') }}"
+    payload: '{"text": "✅ {{ inputs.environment }} environment provisioned"}'
+```
+
+Terraform for provisioning, Ansible for configuration, an HTTP call for CMDB registration, a notification at the end — all coordinated with retries, error handling, and audit logging built into the orchestration layer.
+
+## Implementing Infrastructure Automation
+
+### Steps to Adopt Infrastructure Automation
+
+Successful adoption tends to follow a common arc:
+
+1. **Start with a high-value, low-risk target** — a development environment, a repeatable provisioning task, a frequent manual operation.
+2. **Choose IaC as the foundation** — everything else builds on declarative, version-controlled configuration.
+3. **Add configuration management** once provisioning is reliable — Ansible, Puppet, or Chef to enforce desired state on provisioned resources.
+4. **Introduce an orchestration layer** to tie provisioning, configuration, and operational workflows together with scheduling, triggers, retries, and audit trails.
+5. **Expand coverage incrementally** — one workflow, one environment, one team at a time.
+
+Skipping straight to orchestration without the IaC foundation is a common mistake. The orchestration layer depends on declarative, version-controlled infrastructure to work properly.
+
+### Challenges and How to Overcome Them
+
+Three challenges show up in nearly every adoption:
+
+- **Skill gaps** — IaC and orchestration are different from traditional sysadmin work. Solved with training and declarative tools that have shallow learning curves.
+- **Tool sprawl** — every environment brings its own automation tool. Solved by consolidating onto a single orchestration platform that covers the full footprint.
+- **Governance fragmentation** — different audit trails across tools. Solved by centralizing governance in one orchestration layer rather than stitching reports together after the fact.
+
+## Infrastructure Automation Tools Landscape
+
+A typical automation stack combines four categories of tools:
+
+| Category | Role | Examples |
+| --- | --- | --- |
+| **IaC provisioning** | Declarative infrastructure | Terraform, Pulumi, CloudFormation |
+| **Configuration management** | Desired-state enforcement | Ansible, Puppet, Chef |
+| **Container orchestration** | Workload runtime | Kubernetes, Docker, ECS |
+| **Workflow orchestration** | End-to-end coordination | Kestra, Airflow, Ansible Automation Platform |
+
+The last category is where many organizations under-invest — and where the most operational leverage lives. For direct comparisons, see [Kestra vs Ansible Automation Platform](/vs/ansible-automation-platform), [Kestra vs Chef](/vs/chef), and [Kestra vs Puppet](/vs/puppet).
+
+## Getting Started
+
+Infrastructure automation works when there's a clear hierarchy: IaC at the bottom, configuration management on top of it, and an orchestration layer tying everything together. Skipping the orchestration layer is where most automation programs stall — provisioning gets automated, configuration gets automated, but the end-to-end workflow stays manual.
+
+For teams evaluating orchestration for infrastructure workflows, Kestra is open-source, self-hostable, and integrates natively with Terraform, Ansible, Kubernetes, and cloud APIs. Start with the [infrastructure automation hub](/infra-automation), try the [getting-started blueprint](/blueprints/infrastructure-automation), or read the broader [declarative infrastructure approach](/blogs/infra-automation).

--- a/src/contents/resources/batch-vs-streaming-processing/index.md
+++ b/src/contents/resources/batch-vs-streaming-processing/index.md
@@ -1,0 +1,271 @@
+---
+title: "Batch vs Streaming Processing: Differences, Use Cases & Trade-Offs"
+description: "Understand the real differences between batch and streaming processing, when each one wins, and how modern orchestration lets you run both with the same engine."
+metaTitle: "Batch vs Streaming Processing: Differences, Use Cases & Trade-Offs"
+metaDescription: "Understand the real differences between batch and streaming processing, when each one wins, and how modern orchestration lets you run both with the same engine."
+tag: data
+date: 2026-04-21
+faq:
+  - question: "What is the difference between batch and streaming processing?"
+    answer: "Batch processing operates on bounded datasets — a finite set of records collected over a window (an hour, a day) and processed as one unit. Streaming processing operates on unbounded data — records arriving continuously, processed one at a time or in short windows with low latency. The fundamental difference is not technical, it is about the shape of the data: do you have all the input before you start, or does new input keep arriving?"
+  - question: "When should you use streaming instead of batch processing?"
+    answer: "Use streaming when latency directly affects business outcomes — fraud detection, real-time personalization, monitoring alerts, IoT reactions, or user-facing features that depend on fresh data. Use batch when the data arrives in bulk, the downstream consumer tolerates delay (reports, ML training, historical aggregations), or the cost of running always-on infrastructure outweighs the value of freshness."
+  - question: "Is batch processing still relevant in 2026?"
+    answer: "Yes, batch remains the right answer for a large share of production workloads. Financial reporting, ML training, historical backfills, regulatory exports, and anything where the consumer reads hourly or daily do not benefit from streaming. The shift has not been 'batch to streaming' but 'batch-only to batch plus streaming', with the best platforms handling both."
+  - question: "What is micro-batch processing and when should you use it?"
+    answer: "Micro-batch processes data in small, frequent batches — every few seconds or minutes — rather than as a true continuous stream. It offers most of the freshness benefits of streaming with simpler operational semantics and lower cost. Use micro-batching when you need sub-minute latency but do not need millisecond reactions, or when your team's operational maturity does not yet justify a full streaming stack."
+  - question: "Can the same platform orchestrate batch and streaming workflows?"
+    answer: "Yes, and this is increasingly the default. Modern orchestration engines like Kestra expose schedules, event triggers, and realtime triggers as first-class primitives — the same workflow definition can run on a nightly schedule, on file arrival, or as a realtime Kafka consumer. Unifying the control plane across both paradigms eliminates the coordination gap that plagues teams running separate tools for each."
+  - question: "What is the difference between Lambda and Kappa architecture?"
+    answer: "Lambda architecture runs batch and streaming pipelines in parallel, merging their outputs to get both historical accuracy and real-time freshness. Kappa architecture unifies everything as a stream, replaying historical data through the same pipeline when needed. Lambda is more flexible but doubles the code to maintain. Kappa is simpler but requires a replayable event log as the source of truth. Most teams end up somewhere in between."
+---
+
+Most "batch vs streaming" comparisons treat the choice as binary. In production, it almost never is. Modern data platforms run both, often inside the same business process — a nightly aggregation feeds a real-time dashboard, a streaming fraud detector consults a batch-trained model, a micro-batch ETL bridges the gap between them.
+
+The real question is not "which one should I pick" but "how do I design for both, and orchestrate them consistently". This guide breaks down where the two approaches genuinely differ, when each one wins, and how to handle the hybrid cases that dominate real systems.
+
+## Batch vs streaming processing at a glance
+
+The fundamental distinction is about the shape of the input:
+
+- **Batch processing** operates on **bounded data**: a finite set of records, collected over a time window, processed as one unit. You have all the input before you start. The job runs, produces an output, and exits.
+- **Streaming processing** operates on **unbounded data**: records arrive continuously, with no natural end. The processor is always running, handling records one at a time or in short windows, emitting results as it goes.
+
+Everything else — latency, cost, state management, operational complexity — flows from this distinction. Batch can afford to be slow because the data is already there. Streaming has to be fast because new data keeps coming.
+
+### When latency matters, and when it does not
+
+The biggest mistake in choosing between the two is assuming lower latency is always better. It is not, because latency has a cost. Streaming infrastructure runs 24/7, requires always-on consumers, and usually needs a message broker, schema registry, and state store. Batch infrastructure wakes up, does its work, and goes back to sleep.
+
+If a business process consumes data hourly — a report, a dashboard refresh, an email digest — streaming provides no value over a well-orchestrated batch job. If a business process needs to react in seconds — blocking a fraudulent transaction, personalizing a page — batch is not an option regardless of cost.
+
+### Why most modern systems run both
+
+The mature pattern is hybrid: streaming for the reactive layer, batch for the analytical layer, and shared primitives for state and storage. Trying to force everything into one paradigm creates more complexity than it removes. The interesting engineering question is how to keep the two coordinated without duplicating code, schemas, and operational surface.
+
+## What is batch processing?
+
+Batch processing collects records over a period, then runs a job that reads them, transforms them, and writes an output. The job has a defined start, a defined end, and a known input size.
+
+### Typical architecture and execution model
+
+A batch pipeline usually looks like this: a scheduler triggers the job (cron, or an orchestrator on a schedule), the job reads from a source (object storage, a database, an API), transforms the data, and writes to a destination (warehouse, data lake, another database). Execution is finite, resources are released when the job completes, and observability is retrospective — you look at what happened after it finished.
+
+Tools in this category include Apache Spark (in batch mode), dbt, Apache Airflow for orchestration, and modern engines like Kestra that treat scheduled execution as one primitive among many.
+
+### Strengths
+
+- **Throughput**: processing a large dataset as one unit is computationally efficient. Vectorized operations, parallel reads, and bulk writes all benefit from bounded data.
+- **Cost efficiency**: infrastructure only runs when the job runs. For workloads that execute hourly or daily, this is a fraction of the cost of always-on streaming.
+- **Reproducibility**: the same input and the same code produce the same output. This is essential for financial reporting, regulatory filings, and ML training.
+- **Simplicity**: no state to maintain between runs, no continuous consumer to supervise, no message broker to tune. A batch job is easier to reason about, debug, and replay.
+
+### Weaknesses
+
+- **Latency**: by definition, output is only available after the window completes. An hourly batch adds up to one hour of delay.
+- **Operational windows**: batch jobs running overnight leave a blind spot during the day. If a pipeline fails, you often do not find out until morning.
+- **Staleness**: downstream consumers always see yesterday's — or last hour's — data, which rules out real-time use cases entirely.
+
+## What is streaming processing?
+
+Streaming processing reads records as they arrive, processes each one (or small windows of them), and emits results continuously. The pipeline is always running.
+
+### Typical architecture
+
+A streaming pipeline has three layers: a **producer** that emits events (application, CDC connector, IoT device), a **broker** that buffers and distributes them (Kafka, Pulsar, Kinesis, Pub/Sub), and a **processor** that consumes and transforms them (Flink, Spark Structured Streaming, a consumer application, or a workflow engine with realtime triggers). Outputs go to sinks — databases, other topics, search indexes, caches.
+
+State is first-class: the processor often needs to maintain rolling aggregates, joins across streams, or windowed computations, which means durable state stores and checkpointing to recover from crashes.
+
+### Strengths
+
+- **Low latency**: results are available within milliseconds to seconds of the event occurring.
+- **Continuous insight**: dashboards, monitors, and reactive workflows get a live view of the system rather than periodic snapshots.
+- **Reactive workflows**: streaming enables use cases that are impossible with batch — fraud blocking, dynamic pricing, real-time recommendations, [event-driven orchestration](/resources/event-driven-orchestration) that kicks off downstream work the instant an event lands.
+
+### Weaknesses
+
+- **State complexity**: once you need windowed aggregations, joins, or exactly-once semantics, the engineering effort grows significantly. State stores, checkpoints, watermarks, and reprocessing all become first-order concerns.
+- **Operational overhead**: running a broker, schema registry, dead-letter queues, and always-on consumers is a permanent operational commitment. It is the largest ongoing cost of streaming.
+- **Cost at scale**: always-on infrastructure is more expensive than periodic batch, especially if the event volume is variable.
+- **Debugging**: tracing a bad result through a streaming pipeline is harder than through a batch job. The same input does not always produce the same output if state or timing differs.
+
+## Batch vs streaming: a side-by-side comparison
+
+| Dimension | Batch | Streaming |
+| --- | --- | --- |
+| Data shape | Bounded | Unbounded |
+| Latency | Minutes to hours | Milliseconds to seconds |
+| Throughput | Very high per job | Steady, per-record |
+| Cost profile | Pay when running | Always-on |
+| State management | Usually stateless | Stateful, durable |
+| Fault tolerance | Retry the whole job | Checkpoint and resume |
+| Consistency | Strong, reproducible | Eventual, order-sensitive |
+| Debugging | Retrospective, deterministic | Live, timing-dependent |
+| Typical tools | Spark, dbt, SQL, orchestrators | Kafka, Flink, realtime consumers |
+
+Neither column is universally better. The right choice depends on the use case, and the best production systems use both, routed by the requirements of each workload.
+
+## Choosing between batch and streaming
+
+Five questions decide the right approach. Walk through them in order — the first one that hits a hard constraint usually determines the answer.
+
+### 1. What is the latency SLA?
+
+If the downstream consumer tolerates minutes of delay, batch is almost always cheaper and simpler. If the consumer needs sub-second reactions, streaming is the only option. The middle ground (seconds to a few minutes) is where micro-batching shines.
+
+### 2. What is the data arrival pattern?
+
+If data arrives in bulk (nightly exports, daily dumps, weekly aggregates), batch fits the shape naturally. If data arrives continuously and unpredictably (user events, sensor readings, transactions), streaming or event-driven batch are better matches.
+
+### 3. How complex is the state you need to maintain?
+
+Stateless transformations (filter, enrich, route) work well in both paradigms. Complex stateful operations (multi-stream joins, windowed aggregations, session tracking) are possible in both but significantly easier in batch. If your processing needs a week of rolling context, batch with a proper data warehouse is usually cleaner than a streaming state store.
+
+### 4. What is the cost envelope?
+
+Streaming has a minimum infrastructure cost regardless of volume — the broker, the consumer, the state store all need to be running. For low-volume use cases, this overhead can dwarf the actual processing cost. Batch scales down to zero when idle.
+
+### 5. What is your team's operational maturity?
+
+Streaming stacks demand ongoing investment: schema evolution, broker tuning, consumer lag monitoring, reprocessing strategies. Teams new to data infrastructure often underestimate this and end up with unreliable real-time pipelines they cannot maintain. Batch is more forgiving.
+
+A short checklist: if three or more of these point to batch, pick batch. If three or more point to streaming, pick streaming. If the answers are split, consider a hybrid approach.
+
+## Hybrid approaches: beyond the binary
+
+Most production systems are neither pure batch nor pure streaming. Three patterns dominate.
+
+### Micro-batch processing
+
+Micro-batching runs small, frequent batches — every 10 seconds, every minute, every 5 minutes. It trades the millisecond latency of true streaming for dramatic operational simplification: no always-on consumers, no complex state management, just a very frequent scheduled job.
+
+Spark Structured Streaming in its default mode is micro-batch under the hood. Many "real-time" dashboards are actually micro-batch. For the majority of "we need fresh data" use cases, micro-batching is the right answer — fast enough to feel live, simple enough to operate.
+
+### Lambda architecture
+
+Lambda runs batch and streaming pipelines in parallel over the same input. The batch layer produces the authoritative historical view; the streaming layer produces an approximate real-time view; a serving layer merges them. It was popular in the early 2010s when streaming tools were less mature.
+
+The downside is significant: two pipelines, two codebases, two sources of potential inconsistency, one serving layer responsible for reconciling them. Most teams who adopted Lambda have since moved away from it.
+
+### Kappa architecture
+
+Kappa simplifies Lambda by eliminating the batch layer. All data flows through a streaming pipeline; historical reprocessing happens by replaying the event log through the same code. One pipeline, one codebase, one view of the world.
+
+Kappa requires a durable, replayable event log (Kafka with sufficient retention, for example) and a processor that can keep up with replay speed. It is elegant when it fits, and impractical when the replay volume exceeds what the infrastructure can handle.
+
+### When hybrid is the right answer
+
+Hybrid is the default for any system that serves both analytical and operational workloads. The operational side (real-time dashboards, alerts, user-facing features) gets a streaming or micro-batch feed. The analytical side (reports, ML training, historical comparisons) gets batch pipelines over the warehouse. A unified orchestrator coordinates both.
+
+## Real-world use cases
+
+### Batch-first
+
+- **Financial reporting**: end-of-day, end-of-month, end-of-quarter runs where reproducibility and auditability matter more than latency.
+- **ML training**: most training pipelines run on bounded historical data and do not benefit from streaming input.
+- **Historical backfills**: recomputing a year of aggregates is a batch job by definition, regardless of how the live pipeline is implemented.
+- **Regulatory exports**: formal deliverables to regulators on a fixed schedule.
+- **Classic ETL**: source-to-warehouse pipelines feeding BI tools that refresh hourly or daily — the core of most [data pipeline](/resources/data-pipeline) work.
+
+### Streaming-first
+
+- **Fraud detection**: a fraudulent transaction must be blocked in under a second, not caught in the nightly reconciliation.
+- **Real-time personalization**: content ranking, search suggestions, and product recommendations that must reflect the user's current session.
+- **IoT and sensor data**: continuous telemetry from devices that emit events unpredictably.
+- **Operational alerts**: monitoring systems that must fire within seconds of a threshold breach.
+- **Real-time CDC**: change-data-capture streams that keep derived stores in sync with operational databases.
+
+### Hybrid use cases
+
+- **Customer 360**: batch-built historical profiles enriched with streaming recent-activity updates.
+- **Operational analytics**: dashboards that combine a batch-computed baseline with a streaming overlay of the current day.
+- **ML inference with drift detection**: batch-trained models served in real time, with streaming monitoring of input distributions to trigger retraining.
+- **Fraud rules plus fraud ML**: deterministic streaming rules catching known patterns, batch-trained models catching subtle cases.
+
+## Orchestrating batch and streaming in a single platform
+
+Running separate orchestration tools for batch and streaming is one of the most common sources of operational complexity in data platforms. Different schedulers, different monitoring, different on-call procedures, different secrets management — and the inevitable "is the streaming side or the batch side broken" debugging exercise during incidents.
+
+The alternative is a single orchestration layer that treats schedules, events, and realtime streams as variations on the same primitive: [a declarative definition](/blogs/declarative-from-day-one) of what should run when. This is the approach Kestra takes — and the foundation of Kestra becoming [the first real-time orchestration platform](/blogs/2024-06-25-kestra-become-real-time) to unify scheduled, event-driven, and streaming workloads under one engine.
+
+### Pattern 1: a batch pipeline on a schedule
+
+A classic nightly aggregation, reading from S3 and writing to a warehouse:
+
+```yaml
+id: nightly_aggregate
+namespace: company.analytics
+
+tasks:
+  - id: load_and_aggregate
+    type: io.kestra.plugin.jdbc.duckdb.Query
+    sql: |
+      COPY (
+        SELECT date_trunc('day', event_time) AS day,
+               count(*) AS events
+        FROM read_parquet('s3://events/{{ trigger.date | date("yyyy-MM-dd") }}/*.parquet')
+        GROUP BY 1
+      ) TO 's3://aggregates/{{ trigger.date | date("yyyy-MM-dd") }}.parquet';
+
+triggers:
+  - id: daily
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 2 * * *"
+```
+
+Runs once per day at 2am. Finite input, finite output, predictable cost.
+
+### Pattern 2: a streaming workflow on Kafka
+
+The same engine can run a realtime workflow that creates one execution per message:
+
+```yaml
+id: fraud_check
+namespace: company.payments
+
+tasks:
+  - id: score
+    type: io.kestra.plugin.scripts.python.Script
+    script: |
+      # call fraud model, emit result
+      pass
+
+triggers:
+  - id: realtime
+    type: io.kestra.plugin.kafka.RealtimeTrigger
+    topic: transactions
+    properties:
+      bootstrap.servers: kafka:9092
+    serdeProperties:
+      keyDeserializer: STRING
+      valueDeserializer: JSON
+    groupId: kestra_fraud
+```
+
+Millisecond latency, one execution per transaction, same UI, same observability surface as the batch job.
+
+### Pattern 3: a hybrid workflow
+
+The two paradigms can coexist in the same orchestrator, feeding each other. A batch job trains a model nightly; a streaming job uses it for inference; both report to the same monitoring layer. The orchestrator is not just scheduling tasks — it is [bridging the coordination gap across paradigms](/blogs/orchestration-differences) that used to require two separate tools.
+
+Observability across both is where the unified approach pays off most: a single execution URL per run, the same logs format, the same retry semantics, the same alerting. Debugging a "the dashboard is stale" incident becomes a single investigation instead of a cross-team triage.
+
+## Future of data processing
+
+### Convergence toward event-driven defaults
+
+The historical pattern was batch by default, streaming when forced. The emerging pattern is event-driven by default — work starts when something happens, not when the clock ticks — with schedules as a special case of "periodic events". This does not eliminate batch; it reframes it. A nightly job becomes "an event fires at 2am, trigger the batch workflow".
+
+### The role of declarative orchestration
+
+As the event-driven default takes hold, orchestration becomes the integration layer — the one place where batch, streaming, and hybrid workloads are described, coordinated, and observed. Declarative definitions (YAML, JSON) replace imperative glue code, because integration surfaces scale better as data than as code.
+
+### What to standardize now to stay flexible later
+
+Three decisions matter more than the batch-vs-streaming choice itself:
+
+- **Pick an orchestrator that handles both paradigms natively**, so you never have to migrate workloads between control planes when requirements shift.
+- **Standardize on declarative workflow definitions**, so the same pipeline can be reviewed, versioned, and migrated without rewrites.
+- **Invest in end-to-end observability early**, so that when a hybrid system misbehaves, you can trace the issue through batch and streaming tasks in the same surface.
+
+Batch and streaming are not competing paradigms. They are complementary tools for different data shapes, and the teams that build resilient systems stop treating them as an either-or choice.

--- a/src/contents/resources/create-data-pipeline/index.md
+++ b/src/contents/resources/create-data-pipeline/index.md
@@ -1,0 +1,180 @@
+---
+title: "How to Create a Data Pipeline: A Step-by-Step Guide"
+description: "Creating a data pipeline takes more than stitching scripts together. Learn the five-step process, the three core stages (ingestion, transformation, loading), the main tools, and how to build a pipeline that survives production."
+metaTitle: "How to Create a Data Pipeline: Complete Guide"
+metaDescription: "Learn how to create a data pipeline from scratch: sources, stages, tools, and a production-ready blueprint with real YAML examples."
+tag: data
+date: 2026-04-22
+faq:
+  - question: "How do you build your own data pipeline?"
+    answer: "Five steps: (1) define goals, consumers, and SLAs, (2) select data sources and ingestion patterns, (3) design transformation and storage, (4) choose the destination (warehouse, lake, operational system), and (5) orchestrate the flow with triggers, retries, and monitoring. The fifth step is where most first pipelines fail — without orchestration, a pipeline is just a collection of scripts."
+  - question: "What are the main 3 stages in a data pipeline?"
+    answer: "The three main stages are ingestion (extracting from sources), transformation (cleaning, joining, applying business logic), and loading (writing to the destination). ELT pipelines reverse the last two — load raw data first, transform inside the warehouse. ETL transforms before loading. Both are valid depending on compliance and cost constraints."
+  - question: "What is creating data pipelines?"
+    answer: "Creating a data pipeline means designing, building, and operating the automated chain that moves data from source to destination. It covers the extraction logic, the transformations, the loading strategy, and the orchestration that runs it all reliably — including scheduling, retries, failure handling, and observability."
+  - question: "What is an example of a data pipeline?"
+    answer: "A typical example: an e-commerce company ingests order events via CDC every 15 minutes, lands them in cloud storage, runs dbt models in Snowflake to join orders with customer and product dimensions, and pushes daily revenue metrics to a dashboard and Slack. That's a real pipeline with ingestion, transformation, loading, and orchestration all working together."
+  - question: "Will ETL be replaced by AI?"
+    answer: "No. AI is changing how pipelines are built and maintained — generating boilerplate, suggesting transformations, diagnosing failures faster — but it doesn't replace the need for extract-transform-load operations. Data still has to move from sources to destinations, and orchestration is still required to run that reliably."
+  - question: "How long does it take to build a data pipeline?"
+    answer: "A simple scheduled pipeline (one source, one destination, basic transforms) can be running in a few hours with modern tools like Airbyte plus dbt plus a YAML-based orchestrator. Production-grade pipelines with monitoring, lineage, alerting, and multi-environment deployment typically take one to three weeks to stabilize. Complexity scales with the number of sources and the freshness requirements."
+---
+
+Every analytics dashboard, machine learning model, and operational report depends on a data pipeline somewhere upstream. The question most teams face isn't *whether* to build one — it's how to build one that doesn't break at 3 a.m. and require an engineer to restart it manually.
+
+Creating a data pipeline is more than writing a script that copies data from A to B. A production pipeline needs scheduling, retries, monitoring, lineage, and a way to recover when sources change shape. This guide covers the full process: what a data pipeline is, the three stages it goes through, the five-step build process, the tools you'll choose between, and a concrete YAML example to anchor the theory.
+
+## What Is a Data Pipeline?
+
+A data pipeline is an automated sequence of steps that moves data from source systems, transforms it according to business rules, and loads it into a destination. The sources can be transactional databases, SaaS APIs, event streams, or files. The destination can be a warehouse, a lake, a feature store, or an operational system.
+
+What separates a data pipeline from a one-off script is **repeatability**. A pipeline runs on a trigger (schedule, event, or dependency), handles failures gracefully, and produces consistent output. The system wrapping the pipeline — the orchestration layer — is what turns a collection of steps into infrastructure that can be trusted in production.
+
+For a deeper look at pipeline architecture and patterns, see [What Is a Data Pipeline? Definition, Architecture, and Tools](/resources/data/data-pipeline).
+
+## The Three Main Stages of a Data Pipeline
+
+The three main stages are ingestion (extracting from sources), transformation (cleaning, joining, applying business logic), and loading (writing to the destination). ELT pipelines reverse the last two — load raw data first, transform inside the warehouse. ETL transforms before loading. Both are valid depending on compliance and cost constraints.
+
+### Ingestion — Getting Data In
+
+Ingestion pulls data out of source systems. The method depends on how fresh downstream consumers need the data:
+
+- **Batch** — pull data on a schedule (hourly, daily). Good enough for most analytics, easy to reason about.
+- **Change Data Capture (CDC)** — replicate database changes continuously using tools like Debezium or native connectors.
+- **Event streaming** — consume from Kafka, Kinesis, or Pub/Sub when latency matters in seconds, not hours.
+- **API polling** — pull from SaaS APIs on a schedule, handling pagination and rate limits.
+
+Managed tools like Airbyte and Fivetran handle most ingestion patterns out of the box. Custom Python is still common for APIs with unusual auth or non-standard pagination.
+
+### Transformation — Making Data Useful
+
+Transformation reshapes raw data into something analytics-ready. Typical operations: deduplication, type casting, joining across sources, aggregating metrics, applying business rules, redacting sensitive fields.
+
+Where transformation happens is a design choice. Warehouse-native SQL (via dbt) is the dominant pattern in 2026 — cheap compute, version-controlled logic, native testing. Python and Spark handle the cases SQL can't: unstructured data, ML preprocessing, complex window logic.
+
+### Loading — Delivering to the Destination
+
+Loading writes the final data where consumers can use it. Warehouses (Snowflake, BigQuery, Redshift) dominate analytics. Lakehouses (Databricks, Iceberg on S3) are growing for mixed SQL + ML workloads. Operational systems (CRMs, marketing tools) receive data through reverse ETL when the pipeline's output needs to drive action, not just reporting.
+
+Loading strategy matters: full refresh, incremental loads, and upserts each have different trade-offs around cost, latency, and consistency.
+
+## How to Create a Data Pipeline in Five Steps
+
+Building a data pipeline follows a repeatable sequence. Most teams that skip steps end up rebuilding the pipeline within a year.
+
+### Step 1 — Define Goals and Requirements
+
+Start with the consumer. Who uses the data, how often do they need it, and what's the cost of it being late or wrong? These answers set the non-negotiables: latency target, freshness SLA, acceptable failure modes, observability requirements. Without this step, every downstream decision is guesswork.
+
+### Step 2 — Select Data Sources and Ingestion Patterns
+
+List every source and classify each by access pattern: batch-pullable API, CDC-capable database, streaming feed, file drop. For each, decide between full refresh and incremental ingestion. Incremental wins on cost and speed at scale, but requires a reliable high-watermark or primary key on the source side.
+
+### Step 3 — Design Processing and Storage
+
+Decide where transformations run. In-warehouse with SQL and dbt is the default for structured data. Out-of-warehouse with Python, Polars, or Spark is right for unstructured data, complex ML preprocessing, or when keeping compute off the warehouse matters for cost. Either way, structure the storage layer in distinct zones — raw, staging, curated — so lineage stays clear and debugging stays possible.
+
+### Step 4 — Choose the Destination
+
+Match the destination to the consumer. BI dashboards → warehouse. ML models → feature store or warehouse with point-in-time correctness. Operational systems → reverse ETL to CRM or marketing platform. Many pipelines have multiple destinations and fan out from a single transformation layer.
+
+### Step 5 — Orchestrate the Flow
+
+This is where most first pipelines fail. Without orchestration, the pipeline is a collection of scripts glued together with cron. Orchestration handles triggers (schedule, event, webhook, file-drop), dependencies between tasks, retry logic on failure, alerting, and execution history. It's the difference between a pipeline that runs in production and a pipeline that breaks in production.
+
+## A Concrete Example — Building a Pipeline End to End
+
+Here's what a production pipeline looks like in Kestra: ingest from an API, transform with dbt, load into Snowflake, notify Slack. Everything in one YAML file, triggered on a schedule, with retries and error handling baked in.
+
+```yaml
+id: create_data_pipeline_example
+namespace: company.data
+
+triggers:
+  - id: daily_schedule
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 6 * * *"
+
+tasks:
+  - id: ingest_from_api
+    type: io.kestra.plugin.scripts.python.Script
+    script: |
+      import requests, pandas as pd
+      r = requests.get("https://api.example.com/orders", headers={
+          "Authorization": f"Bearer {{ secret('API_TOKEN') }}"
+      })
+      df = pd.DataFrame(r.json())
+      df.to_parquet("orders.parquet")
+    retry:
+      type: exponential
+      maxAttempts: 3
+      interval: PT1M
+
+  - id: load_to_warehouse
+    type: io.kestra.plugin.gcp.bigquery.Load
+    from: "{{ outputs.ingest_from_api.outputFiles['orders.parquet'] }}"
+    destinationTable: "raw.orders"
+    format: PARQUET
+
+  - id: transform_with_dbt
+    type: io.kestra.plugin.dbt.cli.DbtCLI
+    commands:
+      - dbt deps
+      - dbt build --select tag:daily
+
+  - id: notify_team
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK') }}"
+    payload: '{"text": "Daily pipeline completed ✅"}'
+
+errors:
+  - id: alert_on_failure
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK') }}"
+    payload: '{"text": "⚠️ Pipeline failed — check logs"}'
+```
+
+Five tasks, one trigger, error handling, and secrets management — in one declarative file that any engineer can read on day one. That's what "orchestrated" looks like in practice.
+
+## Tools for Creating Data Pipelines
+
+The pipeline tool landscape splits into two categories: orchestrators (what runs your pipelines) and managed ETL/ELT vendors (what moves data through them). Most production setups use both.
+
+| Tool | Category | Interface | Cloud-agnostic | Best for |
+| --- | --- | --- | --- | --- |
+| **Kestra** | Orchestrator | YAML + UI | ✅ | Multi-language teams, event-driven, hybrid stacks |
+| **Airflow / Astronomer** | Orchestrator | Python DAGs | ✅ | Python-native data teams |
+| **Dagster** | Orchestrator | Python + assets | ✅ | Asset-centric modeling, Python-first |
+| **AWS Glue / Step Functions** | Orchestrator | Visual / JSON | ❌ (AWS) | AWS-native stacks |
+| **Airbyte / Fivetran** | Managed ingestion | Connectors | ✅ | Offloading connector maintenance |
+| **dbt** | Transformation | SQL + Jinja | ✅ | Warehouse-native transforms |
+
+For most teams building a pipeline today, the pragmatic stack is: Airbyte or Fivetran for ingestion, dbt for transformation, and a general orchestrator to tie them together with event triggers, retries, and observability.
+
+## Types of Data Pipelines — Batch, Streaming, Event-Driven
+
+Three patterns dominate in 2026. Most teams run a mix.
+
+- **Batch** — fixed schedule, bounded data per run. Easiest to reason about. Default for analytics where freshness within hours is acceptable.
+- **Streaming** — continuous processing, latency in seconds or milliseconds. Used for fraud detection, real-time personalization, operational dashboards. Higher complexity around ordering, state, and exactly-once guarantees.
+- **Event-driven** — triggers on events (file lands in S3, webhook fires, message on a queue) rather than a schedule. Eliminates the "wait until next run" tax of batch without the full complexity of streaming.
+
+Event-driven is increasingly the default pattern for modern data teams. See the deeper breakdown in [What Is a Data Pipeline?](/resources/data/data-pipeline) for when each pattern fits.
+
+## Best Practices for Production Pipelines
+
+Six practices separate pipelines that scale from pipelines that rot:
+
+- **Idempotent tasks** — the same pipeline run twice should produce the same output. Re-runs are the most common recovery mechanism; non-idempotent tasks turn recovery into a minefield.
+- **Incremental processing** — ingest and transform only what's changed since the last run. Full-refresh pipelines don't scale past a few million rows.
+- **Data quality tests** — assertion tests (dbt tests, Great Expectations) catch regressions before they reach dashboards. Cheaper to fix upstream than to explain to a CFO why Q3 revenue was wrong.
+- **Version control** — every pipeline definition lives in Git, reviewed like application code. The pipeline is infrastructure; treat it that way.
+- **Observability** — logs alone aren't enough. Per-task metrics, data volumes, latency, and SLA tracking are what let you answer "what broke?" in minutes instead of hours.
+- **Secrets management** — credentials in a vault, not in the pipeline code. Rotatable, auditable, and not committed to Git.
+
+## Getting Started
+
+Creating a data pipeline is less about the specific tools and more about the system around them. The orchestrator you pick, the way you structure storage, and the observability you bake in from day one shape whether the pipeline is still running reliably a year later.
+
+For teams evaluating orchestration, Kestra is open-source, self-hostable, and ships with ready-to-use blueprints for the most common pipeline patterns. Start with a [ready-made data pipeline blueprint](/blueprints), explore the [data orchestration guide](/resources/data/data-orchestration), or read about the broader [declarative orchestration approach](/data).

--- a/src/contents/resources/event-driven-orchestration/index.md
+++ b/src/contents/resources/event-driven-orchestration/index.md
@@ -1,0 +1,227 @@
+---
+title: "Event-Driven Orchestration: A Practical Guide (with Examples)"
+description: "Learn what event-driven orchestration is, how it compares to choreography and SOA, and how to implement it with real YAML examples you can copy."
+metaTitle: "Event-Driven Orchestration: Definition, Patterns & Examples"
+metaDescription: "Understand event-driven orchestration, how it differs from choreography, SOA, and DDD, and see production YAML examples for webhooks, Kafka, S3, and SQS triggers."
+tag: infrastructure
+date: 2026-04-21
+faq:
+  - question: "What is event-driven orchestration?"
+    answer: "Event-driven orchestration is an architectural pattern where a central orchestrator starts and coordinates a workflow in response to an external event, such as a file arriving in object storage, a message landing on a queue, or an HTTP webhook call. The orchestrator decides the order of steps, handles retries, and owns the end-to-end process, while the events themselves decide when the workflow runs."
+  - question: "What is the difference between event-driven orchestration and choreography?"
+    answer: "In orchestration, a central engine controls the sequence of tasks and knows the full business process. In choreography, there is no central controller, each service independently reacts to events and emits new ones. Orchestration gives you observability, retries, and a single place to debug. Choreography gives you loose coupling but makes the end-to-end flow harder to trace. Event-driven orchestration combines both, event triggers start the process, but a central engine handles the sequencing."
+  - question: "How is event-driven architecture different from SOA?"
+    answer: "Service-Oriented Architecture (SOA) centers on services exposing synchronous interfaces, typically request-response over SOAP or REST. Event-driven architecture (EDA) centers on asynchronous events, producers emit events without knowing who consumes them. SOA tends toward tight coupling through shared contracts, while EDA favors loose coupling through event streams."
+  - question: "What is the difference between EDD and DDD?"
+    answer: "Event-Driven Design (EDD) structures systems around events and asynchronous reactions between loosely coupled components. Domain-Driven Design (DDD) structures systems around business domain concepts, bounded contexts, and the ubiquitous language shared with domain experts. They are not mutually exclusive, many teams use DDD to define bounded contexts and EDD to connect them via events."
+  - question: "What are the drawbacks of event-driven orchestration?"
+    answer: "The main trade-offs are debugging complexity (async flows are harder to trace), eventual consistency (state is not immediately coherent across services), operational overhead (you need to run message brokers, schema registries, and dead-letter queues), and ordering guarantees (events may arrive out of order). A good orchestrator mitigates most of these by giving you a single UI to inspect every execution, its inputs, outputs, and failures."
+  - question: "When should you not use event-driven orchestration?"
+    answer: "Avoid it for simple, strictly sequential workflows that run on a predictable schedule, small applications where a single cron job is enough, or strongly consistent transactions that require synchronous commits across systems. Event-driven patterns pay off when you have multiple upstream systems, unpredictable arrival times, or workloads that need to react in near real time."
+---
+
+Event-driven orchestration has moved from a niche integration pattern to the default way modern teams connect data pipelines, microservices, and infrastructure operations. Files land in object storage, messages arrive on Kafka, webhooks fire from SaaS tools, and workflows need to start immediately, not at the next scheduled run.
+
+This guide defines event-driven orchestration, contrasts it with choreography, SOA, and domain-driven design, walks through an implementation with real YAML examples, and covers the trade-offs you should know before adopting it.
+
+## What is event-driven orchestration?
+
+Event-driven orchestration is an architectural pattern that combines two ideas:
+
+- **Event-driven**: workflows are triggered by events (file arrivals, message queue records, webhooks, database changes) rather than by a fixed schedule.
+- **Orchestration**: a central engine owns the sequence of steps, handles retries and errors, and gives you end-to-end visibility over the process.
+
+The orchestrator listens for events, starts a workflow instance when a relevant event occurs, and coordinates the downstream tasks — calling APIs, running scripts, moving data, triggering subflows. The workflow itself is declarative: you describe the steps and their dependencies, the engine figures out execution.
+
+## How event-driven orchestration works
+
+A typical event-driven orchestration loop looks like this:
+
+1. An **event source** emits an event. This might be an S3 `PutObject`, a Kafka record, an HTTP POST, or a row appearing in a database.
+2. A **trigger** attached to a workflow listens for that event. Triggers can poll on an interval or maintain an always-on connection for real-time reactions.
+3. When the event matches, the **orchestrator** creates a new workflow execution and injects the event payload as context, so downstream tasks can use it.
+4. The **workflow** runs its tasks in the declared order (sequential, parallel, conditional, fan-out), with retries and error handlers at every step.
+5. Every **execution** is recorded, with inputs, outputs, logs, and timings available in a single UI.
+
+The key distinction from a plain scheduler is that the trigger is external and unpredictable, and from plain event streaming that the orchestrator owns the sequencing and state of the process, not the individual services.
+
+### A concrete example
+
+An e-commerce company wants every new order to flow through a coordinated process: validate the payment, reserve inventory, generate a shipping label, send the confirmation email, and update analytics. Each step touches a different system.
+
+With event-driven orchestration, the order creation event (a new message on an `orders` Kafka topic, for instance) triggers a workflow. The workflow calls the payment service, waits for the response, then branches: on success it reserves inventory and ships, on failure it triggers a refund subflow and notifies support. Every order leaves a single execution trace you can open, inspect, and replay if something goes wrong.
+
+## Benefits of event-driven orchestration
+
+### Real-time responsiveness
+
+Schedules are a poor fit when data arrival is unpredictable. An hourly cron that processes files from S3 adds up to an hour of latency on every upload. An event-driven trigger starts the workflow the moment the file lands, keeping end-to-end latency in the seconds.
+
+### Decoupling without losing visibility
+
+Pure event choreography decouples services at the cost of observability — no single system knows the end-to-end flow. Event-driven orchestration keeps components decoupled (they only emit and consume events) while giving you one place to see the whole process, replay failed runs, and debug.
+
+### Resource efficiency
+
+Scheduled pipelines often run unnecessarily, scanning empty buckets or querying tables with no new data. Event-driven workflows only consume compute when there's actual work to do, which matters both for cloud costs and for database load.
+
+### Unified orchestration across domains
+
+The same engine can orchestrate data pipelines, infrastructure automation, and microservice choreography. A single platform handling all three means fewer tools to operate and consistent observability across data, AI, and infra workflows. This is the approach Kestra takes, with event-driven orchestration as a first-class primitive rather than an add-on.
+
+## Event-driven orchestration vs. other approaches
+
+### Orchestration vs. choreography
+
+Orchestration and choreography are the two main ways to coordinate distributed services:
+
+- **Orchestration**: a central component (the orchestrator) tells each service what to do and when. The control flow is centralized and visible.
+- **Choreography**: each service listens to events and decides independently how to react. The control flow is emergent, distributed across services.
+
+Choreography is simpler to set up for small systems but becomes difficult to reason about as the number of services grows. Teams often end up reinventing a coordinator — badly — through layers of event handlers. Orchestration scales better when processes are complex, have branching logic, or need explicit error handling.
+
+Event-driven orchestration isn't a third option so much as a pragmatic combination: events are used for triggering and decoupling (the "choreography" strength), while the orchestrator handles sequencing and observability.
+
+### EDA vs. SOA
+
+Service-Oriented Architecture (SOA) predates event-driven architecture by a decade. The two differ in three main ways:
+
+| Dimension | SOA | Event-Driven Architecture |
+| --- | --- | --- |
+| Communication | Synchronous (request-response) | Asynchronous (publish-subscribe) |
+| Coupling | Tight — consumers know service contracts | Loose — producers don't know consumers |
+| Focus | Services as the central abstraction | Events as the central abstraction |
+
+SOA shines when you need strict contracts and immediate responses. EDA shines when you need to scale producers and consumers independently and tolerate eventual consistency.
+
+### EDD vs. DDD
+
+Event-Driven Design (EDD) and Domain-Driven Design (DDD) address different concerns. EDD is about *how* components communicate — asynchronously, via events. DDD is about *how you model the business* — around bounded contexts, aggregates, and a shared domain language.
+
+Many production systems use both: DDD defines the boundaries (an "Orders" context, a "Shipping" context), and EDD connects them (the Orders context emits an `OrderPlaced` event that Shipping consumes). The orchestrator sits on top, coordinating cross-context workflows without violating the boundaries.
+
+## Building event-driven orchestration with Kestra
+
+Kestra is an open-source, event-driven orchestration platform. Workflows are declarative YAML, triggers are native, and the same engine handles schedules, webhooks, and real-time event streams. Here are three patterns you'll likely need.
+
+### Pattern 1: webhook trigger
+
+The simplest event source is an HTTP call. Any SaaS tool, GitHub, Amazon EventBridge, or internal service can POST to a Kestra webhook URL and start a workflow:
+
+```yaml
+id: webhook_example
+namespace: company.team
+
+tasks:
+  - id: log_payload
+    type: io.kestra.plugin.core.log.Log
+    message: "Received event: {{ trigger.body }}"
+
+triggers:
+  - id: webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: "{{ secret('WEBHOOK_KEY') }}"
+```
+
+The flow exposes a unique URL (`/api/v1/main/executions/webhook/{namespace}/{flowId}/{key}`) that accepts GET, POST, and PUT requests. The request body and headers are available inside the flow as `{{ trigger.body }}` and `{{ trigger.headers }}`.
+
+### Pattern 2: S3 file-arrival trigger
+
+When files land in S3, a polling trigger can detect them and start a workflow per batch:
+
+```yaml
+id: s3_event_driven
+namespace: company.team
+
+tasks:
+  - id: process_files
+    type: io.kestra.plugin.core.flow.ForEach
+    values: "{{ trigger.objects | jq('.[].uri') }}"
+    tasks:
+      - id: handle
+        type: io.kestra.plugin.core.debug.Return
+        format: "Processing file: {{ taskrun.value }}"
+
+triggers:
+  - id: watch_bucket
+    type: io.kestra.plugin.aws.s3.Trigger
+    interval: "PT5M"
+    accessKeyId: "{{ secret('AWS_ACCESS_KEY_ID') }}"
+    secretKeyId: "{{ secret('AWS_SECRET_KEY_ID') }}"
+    region: "eu-central-1"
+    bucket: "my-bucket"
+    prefix: "incoming/"
+    action: MOVE
+    moveTo:
+      key: archive
+      bucket: "archive-bucket"
+```
+
+The trigger polls every five minutes, downloads detected files to Kestra's internal storage (so you don't need a separate download task), and moves them to an archive bucket after processing to prevent re-triggering.
+
+### Pattern 3: real-time Kafka trigger
+
+For low-latency use cases, Kestra offers realtime triggers that maintain an always-on connection to the event source and create one execution per message:
+
+```yaml
+id: kafka_realtime
+namespace: company.team
+
+tasks:
+  - id: log_event
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ trigger.value }}"
+
+triggers:
+  - id: realtime_trigger
+    type: io.kestra.plugin.kafka.RealtimeTrigger
+    topic: orders
+    properties:
+      bootstrap.servers: localhost:9092
+    serdeProperties:
+      keyDeserializer: STRING
+      valueDeserializer: JSON
+    groupId: kestra_orders
+```
+
+Every message published to the `orders` topic starts a new workflow execution with millisecond latency. The same pattern works for SQS, Google Pub/Sub, Pulsar, NATS, MQTT, Redis, AMQP, and Azure Event Hubs — the only thing that changes is the trigger type.
+
+### Combining triggers
+
+A single workflow can define multiple triggers: a webhook for manual testing, a schedule for nightly backfills, and a real-time event trigger for production. All three produce the same execution type, processed by the same logic, visible in the same UI.
+
+## Drawbacks and considerations
+
+Event-driven orchestration is powerful but not free. Before adopting it, weigh these trade-offs.
+
+### Debugging complexity
+
+Async flows are harder to reason about than linear synchronous code. A request that would fail loudly in a monolith can silently wait in a dead-letter queue for hours. The mitigation is end-to-end tracing: every execution should have a single URL where you can see inputs, outputs, logs, and timing for every task. This is one place a good orchestrator earns its keep.
+
+### Eventual consistency
+
+Because services react asynchronously, the system as a whole is eventually consistent. You cannot assume that after emitting an event, all consumers have already processed it. Design workflows to be idempotent, and prefer explicit state checks over "I just sent the event, it must be done."
+
+### Operational overhead
+
+You need to run the event infrastructure: brokers, schema registries, dead-letter queues, monitoring. For a team of three building a small application, a cron job may genuinely be simpler. Event-driven orchestration starts paying off at the scale where you're already running Kafka, RabbitMQ, or cloud pub/sub for other reasons.
+
+### Ordering and duplication
+
+Most event systems offer "at-least-once" delivery, which means occasional duplicates. Some also don't guarantee order across partitions. Build idempotent tasks (deterministic IDs, upserts instead of inserts) and don't assume strict ordering unless your event source guarantees it.
+
+### When not to use it
+
+Skip event-driven orchestration when the workflow is a simple scheduled batch with no dependency on external events, the transaction requires strong consistency across systems (you need a real distributed transaction or saga, not just a workflow), or the system is small enough that adding a broker and an orchestrator is more overhead than the problem justifies.
+
+## Real-world patterns
+
+Event-driven orchestration shows up in three recurring patterns worth recognizing:
+
+**Data pipeline automation.** File lands in S3 or GCS, orchestrator picks it up, runs validation, loads into the warehouse, triggers dbt, and notifies stakeholders. This replaces the classic "scheduled every hour, hope the data is there" pattern.
+
+**Microservice coordination.** An order event triggers a workflow that calls payment, inventory, shipping, and notification services in a defined sequence, with compensating actions on failure. The orchestrator acts as a saga coordinator.
+
+**Infrastructure automation.** A webhook from a monitoring system triggers a remediation workflow: scale a cluster, rotate credentials, run a diagnostic, open an incident. The orchestrator ties together the cloud APIs, scripts, and notifications.
+
+All three patterns share the same shape: an external event, a declarative workflow, and a single place to observe and debug every run.

--- a/src/contents/resources/hybrid-cloud-automation/index.md
+++ b/src/contents/resources/hybrid-cloud-automation/index.md
@@ -1,0 +1,124 @@
+---
+title: "What Is Hybrid Cloud Automation? Use Cases and Benefits"
+description: "Hybrid environments combine public cloud, private cloud, and on-prem — and automating them is where operations teams scale or stall. Learn what hybrid cloud automation is, the main use cases, and how to choose a platform."
+metaTitle: "What Is Hybrid Cloud Automation? Full Guide"
+metaDescription: "Hybrid cloud automation orchestrates workloads across public cloud, private cloud, and on-prem. Learn the benefits, use cases, and tools."
+tag: infrastructure
+date: 2026-04-22
+faq:
+  - question: "What is hybrid cloud automation?"
+    answer: "Hybrid cloud automation manages, orchestrates, and optimizes workloads, resources, and services across a mixed environment — public cloud services, private clouds, and on-premises infrastructure — through automated processes. It turns the fragmented reality of modern IT into a consistent operating layer that teams can reason about."
+  - question: "What is a hybrid cloud system?"
+    answer: "A hybrid cloud system combines public cloud services with private cloud or on-premises infrastructure into a single coordinated environment. Workloads run in whichever location best fits cost, performance, compliance, or latency requirements — and often move between environments based on changing conditions."
+  - question: "What is an example of a hybrid cloud company?"
+    answer: "Banking firms run transaction systems on-prem while using public cloud for analytics. Media companies store content locally and use public cloud for global distribution. Industrial companies run operational technology (OT) on-prem and business applications in the cloud. Most Fortune 500 enterprises are hybrid by default."
+  - question: "What is a real-life example of a hybrid cloud?"
+    answer: "A financial services firm keeps its transaction database on-prem for regulatory reasons but runs nightly analytics on public cloud. An automated workflow snapshots the database, anonymizes sensitive fields, transfers the snapshot to cloud storage, processes it in a Spark cluster, writes results back on-prem, and tears down the cloud compute. One workflow, two environments, zero manual steps."
+  - question: "What is the difference between hybrid cloud and multi-cloud?"
+    answer: "Hybrid cloud combines public cloud with private or on-prem infrastructure. Multi-cloud combines two or more public cloud providers (AWS, Azure, GCP). Most enterprises are both — running multiple public clouds and keeping workloads on-prem — which is why modern orchestration platforms treat the two as one problem."
+  - question: "What are the 4 hybrid apps?"
+    answer: "Hybrid applications are mobile apps combining web and native technologies. Popular frameworks include Ionic, React Native, Xamarin, and Apache Cordova (formerly PhoneGap). Note: hybrid apps are unrelated to hybrid cloud — they share the name but solve a different problem."
+---
+
+Most enterprise IT doesn't live on a single cloud, and it probably never will. Regulatory constraints keep transaction systems on-prem. Latency-sensitive workloads stay close to their users. Legacy applications resist cloud migration. And cost optimization often argues against putting everything in a single public cloud in the first place.
+
+That's the hybrid cloud — and automating it is where operations teams either scale their impact or drown in manual toil. This guide covers what hybrid cloud automation is, how it differs from general cloud automation, the use cases that matter most in practice, and what to look for in a platform.
+
+## What Is Hybrid Cloud Automation?
+
+Hybrid cloud automation manages, orchestrates, and optimizes workloads, resources, and services across a mixed environment — public cloud services, private clouds, and on-premises infrastructure — through automated processes. It turns the fragmented reality of modern IT (different consoles, different APIs, different security models) into a consistent operating layer that teams can reason about.
+
+The key distinction from traditional cloud automation: hybrid cloud automation is **cross-environment by default**. A single workflow can provision a VM in vSphere, deploy a container to EKS, and update a DNS record in Cloudflare — without rewriting the logic for each environment.
+
+## Key Components of Hybrid Cloud Automation
+
+Four components do the heavy lifting in a hybrid automation stack:
+
+- **Orchestration engine** — coordinates workflows across environments with triggers, retries, and dependency management
+- **Configuration management** — Ansible, Puppet, Chef, or similar for enforcing desired state on provisioned resources
+- **Infrastructure as Code** — Terraform, Pulumi, CloudFormation for declarative provisioning across clouds and on-prem
+- **Governance layer** — identity, secrets, approvals, audit trails, and policy enforcement across every environment
+
+Good hybrid cloud automation depends on all four working together. IaC without orchestration is just provisioning. Configuration management without governance is drift waiting to happen. Orchestration without IaC has nothing to run.
+
+## Key Benefits of Hybrid Cloud Automation
+
+### Enhanced Efficiency and Operational Cost Reduction
+
+Hybrid cloud automation eliminates the manual handoffs that consume disproportionate time in mixed environments. Provisioning a new service used to mean filing tickets across three teams and waiting days. With automation, the same operation runs end-to-end in minutes — no lost context, no config drift, no manual synchronization between environments.
+
+### Improved Agility and Scalability
+
+Teams can shift workloads between environments based on cost, latency, or capacity. Run steady-state production on-prem, burst into the cloud for peaks, and fail over to a secondary region during incidents. Without automation, that flexibility is theoretical. With it, it's a lever that operations teams can actually pull.
+
+### Greater Consistency and Reduced Human Error
+
+The biggest source of outages in hybrid environments isn't technology — it's inconsistent configuration across sites. Automation enforces the same baseline (patch levels, network policies, security groups) across every environment, catching drift before it becomes an incident.
+
+### Security and Compliance
+
+Regulated industries often keep sensitive workloads on-prem while using public cloud for everything else. Automation makes compliance auditable: every change is logged, every approval is captured, every credential is rotated on schedule. Compliance shifts from a quarterly scramble to a continuous property of the system.
+
+## Common Use Cases for Hybrid Cloud Automation
+
+Five use cases appear in nearly every hybrid cloud automation program:
+
+### Workload Migration and Placement
+
+Moving workloads between environments — cloud to on-prem for cost, on-prem to cloud for scale — is fundamentally an automation problem. Manual migrations break. Automated migrations work because each step (snapshot, transfer, validate, cut over, rollback) is codified and testable. The same workflow runs in pre-prod and prod.
+
+### Disaster Recovery and Business Continuity
+
+DR plans that exist only as runbooks fail when the incident actually happens. Hybrid cloud automation turns DR into a workflow that can be tested regularly — failing over from on-prem to cloud, validating the failover, then failing back — until it becomes routine rather than a once-a-year fire drill.
+
+### Development and Testing Environments
+
+Ephemeral dev and test environments that span on-prem databases and cloud compute are a classic hybrid use case. Automation stands them up on demand, tears them down when idle, and ensures every developer gets the same baseline — without the "works on my env" problem.
+
+### Resource Allocation and Cost Management
+
+Cost optimization in hybrid environments requires constant tuning: right-sizing instances, shutting down idle resources, shifting workloads to cheaper regions. Doing this manually across clouds is a losing game. Automation monitors utilization continuously and applies policy-driven actions.
+
+### Real-Life Example — Regulated Analytics Pipeline
+
+A financial services firm keeps its transaction database on-prem for regulatory reasons but runs analytics on the cloud. Every night, a hybrid workflow snapshots the on-prem database, anonymizes sensitive fields, transfers the snapshot to cloud storage, triggers a Spark cluster to compute analytics, writes results back to an on-prem reporting system, and finally tears down the cloud compute. One workflow, two environments, zero manual steps.
+
+This is what hybrid cloud automation looks like when it works — a single declarative workflow that respects compliance boundaries, leverages cloud elasticity for compute, and keeps the orchestration logic version-controlled and auditable.
+
+## Implementing Hybrid Cloud Automation — Best Practices
+
+Five practices that separate functional hybrid automation from theatrical hybrid automation:
+
+- **Start with one high-value workflow** — not a Day-One rewrite of everything. Pick a workflow that actually spans environments, stabilize it, then expand.
+- **Standardize on declarative definitions** — YAML workflows that any engineer can read on day one, regardless of which environment they usually work in.
+- **Centralize secrets from day one** — a single vault (HashiCorp Vault, AWS Secrets Manager, Azure Key Vault) accessed consistently from every workflow.
+- **Build observability before scaling** — if a workflow fails silently in one environment, the whole hybrid strategy loses credibility. Metrics, logs, and lineage across every environment.
+- **Treat air-gapped as a first-class case** — many hybrid environments include air-gapped or regulated networks. Tools that require outbound connectivity to phone home don't work here.
+
+## Choosing a Hybrid Cloud Automation Platform
+
+The filter that matters most: does the platform treat every environment equally, or does it treat one environment as primary and the others as afterthoughts?
+
+| Tool | Hybrid scope | Air-gapped support | Trade-off |
+| --- | --- | --- | --- |
+| **Kestra** | Cloud + on-prem + air-gapped | ✅ Native | General-purpose orchestrator, less deep than vendor-specific tools in their home environment |
+| **VMware Aria Automation** | Strong vSphere, weaker cloud | Partial | Deep VMware integration; orchestration logic lives in vRO |
+| **HPE Morpheus** | Hybrid cloud management | Partial | Catalog-driven provisioning; less flexible for custom workflows |
+| **Red Hat Ansible Automation Platform** | Config management + workflows | ✅ | Playbook-centric; orchestration is a layer on top |
+| **AWS Systems Manager** | AWS + limited hybrid | ❌ | AWS-first; limited for truly mixed environments |
+
+For direct comparisons, see [Kestra vs HPE Morpheus](/vs/morpheus) and [Kestra vs VMware Aria Automation](/vs/vmware-cloud-foundation).
+
+## The Future of Hybrid Cloud Automation
+
+Two trends are reshaping the space:
+
+**AI-assisted workflow authoring** — generating workflow code from natural language, and optimizing workload placement based on predicted demand. Both are early but real. AI-assisted authoring is already reducing the time to build automation; intelligent placement will become standard within a few release cycles of most platforms.
+
+**Stateful infrastructure automation** — treating VMs, IPs, and certs as tracked assets rather than fire-and-forget outputs. This shift is what makes hybrid environments governable at scale, because it gives teams a single live inventory of what exists across every environment. See [Assets for Infra Automation](/blogs/assets-for-infra-automation) for the deeper take.
+
+## Getting Started
+
+Hybrid cloud automation works when there's one orchestration layer spanning every environment — and breaks down when each environment gets its own automation stack. Picking the orchestration layer is the most consequential decision in a hybrid strategy.
+
+For teams evaluating options, Kestra is open-source, self-hostable, and runs the same way across cloud, on-prem, and air-gapped environments. Start with the [infrastructure automation hub](/infra-automation), read the [Fortune 500 hybrid migration case study](/use-cases/stories/27-securing-hybrid-cloud-automation-across-it-and-ot-with-kestra), or explore the [declarative infrastructure approach](/blogs/infra-automation).

--- a/src/contents/resources/multi-cloud-orchestration/index.md
+++ b/src/contents/resources/multi-cloud-orchestration/index.md
@@ -1,0 +1,148 @@
+---
+title: "Multi-Cloud Orchestration: Definition, Benefits, and Tools"
+description: "Enterprise IT rarely lives on a single cloud. Learn what multi-cloud orchestration is, how it differs from hybrid cloud orchestration, the benefits for cost and governance, and how to choose the right platform."
+metaTitle: "Multi-Cloud Orchestration: Definition & Benefits"
+metaDescription: "Multi-cloud orchestration manages workloads across AWS, Azure, GCP, and on-prem from one control plane. Learn the benefits, tools, and best practices."
+tag: infrastructure
+date: 2026-04-22
+faq:
+  - question: "What is multi-cloud orchestration?"
+    answer: "Multi-cloud orchestration is the methodology used to manage workload operations across multiple cloud providers through automation. It covers infrastructure provisioning, load balancing, network coordination, patching, and workload lifecycle — all from a single governed execution layer spanning AWS, Azure, GCP, and other providers."
+  - question: "What is cloud orchestration?"
+    answer: "Cloud orchestration is the process of coordinating tools, applications, APIs, and infrastructure across private and public clouds into comprehensive workflows. Orchestration platforms let IT teams organize automation across teams and domains, so a single workflow can provision resources in one cloud, trigger jobs in another, and notify downstream systems — without handoffs or manual steps."
+  - question: "What is an example of cloud orchestration?"
+    answer: "A deployment workflow that provisions a VPC and RDS database in AWS via Terraform, deploys the application to GKE in Google Cloud, registers the new service in Azure Active Directory for identity, and runs smoke tests against the live endpoint. One workflow, three clouds, no manual handoffs."
+  - question: "What are the 4 types of cloud computing?"
+    answer: "The four main types are public cloud (AWS, Azure, GCP), private cloud (self-hosted infrastructure with cloud-like APIs), hybrid cloud (public plus private), and multi-cloud (multiple public providers). Most real enterprises run a combination, which is why orchestration that treats all four as equal citizens has become a requirement rather than a nice-to-have."
+  - question: "What is the difference between multi-cloud and hybrid cloud orchestration?"
+    answer: "Multi-cloud orchestration spans two or more public cloud providers (AWS, Azure, GCP). Hybrid cloud orchestration spans public cloud and private infrastructure (on-prem data centers, edge locations). Most enterprises are technically both, which is why modern orchestration platforms treat the two as one problem."
+  - question: "What is MultCloud used for?"
+    answer: "MultCloud is a consumer-grade file transfer service that moves files between personal cloud storage providers like Google Drive, OneDrive, and Dropbox. It is unrelated to enterprise multi-cloud orchestration, which coordinates infrastructure, applications, and pipelines across AWS, Azure, GCP, and on-prem systems."
+---
+
+Most enterprises stopped running on a single cloud years ago. A typical setup spans AWS for compute, Azure for identity, GCP for analytics, and a handful of on-prem systems that never quite made it to the public cloud. Each provider brings its own console, IAM model, and automation toolchain — and stitching them together is where operations teams spend most of their time.
+
+Multi-cloud orchestration is the discipline of making that patchwork behave like one platform. This guide covers what it actually means, the benefits it delivers, the trade-offs of different tooling approaches, and how to implement it without creating yet another layer of fragmentation.
+
+## What Is Multi-Cloud Orchestration?
+
+Multi-cloud orchestration is the methodology used to manage workload operations across multiple cloud providers through automation. It covers infrastructure provisioning, load balancing, network coordination, patching, and workload lifecycle — all from a single governed execution layer spanning AWS, Azure, GCP, and other providers.
+
+The underlying idea is simple: instead of running separate automation toolchains for each cloud (AWS Step Functions here, Azure Logic Apps there, custom scripts on-prem), a single orchestration layer coordinates workflows across every environment. One workflow can provision a database in AWS, trigger a Kubernetes job on GCP, update a DNS record in Cloudflare, and notify a Slack channel — without the team rebuilding that logic three times for three clouds.
+
+## Multi-Cloud vs. Hybrid Cloud vs. Cloud Orchestration
+
+These three terms overlap constantly. A clean distinction:
+
+| Term | Scope | Example |
+| --- | --- | --- |
+| **Cloud orchestration** | Any orchestration involving cloud resources, single or multi | Provisioning an EKS cluster via a workflow |
+| **Multi-cloud orchestration** | Workflows spanning two or more public cloud providers | Deploying across AWS and GCP in one pipeline |
+| **Hybrid cloud orchestration** | Workflows spanning public cloud plus private/on-prem | Orchestrating on-prem vSphere alongside Azure |
+
+Most enterprises end up needing all three at once. Modern orchestration platforms treat public cloud, private cloud, on-prem, and edge as equal citizens — because the alternative is maintaining a separate automation stack per environment, which is where most of the toil in large IT organizations comes from.
+
+## Key Benefits of Multi-Cloud Orchestration
+
+### Enhanced Automation and Efficiency
+
+Without a shared orchestration layer, multi-cloud operations devolve into a patchwork of CI/CD pipelines, Terraform runs, and ad-hoc scripts. Orchestration consolidates that into declarative workflows that run the same way every time — reducing manual toil, eliminating config drift between environments, and freeing platform teams to focus on architecture rather than execution.
+
+### Improved Resource Management and Scalability
+
+A unified orchestration layer lets teams provision, scale, and decommission resources across clouds based on workload demand rather than contractual lock-in. Workloads can shift to cheaper regions, fail over to a secondary provider, or scale out burst capacity — without rewriting the automation each time.
+
+### Optimizing Costs and Governance
+
+Multi-cloud becomes expensive fast when every team picks their own tools and regions. Centralized orchestration gives finance and security teams the visibility they need: consistent tagging, auditable execution logs, approval gates for high-cost operations, and policy enforcement across providers. Governance shifts from a quarterly spreadsheet review to a runtime property of the system.
+
+### Avoiding Vendor Lock-In
+
+Single-cloud automation tools (AWS Step Functions, Azure Logic Apps, Google Workflows) integrate deeply with their parent cloud — but stop at its edge. Committing all automation logic to a cloud-native tool makes multi-cloud migration painful when it becomes necessary for cost, latency, or compliance reasons. Vendor-neutral orchestrators keep options open.
+
+## How Multi-Cloud Orchestration Works — A Reference Architecture
+
+The components in most multi-cloud orchestration architectures:
+
+- **Orchestration layer** — declarative workflows spanning all environments, with triggers, retries, and dependency management
+- **Secrets and credentials** — centralized vault (HashiCorp Vault, AWS Secrets Manager, Azure Key Vault) accessed consistently from every workflow
+- **Provider integrations** — native plugins for each cloud's APIs (EC2, GCE, Azure VM, Kubernetes, Terraform providers)
+- **Execution runtime** — workers running close to targets (inside VPCs, on-prem, air-gapped networks)
+- **Audit and observability** — unified logs, metrics, and lineage across all environments
+
+The orchestration layer is the piece most organizations under-invest in. Without it, every cloud becomes its own island with its own automation stack, and the promise of multi-cloud — flexibility, cost optimization, resilience — stays theoretical.
+
+## A Concrete Example — Multi-Cloud Deployment in Kestra
+
+Here's what a multi-cloud workflow looks like: provision infrastructure with Terraform across AWS and GCP, deploy a container to EKS, then register the service in a Cloudflare DNS zone. All in one declarative file.
+
+```yaml
+id: multi_cloud_deployment
+namespace: company.platform
+
+inputs:
+  - id: service_name
+    type: STRING
+
+tasks:
+  - id: provision_aws
+    type: io.kestra.plugin.terraform.cli.TerraformCLI
+    beforeCommands:
+      - terraform init -backend-config="bucket=tf-state-aws"
+    commands:
+      - terraform apply -auto-approve -var="service={{ inputs.service_name }}"
+
+  - id: provision_gcp
+    type: io.kestra.plugin.terraform.cli.TerraformCLI
+    beforeCommands:
+      - terraform init -backend-config="bucket=tf-state-gcp"
+    commands:
+      - terraform apply -auto-approve -var="service={{ inputs.service_name }}"
+
+  - id: deploy_to_eks
+    type: io.kestra.plugin.kubernetes.kubectl.Apply
+    manifests:
+      - deployment.yaml
+      - service.yaml
+
+  - id: register_dns
+    type: io.kestra.plugin.scripts.shell.Commands
+    commands:
+      - |
+        curl -X POST "https://api.cloudflare.com/client/v4/zones/{{ secret('CF_ZONE_ID') }}/dns_records" \
+          -H "Authorization: Bearer {{ secret('CF_TOKEN') }}" \
+          -d '{"type":"CNAME","name":"{{ inputs.service_name }}","content":"ingress.example.com"}'
+```
+
+Four tasks across three cloud providers plus a SaaS DNS provider, with secrets pulled from a central vault, and no manual handoffs between teams.
+
+## Choosing a Multi-Cloud Orchestration Platform
+
+The core trade-off when picking a tool: cloud-native depth versus cross-cloud breadth.
+
+| Tool | Category | Multi-cloud support | Trade-off |
+| --- | --- | --- | --- |
+| **Kestra** | Orchestrator | ✅ Native, all clouds equal | General-purpose; less deep than cloud-native tools for single-cloud cases |
+| **AWS Step Functions** | Cloud-native | ❌ AWS-only | Deep AWS integration; stops at AWS edge |
+| **Azure Logic Apps** | Cloud-native | ❌ Azure-only | Deep Azure integration; limited outside Azure |
+| **Google Workflows** | Cloud-native | ❌ GCP-only | Clean GCP service coordination; limited elsewhere |
+| **Airflow / Astronomer** | Orchestrator | ✅ Via plugins | Python-first; heavier setup for infra use cases |
+| **Terraform Cloud** | IaC platform | ✅ | Provisioning-focused; not a general orchestrator |
+
+Vendor-neutral orchestrators (Kestra, Airflow, Temporal) treat every cloud as equal — which is the whole point of multi-cloud. Cloud-native tools work well inside their home cloud but create friction the moment a workflow crosses a boundary. For comparisons of specific alternatives, see [Kestra vs AWS Step Functions](/vs/aws-step-functions) and [Kestra vs Azure Data Factory](/vs/azure-data-factory).
+
+## Best Practices for Multi-Cloud Orchestration
+
+Five practices that separate functional multi-cloud orchestration from theatrical multi-cloud:
+
+- **Standardize on one workflow language** — declarative YAML is the industry converging point. Every environment, every team, one syntax.
+- **Centralize secrets and credentials** — a single vault accessed the same way from every workflow, regardless of target cloud. Per-cloud secrets stores fragment governance instantly.
+- **Make workflows idempotent** — re-running the same workflow should produce the same result. Multi-cloud failures are never clean; idempotency is what makes recovery possible.
+- **Instrument from day one** — structured logs, per-task metrics, and end-to-end lineage. Debugging a cross-cloud failure with only per-cloud logs is a special kind of pain.
+- **Start with one cross-cloud workflow** — not a Day-One rewrite of the entire stack. Pick one workflow that actually spans clouds, stabilize it, then expand.
+
+## Getting Started
+
+Multi-cloud orchestration works when there's a single control plane that treats every environment equally — and breaks down when each cloud gets its own orchestrator bolted together at the edges. Picking the orchestration layer is the most consequential decision in a multi-cloud strategy.
+
+For teams evaluating options, Kestra is open-source, self-hostable, and runs natively across AWS, Azure, GCP, and on-prem from a single YAML-defined workflow layer. Start with the [multi-cloud deployment blueprint](/blueprints/multi-cloud-deployment), explore the [infrastructure automation hub](/infra-automation), or read the deeper case for [vendor-neutral orchestration](/blogs/kestra-series-a).

--- a/src/contents/resources/orchestration-problems-complexity/index.md
+++ b/src/contents/resources/orchestration-problems-complexity/index.md
@@ -1,0 +1,155 @@
+---
+title: "Orchestration Problems and Complexity: How to Solve Them"
+description: "Most orchestration problems come from layers added to fix other layers. Learn how to diagnose complexity, reduce it, and keep systems observable as they scale."
+metaTitle: "Solve Orchestration Problems & Reduce Complexity"
+metaDescription: "Decipher orchestration problems and complexity without adding more to your system. Learn the challenges & solutions for effective orchestration."
+tag: infrastructure
+date: 2026-04-21
+faq:
+  - question: "What is orchestration complexity?"
+    answer: "Orchestration complexity is the operational and cognitive cost of coordinating tasks, services, and data flows across a system. It shows up as hard-to-debug failures, sprawling glue code, duplicate scheduling logic, and tools that each own a slice of the workflow without a unified view. Complexity is not caused by the orchestrator itself but by the accumulation of partial solutions around it."
+  - question: "Why do orchestration problems arise?"
+    answer: "They arise when teams adopt separate tools for each workload type (data pipelines, CI/CD, infra automation, AI agents), each with its own scheduling, secrets, and monitoring. Every new tool adds a coordination surface, and the gaps between tools become the hardest part of the system to operate. Orchestration problems are almost always coordination problems, not capability problems."
+  - question: "What is the orchestration gap in multi-agent AI systems?"
+    answer: "The orchestration gap is the difference between AI agents that work in a demo and AI agents that work at production scale. Individual agents may reason correctly, but once you chain them, you need deterministic sequencing, retry policies, state persistence, and end-to-end observability. Most agent frameworks stop at the reasoning layer and leave orchestration as an exercise for the developer, which is why scaling agents often fails."
+  - question: "How do you reduce orchestration complexity without adding more tools?"
+    answer: "Consolidate onto a single declarative engine that handles data, infrastructure, and AI workflows; replace imperative glue code with YAML or equivalent declarative definitions; standardize triggers, retries, and error handling across all workflow types; and ensure every execution produces the same observability signals. Most complexity reduction comes from deleting tools, not adding them."
+  - question: "What makes container orchestration complex?"
+    answer: "Container orchestration at scale combines scheduling, networking, storage, secrets, and health checks, each with its own failure modes. Complexity grows when workload orchestration (Kubernetes) is separated from business process orchestration (workflow engines) and from data pipeline orchestration, forcing teams to operate three control planes that barely talk to each other."
+  - question: "How do you debug complex orchestration flows?"
+    answer: "Start with a single execution URL that exposes inputs, outputs, logs, and timing for every task. Trace events end-to-end, not per service. Make every task idempotent so replays are safe. Store execution history long enough to correlate issues across systems. The goal is that any failure, anywhere in the system, has a single place to investigate."
+---
+
+Most orchestration problems are not caused by the orchestrator. They are caused by what gets added around it — the scheduler on the side, the monitoring tool bolted on, the custom retry logic written in Python, the second workflow engine the ML team adopted because the first one could not handle agents. Each addition solves one problem and creates two.
+
+This guide breaks down where orchestration complexity actually comes from, how it shows up across data, infrastructure, container, and AI workloads, and how to reduce it without adding yet another layer. The framing throughout: **solve the problem without adding more complexity to the system**.
+
+## Understanding orchestration problems and complexity
+
+### What is orchestration complexity?
+
+Orchestration complexity is the total cost of coordinating work across a system — not the intrinsic difficulty of the work itself, but the overhead of deciding what runs when, what depends on what, and what to do when something breaks.
+
+It is made of three layers:
+
+- **Structural complexity**: the number of distinct scheduling, triggering, and coordination mechanisms in play. One orchestrator plus three cron jobs plus a Kafka consumer plus a CI/CD runner equals four coordination systems, regardless of how simple each one is.
+- **Operational complexity**: the cost of running those systems — secrets management, version upgrades, monitoring, on-call rotations, per-tool dashboards.
+- **Cognitive complexity**: the effort it takes for a new engineer to understand the end-to-end flow. If answering "what runs when an order is placed" requires reading three codebases and two runbooks, the system is complex regardless of its technical elegance.
+
+A system can be technically sophisticated and still have low complexity, and a system can be technically simple and still have very high complexity. The difference is how well the moving parts compose.
+
+### Why do orchestration problems arise?
+
+The dominant pattern: teams adopt a narrow tool to solve a narrow problem, then discover that the problem was never actually narrow. Airflow for data pipelines, then ML workflows need something else, then AI agents need a third thing, then infra automation runs in Ansible on a separate schedule. Five years later, the same business process touches four orchestrators and no single person can draw it on a whiteboard.
+
+The secondary pattern: building custom glue code instead of using primitives. Retry loops wrapped in bash, a cron job that calls another cron job, a Slack notifier scripted into every pipeline. Each shortcut looks cheap at the moment it is written and becomes expensive the first time it fails silently.
+
+### The impact of complexity on system performance
+
+Complexity shows up in measurable ways: longer incident resolution times (more places to look), higher change failure rate (more things to break), slower onboarding (more systems to learn), and lower deployment frequency (more coordination between teams to ship a change that spans multiple orchestrators). The DORA metrics degrade as orchestration complexity grows, not because individual tools are slow but because the cost of crossing boundaries between them dominates.
+
+## Common challenges in modern orchestration
+
+### Multi-agent systems and AI orchestration
+
+AI agent frameworks are strong at individual reasoning and weak at coordination. LangChain, CrewAI, and similar libraries make it easy to compose a few agents in a notebook. Production is a different environment: agents need deterministic retries, persistent state, long-running execution (hours or days), human-in-the-loop approvals, and observability of every tool call.
+
+The industry is converging on a consistent signal here. A recent Docker State of Application Development report found that nearly half of organizations building agents cite orchestration complexity as their number one challenge — not model quality, not cost, not latency. Orchestration.
+
+The reason: agent frameworks optimize for the single-agent local case and treat orchestration as out-of-scope. But production agents are workflows. They have triggers (a user request, a scheduled scan, a webhook), a sequence of tool calls, branching on tool outputs, retries on API failures, and a final output that needs to be persisted. That is exactly what a workflow engine does — and it is why we have positioned Kestra as [the orchestration control plane of the AI era](/blogs/kestra-series-a).
+
+### The orchestration gap: why AI agents struggle at scale
+
+The gap is this: an agent that works in a demo has all state in memory and all calls synchronous. An agent that works in production needs durable state (what if the process crashes halfway through?), asynchronous tool execution (some tools take minutes to respond), parallel fan-out (evaluate 20 candidates simultaneously), and failure isolation (one flaky API must not kill the whole chain).
+
+Teams usually discover this the hard way: the demo runs fine, the production deployment works for a week, then a model provider rate-limits them and 4,000 agent runs die mid-flight with no way to resume. The fix is not a better agent — it is treating agents as tasks inside a proper workflow, with all the retry, state, and observability machinery workflows already have.
+
+### Monitoring and debugging complex orchestration flows
+
+Debugging is the first place complexity hits. If a pipeline spans Airflow, a Kubernetes job, a Lambda function, and a SQS queue, tracing a single failure means correlating logs across four systems, each with its own timestamp format, trace ID convention, and retention window.
+
+The mitigation is end-to-end execution tracing: one URL per run, every task represented, every input and output preserved. If that single surface does not exist, engineers build it themselves — badly, partially, and redundantly across teams. Every hour spent debugging across tools is an hour that could have been spent improving the workflow itself.
+
+### Data orchestration challenges: quality, volume, and complexity
+
+Data orchestration adds a dimension the other workloads do not have: the work is often not deterministic. The same pipeline on the same schedule against the same source can produce different results because the source data changed. This creates three problem classes:
+
+- **Quality regressions** that appear mid-pipeline and must be caught before they reach downstream consumers.
+- **Volume spikes** that break implicit assumptions about task duration and resource usage.
+- **Schema drift** that silently breaks downstream transformations.
+
+Solving these requires the orchestrator to understand not just task dependencies but data dependencies — which table feeds which model, which column a dashboard relies on. This is why the old "orchestrate the code, track the data separately" split is breaking down in favor of engines that handle both.
+
+## Strategies to reduce orchestration complexity
+
+### Simplify orchestration without adding overhead
+
+The principle: every new tool must remove at least two sources of complexity, not just add one more. A new orchestrator is justified if it lets you delete a scheduler, a secrets manager, and two custom Python wrappers. It is not justified if it lives alongside what you already have.
+
+Concretely, this means:
+
+- **Consolidate triggers**. Schedules, events, webhooks, and manual runs should all produce the same execution type, observable in the same UI — the foundation of [event-driven orchestration](/resources/event-driven-orchestration) done right.
+- **Consolidate retries and error handling**. One declaration of retry policy that applies everywhere, not three different libraries' conventions.
+- **Consolidate state**. Execution state — inputs, outputs, logs, timing — should live in one place regardless of task type.
+
+### Effective patterns for AI agent orchestration
+
+Treat the agent as a task, not as a framework. The workflow defines the trigger, the sequence, the retries, and the observability. The agent defines the reasoning inside a single step. This keeps agent logic replaceable (swap the model, swap the framework) without rewriting orchestration.
+
+Two patterns work well in production:
+
+**Agent-as-step**: the workflow calls an agent as one task, provides the context as input, and receives the result as output. The orchestrator owns retry, timeout, and error handling. The agent owns reasoning. Clear boundary.
+
+**Agent-triggered workflow**: the agent decides what workflow to run, and the orchestrator executes it. This is useful when the agent is a planner and the workflow is the executor — the agent can reason about what to do, then delegate to deterministic, observable, retry-safe tasks.
+
+### Leveraging tools to reduce complexity in production
+
+The biggest complexity reduction usually comes from picking a single platform that handles data, infrastructure, and AI workloads with the same primitives. This is the direction Kestra has taken: one declarative engine, one set of triggers, one observability surface, regardless of whether the workflow loads data, deploys a cluster, or orchestrates an agent chain.
+
+The alternative — best-of-breed tools per domain — sounds reasonable until you count the integration surface. Three tools mean three auth systems, three secret stores, three monitoring dashboards, three upgrade cycles, and three places a new hire has to learn. Consolidation is the single highest-leverage complexity reduction available to most teams.
+
+### Best practices for managing evolving use cases
+
+Orchestration systems fail not because they cannot handle today's workload but because they cannot evolve. Three practices help:
+
+- **Declarative definitions**. Workflows described as data (YAML, JSON) rather than as code are easier to version, review, migrate, and regenerate — [the reasoning behind our choice to be declarative from day one](/blogs/declarative-from-day-one).
+- **Reusable components**. Subflows, templates, and namespace-scoped shared logic prevent the same pattern from being re-implemented six times.
+- **Clear versioning**. Every workflow has a history. Changes are auditable. Rollbacks are a one-click operation, not a git archaeology exercise.
+
+## The role of orchestration in different environments
+
+### Container orchestration: solving common problems
+
+Kubernetes solved workload scheduling — which container runs where, how it is networked, how it is scaled. It did not solve business process orchestration. Running `kubectl apply` does not tell you that a nightly ETL depends on a feature pipeline that depends on a data freshness check.
+
+The mature pattern: Kubernetes handles the infrastructure layer (where containers run), and a workflow engine handles the coordination layer (when and why they run). They are complementary, not competitive — a distinction we unpack in depth in [what orchestration actually means across data, software, and infrastructure](/blogs/orchestration-differences). Complexity appears when teams try to do business process orchestration with Kubernetes primitives alone (CronJobs, Jobs, Argo chains) and end up reinventing a workflow engine — badly.
+
+### Orchestration in AI and machine learning workflows
+
+ML workflows have the same needs as data pipelines (triggers, retries, state, lineage) plus a few extras: experiment tracking, model versioning, feature consistency between training and serving. They do not need a separate orchestrator. They need the existing orchestrator to integrate with MLflow, feature stores, and model registries as tasks.
+
+When teams adopt dedicated "ML orchestrators" they usually end up with two systems that do 90% of the same thing, and they spend the rest of the year keeping them in sync. The simpler path is one engine with ML-specific plugins.
+
+### Addressing complexity in enterprise systems
+
+Enterprise orchestration problems compound: more teams, more compliance requirements, more legacy systems, more handoffs between groups who each own part of a process. The complexity is rarely technical — it is organizational, and the orchestration platform either makes it visible or hides it.
+
+A good enterprise orchestration layer exposes a single view of every business process, regardless of which team owns which step. That is what unlocks audit, compliance reporting, incident response, and cross-team optimization. Without it, every complexity reduction effort stops at the team boundary.
+
+## Future outlook: mastering orchestration challenges
+
+### Innovations in managing multi-agent orchestration
+
+The next few years will see agent frameworks stop trying to own orchestration and start integrating with existing workflow engines. The industry has already moved this way for data (dbt delegates execution to Airflow, Kestra, etc.) and will do the same for agents: frameworks will own reasoning, workflow engines will own coordination.
+
+### Anticipating future complexities in system design
+
+As more workloads become event-driven and more systems converge on the same set of primitives (message queues, object storage, HTTP APIs), the orchestration layer becomes the integration layer. This is a good thing — but it raises the stakes on the orchestrator's own complexity. The tools that win will be the ones that scale down to a single YAML file as gracefully as they scale up to thousands of concurrent executions.
+
+### Building resilient and observable orchestration
+
+Resilience comes from three properties: idempotent tasks, durable state, and end-to-end observability. None of them can be bolted on after the fact — they are either built into the orchestration engine or absent. Teams choosing their orchestrator today should treat these as table stakes, not premium features.
+
+The long-term goal is not a more powerful orchestrator. It is a system where orchestration disappears as a visible concern — where engineers describe what should happen, the platform figures out how, and the only time anyone thinks about the orchestrator is when they want to see why something ran.
+
+That is what it means to solve orchestration problems without adding more complexity.

--- a/src/contents/resources/patch-management-automation/index.md
+++ b/src/contents/resources/patch-management-automation/index.md
@@ -1,0 +1,180 @@
+---
+title: "Automated Patch Management: A Complete Guide"
+description: "Unpatched systems drive most successful cyberattacks. Automated patch management closes the gap between vulnerability disclosure and deployment. Learn the stages, tools, and how to build a patching workflow that runs itself."
+metaTitle: "Automated Patch Management: Complete Guide"
+metaDescription: "Automated patch management streamlines updates, reduces manual effort, and closes security gaps. Learn the stages, tools, and best practices."
+tag: infrastructure
+date: 2026-04-22
+faq:
+  - question: "What is automated patch management?"
+    answer: "Automated patch management uses software to identify missing updates, prioritize them by risk, test them, deploy them on a schedule, and report compliance — with minimal manual intervention. It shifts patching from a repetitive manual chore to a codified workflow that runs continuously in the background."
+  - question: "What are common automation systems used for patch management?"
+    answer: "Common tools include Automox (cloud-native, cross-OS, 580+ third-party apps), NinjaOne (multi-OS with AI-driven patch intelligence and 6,000+ apps), Red Hat Satellite (enterprise Linux fleet patching), Microsoft Intune and WSUS (Windows estates), and Ansible (script-based patching across heterogeneous fleets). Large organizations typically combine several, with orchestration tying them together."
+  - question: "What does patch management software do?"
+    answer: "Patch management software applies vendor-issued updates to close security vulnerabilities and optimize software and device performance. It handles the full lifecycle: discovering missing patches, assessing priority, testing in non-production environments, deploying on a schedule, monitoring success or failure, and reporting compliance. It's typically considered a subset of vulnerability management."
+  - question: "How do you automate server patching?"
+    answer: "Automated server patching typically follows this pattern: a scheduled workflow queries the patch tool for available updates, groups servers into risk rings (dev, staging, canary, production), applies patches to the first ring with health checks, validates stability, then proceeds to the next ring. Failures trigger rollback and notify on-call engineers."
+  - question: "What exactly is patch management?"
+    answer: "Patch management is the process of applying vendor-issued updates to close security vulnerabilities and optimize the performance of software and devices. It covers discovery, assessment, testing, deployment, and reporting — and is typically considered a subset of vulnerability management, which covers the broader discipline of identifying and reducing risk."
+  - question: "How often should patches be applied?"
+    answer: "Critical security patches should deploy within 24-72 hours of disclosure for internet-facing systems and 7-14 days for internal systems. Non-critical patches typically follow a monthly cadence. Feature patches go through the normal change calendar. Automation is what makes aggressive SLAs realistic — manual processes can't keep up with modern disclosure timelines."
+---
+
+Unpatched systems drive most successful cyberattacks — not zero-days, but known vulnerabilities with available fixes that simply weren't deployed in time. The gap between "patch released" and "patch applied across every machine" is where most breaches happen. Automated patch management closes that gap by turning a manual, error-prone process into a repeatable workflow that runs continuously in the background.
+
+This guide covers what automated patch management is, why it matters for security and operations, how the five-stage cycle works, and how to build a patching workflow that handles exceptions without requiring human intervention on every run.
+
+## What Is Automated Patch Management?
+
+Automated patch management is the process of using software to identify, test, and deploy patches across systems without requiring manual intervention at every step. It keeps systems ready to stage and fix vulnerabilities as soon as they're identified, and it lets IT teams spend far less time on repetitive tasks — scanning for missing updates, testing patches, and rolling them out across thousands of endpoints.
+
+The term covers more than just running updates. A real automated patch management system includes discovery (what's installed where), assessment (what needs patching, by priority), testing (does the patch break anything), deployment (staged rollout with health checks), and reporting (what got patched, what failed, what needs attention).
+
+## Why Patch Management Automation Is Critical for Security
+
+Patches are a race. When a vulnerability is disclosed, attackers start scanning for unpatched systems within hours. Manual patch management cycles — weekly scans, quarterly deployments, case-by-case approvals — simply can't keep up. Automation compresses the time-to-patch from weeks to hours, which is often the difference between a non-event and a breach.
+
+Beyond speed, automation also closes two other common gaps:
+
+- **Coverage** — manual processes miss endpoints. Shadow IT, neglected servers, forgotten VMs in a corner of a VPC. Automated discovery catches what human inventory misses.
+- **Consistency** — manual processes apply patches differently across environments. Automation applies the same logic every time, in every environment, so drift doesn't accumulate.
+
+Both are solved when the patching workflow is codified and run the same way every time, regardless of who's on call.
+
+## Benefits of Automated Patch Management
+
+### Increased Efficiency and Reduced Manual Effort
+
+Patch management is the definition of toil: repetitive, error-prone, high-volume, and low-value when done manually. Automation removes the bulk of the manual work — scanning, prioritizing, testing, deploying, reporting — so engineers can focus on architecture and incident response instead of clicking through update dialogs.
+
+### Enhanced Security Posture and Compliance
+
+Automated patching directly reduces the attack surface by shrinking the window of exposure for known vulnerabilities. It also produces the evidence auditors ask for: who approved which patch, when it was deployed, to which systems, whether it succeeded. That audit trail is nearly impossible to produce reliably from manual processes.
+
+### Minimizing System Downtime and Errors
+
+Automation isn't just about speed — it's also about predictability. Automated patching workflows include staged rollouts (dev → staging → canary → production), health checks after each stage, and automated rollback on failure. These safeguards turn patching from a risky chore into a routine operation.
+
+## How Automated Patch Management Works — The Five Stages
+
+Every automated patching system follows the same five-stage cycle:
+
+### 1. Discovery
+
+Inventory every managed endpoint — servers, workstations, network devices, VMs — along with their current patch state. Without this baseline, automation is flying blind. Modern discovery pulls from multiple sources: CMDB, cloud provider APIs, agent-based reporting, network scans.
+
+### 2. Assessment
+
+Identify missing patches and prioritize them by CVSS score and business risk. Not every patch is urgent — a remote-code-execution vulnerability on an internet-facing system matters more than a low-severity bug on an internal tool. Assessment is where risk-based prioritization lives.
+
+### 3. Testing
+
+Apply patches in a non-production environment and validate behavior. Automated test suites catch regressions before they hit production. For critical systems, canary deployments apply the patch to a small percentage of production first, monitor for anomalies, and proceed only if metrics stay clean.
+
+### 4. Deployment
+
+Roll out patches to production on a staged schedule with health checks between stages. Failures at any stage trigger automatic rollback and alert the on-call engineer. Emergency patches for disclosed vulnerabilities follow an expedited path.
+
+### 5. Reporting
+
+Capture which systems were patched, which failed, and surface exceptions for human review. Compliance reports (for PCI, HIPAA, SOC 2, ISO 27001) are generated from this data rather than reconstructed after the fact.
+
+## A Concrete Example — Automated Patching Workflow
+
+Here's what a staged patching workflow looks like in Kestra: query the patch tool, apply to a dev ring, validate, then promote to staging and production with approval gates between each ring.
+
+```yaml
+id: automated_patch_rollout
+namespace: company.infra
+
+triggers:
+  - id: weekly_patch_window
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 2 * * SUN"
+
+tasks:
+  - id: patch_dev_ring
+    type: io.kestra.plugin.ansible.cli.AnsibleCLI
+    inventories:
+      - inventory-dev.yml
+    playbooks:
+      - patch-playbook.yml
+
+  - id: run_healthchecks_dev
+    type: io.kestra.plugin.scripts.python.Script
+    script: |
+      import requests
+      for host in ["dev-01", "dev-02"]:
+          r = requests.get(f"http://{host}/health", timeout=10)
+          assert r.status_code == 200, f"{host} unhealthy"
+
+  - id: await_approval
+    type: io.kestra.plugin.core.flow.Pause
+    onResume:
+      - id: approver
+        type: STRING
+
+  - id: patch_prod_ring
+    type: io.kestra.plugin.ansible.cli.AnsibleCLI
+    inventories:
+      - inventory-prod.yml
+    playbooks:
+      - patch-playbook.yml
+
+  - id: generate_compliance_report
+    type: io.kestra.plugin.scripts.python.Script
+    script: |
+      # generate SOC 2 evidence bundle from execution logs
+      pass
+
+errors:
+  - id: rollback_and_alert
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+    url: "{{ secret('SLACK_ONCALL') }}"
+    payload: '{"text": "🚨 Patch workflow failed — triggering rollback"}'
+```
+
+Approval gates between rings, health checks at each stage, compliance evidence generated automatically, and failure handling built in. That's what "automated" looks like in practice — not fire-and-forget, but governed end-to-end.
+
+## Common Tools for Automated Patch Management
+
+No single tool covers every OS, every environment, every compliance regime. Most enterprises combine several.
+
+| Tool | Best for | Coverage | Trade-off |
+| --- | --- | --- | --- |
+| **Automox** | Cloud-native fleets | Windows, macOS, Linux, 580+ apps | SaaS-only, less suited to air-gapped |
+| **NinjaOne** | Multi-OS MSP-style management | Broad OS + 6,000+ apps | More IT-ops focused than security-first |
+| **Red Hat Satellite** | Linux enterprise fleets | RHEL / CentOS / Fedora | Linux-only |
+| **Microsoft Intune / WSUS** | Windows estates | Windows + Microsoft stack | Windows-first |
+| **Ansible** | Heterogeneous fleets | Any OS via modules | Script-based, needs orchestration on top |
+| **Tanium** | Security-focused large enterprise | Cross-platform | Expensive; heavy agent |
+
+The orchestration layer is what ties these tools together. Ansible handles the actual patching, Satellite owns the RHEL fleet, Intune owns the Windows estate — and a single orchestrator wraps them all in governed workflows with approvals, audit trails, and rollback logic.
+
+## Choosing a Patch Management Solution
+
+Five criteria filter the options quickly:
+
+- **Coverage** — which operating systems and third-party applications are supported
+- **Integration** — does it plug into existing ticketing, monitoring, and orchestration layers
+- **Auditability** — does it produce compliance-grade reports without manual reconstruction
+- **Flexibility** — can approval workflows, rollback logic, and exception handling be customized
+- **Scale** — does it hold up across tens of thousands of endpoints without performance issues
+
+No single tool is strong on all five, which is why orchestration across multiple patching tools is common in large environments. The orchestration layer brings its own value: unified approvals, unified audit trails, unified rollback logic — regardless of which underlying patching tool did the work.
+
+## Best Practices for Automated Patch Management
+
+Five practices that separate mature patching programs from theatrical ones:
+
+- **Automate the boring patches first** — security updates on internal tooling, non-critical dependencies. Extend to higher-stakes systems only once the process is stable.
+- **Use risk rings** — dev, staging, canary, production. Never deploy to production first, even for "safe" patches.
+- **Build rollback into every workflow** — a patch that fails should undo itself automatically, not require a manual intervention at 3 a.m.
+- **Track mean time to patch** — the single best metric for patching program health. If MTTP is measured in weeks, automation isn't working yet.
+- **Integrate with ticketing** — exceptions and approvals should live in the ticketing system, not in email threads that get lost.
+
+## Getting Started
+
+Automated patch management is less about the specific patching tool and more about the orchestration around it — approval gates, audit trails, rollback logic, and integration with the rest of the operations stack. The tool that scans and applies patches is replaceable; the orchestration layer is what makes the whole system governable.
+
+For teams evaluating orchestration for patching workflows, Kestra is open-source, self-hostable, and integrates natively with Ansible, SSH, cloud APIs, and vendor patching tools. Start with the [infrastructure automation hub](/infra-automation), explore [Assets for Infra Automation](/blogs/assets-for-infra-automation) for live inventory-driven patching, or read the broader case for [declarative infrastructure workflows](/blogs/infra-automation).


### PR DESCRIPTION
## Summary

Adds 5 new resource pages to complement the existing ones in PR #4637:

- `automation` (infrastructure) — What Is Infrastructure Automation? Definition, Tools, and Benefits → `/resources/infrastructure/automation`
- `patch-management-automation` (infrastructure) — Automated Patch Management: A Complete Guide → `/resources/infrastructure/patch-management-automation`
- `hybrid-cloud-automation` (infrastructure) — What Is Hybrid Cloud Automation? Use Cases and Benefits → `/resources/infrastructure/hybrid-cloud-automation`
- `multi-cloud-orchestration` (infrastructure) — Multi-Cloud Orchestration: Definition, Benefits, and Tools → `/resources/infrastructure/multi-cloud-orchestration`
- `create-data-pipeline` (data) — How to Create a Data Pipeline: A Step-by-Step Guide → `/resources/data/create-data-pipeline`

All pages follow the same frontmatter schema (`title`, `metaTitle`, `metaDescription`, `description`, `tag`, `date`, `faq`) as the existing resource pages in #4637.

🤖 Generated with [Claude Code](https://claude.com/claude-code)