### PR TITLE
fix: replace remaining hardcoded plugin counts in components and pages

### DIFF
--- a/src/components/data/Actual.astro
+++ b/src/components/data/Actual.astro
@@ -1,6 +1,7 @@
 ---
 import CardGrid from "~/components/card/CardGrid.astro"
 import SectionCard from "~/components/layout/SectionCard.astro"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
 
 import execution1 from "./assets/execution-1.webp"
 import execution2 from "./assets/execution-2.webp"
@@ -8,6 +9,8 @@ import execution3 from "./assets/execution-3.webp"
 import execution4 from "./assets/execution-4.webp"
 import execution5 from "./assets/execution-5.webp"
 import execution6 from "./assets/execution-6.webp"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const title = `Cut Orchestration Costs By <span class='highlight'>80%</span> *`
 
@@ -55,7 +58,7 @@ const ACTUALS = [
     {
         title: "Built For The Stack You Run in Production",
         description:
-            "Native integrations for dbt, Airbyte, Spark, Snowflake, BigQuery, Databricks, and 1200+ integrationsfrom event-driven triggers for files, APIs, databases, and queues.",
+            `Native integrations for dbt, Airbyte, Spark, Snowflake, BigQuery, Databricks, and ${totalPlugins}+ integrations from event-driven triggers for files, APIs, databases, and queues.`,
         image: execution4,
         reverse: true,
     },

--- a/src/components/features/core/Simple.astro
+++ b/src/components/features/core/Simple.astro
@@ -1,5 +1,8 @@
 ---
 import CardGrid from "~/components/card/CardGrid.astro"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const ITEMS = [
     {
@@ -9,7 +12,7 @@ const ITEMS = [
             "Flows are declarative definitions of what should run and in what order: tasks, dependencies, conditions, triggers, and runtime parameters.",
     },
     {
-        title: "Integrate with 1200+ Tools",
+        title: `Integrate with ${totalPlugins}+ Tools`,
         icon: "mdi:puzzle-check-outline",
         description:
             "Everything is plugin, from core building blocks to integrations with your stack. That's how Kestra stays universal without becoming a monolith.",

--- a/src/components/get-started/Differentiators.astro
+++ b/src/components/get-started/Differentiators.astro
@@ -1,5 +1,8 @@
 ---
 import CardGrid from "~/components/card/CardGrid.astro"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const ITEMS = [
     {
@@ -16,7 +19,7 @@ const ITEMS = [
     },
     {
         icon: "mdi:puzzle-outline",
-        title: "1200+ Plugins",
+        title: `${totalPlugins}+ Plugins`,
         description:
             "Connect to databases, cloud services, APIs, and SaaS tools. No custom integrations required.",
     },

--- a/src/components/get-started/Hero.astro
+++ b/src/components/get-started/Hero.astro
@@ -1,10 +1,13 @@
 ---
 import { Icon } from "astro-icon/components"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const TAGS = [
     { label: "Declarative", icon: "mdi:xml" },
     { label: "Any Language", icon: "mdi:code-tags" },
-    { label: "1200+ Plugins", icon: "mdi:puzzle-outline" },
+    { label: `${totalPlugins}+ Plugins`, icon: "mdi:puzzle-outline" },
     { label: "API-First", icon: "mdi:api" },
     { label: "No Lock-in", icon: "mdi:lock-open-outline" },
     { label: "Self-Hosted", icon: "mdi:server-network-outline" },
@@ -32,7 +35,7 @@ const dockerCommand = `<span class="t-cmd">docker</span> <span class="t-sub">run
                     <span class="gradient">Start Orchestrating.</span>
                 </h1>
                 <p class="subtitle">
-                    One YAML file. Any language. 1200+ integrations.<br />
+                    One YAML file. Any language. {totalPlugins}+ integrations.<br />
                     Your first workflow runs in under 2 minutes.
                 </p>
             </div>

--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -9,6 +9,9 @@ import CloudIcon from "./assets/hero/cloud.svg"
 import HeroAnimation from "./hero-animation.astro"
 import AnimatedWord from "./AnimatedWord.vue"
 import ArrowRight from "vue-material-design-icons/ArrowRight.vue"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 import LogoBar from "./LogoBar.astro"
 import LogoCarousel from "~/components/common/LogoCarousel.astro"
 import JPMorganIcon from "./assets/companies/jpmorgan.svg"
@@ -40,7 +43,7 @@ import AmdocsIcon from "./assets/companies/amdocs.svg"
             <span><DeclarativeIcon />Declarative</span>
             <span><AnyLangIcon />Any Language</span>
             <span><ApiFirstIcon />API-First</span>
-            <span><PluginsIcon />1200+ Plugins</span>
+            <span><PluginsIcon />{totalPlugins}+ Plugins</span>
             <span><LockInIcon />No Lock-in</span>
             <span><SelfHostedIcon />Self-Hosted</span>
             <span><CloudIcon />Cloud</span>

--- a/src/components/home/PlatformOverview.astro
+++ b/src/components/home/PlatformOverview.astro
@@ -2,10 +2,13 @@
 import { Image } from "astro:assets"
 
 import agent from "./assets/overview/agent.png"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
 import code from "./assets/overview/code.png"
 import eventDriven from "./assets/overview/event-driven.png"
 import governance from "./assets/overview/governance.png"
 import { API_URL } from "astro:env/client"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const images = [
     {
@@ -89,7 +92,7 @@ const pluginIcons = await Promise.all(
                                         {pluginIcons.map((icon, index) => (
                                             <span set:html={icon} />
                                         ))}
-                                        1200+ plugins
+                                        {totalPlugins}+ plugins
                                     </p>
                                 )}
                             </figcaption>

--- a/src/pages/use-cases/healthcare.astro
+++ b/src/pages/use-cases/healthcare.astro
@@ -36,7 +36,7 @@ const HERO_TAGS = [
     { label: "Apache 2.0 licensed", icon: "mdi:code-tags" },
     { label: "Kubernetes & GPU workers", icon: "mdi:server-network-outline" },
     { label: "Multi-tenant data science", icon: "mdi:account-group-outline" },
-    { label: "1200+ open-source plugins", icon: "mdi:puzzle-outline" },
+    { label: `${totalPlugins}+ open-source plugins`, icon: "mdi:puzzle-outline" },
 ]
 
 const title = "Kestra for Healthcare & Life Sciences"

--- a/src/pages/use-cases/public-services.astro
+++ b/src/pages/use-cases/public-services.astro
@@ -27,6 +27,9 @@ import ITZBundLogoImg from "~/assets/trusted-companies/ITZBunds.svg"
 import BundesagenturLogoImg from "~/assets/trusted-companies/Bundesagentur.svg"
 import BattelleLogoImg from "~/assets/trusted-companies/Battelle.svg"
 import { optimizeSvgIcon } from "~/utils/svgo"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const HERO_TAGS = [
     { label: "On-prem & air-gapped", icon: "mdi:shield-lock-outline" },
@@ -35,7 +38,7 @@ const HERO_TAGS = [
     { label: "Replayable audit trail", icon: "mdi:history" },
     { label: "Multi-tenant by namespace", icon: "mdi:domain" },
     { label: "LDAP, OIDC, SAML, SCIM", icon: "mdi:account-key-outline" },
-    { label: "1200+ plugins", icon: "mdi:puzzle-outline" },
+    { label: `${totalPlugins}+ plugins`, icon: "mdi:puzzle-outline" },
 ]
 
 const title = "Kestra for Public Services & Institutions"

--- a/src/pages/use-cases/retail.astro
+++ b/src/pages/use-cases/retail.astro
@@ -40,7 +40,7 @@ const HERO_TAGS = [
     { label: "DataMesh-ready multi-tenant", icon: "mdi:account-group-outline" },
     { label: "Approval gates & RBAC", icon: "mdi:account-supervisor-outline" },
     { label: "Apps for self-service UIs", icon: "mdi:application-outline" },
-    { label: "1200+ open-source plugins", icon: "mdi:puzzle-outline" },
+    { label: `${totalPlugins}+ open-source plugins`, icon: "mdi:puzzle-outline" },
 ]
 
 const title = "Kestra for Retail & Commerce"


### PR DESCRIPTION
## Summary

- Follow-up to #4677 which fixed 9 pages but missed components used across the site
- 9 files still had `1200+` hardcoded: `home/Hero.astro`, `home/PlatformOverview.astro`, `get-started/Hero.astro`, `get-started/Differentiators.astro`, `features/core/Simple.astro`, `data/Actual.astro`, and use-case pages for retail, healthcare, public-services
- All now call `fetchTotalPluginsCount()` at build time

## Test plan

- [ ] Build site and verify plugin count renders dynamically on homepage hero, platform overview, get-started, features, and use-case pages