### PR TITLE
docs: document RealtimeTrigger worker failover behavior  

### DIFF
--- a/src/contents/docs/05.workflow-components/07.triggers/05.realtime-trigger/index.md
+++ b/src/contents/docs/05.workflow-components/07.triggers/05.realtime-trigger/index.md
@@ -30,7 +30,7 @@ Realtime Triggers continuously listen for events and launch a new workflow execu
 - an item is added to a [Redis list](/plugins/plugin-redis)
 - a row is added, modified or deleted in [Postgres](/plugins/plugin-debezium-postgres/io.kestra.plugin.debezium.postgres.realtimetrigger), [MySQL](/plugins/plugin-debezium-mysql/io.kestra.plugin.debezium.mysql.realtimetrigger), or [SQL Server](/plugins/plugin-debezium-sqlserver/io.kestra.plugin.debezium.sqlserver.realtimetrigger).
 
-## How realtime triggers work
+## How Realtime Triggers work
 
 Once a Realtime Trigger is added to a workflow, Kestra spins up a dedicated listener thread that remains active. As soon as a new event arrives, the listener immediately starts a workflow execution to process it.
 
@@ -63,9 +63,9 @@ The table below compares Triggers with Realtime Triggers to help you choose the 
 | **Use cases**        | Data orchestration for analytics and building data products           | Process and microservice orchestration (real time updates, anomaly detection, order processing) |
 
 
-## How to Use Realtime Triggers
+## How to use Realtime Triggers
 
-To use Realtime Triggers, simply choose the `RealtimeTrigger` as a trigger type of your desired service. Here, we use the `RealtimeTrigger` to [listen to new messages in an AWS SQS queue](https://youtu.be/bLzk4dKc95g):
+To use Realtime Triggers, choose the `RealtimeTrigger` as the trigger type for your desired service. The following flow uses the `RealtimeTrigger` to [listen to new messages in an AWS SQS queue](https://youtu.be/bLzk4dKc95g):
 
 ```yaml
 id: sqs
@@ -87,12 +87,12 @@ triggers:
 
 ## Worker failover for Realtime Triggers
 
-Each Realtime Trigger runs as a dedicated listener thread on one specific worker. If that worker stops, the listener stops with it. Kestra's [liveness mechanism](../../../10.administrator-guide/server-lifecycle/index.md) will detect this and re-emit the trigger so another available worker can pick it up.
+Each Realtime Trigger runs as a dedicated listener thread on one specific worker. If that worker stops, the listener stops with it. Kestra's [liveness mechanism](../../../10.administrator-guide/server-lifecycle/index.md) detects this and re-emits the trigger so another available worker can pick it up.
 
 The time before failover depends on how the worker stopped:
 
-- **Graceful shutdown** (e.g. `docker stop`, rolling deploy): the executor waits for `kestra.server.terminationGracePeriod` (default `PT5M`) before reassigning the trigger. This prevents duplicate processing when the worker is expected to come back shortly, such as during a rolling deployment.
-- **Abrupt failure** (no heartbeat received): the executor detects the missing heartbeat within `kestra.server.liveness.timeout` and reassigns the trigger without waiting for the grace period.
+- **Graceful shutdown** (e.g. `docker stop`, rolling deploy): the Executor waits for `kestra.server.terminationGracePeriod` (default `PT5M`) before reassigning the trigger. This prevents duplicate processing when the worker is expected to come back shortly, such as during a rolling deployment.
+- **Abrupt failure** (no heartbeat received): the Executor detects the missing heartbeat within `kestra.server.liveness.timeout` and reassigns the trigger without waiting for the grace period.
 
 To reduce the failover time after a graceful shutdown, lower the `terminationGracePeriod`:
 
@@ -108,7 +108,7 @@ Events are not lost during the failover window. They remain in the source system
 
 ## Comparison with real-time data processing engines
 
-It's important to note that Kestra's Realtime Triggers are not intended to be used as a replacement for real-time data processing engines such as Apache Flink, Apache Beam, or Google Dataflow.
+Kestra's Realtime Triggers are not a replacement for real-time data processing engines such as Apache Flink, Apache Beam, or Google Dataflow.
 
 Those data processing engines excel at **stateful** streaming applications and complex SQL transformations over real-time data streams.
 

--- a/src/contents/docs/05.workflow-components/07.triggers/05.realtime-trigger/index.md
+++ b/src/contents/docs/05.workflow-components/07.triggers/05.realtime-trigger/index.md
@@ -85,6 +85,27 @@ triggers:
     queueUrl: https://sqs.eu-north-1.amazonaws.com/123456789/MyQueue
 ```
 
+## Worker failover for Realtime Triggers
+
+Each Realtime Trigger runs as a dedicated listener thread on one specific worker. If that worker stops, the listener stops with it. Kestra's [liveness mechanism](../../../10.administrator-guide/server-lifecycle/index.md) will detect this and re-emit the trigger so another available worker can pick it up.
+
+The time before failover depends on how the worker stopped:
+
+- **Graceful shutdown** (e.g. `docker stop`, rolling deploy): the executor waits for `kestra.server.terminationGracePeriod` (default `PT5M`) before reassigning the trigger. This prevents duplicate processing when the worker is expected to come back shortly, such as during a rolling deployment.
+- **Abrupt failure** (no heartbeat received): the executor detects the missing heartbeat within `kestra.server.liveness.timeout` and reassigns the trigger without waiting for the grace period.
+
+To reduce the failover time after a graceful shutdown, lower the `terminationGracePeriod`:
+
+```yaml
+kestra:
+  server:
+    terminationGracePeriod: PT1M  # default is PT5M
+```
+
+::alert{type="info"}
+Events are not lost during the failover window. They remain in the source system (Kafka topic, SQS queue, etc.) and will be consumed once the trigger listener is restarted on another worker.
+::
+
 ## Comparison with real-time data processing engines
 
 It's important to note that Kestra's Realtime Triggers are not intended to be used as a replacement for real-time data processing engines such as Apache Flink, Apache Beam, or Google Dataflow.

--- a/src/contents/docs/10.administrator-guide/server-lifecycle/index.md
+++ b/src/contents/docs/10.administrator-guide/server-lifecycle/index.md
@@ -10,17 +10,17 @@ Kestra is separated into several components that can be deployed independently o
 
 ## Monitor Kestra server liveness and recovery
 
-We refer to these components as **server components** or just **servers**.
+These components are called **server components** or just **servers**.
 
 See the [server components](../../08.architecture/02.server-components/index.md) and [deployment](../../08.architecture/03.deployment-architecture/index.md) sections for more information.
 
-Kestra has a built-in liveness mechanism. Each server will send a periodical heartbeat stored inside the database, and other servers will check if the server is still alive.
+Kestra has a built-in liveness mechanism. Each server sends a periodic heartbeat stored inside the database, and other servers check whether the server is still alive.
 
 When a server is not alive, Kestra runs maintenance routines such as [worker job resubmission](#worker-job-resubmission).
 
 ## The liveness mechanism
 
-When a server starts, it will send a heartbeat to the database with a `RUNNING` status.
+When a server starts, it sends a heartbeat to the database with a `RUNNING` status.
 When it stops, it first transitions to `TERMINATING`. If the server has pending tasks, it waits up to the configured `kestra.server.terminationGracePeriod` for them to finish. If it completes within that window, it sends a `TERMINATED_GRACEFULLY` heartbeat; otherwise the process is terminated with status `TERMINATED_FORCED`.
 
 Other servers detect missing heartbeats and run maintenance tasks:
@@ -29,7 +29,7 @@ Other servers detect missing heartbeats and run maintenance tasks:
 
 By default, liveness checks run every 10 seconds.
 
-`NOT_RUNNING` servers will be transitioned to `INACTIVE` at the next liveness check.
+`NOT_RUNNING` servers transition to `INACTIVE` at the next liveness check.
 
 If a server does not send a heartbeat within `kestra.server.liveness.timeout`, it is marked `DISCONNECTED` and then `NOT_RUNNING` at the next check. If that server is still alive, it self-terminates after detecting that other components classified it as `NOT_RUNNING`, preventing “resurrection.”
 
@@ -51,7 +51,7 @@ Configure this behavior via `kestra.server.workerTaskRestartStrategy`:
 - `NEVER`: never resubmit jobs (tasks remain incomplete and flows stay `RUNNING`).
 
 ::alert{type="info"}
-This resubmission mechanism also applies to **Realtime Triggers**. If the worker running a Realtime Trigger listener is stopped gracefully, Kestra will wait for the `terminationGracePeriod` before reassigning the trigger to another worker. See [Worker failover for Realtime Triggers](../../05.workflow-components/07.triggers/05.realtime-trigger/index.md#worker-failover-for-realtime-triggers) for more details.
+This resubmission mechanism also applies to **Realtime Triggers**. If the worker running a Realtime Trigger listener is stopped gracefully, Kestra waits for the `terminationGracePeriod` before reassigning the trigger to another worker. See [Worker failover for Realtime Triggers](../../05.workflow-components/07.triggers/05.realtime-trigger/index.md#worker-failover-for-realtime-triggers) for more details.
 ::
 
 Resubmitted task runs show multiple attempts in the UI.

--- a/src/contents/docs/10.administrator-guide/server-lifecycle/index.md
+++ b/src/contents/docs/10.administrator-guide/server-lifecycle/index.md
@@ -50,6 +50,10 @@ Configure this behavior via `kestra.server.workerTaskRestartStrategy`:
 - `IMMEDIATELY`: resubmit jobs right away.
 - `NEVER`: never resubmit jobs (tasks remain incomplete and flows stay `RUNNING`).
 
+::alert{type="info"}
+This resubmission mechanism also applies to **Realtime Triggers**. If the worker running a Realtime Trigger listener is stopped gracefully, Kestra will wait for the `terminationGracePeriod` before reassigning the trigger to another worker. See [Worker failover for Realtime Triggers](../../05.workflow-components/07.triggers/05.realtime-trigger/index.md#worker-failover-for-realtime-triggers) for more details.
+::
+
 Resubmitted task runs show multiple attempts in the UI.
 
 ![resubmitted task run](./taskrun-resubmitted-attempts.png)


### PR DESCRIPTION
  Adds documentation for how Kestra handles Realtime Trigger failover when a worker goes down.