### PR TITLE
feat(seo): add WebSite schema on homepage

### DIFF
--- a/src/components/layout.astro
+++ b/src/components/layout.astro
@@ -85,6 +85,18 @@ const annonces = parsedAnnonces.filter((a: { id: number }) => a.id !== 0)
 const isHomepage = Astro.url.pathname === "/"
 const hasAnnounce = isHomepage && annonces.length > 0
 
+const websiteSchema = isHomepage
+    ? {
+          "@context": "https://schema.org",
+          "@type": "WebSite",
+          "@id": "https://kestra.io/#website",
+          "url": "https://kestra.io",
+          "name": "Kestra",
+          "description":
+              "Open-source declarative orchestration platform for data, AI, and infrastructure workflows",
+      }
+    : null
+
 const organizationSchema = {
     "@context": "https://schema.org",
     "@type": "Organization",
@@ -212,6 +224,7 @@ const organizationSchema = {
         <link rel="dns-prefetch" href="https://api.cr-relay.com" />
 
         <script type="application/ld+json" set:html={JSON.stringify(organizationSchema)}></script>
+        {websiteSchema && <script type="application/ld+json" set:html={JSON.stringify(websiteSchema)}></script>}
 
         <slot name="head" />
 


### PR DESCRIPTION
## Summary

Adds a `WebSite` JSON-LD schema block on the homepage, linking `kestra.io` to the existing `Organization` schema via shared `@id` anchors. Helps Google formally identify Kestra's canonical web presence as an entity.

## Schema added (homepage only)

```json
{
  "@context": "https://schema.org",
  "@type": "WebSite",
  "@id": "https://kestra.io/#website",
  "url": "https://kestra.io",
  "name": "Kestra",
  "description": "Open-source declarative orchestration platform for data, AI, and infrastructure workflows"
}
```

The block renders conditionally via `isHomepage` — no impact on other pages.

## Test plan

- [ ] Validate via [Google Rich Results Test](https://search.google.com/test/rich-results) on `kestra.io`
- [ ] Confirm schema block only renders on `/`
- [ ] Confirm `Organization` + `WebSite` schemas both appear in page source on homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)