### PR TITLE
fix: replace hardcoded plugin counts with dynamic fetchTotalPluginsCount

### DIFF
--- a/src/contents/blogs/2026-04-27-kestra-mcp-plugins-blueprints/index.md
+++ b/src/contents/blogs/2026-04-27-kestra-mcp-plugins-blueprints/index.md
@@ -1,0 +1,197 @@
+---
+title: "Kestra MCP: A Live Plugin and Blueprint Catalog for AI Coding Agents"
+description: "The Kestra MCP server exposes the full plugin registry and blueprint catalog as Model Context Protocol tools. Connect any AI coding agent to it once, and it can discover plugins, inspect task schemas, and fetch ready-made flow YAML without leaving the conversation."
+date: 2026-04-27T09:00:00
+category: Solutions
+author:
+  name: François Delbrayelle
+  image: fdelbrayelle
+  role: Senior Software Engineer
+image: ./main.png
+schema:
+  "@context": "https://schema.org"
+  "@type": "FAQPage"
+  mainEntity:
+    - "@type": "Question"
+      name: "What is the Kestra MCP server?"
+      acceptedAnswer:
+        "@type": "Answer"
+        text: "The Kestra MCP server is a remote HTTP endpoint at https://api.kestra.io/v1/mcp that implements the Model Context Protocol. It exposes Kestra's full plugin registry and blueprint catalog as 13 read-only callable tools, so AI coding agents can discover plugins, list tasks, fetch task schemas, and retrieve blueprint templates without leaving their environment."
+    - "@type": "Question"
+      name: "How do I connect Claude Code to the Kestra MCP server?"
+      acceptedAnswer:
+        "@type": "Answer"
+        text: "Run: claude mcp add --transport http kestra https://api.kestra.io/v1/mcp. This registers the MCP server for the current project. Add --scope user to make it available globally across all projects."
+    - "@type": "Question"
+      name: "What tools does the Kestra MCP server expose?"
+      acceptedAnswer:
+        "@type": "Answer"
+        text: "It provides 13 tools: list_plugins, plugin_tasks, versions, list_task_runners, list_triggers, list_storages, list_secret_managers, list_log_exporters, plugin_versions, blueprints, get_blueprint_flow, search, and task_schema. Together they let an agent explore the full plugin ecosystem, inspect task schemas, and retrieve ready-made flow templates."
+    - "@type": "Question"
+      name: "Does the Kestra MCP server require authentication?"
+      acceptedAnswer:
+        "@type": "Answer"
+        text: "No. The public endpoint at https://api.kestra.io/v1/mcp is open and requires no API key or login. All 13 tools are read-only."
+    - "@type": "Question"
+      name: "Can I use the Kestra MCP server with AI agents other than Claude Code?"
+      acceptedAnswer:
+        "@type": "Answer"
+        text: "Yes. Any MCP-compatible client works: Codex CLI, Gemini CLI, OpenCode, or any agent framework that supports MCP over HTTP. The endpoint is the same for all clients: https://api.kestra.io/v1/mcp."
+---
+
+Writing a Kestra flow from scratch means knowing what plugins exist, which tasks they expose, and what properties each task accepts. For simple, familiar workflows this is fine. For anything more complex — choosing the right S3 trigger variant, checking what secret managers are supported, or confirming whether a blueprint already covers your use case — you end up context-switching to the docs browser mid-task.
+
+The Kestra MCP server eliminates that friction. It is a remote HTTP server at `https://api.kestra.io/v1/mcp` that speaks the [Model Context Protocol](https://modelcontextprotocol.io), exposing the full Kestra plugin registry and blueprint catalog as callable tools. Connect it to your AI coding agent once; from that point, the agent can discover plugins, inspect task schemas, and fetch blueprint YAML without ever leaving the conversation.
+
+## What is MCP?
+
+The [Model Context Protocol](https://modelcontextprotocol.io) is an open standard for connecting AI agents to external tools over a well-defined interface. An MCP server declares a set of tools; a compatible client (your AI agent) invokes them by name and receives structured results. Because MCP is transport-agnostic, the Kestra server uses HTTP with Server-Sent Events — no local process to install or manage, just a URL.
+
+## Connecting Claude Code
+
+Add the Kestra MCP server to Claude Code with a single command:
+
+```bash
+# Project-scoped (stores in .claude/settings.json in current repo)
+claude mcp add --transport http kestra https://api.kestra.io/v1/mcp
+
+# User-scoped (global, available in every project)
+claude mcp add --transport http --scope user kestra https://api.kestra.io/v1/mcp
+```
+
+Or add it manually to `.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "kestra": {
+      "type": "http",
+      "url": "https://api.kestra.io/v1/mcp"
+    }
+  }
+}
+```
+
+Once connected, the 13 tools are immediately available in every Claude Code session. You can verify with `/mcp`, or simply start a flow-writing task — Claude will invoke the relevant tools automatically.
+
+## What the server exposes
+
+All 13 tools carry `readOnlyHint: true`. The server is a pure catalog; it never modifies state.
+
+### Plugin discovery
+
+| Tool | What it returns |
+|------|-----------------|
+| `list_plugins` | All loaded plugins with name, categories, and counts per element type (tasks, triggers, task runners, storages, secret managers, log exporters). Optional `category` filter: `AI`, `ALERTING`, `BUSINESS`, `CLOUD`, `CORE`, `DATA`, `INFRASTRUCTURE`. |
+| `plugin_tasks` | All tasks, triggers, conditions, and task runners for one plugin, grouped by subpackage. Accepts a plugin name (`plugin-aws`) or group (`io.kestra.plugin.aws`). |
+| `versions` | Installed version of every plugin. Optional name filter. |
+| `list_task_runners` | All task runner backends across all plugins (Docker, Kubernetes, GCP Batch, AWS Batch, …). |
+| `list_triggers` | All trigger types across all plugins (Schedule, Webhook, Kafka, JDBC, …). |
+| `list_storages` | All internal storage backends (GCS, S3, Azure Blob Storage, MinIO, …). |
+| `list_secret_managers` | All secret manager integrations (HashiCorp Vault, AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, 1Password, …). |
+| `list_log_exporters` | All log shipper backends. |
+
+### Task documentation
+
+| Tool | What it returns |
+|------|-----------------|
+| `task_schema` | Full JSON schema and documentation for a task class, including all properties and outputs. Accepts the fully-qualified class name (e.g. `io.kestra.plugin.aws.s3.Upload`) and an optional `all` flag to include inherited properties. |
+
+### Blueprints
+
+| Tool | What it returns |
+|------|-----------------|
+| `blueprints` | Search flow templates by text query and/or tags. Returns id, title, description, tags, and included task list. |
+| `get_blueprint_flow` | Full YAML source for a blueprint by id. Ready to paste into a flow. |
+
+### Plugin release history
+
+| Tool | What it returns |
+|------|-----------------|
+| `plugin_versions` | Full GitHub release history for a plugin, including the Kestra version each release targets. |
+
+### Full-text search
+
+| Tool | What it returns |
+|------|-----------------|
+| `search` | Full-text search across plugins, docs, blueprints, or blogs. Optional `type` filter: `PLUGINS` (default), `DOCS`, `BLUEPRINTS`, `BLOGS`. |
+
+## Use cases
+
+### Writing a flow from scratch
+
+Ask Claude Code to write a flow that reads from S3 and loads into BigQuery. Instead of guessing task names or hallucinating property shapes, the agent calls `list_plugins` to discover `plugin-aws` and `plugin-gcp`, then `plugin_tasks` for each to enumerate available tasks, then `task_schema` on `io.kestra.plugin.aws.s3.Downloads` and `io.kestra.plugin.gcp.bigquery.Load` to get exact property names, types, and defaults. The resulting YAML is valid on the first attempt.
+
+### Checking what integrations are available
+
+_"Does Kestra support Vault for secrets?"_ — the agent calls `list_secret_managers` and returns the full list including the FQCN and description for the HashiCorp Vault implementation. The same pattern works for `list_task_runners` ("can I run tasks on GCP Batch?"), `list_storages` ("does Kestra support MinIO?"), and `list_triggers` ("is there a Kafka realtime trigger?"). No guessing, no docs tab, no stale answers.
+
+### Bootstrapping with blueprints
+
+Before writing a flow from scratch, the agent calls `blueprints` with a query like `"dbt"` or `"slack notification"`, scans the matches, and calls `get_blueprint_flow` on the best result to retrieve the full YAML. This is faster than authoring from scratch and guarantees the output follows Kestra's own patterns and best practices.
+
+### Investigating plugin compatibility
+
+When a flow breaks after a plugin upgrade, the agent calls `plugin_versions` to retrieve the full release history with the target Kestra version for each tag. This surfaces the exact release where a change was introduced without leaving the conversation or opening GitHub.
+
+## Connecting other AI clients
+
+The same endpoint works with any MCP-compatible tool:
+
+**Codex CLI** — `~/.codex/config.toml`:
+```toml
+[[mcp_servers]]
+name = "kestra"
+url  = "https://api.kestra.io/v1/mcp"
+```
+
+**Gemini CLI** — `~/.gemini/settings.json`:
+```json
+{
+  "mcpServers": {
+    "kestra": {
+      "httpUrl": "https://api.kestra.io/v1/mcp"
+    }
+  }
+}
+```
+
+**OpenCode** — `~/.config/opencode/config.json`:
+```json
+{
+  "mcp": {
+    "kestra": {
+      "type": "remote",
+      "url": "https://api.kestra.io/v1/mcp"
+    }
+  }
+}
+```
+
+## Why a remote server?
+
+Most MCP servers are local processes: install them, keep them updated, configure them per machine. A remote HTTP MCP server requires none of that. There is nothing to install, nothing to update locally, and no background process consuming memory. The catalog stays current because it mirrors the live plugin registry and blueprint index that powers [kestra.io/plugins](https://kestra.io/plugins) — updated on every Kestra release.
+
+Want to develop against unreleased plugins? The same endpoint is available locally if you run `api.kestra.io` yourself: `http://localhost:8080/v1/mcp`.
+
+---
+
+## Frequently asked questions
+
+### What is the Kestra MCP server?
+A remote HTTP endpoint at `https://api.kestra.io/v1/mcp` that implements the [Model Context Protocol](https://modelcontextprotocol.io). It gives AI coding agents live access to Kestra's plugin registry and blueprint catalog through 13 read-only tools — with no installation required.
+
+### How do I connect Claude Code to the Kestra MCP server?
+Run `claude mcp add --transport http kestra https://api.kestra.io/v1/mcp` for project scope, or add `--scope user` for global availability. You can also add the `mcpServers` entry directly to `.claude/settings.json`.
+
+### What tools does the Kestra MCP server expose?
+13 tools covering plugin discovery (`list_plugins`, `plugin_tasks`, `versions`), element-type listing (`list_task_runners`, `list_triggers`, `list_storages`, `list_secret_managers`, `list_log_exporters`), task documentation (`task_schema`), blueprint search and retrieval (`blueprints`, `get_blueprint_flow`), release history (`plugin_versions`), and full-text search (`search`).
+
+### Does the Kestra MCP server require authentication?
+No. The endpoint is public and requires no API key or login. All tools are read-only.
+
+### Can I use it with AI agents other than Claude Code?
+Yes. Codex CLI, Gemini CLI, OpenCode, or any framework that supports MCP over HTTP. Configuration snippets for each are in the post above.
+
+### Is there a local version for development?
+Yes. Run `api.kestra.io` locally and point your MCP client at `http://localhost:8080/v1/mcp`. Useful for testing with private or unreleased plugins.

--- a/src/contents/blogs/2026-04-27-kestra-mcp-plugins-blueprints/index.md
+++ b/src/contents/blogs/2026-04-27-kestra-mcp-plugins-blueprints/index.md
@@ -5,8 +5,9 @@ date: 2026-04-27T09:00:00
 category: Solutions
 author:
   name: François Delbrayelle
+  linkedin: https://www.linkedin.com/in/fdelbrayelle/
   image: fdelbrayelle
-  role: Senior Software Engineer
+  role: Lead Software Engineer
 image: ./main.png
 schema:
   "@context": "https://schema.org"

--- a/src/contents/blogs/2026-04-27-kestra-mcp-plugins-blueprints/index.md
+++ b/src/contents/blogs/2026-04-27-kestra-mcp-plugins-blueprints/index.md
@@ -173,8 +173,6 @@ url  = "https://api.kestra.io/v1/mcp"
 
 Most MCP servers are local processes: install them, keep them updated, configure them per machine. A remote HTTP MCP server requires none of that. There is nothing to install, nothing to update locally, and no background process consuming memory. The catalog stays current because it mirrors the live plugin registry and blueprint index that powers [kestra.io/plugins](https://kestra.io/plugins) — updated on every Kestra release.
 
-Want to develop against unreleased plugins? The same endpoint is available locally if you run `api.kestra.io` yourself: `http://localhost:8080/v1/mcp`.
-
 ---
 
 ## Frequently asked questions
@@ -193,6 +191,3 @@ No. The endpoint is public and requires no API key or login. All tools are read-
 
 ### Can I use it with AI agents other than Claude Code?
 Yes. Codex CLI, Gemini CLI, OpenCode, or any framework that supports MCP over HTTP. Configuration snippets for each are in the post above.
-
-### Is there a local version for development?
-Yes. Run `api.kestra.io` locally and point your MCP client at `http://localhost:8080/v1/mcp`. Useful for testing with private or unreleased plugins.

--- a/src/contents/blogs/control-vmware-with-kestra/index.md
+++ b/src/contents/blogs/control-vmware-with-kestra/index.md
@@ -7,7 +7,7 @@ author:
   name: François Delbrayelle
   linkedin: https://www.linkedin.com/in/fdelbrayelle/
   image: fdelbrayelle
-  role: 
+  role: Lead Software Engineer
 image: ./control-vmware-with-kestra.jpg
 ---
 

--- a/src/pages/features/api-first.astro
+++ b/src/pages/features/api-first.astro
@@ -10,6 +10,9 @@ import SectionCard from "~/components/layout/SectionCard.astro"
 import visualHero from "~/assets/landing/features/api/api-hero.webp"
 import flexibility from "~/assets/landing/features/api/flexibility.webp"
 import integration from "~/assets/landing/features/api/integration.webp"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const title = "API-First Design"
 const description =
@@ -70,7 +73,7 @@ const FEATURES = [
     <PluginsBlock>
         <Fragment slot="title"> Plugin-Powered Flexibility </Fragment>
         <Fragment slot="description">
-            Choose from over 1200+ plugins that offer direct integration with
+            Choose from over {totalPlugins}+ plugins that offer direct integration with
             third-party services, databases, messaging systems, and more.
         </Fragment>
     </PluginsBlock>

--- a/src/pages/features/index.astro
+++ b/src/pages/features/index.astro
@@ -8,6 +8,9 @@ import Operate from "~/components/features/core/Operate.astro"
 import Simple from "~/components/features/core/Simple.astro"
 import GetStarted from "~/components/common/GetStarted.astro"
 import EveryPlugin from "~/components/features/core/EveryPlugin.astro"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const title = "Powerful Features for Reliable Workflows"
 const description =
@@ -28,7 +31,7 @@ const items = [
     },
     {
         question: "What's included in OSS vs Enterprise?",
-        answer: "<strong>OSS</strong>: Full orchestration, unlimited executions, 1200+ plugins, event triggers. <strong>Enterprise</strong>: Adds RBAC, SSO, audit logs, multi-tenancy. <a href='/pricing'>Compare editions →</a>",
+        answer: `<strong>OSS</strong>: Full orchestration, unlimited executions, ${totalPlugins}+ plugins, event triggers. <strong>Enterprise</strong>: Adds RBAC, SSO, audit logs, multi-tenancy. <a href='/pricing'>Compare editions →</a>`,
     },
     {
         question: "What deployment options exist?",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,9 @@ import Blueprints from "~/components/home/Blueprints.astro"
 import ClosingCTA from "~/components/home/ClosingCTA.astro"
 import GetStarted from "~/components/common/GetStarted.astro"
 import PluginsBlock from "~/components/common/PluginsBlock.astro"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 ---
 
 <Layout headerTheme="darkHeader">
@@ -33,7 +36,7 @@ import PluginsBlock from "~/components/common/PluginsBlock.astro"
             </span>
             <span slot="description">
                 Kestra integrates with your existing cloud, data,
-                infrastructure, and SaaS tools. <br />With 1,200+ plugins, you
+                infrastructure, and SaaS tools. <br />With {totalPlugins}+ plugins, you
                 can orchestrate everything without building custom glue code.
             </span>
         </PluginsBlock>

--- a/src/pages/use-cases/automotive.astro
+++ b/src/pages/use-cases/automotive.astro
@@ -25,6 +25,9 @@ import RenaultLogoImg from "~/assets/trusted-companies/Renault.svg"
 import MichelinLogoImg from "~/assets/trusted-companies/Michelin.svg"
 import XiaomiLogoImg from "~/assets/landing/infrastructure/companies/xiaomi.svg"
 import { optimizeSvgIcon } from "~/utils/svgo"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const HERO_TAGS = [
     { label: "Plant & edge ready", icon: "mdi:factory" },
@@ -439,7 +442,7 @@ const FAQ = [
     },
     {
         question: "How is Kestra different from IBM Maximo, SAP IPC, or hand-rolled MES scripts?",
-        answer: "Maximo and SAP IPC are domain suites, not orchestration engines. Hand-rolled scripts die the day the engineer who wrote them leaves. Kestra is declarative YAML in Git with 1,200+ plugins covering plant floor to cloud — so quality, warranty, recall, and telemetry live in one versioned, owned-by-your-team system.",
+        answer: `Maximo and SAP IPC are domain suites, not orchestration engines. Hand-rolled scripts die the day the engineer who wrote them leaves. Kestra is declarative YAML in Git with ${totalPlugins}+ plugins covering plant floor to cloud — so quality, warranty, recall, and telemetry live in one versioned, owned-by-your-team system.`,
     },
     {
         question: "How do you handle secrets and engineering IP?",
@@ -692,7 +695,7 @@ const FAQ = [
             </Fragment>
             <Fragment slot="description">
                 Connect MES, SCADA, PLM, ERP, dealer DMS, supplier EDI feeds, telemetry platforms, data stacks,
-                and security controls through 1,200+ plugins. Or build the exact integration your environment requires.
+                and security controls through {totalPlugins}+ plugins. Or build the exact integration your environment requires.
             </Fragment>
         </PluginsBlock>
 

--- a/src/pages/use-cases/financial-services.astro
+++ b/src/pages/use-cases/financial-services.astro
@@ -28,6 +28,9 @@ import MatmutLogoImg from "~/assets/trusted-companies/Matmut.svg"
 import GateIoLogoImg from "~/assets/trusted-companies/GateIO.svg"
 import TotalEnergiesLogoImg from "~/assets/trusted-companies/TotalEnergies.svg"
 import { optimizeSvgIcon } from "~/utils/svgo"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const HERO_TAGS = [
     { label: "Air-gapped", icon: "mdi:shield-lock-outline" },
@@ -36,7 +39,7 @@ const HERO_TAGS = [
     { label: "Four-eyes approval", icon: "mdi:account-supervisor-outline" },
     { label: "Replayable lineage", icon: "mdi:history" },
     { label: "EU & US residency", icon: "mdi:earth" },
-    { label: "1200+ plugins", icon: "mdi:puzzle-outline" },
+    { label: `${totalPlugins}+ plugins`, icon: "mdi:puzzle-outline" },
 ]
 
 const title = "Kestra for Financial Services & Insurance"
@@ -773,7 +776,7 @@ const FAQ = [
             </Fragment>
             <Fragment slot="description">
                 Connect core platforms, policy and claims systems, data stacks, messaging layers, case tools,
-                and security controls through 1,200+ plugins. Or build the exact integration your environment requires.
+                and security controls through {totalPlugins}+ plugins. Or build the exact integration your environment requires.
             </Fragment>
         </PluginsBlock>
 

--- a/src/pages/use-cases/healthcare.astro
+++ b/src/pages/use-cases/healthcare.astro
@@ -24,6 +24,9 @@ import ApotekHjartatLogoImg from "~/contents/customer-stories/29/logo.svg"
 import SophiaGeneticsLogoImg from "~/assets/use-cases/healthcare/SophiaGenetics.svg"
 import BrainlabLogoImg from "~/assets/landing/infrastructure/companies/brainlab.svg"
 import { optimizeSvgIcon } from "~/utils/svgo"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const HERO_TAGS = [
     { label: "HIPAA-ready", icon: "mdi:shield-check-outline" },
@@ -700,7 +703,7 @@ const FAQ = [
             </Fragment>
             <Fragment slot="description">
                 Connect EHRs, HL7 and FHIR engines, payer APIs, clearinghouses, lab and imaging systems,
-                data platforms, and security controls through 1,200+ plugins. Or build the exact integration
+                data platforms, and security controls through {totalPlugins}+ plugins. Or build the exact integration
                 your environment requires.
             </Fragment>
         </PluginsBlock>

--- a/src/pages/use-cases/retail.astro
+++ b/src/pages/use-cases/retail.astro
@@ -28,6 +28,9 @@ import IntersportLogoImg from "~/assets/trusted-companies/Intersport.svg"
 import DiorLogoImg from "~/assets/trusted-companies/Dior.svg"
 import FilaLogoImg from "~/assets/trusted-companies/Fila.svg"
 import { optimizeSvgIcon } from "~/utils/svgo"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const HERO_TAGS = [
     { label: "Peak-season scale", icon: "mdi:flash-outline" },
@@ -715,7 +718,7 @@ const FAQ = [
             </Fragment>
             <Fragment slot="description">
                 Connect OMS, WMS, POS, storefronts, PIM, payment gateways, carriers, CS tools, loyalty platforms,
-                and analytics stacks through 1,200+ plugins. Or build the exact integration your environment requires.
+                and analytics stacks through {totalPlugins}+ plugins. Or build the exact integration your environment requires.
             </Fragment>
         </PluginsBlock>
 

--- a/src/pages/vs/google-workflows.astro
+++ b/src/pages/vs/google-workflows.astro
@@ -22,6 +22,9 @@ import data3 from "~/components/versus/assets/data-3.svg"
 import kestraImg from "~/components/versus/assets/kestra-img.svg"
 import googleWorkflowsImg from "~/components/versus/assets/google-workflows-img.svg"
 import heroUI from "~/components/versus/assets/google_workflows_hero_ui.webp"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const entry = await getEntry("vs", "google-workflows")
 if (!entry)
@@ -123,7 +126,7 @@ const {
         <Fragment slot="title">
             Orchestrate Beyond GCP Service Coordination
         </Fragment>
-        See how Kestra runs code directly, connects to 1200+ plugins, and works across
+        See how Kestra runs code directly, connects to {totalPlugins}+ plugins, and works across
         every cloud — without Cloud Functions.
     </SeeHow>
 </VsLayout>

--- a/src/pages/vs/index.astro
+++ b/src/pages/vs/index.astro
@@ -6,6 +6,9 @@ import SchemaFAQ from "~/components/common/SchemaFAQ.astro"
 import GetStarted from "~/components/common/GetStarted.astro"
 import kestraIcon from "~/components/versus/assets/ks-icon.svg?raw"
 import vsBadgeSvg from "~/components/versus/assets/vs-badge.svg?raw"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const vsEntries = await getCollection("vs")
 
@@ -35,7 +38,7 @@ const entries = vsEntries
 const faqItems = [
     {
         question: "What makes Kestra different from other orchestration tools?",
-        answer: "Kestra is a universal orchestration platform that works with any language, any stack, and any cloud. Unlike tools that lock you into Python, a specific cloud, or a proprietary GUI, Kestra uses declarative YAML workflows that are version-controlled in Git, with 1200+ plugins and a built-in code editor supporting Python, R, Node.js, Shell, and more.",
+        answer: `Kestra is a universal orchestration platform that works with any language, any stack, and any cloud. Unlike tools that lock you into Python, a specific cloud, or a proprietary GUI, Kestra uses declarative YAML workflows that are version-controlled in Git, with ${totalPlugins}+ plugins and a built-in code editor supporting Python, R, Node.js, Shell, and more.`,
     },
     {
         question: "Can Kestra replace my current workflow orchestration tool?",


### PR DESCRIPTION
## Summary

- 9 pages had hardcoded `1200+` / `1,200+` plugin counts
- All now call `fetchTotalPluginsCount()` from `~/utils/plugins/pluginCount` at build time
- Slots in Astro templates use `{totalPlugins}+`; JS strings use template literals `${totalPlugins}+`

## Pages changed

- `pages/index.astro`
- `pages/features/api-first.astro`
- `pages/features/index.astro`
- `pages/vs/google-workflows.astro`
- `pages/vs/index.astro`
- `pages/use-cases/automotive.astro`
- `pages/use-cases/retail.astro`
- `pages/use-cases/healthcare.astro`
- `pages/use-cases/financial-services.astro`