### PR TITLE
[Docs] Rename sequential in workflow-components (outputs)

### DIFF
--- a/src/contents/docs/05.workflow-components/06.outputs/index.md
+++ b/src/contents/docs/05.workflow-components/06.outputs/index.md
@@ -313,7 +313,7 @@ namespace: company.team
 
 tasks:
   - id: sequential
-    type: io.kestra.core.tasks.flows.Sequential
+    type: io.kestra.plugin.core.flow.Sequential
     tasks:
       - id: first
         type: io.kestra.plugin.core.output.OutputValues


### PR DESCRIPTION
I _think_ this was the last place that needed to be renamed. Doing a search through the docs the only other instance of the old name was the file with the table where we specifically map the plugin names old to new.