### PR TITLE
fix: replace hardcoded plugin counts with dynamic fetchTotalPluginsCount

### DIFF
--- a/src/pages/features/api-first.astro
+++ b/src/pages/features/api-first.astro
@@ -10,6 +10,9 @@ import SectionCard from "~/components/layout/SectionCard.astro"
 import visualHero from "~/assets/landing/features/api/api-hero.webp"
 import flexibility from "~/assets/landing/features/api/flexibility.webp"
 import integration from "~/assets/landing/features/api/integration.webp"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const title = "API-First Design"
 const description =
@@ -70,7 +73,7 @@ const FEATURES = [
     <PluginsBlock>
         <Fragment slot="title"> Plugin-Powered Flexibility </Fragment>
         <Fragment slot="description">
-            Choose from over 1200+ plugins that offer direct integration with
+            Choose from over {totalPlugins}+ plugins that offer direct integration with
             third-party services, databases, messaging systems, and more.
         </Fragment>
     </PluginsBlock>

--- a/src/pages/features/index.astro
+++ b/src/pages/features/index.astro
@@ -8,6 +8,9 @@ import Operate from "~/components/features/core/Operate.astro"
 import Simple from "~/components/features/core/Simple.astro"
 import GetStarted from "~/components/common/GetStarted.astro"
 import EveryPlugin from "~/components/features/core/EveryPlugin.astro"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const title = "Powerful Features for Reliable Workflows"
 const description =
@@ -28,7 +31,7 @@ const items = [
     },
     {
         question: "What's included in OSS vs Enterprise?",
-        answer: "<strong>OSS</strong>: Full orchestration, unlimited executions, 1200+ plugins, event triggers. <strong>Enterprise</strong>: Adds RBAC, SSO, audit logs, multi-tenancy. <a href='/pricing'>Compare editions →</a>",
+        answer: `<strong>OSS</strong>: Full orchestration, unlimited executions, ${totalPlugins}+ plugins, event triggers. <strong>Enterprise</strong>: Adds RBAC, SSO, audit logs, multi-tenancy. <a href='/pricing'>Compare editions →</a>`,
     },
     {
         question: "What deployment options exist?",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,9 @@ import Blueprints from "~/components/home/Blueprints.astro"
 import ClosingCTA from "~/components/home/ClosingCTA.astro"
 import GetStarted from "~/components/common/GetStarted.astro"
 import PluginsBlock from "~/components/common/PluginsBlock.astro"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 ---
 
 <Layout headerTheme="darkHeader">
@@ -33,7 +36,7 @@ import PluginsBlock from "~/components/common/PluginsBlock.astro"
             </span>
             <span slot="description">
                 Kestra integrates with your existing cloud, data,
-                infrastructure, and SaaS tools. <br />With 1,200+ plugins, you
+                infrastructure, and SaaS tools. <br />With {totalPlugins}+ plugins, you
                 can orchestrate everything without building custom glue code.
             </span>
         </PluginsBlock>

--- a/src/pages/use-cases/automotive.astro
+++ b/src/pages/use-cases/automotive.astro
@@ -25,6 +25,9 @@ import RenaultLogoImg from "~/assets/trusted-companies/Renault.svg"
 import MichelinLogoImg from "~/assets/trusted-companies/Michelin.svg"
 import XiaomiLogoImg from "~/assets/landing/infrastructure/companies/xiaomi.svg"
 import { optimizeSvgIcon } from "~/utils/svgo"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const HERO_TAGS = [
     { label: "Plant & edge ready", icon: "mdi:factory" },
@@ -439,7 +442,7 @@ const FAQ = [
     },
     {
         question: "How is Kestra different from IBM Maximo, SAP IPC, or hand-rolled MES scripts?",
-        answer: "Maximo and SAP IPC are domain suites, not orchestration engines. Hand-rolled scripts die the day the engineer who wrote them leaves. Kestra is declarative YAML in Git with 1,200+ plugins covering plant floor to cloud — so quality, warranty, recall, and telemetry live in one versioned, owned-by-your-team system.",
+        answer: `Maximo and SAP IPC are domain suites, not orchestration engines. Hand-rolled scripts die the day the engineer who wrote them leaves. Kestra is declarative YAML in Git with ${totalPlugins}+ plugins covering plant floor to cloud — so quality, warranty, recall, and telemetry live in one versioned, owned-by-your-team system.`,
     },
     {
         question: "How do you handle secrets and engineering IP?",
@@ -692,7 +695,7 @@ const FAQ = [
             </Fragment>
             <Fragment slot="description">
                 Connect MES, SCADA, PLM, ERP, dealer DMS, supplier EDI feeds, telemetry platforms, data stacks,
-                and security controls through 1,200+ plugins. Or build the exact integration your environment requires.
+                and security controls through {totalPlugins}+ plugins. Or build the exact integration your environment requires.
             </Fragment>
         </PluginsBlock>
 

--- a/src/pages/use-cases/financial-services.astro
+++ b/src/pages/use-cases/financial-services.astro
@@ -28,6 +28,9 @@ import MatmutLogoImg from "~/assets/trusted-companies/Matmut.svg"
 import GateIoLogoImg from "~/assets/trusted-companies/GateIO.svg"
 import TotalEnergiesLogoImg from "~/assets/trusted-companies/TotalEnergies.svg"
 import { optimizeSvgIcon } from "~/utils/svgo"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const HERO_TAGS = [
     { label: "Air-gapped", icon: "mdi:shield-lock-outline" },
@@ -36,7 +39,7 @@ const HERO_TAGS = [
     { label: "Four-eyes approval", icon: "mdi:account-supervisor-outline" },
     { label: "Replayable lineage", icon: "mdi:history" },
     { label: "EU & US residency", icon: "mdi:earth" },
-    { label: "1200+ plugins", icon: "mdi:puzzle-outline" },
+    { label: `${totalPlugins}+ plugins`, icon: "mdi:puzzle-outline" },
 ]
 
 const title = "Kestra for Financial Services & Insurance"
@@ -773,7 +776,7 @@ const FAQ = [
             </Fragment>
             <Fragment slot="description">
                 Connect core platforms, policy and claims systems, data stacks, messaging layers, case tools,
-                and security controls through 1,200+ plugins. Or build the exact integration your environment requires.
+                and security controls through {totalPlugins}+ plugins. Or build the exact integration your environment requires.
             </Fragment>
         </PluginsBlock>
 

--- a/src/pages/use-cases/healthcare.astro
+++ b/src/pages/use-cases/healthcare.astro
@@ -25,6 +25,9 @@ import ApotekHjartatLogoImg from "~/contents/customer-stories/29/logo.svg"
 import SophiaGeneticsLogoImg from "~/assets/use-cases/healthcare/SophiaGenetics.svg"
 import BrainlabLogoImg from "~/assets/landing/infrastructure/companies/brainlab.svg"
 import { optimizeSvgIcon } from "~/utils/svgo"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const HERO_TAGS = [
     { label: "HIPAA & HITRUST friendly", icon: "mdi:shield-check-outline" },
@@ -757,9 +760,9 @@ const FAQ = [
                 Integrates with the <span class="highlight">systems healthcare and life-sciences teams</span> already run.
             </Fragment>
             <Fragment slot="description">
-                Native plugins for PACS and DICOM systems, Epic, Cerner and HL7 feeds where needed, lab and genomics
-                platforms, AWS, GCP, Azure, Kubernetes, Vault, CyberArk, Splunk, Elastic, plus 1,200+ more.
-                Or build the exact integration your environment needs.
+                Connect EHRs, HL7 and FHIR engines, payer APIs, clearinghouses, lab and imaging systems,
+                data platforms, and security controls through {totalPlugins}+ plugins. Or build the exact integration
+                your environment requires.
             </Fragment>
         </PluginsBlock>
 

--- a/src/pages/use-cases/retail.astro
+++ b/src/pages/use-cases/retail.astro
@@ -29,6 +29,9 @@ import IntersportLogoImg from "~/assets/trusted-companies/Intersport.svg"
 import DiorLogoImg from "~/assets/trusted-companies/Dior.svg"
 import FilaLogoImg from "~/assets/trusted-companies/Fila.svg"
 import { optimizeSvgIcon } from "~/utils/svgo"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const HERO_TAGS = [
     { label: "Self-hosted & EU residency", icon: "mdi:earth" },
@@ -769,9 +772,8 @@ const FAQ = [
                 Integrates with the <span class="highlight">systems retail teams</span> already run.
             </Fragment>
             <Fragment slot="description">
-                Native plugins for SAP, Oracle, mainframe, Shopify, Salesforce Commerce, Manhattan, Snowflake,
-                BigQuery, dbt, Gorgias, Zendesk, Salesforce Service Cloud, Vault, AWS, GCP, Azure, plus 1,200+ more.
-                Or build the exact integration your environment needs.
+                Connect OMS, WMS, POS, storefronts, PIM, payment gateways, carriers, CS tools, loyalty platforms,
+                and analytics stacks through {totalPlugins}+ plugins. Or build the exact integration your environment requires.
             </Fragment>
         </PluginsBlock>
 

--- a/src/pages/vs/google-workflows.astro
+++ b/src/pages/vs/google-workflows.astro
@@ -22,6 +22,9 @@ import data3 from "~/components/versus/assets/data-3.svg"
 import kestraImg from "~/components/versus/assets/kestra-img.svg"
 import googleWorkflowsImg from "~/components/versus/assets/google-workflows-img.svg"
 import heroUI from "~/components/versus/assets/google_workflows_hero_ui.webp"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const entry = await getEntry("vs", "google-workflows")
 if (!entry)
@@ -123,7 +126,7 @@ const {
         <Fragment slot="title">
             Orchestrate Beyond GCP Service Coordination
         </Fragment>
-        See how Kestra runs code directly, connects to 1200+ plugins, and works across
+        See how Kestra runs code directly, connects to {totalPlugins}+ plugins, and works across
         every cloud — without Cloud Functions.
     </SeeHow>
 </VsLayout>

--- a/src/pages/vs/index.astro
+++ b/src/pages/vs/index.astro
@@ -6,6 +6,9 @@ import SchemaFAQ from "~/components/common/SchemaFAQ.astro"
 import GetStarted from "~/components/common/GetStarted.astro"
 import kestraIcon from "~/components/versus/assets/ks-icon.svg?raw"
 import vsBadgeSvg from "~/components/versus/assets/vs-badge.svg?raw"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const vsEntries = await getCollection("vs")
 
@@ -35,7 +38,7 @@ const entries = vsEntries
 const faqItems = [
     {
         question: "What makes Kestra different from other orchestration tools?",
-        answer: "Kestra is a universal orchestration platform that works with any language, any stack, and any cloud. Unlike tools that lock you into Python, a specific cloud, or a proprietary GUI, Kestra uses declarative YAML workflows that are version-controlled in Git, with 1200+ plugins and a built-in code editor supporting Python, R, Node.js, Shell, and more.",
+        answer: `Kestra is a universal orchestration platform that works with any language, any stack, and any cloud. Unlike tools that lock you into Python, a specific cloud, or a proprietary GUI, Kestra uses declarative YAML workflows that are version-controlled in Git, with ${totalPlugins}+ plugins and a built-in code editor supporting Python, R, Node.js, Shell, and more.`,
     },
     {
         question: "Can Kestra replace my current workflow orchestration tool?",


### PR DESCRIPTION
## Summary

- 9 pages had hardcoded `1200+` / `1,200+` plugin counts
- All now call `fetchTotalPluginsCount()` from `~/utils/plugins/pluginCount` at build time
- Slots in Astro templates use `{totalPlugins}+`; JS strings use template literals `${totalPlugins}+`

## Pages changed

- `pages/index.astro`
- `pages/features/api-first.astro`
- `pages/features/index.astro`
- `pages/vs/google-workflows.astro`
- `pages/vs/index.astro`
- `pages/use-cases/automotive.astro`
- `pages/use-cases/retail.astro`
- `pages/use-cases/healthcare.astro`
- `pages/use-cases/financial-services.astro`