### PR TITLE
feat(seo): add structured data schema + deduplicate plugin task meta titles

### DIFF
--- a/src/pages/plugins/[...slug].astro
+++ b/src/pages/plugins/[...slug].astro
@@ -101,6 +101,7 @@ const {
     currentPluginMetadata,
     metadataMap,
     headingTitle,
+    seoTitle,
     headingDescription,
     pageNamesHeading,
     currentPageIcon,
@@ -208,7 +209,7 @@ const pluginSchema = pluginType
       }
 ---
 
-<Layout title={headingTitle} description={headingDescription} image={ogImage}>
+<Layout title={seoTitle} description={headingDescription} image={ogImage}>
     <Fragment slot="head">
         <script
             type="application/ld+json"

--- a/src/pages/plugins/[...slug].astro
+++ b/src/pages/plugins/[...slug].astro
@@ -138,9 +138,83 @@ if (
         301,
     )
 }
+
+const latestVersion = githubVersions.versions?.[0]
+const imageUrl = `${Astro.site}${ogImage.replace(/^\//, "")}`
+
+const pluginSchema = pluginType
+    ? {
+          "@context": "https://schema.org",
+          "@type": "TechArticle",
+          "@id": Astro.url.href,
+          headline: headingTitle,
+          ...(headingDescription ? { description: headingDescription } : {}),
+          url: Astro.url.href,
+          image: imageUrl,
+          inLanguage: "en",
+          about: {
+              "@type": "SoftwareApplication",
+              "@id": `https://kestra.io/plugins/${pluginName}#${pluginName}`,
+          },
+          isPartOf: {
+              "@type": "WebSite",
+              "@id": "https://kestra.io/#website",
+          },
+          author: { "@id": "https://kestra.io/#organization" },
+          publisher: { "@id": "https://kestra.io/#organization" },
+      }
+    : {
+          "@context": "https://schema.org",
+          "@type": "SoftwareApplication",
+          "@id": effectiveSubGroup
+              ? `https://kestra.io/plugins/${pluginName}/${effectiveSubGroup}#${effectiveSubGroup}`
+              : `https://kestra.io/plugins/${pluginName}#${pluginName}`,
+          name: headingTitle,
+          url: Astro.url.href,
+          image: imageUrl,
+          ...(headingDescription ? { description: headingDescription } : {}),
+          applicationCategory: "DeveloperApplication",
+          ...(currentPluginCategories.length > 0
+              ? { applicationSubCategory: currentPluginCategories.join(", ") }
+              : {}),
+          operatingSystem: "Linux, macOS, Windows, Docker, Kubernetes",
+          ...(latestVersion?.version ? { softwareVersion: latestVersion.version } : {}),
+          ...(latestVersion?.minCoreCompatibilityVersion
+              ? { softwareRequirements: `Kestra Core >= ${latestVersion.minCoreCompatibilityVersion}` }
+              : {}),
+          offers: isEePlugin
+              ? {
+                    "@type": "Offer",
+                    priceSpecification: {
+                        "@type": "UnitPriceSpecification",
+                        priceType: "https://schema.org/InvoicePrice",
+                        description: "Enterprise Edition — contact sales",
+                    },
+                    availability: "https://schema.org/InStock",
+                    url: "https://kestra.io/demo",
+                }
+              : {
+                    "@type": "Offer",
+                    price: "0",
+                    priceCurrency: "USD",
+                    availability: "https://schema.org/InStock",
+                    url: Astro.url.href,
+                },
+          isPartOf: {
+              "@type": "SoftwareApplication",
+              "@id": "https://kestra.io/#software",
+          },
+          author: { "@id": "https://kestra.io/#organization" },
+      }
 ---
 
 <Layout title={headingTitle} description={headingDescription} image={ogImage}>
+    <Fragment slot="head">
+        <script
+            type="application/ld+json"
+            set:html={JSON.stringify(pluginSchema)}
+        />
+    </Fragment>
     <PluginLayout>
         <PluginSidebar
             slot="sidebar"

--- a/src/pages/plugins/index.astro
+++ b/src/pages/plugins/index.astro
@@ -36,6 +36,25 @@ const categories = [
 const title = "Hundreds of Plugins For All Your Orchestrations Needs"
 const description = "Connect Kestra with tools you already know and love"
 
+const pluginsIndexSchema = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": "https://kestra.io/plugins",
+    name: title,
+    description: description,
+    url: "https://kestra.io/plugins",
+    about: {
+        "@type": "SoftwareApplication",
+        "@id": "https://kestra.io/#software",
+    },
+    hasPart: cardPlugins.slice(0, 50).map((p) => ({
+        "@type": "SoftwareApplication",
+        "@id": `https://kestra.io/plugins/${p.name}#${p.name}`,
+        name: p.title ?? p.name,
+        url: `https://kestra.io/plugins/${p.name}`,
+    })),
+}
+
 const ITEMS = [
     {
         question: "What is a Kestra plugin?",
@@ -69,6 +88,12 @@ const ITEMS = [
 ---
 
 <Layout {title} {description}>
+    <Fragment slot="head">
+        <script
+            type="application/ld+json"
+            set:html={JSON.stringify(pluginsIndexSchema)}
+        />
+    </Fragment>
     <PluginsLists
         client:idle
         plugins={cardPlugins}

--- a/src/utils/plugins/buildPluginPageProps.ts
+++ b/src/utils/plugins/buildPluginPageProps.ts
@@ -10,6 +10,7 @@ import {
 import {
     formatElementName,
     formatElementType,
+    formatPluginName,
     getBlueprintsHeading,
     getPluginTitle,
 } from "~/utils/plugins/pluginUtils"
@@ -120,15 +121,37 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
         )
     })()
 
+    const rootPluginTitle = rootPlugin
+        ? getPluginTitle(rootPlugin, metadataMap)
+        : pluginName
+
     const headingTitle = pluginType
         ? formatElementName(pluginType)
         : ((rootPlugin
               ? getPluginTitle(currentSubgroupPlugin ?? rootPlugin, metadataMap)
               : undefined) ?? pluginName)
 
-    const rootPluginTitle = rootPlugin
-        ? getPluginTitle(rootPlugin, metadataMap)
-        : pluginName
+    // Unique SEO meta title for individual task pages — includes plugin/service context
+    // to prevent the "Upload | Kestra" × N duplicate-title problem across plugins.
+    // H1 (headingTitle) stays short; only the <title> tag gets the enriched version.
+    const seoTitle = (() => {
+        if (!pluginType) return headingTitle
+        const taskName = formatElementName(pluginType)
+        // Core plugin tasks are unique by nature — no risk of cross-plugin duplicates
+        if (pluginName === "core") return taskName
+        // Find the subgroup plugin for context (currentSubgroupPlugin is undefined when
+        // pluginType is set, so we look it up directly from the full plugin list)
+        const subgroupPlugin = effectiveSubGroup
+            ? pluginsWithoutDeprecated.find((p) => matchesSubGroup(p, effectiveSubGroup))
+            : undefined
+        const subgroupTitle = subgroupPlugin
+            ? getPluginTitle(subgroupPlugin, metadataMap) || formatPluginName(effectiveSubGroup)
+            : null
+        if (subgroupTitle && subgroupTitle !== rootPluginTitle) {
+            return `${taskName} ${rootPluginTitle} ${subgroupTitle}`
+        }
+        return `${taskName} ${rootPluginTitle}`
+    })()
 
     let combinedDescription = currentPageMetadata?.description
     const bodyText = (currentPageMetadata as any)?.body
@@ -281,6 +304,7 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
 
     return {
         headingTitle,
+        seoTitle,
         headingDescription,
         ogImage,
 


### PR DESCRIPTION
## Contexte

Cette PR regroupe deux améliorations SEO sur les pages plugins :

1. **Structured data schema** — ajout de JSON-LD `TechArticle` / `SoftwareApplication` sur les pages plugins
2. **Déduplication des meta titles** — les pages de tâches individuelles généraient des `<title>` identiques entre tous les plugins

---

## Problème (meta titles)

Les pages de tâches généraient des `<title>` identiques à travers tous les plugins :

- `/plugins/plugin-aws/s3/…upload` → `Upload | Kestra`
- `/plugins/plugin-gcp/gcs/…upload` → `Upload | Kestra`
- `/plugins/plugin-azure/storage/…upload` → `Upload | Kestra`

Avec 1 200+ pages de tâches et ~20 noms génériques (Upload, Query, Trigger…), Google perçoit cela comme du contenu dupliqué.

## Solution

Ajout d'un `seoTitle` calculé séparément du `headingTitle` (H1). Pour les pages de tâches (`pluginType` présent), le titre inclut le contexte plugin + sous-groupe :

| URL | Avant | Après |
|---|---|---|
| `…/plugin-aws/s3/…upload` | `Upload \| Kestra` | `Upload AWS S3 \| Kestra` |
| `…/plugin-gcp/gcs/…upload` | `Upload \| Kestra` | `Upload Google Cloud GCS \| Kestra` |
| `…/plugin-azure/storage/…upload` | `Upload \| Kestra` | `Upload Azure Storage \| Kestra` |
| `…/plugin-jdbc-mysql/…query` | `Query \| Kestra` | `Query MySQL \| Kestra` |
| `…/plugin-jdbc-postgres/…query` | `Query \| Kestra` | `Query PostgreSQL \| Kestra` |
| `…/core/flow/…foreach` | `ForEach \| Kestra` | `ForEach \| Kestra` *(inchangé — core exempté)* |
| `…/plugin-aws/s3` *(sous-cat)* | `S3 \| Kestra` | `S3 \| Kestra` *(inchangé)* |

Le H1 visible et la sidebar restent inchangés. Seul le `<title>` meta est enrichi.

## Fichiers modifiés

- `src/utils/plugins/buildPluginPageProps.ts` — ajout de `seoTitle` + `formatPluginName` import
- `src/pages/plugins/[...slug].astro` — `<Layout title={seoTitle}>` au lieu de `headingTitle`

---

## Checklist de test en dev

### Setup
- [ ] Lancer le serveur de dev : `npm run dev`

### Pages de tâches avec sous-groupe (cas principal)
- [ ] `/plugins/plugin-aws/s3/io.kestra.plugin.aws.s3.upload` → `<title>` = **"Upload AWS S3 | Kestra"**
- [ ] `/plugins/plugin-gcp/gcs/io.kestra.plugin.gcp.gcs.upload` → `<title>` = **"Upload Google Cloud GCS | Kestra"**
- [ ] `/plugins/plugin-azure/storage/io.kestra.plugin.azure.storage.blob.upload` → `<title>` contient **"Azure"** et **"Upload"**

### Pages de tâches sans sous-groupe
- [ ] `/plugins/plugin-jdbc-mysql/io.kestra.plugin.jdbc.mysql.query` → `<title>` = **"Query MySQL | Kestra"**
- [ ] `/plugins/plugin-jdbc-postgres/io.kestra.plugin.jdbc.postgresql.query` → `<title>` = **"Query PostgreSQL | Kestra"**
- [ ] `/plugins/plugin-kafka/io.kestra.plugin.kafka.produce` → `<title>` contient **"Kafka"** et **"Produce"**

### Cas exempté (core — inchangé)
- [ ] `/plugins/core/flow/io.kestra.plugin.core.flow.foreach` → `<title>` = **"ForEach | Kestra"**
- [ ] `/plugins/core/trigger/io.kestra.plugin.core.trigger.schedule` → `<title>` = **"Schedule | Kestra"**

### Non-régression — pages non affectées
- [ ] `/plugins/plugin-aws` → `<title>` = **"AWS | Kestra"** (plugin principal)
- [ ] `/plugins/plugin-aws/s3` → `<title>` = **"S3 | Kestra"** (sous-catégorie)
- [ ] `/plugins/core` → `<title>` = **"Core Plugins and tasks | Kestra"**
- [ ] `/plugins` → `<title>` = **"Hundreds of Plugins For All Your Orchestrations Needs | Kestra"**

### H1 inchangé (régression visuelle critique)
- [ ] Sur une page de tâche, le H1 visible = **nom court** ("Upload", "Query") — pas le titre SEO enrichi
- [ ] Le breadcrumb affiche le nom court
- [ ] La sidebar affiche le nom court

### Open Graph
- [ ] `<meta property="og:title">` sur une page de tâche = nouveau `seoTitle` enrichi