### PR TITLE
feat(seo): deduplicate plugin task page meta titles

### DIFF
--- a/src/pages/plugins/[...slug].astro
+++ b/src/pages/plugins/[...slug].astro
@@ -101,6 +101,7 @@ const {
     currentPluginMetadata,
     metadataMap,
     headingTitle,
+    seoTitle,
     headingDescription,
     pageNamesHeading,
     currentPageIcon,
@@ -140,7 +141,7 @@ if (
 }
 ---
 
-<Layout title={headingTitle} description={headingDescription} image={ogImage}>
+<Layout title={seoTitle} description={headingDescription} image={ogImage}>
     <PluginLayout>
         <PluginSidebar
             slot="sidebar"

--- a/src/pages/plugins/[...slug].astro
+++ b/src/pages/plugins/[...slug].astro
@@ -102,6 +102,7 @@ const {
     currentPluginMetadata,
     metadataMap,
     headingTitle,
+    seoTitle,
     headingDescription,
     pageNamesHeading,
     currentPageIcon,
@@ -206,7 +207,7 @@ const pluginSchema = pluginType
       }
 ---
 
-<Layout title={headingTitle} description={headingDescription} image={ogImage}>
+<Layout title={seoTitle} description={headingDescription} image={ogImage}>
     <Fragment slot="head">
         <script
             type="application/ld+json"

--- a/src/utils/plugins/buildPluginPageProps.ts
+++ b/src/utils/plugins/buildPluginPageProps.ts
@@ -148,7 +148,18 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
             ? getPluginTitle(subgroupPlugin, metadataMap) || formatPluginName(effectiveSubGroup)
             : null
         if (subgroupTitle && subgroupTitle !== rootPluginTitle) {
-            return `${taskName} ${rootPluginTitle} ${subgroupTitle}`
+            // Skip the parent name when the subgroup already contains it
+            // (e.g. "Google Cloud" + "Cloud Storage (GCS)" → just "Cloud Storage (GCS)")
+            const subLower = subgroupTitle.toLowerCase()
+            const rootLower = rootPluginTitle.toLowerCase()
+            const overlaps =
+                subLower.includes(rootLower) ||
+                rootLower
+                    .split(/\s+/)
+                    .some((w) => w.length > 2 && subLower.includes(w.toLowerCase()))
+            return overlaps
+                ? `${taskName} ${subgroupTitle}`
+                : `${taskName} ${rootPluginTitle} ${subgroupTitle}`
         }
         return `${taskName} ${rootPluginTitle}`
     })()

--- a/src/utils/plugins/buildPluginPageProps.ts
+++ b/src/utils/plugins/buildPluginPageProps.ts
@@ -11,6 +11,7 @@ import { slugify } from "../slugify"
 import {
     formatElementName,
     formatElementType,
+    formatPluginName,
     getBlueprintsHeading,
     getPluginTitle,
 } from "~/utils/plugins/pluginUtils"
@@ -157,6 +158,41 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
     const rootPluginTitle = rootPlugin
         ? getPluginTitle(rootPlugin, metadataMap)
         : pluginName
+
+    // Unique SEO meta title for individual task pages — includes plugin/service context
+    // to prevent the "Upload | Kestra" × N duplicate-title problem across plugins.
+    // H1 (headingTitle) stays short; only the <title> tag gets the enriched version.
+    // Titles are sourced from the plugin metadata (getPluginTitle reads metadataMap[key].title
+    // populated from the plugins API) and fall back to the formatted plugin name.
+    const seoTitle = (() => {
+        if (!pluginType) return headingTitle
+        const taskName = formatElementName(pluginType)
+        // Core plugin tasks are unique by nature — no risk of cross-plugin duplicates
+        if (pluginName === "core") return taskName
+        // Find the subgroup plugin for context (currentSubgroupPlugin is undefined when
+        // pluginType is set, so we look it up directly from the full plugin list)
+        const subgroupPlugin = effectiveSubGroup
+            ? pluginsWithoutDeprecated.find((p) => matchesSubGroup(p, effectiveSubGroup))
+            : undefined
+        const subgroupTitle = subgroupPlugin
+            ? getPluginTitle(subgroupPlugin, metadataMap) || formatPluginName(effectiveSubGroup)
+            : null
+        if (subgroupTitle && subgroupTitle !== rootPluginTitle) {
+            // Skip the parent name when the subgroup already contains it
+            // (e.g. "Google Cloud" + "Cloud Storage (GCS)" → just "Cloud Storage (GCS)")
+            const subLower = subgroupTitle.toLowerCase()
+            const rootLower = rootPluginTitle.toLowerCase()
+            const overlaps =
+                subLower.includes(rootLower) ||
+                rootLower
+                    .split(/\s+/)
+                    .some((w) => w.length > 2 && subLower.includes(w.toLowerCase()))
+            return overlaps
+                ? `${taskName} ${subgroupTitle}`
+                : `${taskName} ${rootPluginTitle} ${subgroupTitle}`
+        }
+        return `${taskName} ${rootPluginTitle}`
+    })()
 
     let combinedDescription = currentPageMetadata?.description
     const bodyText = (currentPageMetadata as any)?.body
@@ -312,6 +348,7 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
 
     return {
         headingTitle,
+        seoTitle,
         headingDescription,
         ogImage,
 

--- a/src/utils/plugins/buildPluginPageProps.ts
+++ b/src/utils/plugins/buildPluginPageProps.ts
@@ -10,6 +10,7 @@ import {
 import {
     formatElementName,
     formatElementType,
+    formatPluginName,
     getBlueprintsHeading,
     getPluginTitle,
 } from "~/utils/plugins/pluginUtils"
@@ -120,15 +121,37 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
         )
     })()
 
+    const rootPluginTitle = rootPlugin
+        ? getPluginTitle(rootPlugin, metadataMap)
+        : pluginName
+
     const headingTitle = pluginType
         ? formatElementName(pluginType)
         : ((rootPlugin
               ? getPluginTitle(currentSubgroupPlugin ?? rootPlugin, metadataMap)
               : undefined) ?? pluginName)
 
-    const rootPluginTitle = rootPlugin
-        ? getPluginTitle(rootPlugin, metadataMap)
-        : pluginName
+    // Unique SEO meta title for individual task pages — includes plugin/service context
+    // to prevent the "Upload | Kestra" × N duplicate-title problem across plugins.
+    // H1 (headingTitle) stays short; only the <title> tag gets the enriched version.
+    const seoTitle = (() => {
+        if (!pluginType) return headingTitle
+        const taskName = formatElementName(pluginType)
+        // Core plugin tasks are unique by nature — no risk of cross-plugin duplicates
+        if (pluginName === "core") return taskName
+        // Find the subgroup plugin for context (currentSubgroupPlugin is undefined when
+        // pluginType is set, so we look it up directly from the full plugin list)
+        const subgroupPlugin = effectiveSubGroup
+            ? pluginsWithoutDeprecated.find((p) => matchesSubGroup(p, effectiveSubGroup))
+            : undefined
+        const subgroupTitle = subgroupPlugin
+            ? getPluginTitle(subgroupPlugin, metadataMap) || formatPluginName(effectiveSubGroup)
+            : null
+        if (subgroupTitle && subgroupTitle !== rootPluginTitle) {
+            return `${taskName} ${rootPluginTitle} ${subgroupTitle}`
+        }
+        return `${taskName} ${rootPluginTitle}`
+    })()
 
     let combinedDescription = currentPageMetadata?.description
     const bodyText = (currentPageMetadata as any)?.body
@@ -281,6 +304,7 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
 
     return {
         headingTitle,
+        seoTitle,
         headingDescription,
         ogImage,
 


### PR DESCRIPTION
## Problem

Individual task pages were generating identical `<title>` tags across all plugins. With 1,200+ pages and ~20 reused generic names (Upload, Query, Trigger, Download…), Google treats this as duplicate content, which dilutes rankings.

Examples of duplicates before the fix:
| URL | `<title>` |
|---|---|
| `/plugins/plugin-aws/s3/…upload` | `Upload \| Kestra` |
| `/plugins/plugin-gcp/gcs/…upload` | `Upload \| Kestra` |
| `/plugins/plugin-azure/storage/…upload` | `Upload \| Kestra` |
| `/plugins/plugin-jdbc-mysql/…query` | `Query \| Kestra` |
| `/plugins/plugin-jdbc-postgres/…query` | `Query \| Kestra` |

## Solution

Adds a `seoTitle` computed separately from the `headingTitle` (the visible H1). For task pages (`pluginType` present), the title includes the plugin + subgroup context. Titles are sourced from the **plugin API metadata** (`/plugins/metadata` via `getPluginTitle`, reading `metadataMap[key].title`), with a formatted plugin-name fallback:

| URL | Before | After |
|---|---|---|
| `…/plugin-aws/s3/…upload` | `Upload \| Kestra` | `Upload AWS S3 \| Kestra` |
| `…/plugin-gcp/gcs/…upload` | `Upload \| Kestra` | `Upload Google Cloud Storage (GCS) \| Kestra` |
| `…/plugin-azure/storage/…upload` | `Upload \| Kestra` | `Upload Azure Blob Storage \| Kestra` |
| `…/plugin-jdbc-mysql/…query` | `Query \| Kestra` | `Query MySQL \| Kestra` |
| `…/plugin-jdbc-postgres/…query` | `Query \| Kestra` | `Query PostgreSQL \| Kestra` |
| `…/core/flow/…foreach` | `ForEach \| Kestra` | `ForEach \| Kestra` *(unchanged — core exempted)* |

When the subgroup title already contains the parent name (e.g. `Google Cloud` + `Google Cloud Storage (GCS)`), the parent is skipped to avoid duplicate words.

**The H1, breadcrumb and sidebar stay unchanged.** Only the `<title>` meta tag (and the `og:title` / `twitter:title` derived from it in `Layout`) is enriched.

## Modified files

- `src/utils/plugins/buildPluginPageProps.ts` — adds `seoTitle` + `formatPluginName` import
- `src/pages/plugins/[...slug].astro` — `<Layout title={seoTitle}>` instead of `headingTitle`

> Re-applied cleanly on top of the current `main` (the previous branch conflicted after a large refactor of the plugin-utils imports and the JSON-LD schema additions). Titles verified against the live `/plugins/metadata` API.

---

## Dev testing checklist

### Setup
- [ ] Start the dev server: `npm run dev`

### Task pages with a subgroup (main case)
- [ ] `/plugins/plugin-aws/s3/io.kestra.plugin.aws.s3.upload` → `<title>` = **"Upload AWS S3 | Kestra"**
- [ ] `/plugins/plugin-gcp/gcs/io.kestra.plugin.gcp.gcs.upload` → `<title>` = **"Upload Google Cloud Storage (GCS) | Kestra"**
- [ ] `/plugins/plugin-azure/storage/io.kestra.plugin.azure.storage.blob.upload` → `<title>` contains **"Azure"** and **"Upload"**

### Task pages without a subgroup
- [ ] `/plugins/plugin-jdbc-mysql/io.kestra.plugin.jdbc.mysql.query` → `<title>` = **"Query MySQL | Kestra"**
- [ ] `/plugins/plugin-jdbc-postgres/io.kestra.plugin.jdbc.postgresql.query` → `<title>` = **"Query PostgreSQL | Kestra"**
- [ ] `/plugins/plugin-kafka/io.kestra.plugin.kafka.produce` → `<title>` contains **"Kafka"** and **"Produce"**

### Exempted case — core (unchanged)
- [ ] `/plugins/core/flow/io.kestra.plugin.core.flow.foreach` → `<title>` = **"ForEach | Kestra"**
- [ ] `/plugins/core/trigger/io.kestra.plugin.core.trigger.schedule` → `<title>` = **"Schedule | Kestra"**

### Non-regression — unaffected pages
- [ ] `/plugins/plugin-aws` → `<title>` = **"AWS | Kestra"** (root plugin, unchanged)
- [ ] `/plugins/plugin-aws/s3` → `<title>` = **"AWS S3 | Kestra"** (subcategory, unchanged)
- [ ] `/plugins/core` → `<title>` = **"Core Plugins and tasks | Kestra"** (unchanged)
- [ ] `/plugins` → `<title>` = **"Hundreds of Plugins For All Your Orchestrations Needs | Kestra"** (unchanged)

### H1 unchanged (critical visual regression)
- [ ] On a task page, the **visible H1** = short name ("Upload", "Query") — not the SEO title
- [ ] The **breadcrumb** shows the short name
- [ ] The **sidebar** shows the short name

### Open Graph
- [ ] `<meta property="og:title">` on a task page = the enriched `seoTitle`
