### PR TITLE
SEO: import 5 new resources pages from kestra-seo 2026-W18

### DIFF
--- a/src/contents/resources/agentic-ai/index.md
+++ b/src/contents/resources/agentic-ai/index.md
@@ -1,0 +1,155 @@
+---
+title: "What is Agentic AI? Explained Simply"
+description: "Understand agentic AI, how it operates autonomously, and its distinctions from traditional AI. Explore potential applications and Kestra's role in orchestrating these advanced systems."
+metaTitle: "What is Agentic AI? Explained Simply"
+metaDescription: "Learn what agentic AI is, how it works autonomously to achieve goals, and its key differences from traditional and generative AI. Explore its practical applications."
+tag: ai
+date: 2024-05-16
+faq:
+  - question: "What exactly is agentic AI?"
+    answer: "Agentic AI refers to artificial intelligence systems capable of autonomous decision-making and action to achieve a predefined goal with limited human supervision. Unlike reactive AI, agentic systems can perceive environments, plan steps, execute actions, and learn from outcomes to adapt their behavior over time."
+  - question: "Is ChatGPT an agentic AI?"
+    answer: "While powerful, ChatGPT (and similar large language models) is primarily a generative AI, not an agentic AI. It excels at generating text based on prompts but lacks the inherent ability to autonomously initiate actions, adapt to real-world feedback, or orchestrate complex, multi-step goal attainment without explicit human instruction."
+  - question: "What is the difference between generative AI and agentic AI?"
+    answer: "Generative AI focuses on creating new content (text, images, code) based on patterns learned from data. Agentic AI, however, is designed for autonomous action and goal achievement. It uses various tools, including generative AI models, to plan and execute tasks in dynamic environments, often iterating until a goal is met."
+  - question: "What is the 30% rule in AI?"
+    answer: "The '30% rule in AI' is not a formal industry term but often refers to the challenge of AI reliability. It suggests that while an AI might handle 70-80% of a task correctly, the remaining 20-30% represents complex edge cases that require significant human oversight or robust error handling. This highlights the difficulty in achieving full, unmonitored autonomy in production environments."
+  - question: "How does Kestra support agentic AI workflows?"
+    answer: "Kestra provides a declarative orchestration layer for agentic AI, allowing users to define agent behavior, tool calls, and decision logic in YAML. Its event-driven nature and extensive plugin ecosystem enable agents to interact with diverse systems, while the platform's observability features ensure transparency and control over autonomous executions."
+---
+
+The promise of AI has long been about intelligent systems that can act autonomously. While Large Language Models (LLMs) have captivated the world with their ability to generate human-like text, a new paradigm is emerging: Agentic AI. This advanced form of artificial intelligence moves beyond mere generation, empowering systems to perceive, plan, act, and learn independently to achieve complex goals.
+
+This article will demystify Agentic AI, explaining its core principles, distinguishing it from other AI categories, and exploring its practical applications. We'll examine the benefits and challenges of these self-governing systems and see how platforms like Kestra provide the essential orchestration layer for building reliable and auditable agentic workflows.
+
+## Defining Agentic AI: Autonomy and Goal-Oriented Systems
+
+At its core, agentic AI refers to systems designed to achieve specific goals with limited human supervision. The term "agentic" comes from the concept of an "agent"—an autonomous entity that perceives its environment and acts upon it to reach a desired outcome.
+
+Unlike traditional, reactive AI systems that simply respond to direct inputs, an agentic system operates on a continuous perception-action loop:
+1.  **Perceive:** It gathers information about its current state and environment.
+2.  **Reason:** It analyzes this information in the context of its primary goal.
+3.  **Plan:** It formulates a sequence of actions to move closer to its goal.
+4.  **Act:** It executes these actions by interacting with its environment, often using a set of available tools.
+5.  **Observe:** It assesses the result of its actions and updates its understanding, repeating the loop until the goal is achieved.
+
+This goal-driven behavior is the key differentiator. A traditional machine learning model might predict customer churn, but an agentic AI system would take that prediction and autonomously execute a series of steps to retain the customer, such as sending a personalized offer or scheduling a follow-up call. This shift from prediction to action is what defines the agentic paradigm. Building these autonomous systems is a core focus of modern [AI agents in Kestra](https://kestra.io/docs/ai-tools/ai-agents), where workflows can be designed to think, remember, and use tools to solve complex problems.
+
+## Key Characteristics and Components of Agentic AI
+
+Agentic AI is not a single technology but an architecture that combines several components to enable autonomous operation. Understanding these building blocks is essential to grasping how these systems function.
+
+### Understanding AI Agents: Perception, Planning, and Execution
+
+An AI agent is composed of several key elements working in concert:
+*   **The "Brain" (LLM):** At the heart of most modern AI agents is a Large Language Model (LLM) like GPT-4 or Claude. The LLM provides the reasoning and planning capabilities, allowing the agent to understand complex instructions, break down goals into smaller steps, and decide which actions to take.
+*   **Memory:** Agents require memory to maintain context and learn from past interactions. This can be short-term (remembering the steps in the current task) or long-term (storing knowledge from previous tasks to improve future performance).
+*   **Tools:** An agent's ability to act depends on its tools. These can be anything from external APIs (for web searches or sending emails) and code execution environments (for running Python scripts) to internal databases and software systems. The agent's brain decides which tool to use, with what inputs, to accomplish each step of its plan.
+
+The process is iterative. The agent formulates a plan, executes the first step with a tool, observes the outcome, and then re-evaluates its plan based on the new information. This loop continues until the overarching goal is met.
+
+### Orchestration and Continuous Learning in Agentic Systems
+
+A single agent can perform simple tasks, but achieving complex business goals often requires multiple agents or a sequence of sophisticated tool calls. This is where orchestration becomes critical. An orchestration platform acts as the control plane, defining the rules of engagement, managing the flow of information, and ensuring that the agent's actions are auditable and reliable.
+
+This control plane is also vital for continuous learning. By logging every decision, action, and outcome, the system can analyze its performance. If an agent fails to achieve a goal, the orchestration layer can trigger a fallback process, alert a human operator, or feed the failure data back into a training loop to prevent similar mistakes in the future. This structured approach, facilitated by tools like Kestra's [AI Copilot](https://kestra.io/docs/ai-tools/ai-copilot) and its vast library of [plugins](https://kestra.io/plugins), transforms a simple agent into a robust, enterprise-ready system.
+
+## Use Cases and Practical Applications of Agentic AI
+
+The potential applications for agentic AI span nearly every industry, moving from theoretical concepts to practical, value-driving implementations.
+
+### Agentic AI in Enterprise Solutions and Data Interaction
+
+In the enterprise, agentic AI is being deployed to automate complex, multi-step processes that previously required significant human expertise and intervention.
+*   **Cybersecurity Analytics:** Leading financial institutions like JPMorgan Chase use agentic workflows to analyze billions of security events, identify threats, and trigger automated remediation actions, reducing response times from hours to seconds.
+*   **Infrastructure Provisioning:** Global companies like BHP have replaced legacy automation tools with agentic systems to manage infrastructure. This has allowed them to provision complex cloud and on-prem resources in days instead of months, all governed by declarative, auditable workflows.
+*   **AI/ML Pipelines:** Tech giants like Apple leverage agentic orchestration to manage large-scale AI pipelines. These systems handle data preparation, model training, versioning, and deployment, ensuring reproducibility and reliability across hundreds of engineers.
+
+### Real-World Examples: Automation and Problem-Solving
+
+Beyond these large-scale examples, agentic AI excels at solving specific, targeted problems. Imagine a workflow designed to monitor customer support tickets. When a high-priority ticket arrives, an AI agent could:
+1.  **Analyze the ticket text** to understand the user's issue.
+2.  **Query internal documentation** to find a potential solution.
+3.  **Check the user's account status** in a CRM system.
+4.  **Draft a personalized response** with the solution.
+5.  If the issue is a bug, **create a new ticket** in the engineering team's Jira project.
+
+Each of these steps involves a different tool and a decision based on the outcome of the previous step. This is the power of agentic AI: it can autonomously coordinate multiple systems to achieve a resolution, removing the need to write complex and brittle glue code. This is the core principle behind dedicated platforms for [AI automation](https://kestra.io/ai-automation).
+
+## Agentic AI vs. Generative AI: Understanding the Distinctions
+
+A common point of confusion is the relationship between agentic AI and generative AI models like ChatGPT. While they are related, they serve fundamentally different purposes.
+
+### Is ChatGPT an Agentic AI?
+
+No, ChatGPT is not an agentic AI. It is a generative AI model. It is incredibly proficient at understanding prompts and generating coherent, contextually relevant text. However, it operates in a reactive mode—it responds to inputs but cannot act on its own.
+
+An LLM is a critical component *within* an agentic system, acting as its reasoning engine. But the LLM alone lacks the other necessary components of an agent, such as the ability to interact with external tools, maintain long-term memory, or autonomously pursue a goal without continuous human prompting.
+
+### Key Differences in Functionality and Autonomy
+
+The primary distinction lies in their core function:
+*   **Generative AI creates.** Its purpose is to produce new content based on patterns in its training data.
+*   **Agentic AI acts.** Its purpose is to achieve a goal by performing tasks in an environment.
+
+Think of it this way: Generative AI is a highly skilled specialist, like a copywriter or a programmer. Agentic AI is the project manager that hires that specialist, along with others, to complete a project. It uses the generative model to draft an email, a code execution tool to run a script, and an API tool to update a database, orchestrating all these specialists to achieve its objective. This is particularly evident in advanced use cases like [RAG (Retrieval-Augmented Generation) pipelines](https://kestra.io/resources/ai/rag-pipeline), where an agent might decide when and what information to retrieve to improve the quality of a generated response.
+
+## Benefits and Challenges of Implementing Agentic AI
+
+While agentic AI offers transformative potential, its implementation comes with both significant advantages and notable challenges.
+
+### Advantages: Efficiency, Scalability, and Reduced Human Oversight
+
+The primary benefit of agentic AI is the ability to automate complex, end-to-end workflows. This leads to:
+*   **Increased Efficiency:** Agents can execute tasks 24/7 at machine speed, drastically reducing the time required for processes like data analysis, incident response, or customer onboarding.
+*   **Enhanced Scalability:** Once an agentic workflow is defined, it can be scaled to handle thousands or millions of events without a linear increase in human effort.
+*   **Reduced Human Oversight:** By automating routine decision-making, agentic systems free up skilled professionals to focus on strategic, high-value work that requires human creativity and intuition.
+
+### Disadvantages: Speed, Reliability, and the "30% Rule in AI"
+
+Despite its power, agentic AI is not a silver bullet. Organizations must be aware of its limitations:
+*   **Reliability and Hallucinations:** Because agents often rely on probabilistic LLMs for reasoning, they can sometimes make mistakes, misinterpret instructions, or "hallucinate" incorrect information. This makes robust error handling and validation essential.
+*   **Debugging Complexity:** An autonomous system that makes its own decisions can be difficult to debug. When something goes wrong, tracing the agent's reasoning process requires strong observability and logging.
+*   **The "30% Rule":** This informal rule highlights the last-mile problem in AI. While an agent might successfully handle 70% of cases autonomously, the remaining 30% often consist of complex edge cases that require more sophisticated logic or human intervention. Building systems that can gracefully handle these exceptions is a major engineering challenge, requiring robust strategies for [workflow error handling](https://kestra.io/docs/workflow-components/errors).
+
+## Kestra: The Orchestration Control Plane for Agentic AI
+
+To harness the power of agentic AI while mitigating its risks, a robust orchestration platform is essential. Kestra provides the ideal control plane for defining, managing, and monitoring agentic workflows.
+
+With Kestra, you can define the entire logic of an AI agent—its goals, tools, and decision-making processes—as a declarative YAML [flow](https://kestra.io/docs/concepts/flow). This approach brings the principles of Infrastructure as Code to AI, making agentic workflows versionable, auditable, and repeatable.
+
+```yaml
+id: ai-incident-responder
+namespace: company.team.secops
+
+tasks:
+  - id: analyze_alert
+    type: io.kestra.plugin.ai.completion.ChatCompletion
+    provider: OPENAI
+    prompt: "Analyze this security alert and determine its severity: {{ trigger.body }}"
+  
+  - id: decide_next_step
+    type: io.kestra.plugin.core.flow.Switch
+    value: "{{ outputs.analyze_alert.choices[0].message.content }}"
+    cases:
+      - if: "{{ value.contains('CRITICAL') }}"
+        tasks:
+          - id: page_on_call_engineer
+            type: io.kestra.plugin.notifications.pagerduty.PagerDutyAlert
+            # ... configuration ...
+      - if: "{{ value.contains('LOW') }}"
+        tasks:
+          - id: create_jira_ticket
+            type: io.kestra.plugin.jira.issues.Create
+            # ... configuration ...
+```
+
+Kestra's event-driven architecture, powered by a wide range of [triggers](https://kestra.io/docs/workflow-components/triggers), allows agents to react to real-time events from systems like Kafka, S3, or webhooks. Its extensive plugin library provides the tools agents need to interact with virtually any database, API, or platform. By combining a declarative interface with polyglot execution and built-in observability, Kestra provides the guardrails necessary to deploy [AI agents and copilots](https://kestra.io/blogs/release-1-0) confidently in production.
+
+## The Future of Agentic AI and Its Impact
+
+Agentic AI represents a significant step towards more capable and autonomous artificial intelligence. As the underlying models become more powerful and their reasoning abilities improve, agents will be able to tackle increasingly complex and ambiguous tasks. We will see them integrated more deeply into core business operations, not just as peripheral automation tools but as active participants in decision-making processes.
+
+However, the future is not one of complete replacement but of collaboration. The most effective systems will incorporate human-in-the-loop (HITL) workflows, where agents handle the bulk of the work but defer to human experts for final approval or for handling novel situations. The journey towards truly autonomous systems is just beginning, and the platforms that provide the best tools for orchestration, governance, and human-computer interaction will be the ones that lead the way.
+
+For more resources on building and managing advanced AI systems, explore our collection of [AI orchestration resources](https://kestra.io/resources/ai).

--- a/src/contents/resources/automate-data-pipeline/index.md
+++ b/src/contents/resources/automate-data-pipeline/index.md
@@ -1,0 +1,248 @@
+---
+title: "Automate Data Pipeline: Guide to Efficient Workflows"
+description: "Explore comprehensive strategies and tools to automate data pipeline processes. Learn to build reliable, efficient, and scalable data workflows with best practices and Kestra's declarative orchestration."
+metaTitle: "Automate Data Pipeline: Efficient Workflow Guide | Kestra"
+metaDescription: "Learn to automate data pipeline processes with proven strategies and tools. Build reliable, efficient data workflows today using Kestra's declarative approach."
+tag: data
+date: 2026-05-01
+faq:
+  - question: "What does it mean to automate data pipelines?"
+    answer: "Data pipeline automation involves setting up automated processes to move, transform, and load data between various systems and applications, often across diverse platforms. This ensures data flows efficiently and reliably without manual intervention."
+  - question: "Is ETL obsolete?"
+    answer: "No, ETL is not obsolete. While ELT (Extract, Load, Transform) has gained popularity, ETL remains crucial for scenarios requiring data transformation before loading, such as anonymizing sensitive data for compliance or handling specific legacy system integrations."
+  - question: "How to create an automated data pipeline?"
+    answer: "To create an automated data pipeline, first identify your automation needs and data sources. Next, select appropriate tools for ingestion, transformation, and orchestration. Implement CI/CD for continuous validation, then set up robust monitoring, debugging, and scaling mechanisms."
+  - question: "What are the main 3 stages in a data pipeline?"
+    answer: "The three main stages in a data pipeline are: 1. Data Ingestion/Collection: Gathering raw data from various sources. 2. Data Transformation/Processing: Cleaning, structuring, and enriching the data. 3. Data Loading/Storage: Delivering the processed data to its final destination, such as a data warehouse or lake."
+  - question: "Will ETL be replaced by AI?"
+    answer: "AI will not entirely replace ETL but will significantly transform it. AI enhances ETL by automating complex transformations, improving data quality, and optimizing processes. The core functions of extracting, transforming, and loading data will still be necessary, but AI will make them more intelligent and efficient."
+  - question: "How does automation apply to CI/CD pipelines?"
+    answer: "In CI/CD, automation streamlines the software delivery process, moving code changes through compilation, unit testing, integration testing, and deployment. This enables rapid iteration, continuous feedback, and consistent deployments, reducing manual errors and accelerating time to market."
+---
+
+In today's data-driven landscape, the efficiency and reliability of data pipelines are paramount. Manual data processes, from ingestion to transformation and loading, are prone to errors, delays, and resource drain, hindering an organization's ability to derive timely insights. Automating these pipelines is no longer a luxury but a necessity for scaling data operations and maintaining data quality.
+
+This guide delves into the core concepts of data pipeline automation, exploring its benefits, best practices, and the tools that make it possible. We’ll cover the essential stages of a data pipeline, the critical role of automated testing, and how modern approaches are reshaping traditional ETL. Discover how a declarative [orchestration platform](/) like Kestra can unify and simplify your automation efforts, enabling you to build robust and efficient data workflows.
+
+## What is data pipeline automation?
+
+Data pipeline automation is the process of setting up and managing the movement, transformation, and processing of data between systems with minimal human intervention. It involves using software and tools to define, schedule, and execute a series of data-related tasks in a repeatable and reliable manner.
+
+### What does it mean to automate data pipelines?
+
+To automate a data pipeline means to create a system where data flows seamlessly from its source to its destination. This automation can be triggered by a schedule (e.g., every hour), an event (e.g., a new file arriving in a storage bucket), or an API call. The goal is to replace manual, error-prone steps—like running scripts, copying files, or monitoring jobs—with a resilient, self-operating workflow. An automated pipeline handles data ingestion, cleaning, validation, transformation, and loading into a target system such as a data warehouse, data lake, or analytics application.
+
+### Key components of an automated data pipeline
+
+A robust automated data pipeline consists of several interconnected components working in concert:
+
+*   **Orchestration Engine:** The core of the system, responsible for scheduling, executing, and monitoring the entire workflow. It manages dependencies between [tasks](/docs/workflow-components/tasks) and handles error recovery.
+*   **Data Sources:** The origin points of your data, which can include databases, APIs, streaming platforms, or file systems.
+*   **Connectors/Integrations:** Plugins or modules that facilitate data extraction from sources and loading into destinations without requiring custom code.
+*   **Transformation Logic:** The code or configuration that cleans, enriches, aggregates, and prepares the data for analysis. This can be SQL, Python scripts, or dedicated transformation tools.
+*   **Data Destination:** The final storage location for the processed data, such as a data warehouse (Snowflake, BigQuery), a data lake, or a BI tool.
+*   **Monitoring and Alerting:** Mechanisms to track the health of the pipeline, log performance metrics, and notify teams of failures or anomalies.
+*   **Version Control:** Integrating the pipeline definition with a system like Git to track changes, collaborate, and enable CI/CD practices.
+
+These components come together to form a complete [flow](/docs/concepts/flow) that reliably delivers data for business use.
+
+## Why is data pipeline automation important?
+
+Automating data pipelines is critical for any organization that relies on data to make decisions. Manual processes are not just slow; they are a significant source of operational risk. Automation addresses these challenges directly, transforming data management from a reactive, labor-intensive task into a strategic, efficient process. Leading companies like Toyota have used automation to replace fragmented data and AI pipelines with a unified orchestration layer, accelerating innovation.
+
+### Six benefits of data pipeline automation
+
+1.  **Increased Efficiency:** Automation eliminates manual handoffs and repetitive tasks, allowing data teams to focus on higher-value activities like data analysis and modeling.
+2.  **Improved Data Quality:** Automated validation and testing steps catch errors early, ensuring that data is accurate, consistent, and trustworthy.
+3.  **Faster Time-to-Insight:** Data is processed and delivered to stakeholders more quickly, enabling faster and more informed decision-making.
+4.  **Enhanced Scalability:** Automated pipelines can handle growing data volumes and complexity without a proportional increase in manual effort or resources.
+5.  **Greater Reliability:** With automated retries, error handling, and monitoring, pipelines become more resilient to transient failures, ensuring consistent data delivery.
+6.  **Better Governance and Compliance:** Automation provides a clear, auditable trail of how data is processed, making it easier to enforce security policies and meet regulatory requirements.
+
+### Increase efficiency and productivity
+
+By automating repetitive tasks, [data engineers](/use-cases/data-engineers) can significantly reduce the time spent on pipeline maintenance and troubleshooting. This frees them up to design new data products, optimize queries, and support data consumers. An orchestration platform centralizes the management of all data workflows, providing a single point of control and visibility, which further boosts team productivity.
+
+### Improve data quality and reliability
+
+Manual data handling is a primary cause of data quality issues. A forgotten step, a typo in a script, or an inconsistent process can corrupt data and erode trust in analytics. Automation enforces consistency. Every time the pipeline runs, it follows the exact same predefined steps. By incorporating automated data validation and quality checks, pipelines can proactively identify and quarantine bad data, preventing it from contaminating downstream systems. This leads to more reliable datasets and more confident decision-making across the business.
+
+## How to create an automated data pipeline?
+
+Building an automated data pipeline involves careful planning, tool selection, and adherence to best practices. The goal is to create a system that is not only automated but also maintainable, scalable, and resilient.
+
+### Planning your data pipeline architecture
+
+Before writing any code, map out your data flow. Identify your data sources, the transformations required, and the final destinations. Consider the volume, velocity, and variety of your data. Will you be processing data in batches or in real-time streams? What are the latency requirements? Answering these questions will help you design an architecture that meets your business needs and technical constraints. Documenting this plan ensures all stakeholders are aligned and provides a blueprint for development.
+
+### Choosing the right tools and technologies
+
+The right toolset is crucial for successful automation. A modern orchestration platform should be at the center of your stack, coordinating the various processes. When selecting a tool, consider the following:
+
+*   **Declarative Configuration:** Tools that use declarative configuration, like Kestra's YAML-based workflows, make pipelines easier to read, version, and manage as code.
+*   **Language Agnostic:** Your data ecosystem is likely polyglot. An orchestrator that can run Python, SQL, shell scripts, and Docker containers natively provides the flexibility to use the best tool for each job.
+*   **Extensive Integrations:** A rich ecosystem of [plugins](/plugins) for databases, storage systems, and applications accelerates development by eliminating the need to write custom integration code.
+*   **Scalability:** The platform should be able to scale with your data volume and the number of pipelines you manage.
+
+Kestra provides a powerful solution by combining a declarative interface with a language-agnostic execution engine, supported by hundreds of [blueprints](/blueprints) to get you started quickly.
+
+Here is an example of a simple, declarative data pipeline in Kestra that fetches data from an API, processes it with a Python script, and loads it into a database:
+
+```yaml
+id: api-to-database
+namespace: company.team.marketing
+description: Fetches user data from an API and loads it into PostgreSQL.
+
+tasks:
+  - id: fetch-users
+    type: io.kestra.plugin.core.http.Request
+    uri: https://api.example.com/users
+
+  - id: process-users
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      data.json: "{{ outputs['fetch-users'].body }}"
+    script: |
+      import json
+      import pandas as pd
+
+      with open('data.json', 'r') as f:
+          users = json.load(f)
+
+      df = pd.DataFrame(users)
+      df_clean = df[['id', 'name', 'email']].dropna()
+      df_clean.to_csv('users.csv', index=False)
+
+  - id: load-to-postgres
+    type: io.kestra.plugin.jdbc.postgresql.CopyIn
+    url: "{{ secrets.POSTGRES_URL }}"
+    table: users
+    from: "{{ outputs['process-users'].outputFiles['users.csv'] }}"
+    format: CSV
+    header: true
+```
+
+### Best practices for data pipeline automation
+
+Adhering to software engineering best practices is key to building robust data pipelines.
+
+*   **Version Control (GitOps):** Store your pipeline definitions in a Git repository. This enables collaboration, provides a history of changes, and allows for automated deployment through [CI/CD practices](/docs/version-control-cicd/git).
+*   **Modularity:** Break down complex pipelines into smaller, reusable components or subflows. This makes pipelines easier to understand, test, and maintain.
+*   **Idempotency:** Design your tasks so that running them multiple times with the same input produces the same result. This makes recovery from failures safer and more predictable.
+*   **Monitoring and Alerting:** Implement comprehensive monitoring to track pipeline health, performance, and data quality. Set up alerts to notify the team immediately when issues arise.
+*   **Error Handling:** Define clear error handling and retry logic within your pipelines. Decide what happens when a task fails—should it retry, trigger an alert, or kick off a rollback process?
+
+Following these [flow best practices](/docs/best-practices/flows) will help you build automated systems that are reliable and easy to manage.
+
+## Understanding the stages of a data pipeline
+
+Every data pipeline, regardless of its complexity, generally follows a sequence of stages to move data from source to destination. Understanding these stages is fundamental to designing effective automation.
+
+### What are the main 3 stages in a data pipeline?
+
+The three primary stages of a data pipeline are:
+
+1.  **Data Ingestion and Collection:** The process of acquiring raw data from various sources.
+2.  **Data Transformation and Processing:** The steps taken to clean, validate, enrich, and structure the data.
+3.  **Data Loading and Storage:** The final step of delivering the processed data to a target system.
+
+### Data ingestion and collection
+
+This initial stage involves connecting to data sources and extracting data. Sources can be incredibly diverse, including relational databases, NoSQL databases, SaaS application APIs, message queues like Kafka, and files in cloud storage like S3 or GCS. The goal is to move this raw data into a staging area where it can be processed. Tools like Airbyte or Fivetran, often orchestrated as part of a larger workflow, excel at this stage.
+
+### Data transformation and processing
+
+Once ingested, the raw data is rarely in a usable format. The transformation stage is where the heavy lifting happens. This can include:
+
+*   **Cleaning:** Handling missing values, correcting errors, and removing duplicates.
+*   **Enriching:** Combining data from multiple sources to add context.
+*   **Structuring:** Converting data from formats like JSON or XML into a tabular structure.
+*   **Aggregating:** Summarizing data to create metrics and KPIs.
+
+Tools like dbt (for SQL-based transformations) and Spark (for large-scale data processing) are commonly used here. An orchestration tool can seamlessly chain ingestion and transformation steps, for example, by running an [Airbyte sync followed by a dbt transformation](/blueprints/airbyte-sync-parallel-with-dbt).
+
+### Data loading and storage
+
+In the final stage, the transformed, analysis-ready data is loaded into its destination. This is typically a data warehouse like Snowflake, BigQuery, or Redshift, a data lakehouse, or a specialized analytics database. The loading strategy can be a full refresh or an incremental update (upsert), depending on the use case. The pipeline ensures this data is delivered reliably and on schedule, making it available for BI tools, machine learning models, and other applications.
+
+## Automated testing in data pipelines
+
+Automation isn't just about moving data; it's also about ensuring the data is correct. Automated testing is a non-negotiable component of a mature data pipeline, acting as a quality gate that prevents bad data from reaching consumers.
+
+### The essential role of automated tests in data pipelines
+
+Automated tests in data pipelines serve the same purpose as in software engineering: to verify that the system behaves as expected. For data pipelines, this means validating not just the code but the data itself. These tests run automatically as part of the pipeline, providing continuous feedback on data quality and integrity.
+
+### Why testing data pipelines is crucial
+
+Without testing, data pipelines are black boxes. Issues like schema changes in source systems, bugs in transformation logic, or upstream data quality problems can go undetected, silently corrupting your data. This leads to flawed analysis, incorrect business reports, and a loss of trust in the data team. Crucial business decisions at companies like JPMorgan Chase rely on analytics from pipelines that process billions of rows; automated testing is essential to ensure the reliability of such critical workflows.
+
+### Implementing automated tests with examples
+
+Testing can be implemented at various points in the pipeline:
+
+*   **Source Data Tests:** Check for freshness, volume anomalies, or schema drift in the source data before ingestion.
+*   **Transformation Tests:** Use tools like dbt tests to assert conditions on your transformed data models (e.g., a primary key column must be unique and not null).
+*   **End-to-End Reconciliation:** Compare record counts or aggregate values between the source and destination to ensure no data was lost.
+*   **Unit Tests for Flows:** With platforms like Kestra, you can even create [unit tests for your orchestration logic](/docs/enterprise/governance/unit-tests) to validate that your flow behaves correctly under different conditions before deploying to production.
+
+## Data pipeline automation vs. traditional ETL
+
+The landscape of data integration has evolved significantly. While traditional ETL (Extract, Transform, Load) processes are still relevant, modern approaches offer greater flexibility and performance for today's data challenges.
+
+### Is ETL obsolete?
+
+ETL is not obsolete, but its dominance has been challenged by ELT (Extract, Load, Transform). In the ELT pattern, raw data is loaded directly into the data warehouse, and transformations are performed in-place using the warehouse's powerful compute engine. This approach is well-suited for cloud data warehouses and allows for more flexibility, as the raw data is preserved. However, ETL remains the best choice for certain use cases, such as when sensitive data must be masked or anonymized *before* it lands in the warehouse for compliance reasons. The choice between [ETL and ELT](/blogs/2022-04-27-etl-vs-elt) depends on your specific architecture, tools, and requirements.
+
+### Will ETL be replaced by AI?
+
+AI will not replace ETL, but it will augment and enhance it. AI and machine learning models can be used to automate complex data quality checks, intelligently map schemas, and even generate transformation logic based on examples. This reduces the manual effort required to build and maintain pipelines. The fundamental process of moving and preparing data remains, but AI is making that process smarter, faster, and more efficient.
+
+### Modern approaches to data integration
+
+Modern data integration goes beyond simple batch ETL. Key trends include:
+
+*   **Streaming and Real-Time Processing:** Ingesting and processing data as it is generated, enabling real-time analytics and applications.
+*   **Change Data Capture (CDC):** Efficiently capturing row-level changes from source databases and streaming them to the destination.
+*   **Reverse ETL:** Syncing enriched data from the warehouse back into operational SaaS applications (like Salesforce or HubSpot).
+*   **Data Mesh:** A decentralized architectural approach where data is treated as a product, owned by domain-specific teams.
+
+A modern orchestration platform must be ableto support all these patterns, from batch jobs to event-driven workflows.
+
+## Tools and techniques for data pipeline automation
+
+The market for data pipeline tools is vast. They can be categorized into open-source solutions, cloud-native services, and orchestration platforms that tie everything together.
+
+### Open source tools for automation
+
+Open-source tools provide flexibility and prevent vendor lock-in. Popular choices include:
+
+*   **Apache Airflow:** A long-standing, code-based orchestrator with a massive ecosystem.
+*   **Dagster:** An asset-centric orchestrator focused on data lineage and developer productivity.
+*   **Kestra:** A declarative, language-agnostic orchestration platform that simplifies building complex workflows with YAML.
+
+When comparing tools like [Airflow vs. Kestra](/vs/airflow) or [Dagster vs. Kestra](/vs/dagster), consider factors like ease of use, scalability, and support for your specific technology stack.
+
+### Cloud provider solutions
+
+AWS, GCP, and Azure all offer managed services for building data pipelines, such as AWS Step Functions, Azure Data Factory, and Google Cloud Composer. These tools integrate tightly with their respective cloud ecosystems but can lead to vendor lock-in and may lack the flexibility to orchestrate processes across different clouds or on-premise systems.
+
+### Orchestration and scheduling
+
+Orchestration is the key to automating complex data pipelines. An orchestration platform is responsible for triggering workflows, managing dependencies between tasks, handling retries, and providing observability. While simple cron jobs can schedule individual scripts, a true orchestrator manages the entire end-to-end process. Kestra excels here by providing a single control plane to automate not just [data workflows](/data), but also [infrastructure automation](/infra-automation) and [AI pipelines](/ai-automation), creating a unified automation strategy across the organization.
+
+## Why Kestra is ideal for data pipeline automation
+
+Kestra is designed from the ground up to address the challenges of modern data pipeline automation. Its unique architecture and feature set make it a powerful choice for teams looking to build reliable, scalable, and maintainable workflows.
+
+*   **Declarative YAML Interface:** Workflows are defined in simple, human-readable YAML. This makes pipelines easy to understand, version control, and manage as code, aligning with GitOps best practices.
+*   **Language-Agnostic:** Kestra is not tied to a single language. It can run tasks written in Python, R, Julia, SQL, Node.js, and shell scripts as first-class citizens, allowing your team to use the best tool for every job.
+*   **Unified Platform:** Kestra is one of the few platforms that can orchestrate data, AI, and infrastructure workflows from a single control plane. This breaks down silos between teams and creates a cohesive automation strategy.
+*   **Extensive Plugin Ecosystem:** With over 1,200 plugins, Kestra offers out-of-the-box integrations for a vast array of databases, storage systems, and applications, dramatically reducing development time.
+*   **Built for Scale and Resilience:** The enterprise edition offers high availability, multi-tenancy, RBAC, and audit logs, providing the governance and reliability needed for mission-critical pipelines.
+
+By combining these capabilities, Kestra empowers [data teams](/features) to build sophisticated automated pipelines with less complexity and more confidence.
+
+Automating data pipelines is essential for any modern data-driven organization. It increases efficiency, improves data quality, and accelerates time-to-insight. By following a structured approach—planning your architecture, choosing the right tools, and implementing best practices like automated testing and version control—you can build robust and scalable data workflows. A declarative, polyglot orchestration platform like Kestra provides the ideal foundation, unifying all your data, AI, and infrastructure processes into a single, manageable control plane.
+
+Ready to build more reliable data pipelines? Explore how Kestra can [automate your data workflows](/data) today.

--- a/src/contents/resources/disaster-recovery/index.md
+++ b/src/contents/resources/disaster-recovery/index.md
@@ -1,0 +1,144 @@
+---
+title: "What is Disaster Recovery? Plan for Business Continuity"
+description: "Understand what disaster recovery is and how it protects your IT infrastructure. Learn to plan for business continuity and minimize disruptions."
+metaTitle: "What is Disaster Recovery? Plan for Business Continuity"
+metaDescription: "Explore IT disaster recovery, its types, and lifecycle. Learn to build, test, and automate your disaster recovery plan for business continuity with modern orchestration."
+tag: infrastructure
+date: 2026-05-01
+faq:
+  - question: "What is IT disaster recovery?"
+    answer: "IT disaster recovery (DR) is an organization's plan to restore access and functionality to critical IT infrastructure and data after a disruptive event. This includes natural disasters, cyberattacks, equipment failures, or human error, aiming to minimize downtime and ensure business continuity."
+  - question: "What are the common types of disaster recovery strategies?"
+    answer: "Common disaster recovery types include data center DR, focusing on dedicated recovery sites; network DR for communication infrastructure; virtualized DR for virtual machines; cloud DR leveraging cloud resources; and Disaster Recovery as a Service (DRaaS), where a third-party manages DR for you."
+  - question: "What are the key stages in the disaster recovery lifecycle?"
+    answer: "The disaster recovery lifecycle typically involves four stages: Preparation (planning and readiness), Response (immediate actions during a disaster), Recovery (restoring systems and data), and Mitigation (reducing future risks). Effective DR planning addresses each stage comprehensively."
+  - question: "What are the 'Four Cs' of effective disaster recovery planning?"
+    answer: "The 'Four Cs' of disaster recovery emphasize crucial aspects for successful partnerships and internal coordination: Communication (clear information flow), Cooperation (teams working together), Coordination (synchronized efforts), and Collaboration (shared goals and responsibilities). These ensure a unified response."
+  - question: "What is the difference between disaster recovery and business continuity?"
+    answer: "Disaster recovery (DR) focuses specifically on restoring IT systems and data after a disruption. Business continuity (BC), on the other hand, is a broader strategy that ensures an organization's critical business functions continue during and after a disaster, encompassing people, processes, and IT."
+  - question: "How does orchestration improve disaster recovery?"
+    answer: "Orchestration platforms automate complex DR processes, from failover to data restoration and system re-provisioning. By defining DR steps as code, organizations can ensure consistent, repeatable, and faster recovery, reducing manual errors and human intervention during critical events."
+---
+
+In today's interconnected digital landscape, the unexpected is inevitable. From natural disasters to cyberattacks, or even simple human error, a disruptive event can cripple IT infrastructure and bring business operations to a halt. The ability to swiftly recover from such incidents isn't just a best practice—it's a critical imperative for maintaining trust, ensuring compliance, and safeguarding revenue.
+
+This article delves into the world of IT disaster recovery (DR), explaining what it is, its various forms, and why a robust DR plan is non-negotiable for modern enterprises. We'll explore the lifecycle of disaster recovery and highlight how advanced orchestration platforms like Kestra can transform your DR strategy from a reactive scramble into a proactive, automated, and highly resilient system.
+
+## What is disaster recovery?
+
+Disaster recovery is a strategic approach to preparing for and recovering from disruptive events that threaten an organization's IT infrastructure. It encompasses the policies, tools, and procedures required to restore critical systems and data, ensuring business operations can resume as quickly as possible.
+
+### Defining IT disaster recovery
+
+In an IT context, disaster recovery (DR) is the process of reestablishing vital infrastructure and systems following a disruptive event. These events can range from natural disasters like floods and earthquakes to technical failures, human-induced errors, or malicious cyberattacks. The primary goal of any [disaster recovery use case](https://kestra.io/use-cases/disaster-recovery) is to minimize downtime and data loss.
+
+Two key metrics define the effectiveness of a DR plan:
+*   **Recovery Time Objective (RTO):** The maximum acceptable amount of time that an application, system, or business process can be down after a failure or disaster occurs.
+*   **Recovery Point Objective (RPO):** The maximum acceptable amount of data loss measured in time. It defines the point in time to which data must be recoverable. For example, an RPO of one hour means that data must be restored to a state that is no more than one hour old.
+
+### Key components of a disaster recovery plan
+
+A comprehensive disaster recovery plan is not a single document but a collection of resources and procedures. Key components include:
+*   **Risk Assessment:** Identifying potential threats to your IT infrastructure.
+*   **Business Impact Analysis (BIA):** Determining the criticality of each system and the potential impact of its failure on business operations.
+*   **Data Backup and Restoration:** Establishing clear procedures for backing up data and restoring it at a secondary site. The [Kestra Administrator Guide provides details on backup and restore procedures](https://kestra.io/docs/administrator-guide/backup-and-restore).
+*   **Network Recovery:** Planning for the restoration of network connectivity and services.
+*   **Application Recovery:** Documenting the steps to bring critical applications back online.
+*   **Security Considerations:** Ensuring the recovery process maintains security standards and protects data.
+*   **Communication Plan:** Outlining how to communicate with employees, customers, and stakeholders during a disaster.
+*   **Documentation:** Keeping all DR procedures, contact lists, and system configurations up-to-date and accessible.
+*   **Regular Testing:** Periodically testing the DR plan to ensure it works as expected and to identify areas for improvement.
+
+## Types of disaster recovery
+
+Disaster recovery is not a one-size-fits-all solution. The right approach depends on an organization's specific needs, budget, and risk tolerance.
+
+### Common disaster recovery strategies
+
+Several models have emerged to address different recovery needs:
+*   **Data Center Disaster Recovery:** This involves having a secondary data center to failover to. These sites are categorized as:
+    *   **Cold Site:** A basic facility with power and cooling, but no equipment. It's the most affordable but has the longest recovery time.
+    *   **Warm Site:** Contains network connectivity and some hardware, but requires configuration and data restoration.
+    *   **Hot Site:** A fully operational duplicate of the primary data center, offering the fastest recovery but at the highest cost.
+*   **Network Disaster Recovery:** Focuses on restoring network infrastructure, including routers, switches, and communication lines.
+*   **Virtualized Disaster Recovery:** Uses virtual machines (VMs) that can be easily replicated and restored on different hardware, significantly speeding up recovery.
+*   **Cloud Disaster Recovery:** Leverages cloud infrastructure (IaaS, PaaS) to host a recovery environment, offering scalability and pay-as-you-go pricing.
+*   **Disaster Recovery as a Service (DRaaS):** A third-party service that manages and hosts an organization's DR environment, simplifying the process and often reducing costs.
+
+### On-premise vs. cloud disaster recovery
+
+Choosing between on-premise and cloud-based DR involves a trade-off between control and cost.
+*   **On-premise DR** offers complete control over the recovery environment and can be tailored to specific security and compliance needs. However, it requires significant capital investment in hardware and facilities, plus ongoing maintenance costs.
+*   **Cloud DR** provides greater flexibility, scalability, and often lower upfront costs. It allows organizations to pay only for the resources they use and can scale capacity on demand. The main trade-offs are less direct control and potential data transfer costs.
+
+Many organizations now opt for a hybrid model, combining on-premise resources for critical systems with cloud-based recovery for less sensitive applications.
+
+## The disaster recovery lifecycle
+
+Effective disaster recovery is a continuous process, not a one-time project. It follows a lifecycle that ensures readiness and constant improvement.
+
+### The four stages of disaster recovery
+
+1.  **Preparation:** This proactive phase involves creating the DR plan, conducting risk assessments, training staff, and setting up the recovery infrastructure.
+2.  **Response:** When a disaster strikes, this phase involves activating the DR plan, assessing the damage, and taking immediate steps to contain the incident and protect critical assets.
+3.  **Recovery:** The focus shifts to restoring systems and data at the recovery site. This includes bringing hardware online, restoring data from backups, and verifying that applications are functional.
+4.  **Mitigation:** After recovery, a post-incident review is conducted to identify lessons learned. The DR plan is updated to address any weaknesses and reduce the risk of future incidents.
+
+### The "Four Cs" of effective DR planning
+
+Successful disaster recovery relies on a coordinated effort. The "Four Cs" provide a framework for this alignment:
+*   **Communication:** Ensuring a clear and consistent flow of information among all stakeholders.
+*   **Cooperation:** Fostering a willingness among teams and departments to work together toward a common goal.
+*   **Coordination:** Synchronizing the efforts of different teams to avoid conflicts and ensure an efficient recovery process.
+*   **Collaboration:** Working closely with internal teams, external partners, and vendors to achieve shared recovery objectives.
+
+## Why disaster recovery is essential for business continuity
+
+A robust DR plan is a cornerstone of business continuity, ensuring that an organization can withstand disruptions and continue to operate.
+
+### Preventing data loss and system downtime
+
+Downtime can have severe consequences, including direct financial losses from lost revenue, reputational damage that erodes customer trust, and potential legal or compliance penalties. A well-executed DR plan minimizes these impacts by restoring services quickly and ensuring data integrity. Effective [infrastructure monitoring](https://kestra.io/use-cases/monitoring) is a key part of this, providing early warnings of potential issues.
+
+### Ensuring operational resilience
+
+Operational resilience is the ability of an organization to adapt to and recover from disruptions. Disaster recovery is a critical component of this resilience, providing a structured approach to restoring IT services. For [platform engineers](https://kestra.io/use-cases/platform-engineers), a strong DR strategy means they can provide a stable and reliable platform for the business, even in the face of unforeseen events.
+
+## Orchestrating disaster recovery with Kestra
+
+Modern disaster recovery requires speed, reliability, and precision—all areas where manual processes fall short. Orchestration platforms like Kestra transform DR by automating complex recovery workflows, reducing human error, and dramatically shortening recovery times. By defining DR as code, organizations can manage, test, and execute their recovery plans with the same rigor as their production software.
+
+Here’s how Kestra enables a more robust DR strategy:
+*   **Declarative Workflows:** DR plans are defined in simple, human-readable YAML files. This makes them easy to version control, review, and audit. You can manage your DR plan using [GitOps principles](https://kestra.io/docs/version-control-cicd/git), ensuring a single source of truth.
+*   **Automated Remediation:** Kestra can automatically trigger recovery workflows in response to alerts from monitoring systems. For example, JPMorgan Chase uses Kestra for automated remediation in its cybersecurity analytics workflows, a principle directly applicable to incident response.
+*   **Polyglot Execution:** DR often involves a mix of technologies. Kestra can orchestrate any tool or script needed for recovery, whether it's running a Python script to validate data, applying a [Terraform configuration](https://kestra.io/docs/terraform) to provision new infrastructure, or executing a shell command to restart a service.
+*   **Automated Testing:** The best DR plan is one that is regularly tested. Kestra allows you to schedule automated DR drills and even use [built-in unit tests](https://kestra.io/docs/enterprise/governance/unit-tests) to validate your recovery flows, ensuring they will work when you need them most.
+*   **Multi-Cloud and Hybrid Automation:** Kestra operates across any environment, making it ideal for automating failover and recovery in complex multi-cloud or hybrid setups. This is crucial for building a truly [high-availability system](https://kestra.io/docs/administrator-guide/high-availability).
+
+```yaml
+id: database-failover-drill
+namespace: company.ops.dr
+description: A scheduled weekly drill to test database backup and failover infrastructure provisioning.
+
+tasks:
+  - id: backup_primary_db
+    type: io.kestra.plugin.scripts.shell.Commands
+    commands:
+      # In production, use a dedicated backup tool or a specific plugin
+      - pg_dump -U user -h primary.db.host -Fc -f /tmp/backup.dump dbname
+
+  - id: upload_backup_to_dr_site
+    type: io.kestra.plugin.aws.s3.Upload
+    from: "/tmp/backup.dump"
+    key: "backups/db/{{ now() | date('yyyy-MM-dd') }}/backup.dump"
+    bucket: "dr-site-bucket"
+
+  - id: provision_standby_server
+    type: io.kestra.plugin.terraform.cli.TerraformCLI
+    commands:
+      - terraform init
+      - terraform apply -auto-approve
+    workingDir: "/app/terraform/standby-server"
+```
+
+By leveraging a powerful orchestration platform, organizations like Crédit Agricole have successfully scaled their secure infrastructure, and companies like BHP have drastically reduced provisioning times—a key factor in rapid recovery. Kestra provides the control plane for a modern [infrastructure automation strategy](https://kestra.io/infra-automation), turning disaster recovery from a manual, error-prone process into a reliable, automated, and governed system. Explore our [infrastructure automation resources](https://kestra.io/resources/infrastructure) to learn more.

--- a/src/contents/resources/it-automation-platform/index.md
+++ b/src/contents/resources/it-automation-platform/index.md
@@ -1,0 +1,218 @@
+---
+title: "Best IT Automation Platform: Ranked & Reviewed"
+description: "Explore the leading IT automation platforms to streamline operations, boost productivity, and drive AI transformation. Find the best fit for your enterprise."
+metaTitle: "Best IT Automation Platform: Ranked & Reviewed"
+metaDescription: "Explore leading IT automation platforms. Streamline operations, boost productivity, and drive AI transformation. Find the best fit today!"
+tag: infrastructure
+date: 2026-05-15
+faq:
+  - question: "What is an IT automation platform?"
+    answer: "An IT automation platform is a software solution designed to automate repetitive and complex tasks across an organization's IT infrastructure and operations. This includes provisioning, configuration management, incident response, and workflow orchestration, reducing manual effort and improving efficiency."
+  - question: "What are some examples of IT automation platforms?"
+    answer: "Key IT automation platforms include Kestra for universal declarative orchestration, UiPath for robotic process automation (RPA) and AI, n8n for visual app integration, and Ansible Automation Platform for configuration management. Each offers distinct strengths for different automation needs."
+  - question: "What is an example of IT automation in practice?"
+    answer: "A common example of IT automation is automated incident response. When a monitoring system detects an anomaly (trigger), an automation platform can automatically create a ticket, notify the relevant team, collect diagnostic data, and even initiate remediation steps, all without human intervention."
+  - question: "What's the best IT automation platform?"
+    answer: "The 'best' IT automation platform depends on your specific needs. For universal, declarative orchestration across data, AI, and infrastructure, Kestra stands out. Other top platforms excel in niche areas, such as UiPath for RPA, n8n for visual integrations, or Ansible for configuration management."
+  - question: "Will AI replace human testers or existing automation tools like Selenium?"
+    answer: "AI is not expected to fully replace human testers or existing automation tools like Selenium. Instead, AI enhances these capabilities by providing smarter test generation, self-healing locators, and intelligent maintenance. AI acts as an accelerator and enhancer, allowing human teams to focus on more complex, strategic tasks."
+  - question: "How does Kestra compare to legacy IT automation solutions like Control-M or IBM Workload Automation?"
+    answer: "Kestra offers a modern, developer-centric, and declarative approach compared to legacy platforms like Control-M or IBM Workload Automation. While legacy systems excel in traditional batch scheduling, Kestra provides event-driven, polyglot execution across cloud-native and hybrid environments, with GitOps-native version control and a lower operational footprint."
+---
+
+The promise of streamlined IT operations often collides with the reality of fragmented tools and manual handoffs. As infrastructure grows more complex and AI transforms the enterprise, the need for a unified approach to IT automation has never been greater. Teams are grappling with managing everything from cloud provisioning and configuration management to data pipelines and AI agent orchestration, often with a patchwork of disparate systems.
+
+This article cuts through the noise, reviewing the leading IT automation platforms available today. We'll explore their core capabilities, how they integrate with your existing stack, and their readiness for the AI era. You'll gain a clear understanding of what to look for, helping you choose the best platform to consolidate your automation efforts and drive efficiency across your organization.
+
+## What is an IT Automation Platform?
+
+An IT automation platform is a centralized system designed to execute, manage, and orchestrate tasks and workflows across an organization's entire technology stack. It replaces manual, repetitive processes with automated sequences that are more reliable, faster, and less prone to human error.
+
+### Defining IT Automation
+
+At its core, IT automation is the practice of using software to perform tasks that would otherwise require a human operator. This goes beyond simple scripting. A true automation platform provides a framework for defining complex logic, integrating with diverse systems, and managing the full lifecycle of automated processes. The primary goal is to increase operational efficiency, improve system reliability, and free up skilled engineering teams to focus on strategic initiatives rather than routine maintenance.
+
+### Key Components of a Modern Automation Platform
+
+While implementations vary, modern IT automation platforms share several key architectural components:
+
+*   **Orchestration Engine:** The brain of the platform, responsible for scheduling, executing, and monitoring workflows. It manages state, handles errors, and ensures tasks run in the correct sequence.
+*   **Workflow Definition Layer:** The interface for defining automation logic. Modern platforms favor declarative approaches, such as YAML or HCL, which allow workflows to be version-controlled, reviewed, and managed like any other piece of code (GitOps).
+*   **Triggers and Event Listeners:** These components enable event-driven automation, allowing workflows to react in real-time to system events, API calls, or messages from other services, rather than relying solely on fixed schedules.
+*   **Plugin and Connector Ecosystem:** A library of pre-built integrations that allow the platform to communicate with a wide range of systems, from databases and cloud services to SaaS applications and legacy infrastructure.
+*   **Execution Engine:** The component that actually performs the work, whether it's running a script, executing a container, calling an API, or running a SQL query. Flexible platforms support polyglot execution across different languages and environments.
+*   **Observability and Monitoring:** A user interface and API for tracking the status of workflows, inspecting logs, and monitoring performance metrics. This is critical for debugging and ensuring reliability.
+
+### Real-World Examples of IT Automation in Practice
+
+IT automation isn't just a theoretical concept; it solves concrete business problems every day. Here are a few examples:
+
+*   **Automated Incident Response:** When a monitoring tool like Prometheus detects a CPU spike, it can trigger a workflow. The platform automatically creates a Jira ticket, sends a notification to the on-call team in Slack, pulls diagnostic logs from the affected server, and presents all the information in one place.
+*   **Cloud Resource Provisioning:** A developer can request a new testing environment via a self-service portal. An automation platform orchestrates the entire process: running a Terraform plan to provision the VMs, configuring them with Ansible, updating DNS records, and notifying the developer once the environment is ready. Leading companies like BHP have used this approach to reduce provisioning times from months to days.
+*   **New Employee Onboarding:** When a new employee is added to an HR system, a workflow is triggered to create their accounts in Active Directory, Google Workspace, and Salesforce; assign them to the correct user groups; and ship a pre-configured laptop.
+
+These examples highlight how a central platform can coordinate actions across multiple, disparate systems to [automate infrastructure](https://kestra.io/docs/use-cases/infrastructure) and business processes, creating a cohesive [orchestration control plane](https://kestra.io/infra-automation).
+
+## Essential Capabilities of Leading IT Automation Tools
+
+The market for IT automation is crowded, but the top-tier platforms distinguish themselves through a common set of powerful capabilities. When evaluating solutions, look for these essential features that separate robust, scalable platforms from simple task runners.
+
+### Core Functionalities for IT Operations and Management
+
+A modern IT automation platform must provide more than just basic scheduling. Key functionalities include:
+
+*   **Declarative Configuration:** Workflows should be defined as code (typically YAML) and stored in a Git repository. This enables version control, peer reviews, and automated CI/CD pipelines for your automation logic, a practice detailed in our guide on how to [make GitOps, DNS, inventory, and compute behave like one system](https://kestra.io/blogs/infra-automation).
+*   **Event-Driven Architecture:** The ability to react to events in real-time is crucial. Look for platforms with native support for [triggers](https://kestra.io/docs/workflow-components/triggers) from webhooks, message queues (like Kafka or SQS), and database changes. This allows you to build responsive, event-driven systems.
+*   **Polyglot Task Execution:** Your teams use a variety of languages—Python, Go, PowerShell, Bash. A strong platform doesn't force them into a single language. It should be able to run any code, in any container, on any environment, without friction.
+*   **Scalability and High Availability:** The platform must be ableto handle thousands of concurrent workflow executions without performance degradation. This requires a distributed architecture that can be scaled horizontally and is resilient to component failures.
+*   **Observability and Auditing:** Detailed logs, execution history, and performance metrics are non-negotiable for troubleshooting and compliance. Enterprise-grade platforms also provide comprehensive audit logs to track every change and execution.
+
+### The Role of AI in IT Workflow Automation
+
+AI is transforming IT automation from a set of pre-defined rules into an intelligent, adaptive system. Leading platforms are integrating AI in several ways:
+
+*   **AI Copilots:** Natural language interfaces that allow users to describe a workflow in plain English, which the AI then translates into valid code or YAML. This dramatically lowers the barrier to entry and accelerates development.
+*   **Agentic Orchestration:** AI agents can now execute complex, multi-step tasks to achieve a specific goal. An automation platform provides the governance layer for these agents, allowing them to interact with tools (like web search or code execution) and memory in a secure, auditable way.
+*   **Intelligent Decision-Making:** AI models can be used within a workflow to analyze data and make decisions, such as routing an incident ticket to the most qualified engineer based on its content or predicting potential system failures based on telemetry data. Explore how to build [AI workflows in Kestra](https://kestra.io/docs/ai-tools/ai-workflows).
+
+### Seamless Integration with Existing Systems and Tools
+
+An automation platform is only as powerful as the systems it can connect to. A comprehensive and extensible integration library is essential. Look for a platform with a large ecosystem of [hundreds of plugins](https://kestra.io/plugins) covering:
+
+*   **Cloud Providers:** AWS, Google Cloud, Azure.
+*   **Infrastructure Tools:** Terraform, Ansible, Kubernetes, Docker.
+*   **Databases & Data Warehouses:** PostgreSQL, Snowflake, BigQuery, MySQL.
+*   **Messaging Systems:** Kafka, RabbitMQ, SQS, Google Pub/Sub.
+*   **ITSM & Collaboration:** ServiceNow, Jira, Slack, Microsoft Teams.
+*   **SaaS Applications:** Salesforce, HubSpot, Stripe.
+
+The platform should also have a well-documented API and an SDK to allow for the development of custom integrations, ensuring it can adapt to your unique technology stack.
+
+## Top IT Automation Platforms: A Comparative Review
+
+Choosing the right IT automation platform involves understanding the strengths and trade-offs of the leading contenders. Each platform has a different center of gravity, excelling in specific domains. Here’s a review of the top solutions.
+
+### Kestra: The Declarative Control Plane for Universal Orchestration
+
+[Kestra](https://kestra.io/) is an open-source, declarative orchestration platform designed to unify data, AI, and infrastructure workflows. Its core philosophy is that all orchestration logic should be defined as YAML, enabling a GitOps-native approach to automation.
+
+**Key Strengths:**
+
+*   **Universal and Polyglot:** Kestra is language-agnostic, capable of orchestrating tasks written in Python, Go, SQL, shell scripts, or any language that can be containerized. This makes it a true control plane that can serve diverse teams.
+*   **Declarative and Event-Driven:** By defining workflows in YAML, teams gain auditability, version control, and easier collaboration. Its architecture is built for [real-time, event-driven automation](https://kestra.io/blogs/2024-06-25-kestra-become-real-time).
+*   **Unified Platform:** Kestra bridges the gap between different domains. The same platform can orchestrate a Terraform deployment, run a dbt data transformation, and coordinate an AI agent workflow, eliminating tool sprawl.
+*   **Scalable and Enterprise-Ready:** Built on a robust JVM-based architecture, Kestra is designed for high-throughput workloads. The [Enterprise Edition](https://kestra.io/enterprise) adds features like RBAC, SSO, audit logs, and multi-tenancy for secure, governed automation at scale.
+
+Kestra is the right choice for organizations looking for a single, flexible platform to manage complex, cross-domain workflows with an engineering-first, code-adjacent approach. You can learn more about its philosophy in the [Why Kestra documentation](https://kestra.io/docs/why-kestra).
+
+### UiPath: RPA and AI-Driven Transformation for Business Processes
+
+UiPath is a leader in the Robotic Process Automation (RPA) space. Its strength lies in automating tasks that involve interacting with graphical user interfaces (GUIs), making it ideal for processes involving legacy systems or applications without APIs.
+
+**Key Strengths:**
+
+*   **Visual Workflow Builder:** UiPath offers a low-code, drag-and-drop interface that empowers business users and citizen developers to build automations.
+*   **AI Integration:** The platform heavily incorporates AI for tasks like document understanding, process mining, and building agentic automations for customer service and back-office operations.
+*   **Strong for Business Processes:** UiPath excels at automating repetitive, rule-based business tasks like data entry, invoice processing, and CRM updates.
+
+UiPath is best suited for large enterprises looking to automate manual business processes, especially those involving desktop applications and legacy systems.
+
+### n8n: Visual Workflow Automation for App Integration
+
+[n8n](https://kestra.io/vs/n8n) is an open-source platform that focuses on visual workflow automation, often described as a self-hostable alternative to Zapier. It excels at connecting various SaaS applications and APIs.
+
+**Key Strengths:**
+
+*   **Node-Based Visual Editor:** Users build workflows by connecting nodes in a visual interface, which is intuitive for both technical and non-technical users.
+*   **Large Connector Library:** n8n boasts a vast number of pre-built integrations, primarily for SaaS applications.
+*   **Self-Hosting and Extensibility:** Being open-source, n8n can be self-hosted for greater data control and can be extended with custom JavaScript code.
+
+n8n is a strong choice for teams focused on SaaS-to-SaaS integrations and internal tool-building, where a visual, low-code approach is preferred.
+
+### IBM IT Automation Solutions: Enterprise-Grade Orchestration
+
+IBM offers a broad portfolio of IT automation products, including IBM Workload Automation. These tools have a long history in enterprise IT and are known for their robustness in managing complex batch jobs and mainframe operations.
+
+**Key Strengths:**
+
+*   **Enterprise-Grade Reliability:** IBM's solutions are built for mission-critical workload automation in large, complex IT environments.
+*   **Hybrid Cloud Management:** The portfolio includes tools for managing infrastructure and applications across on-premises data centers and multiple clouds.
+*   **Deep Integration with IBM Ecosystem:** They offer seamless integration with other IBM products, from mainframes to Watson AI.
+
+IBM is a suitable choice for large enterprises with significant investment in the IBM ecosystem or those needing to manage legacy and mainframe workloads alongside modern applications. It represents a more traditional approach compared to [modern, declarative orchestration platforms](https://kestra.io/vs/broadcom).
+
+### Other Notable IT Automation Tools
+
+*   **[Ansible Automation Platform](https://kestra.io/vs/ansible-automation-platform):** Excels at configuration management and application deployment. It's often orchestrated by a platform like Kestra to fit into a larger end-to-end workflow.
+*   **[PagerDuty Process Automation (Rundeck)](https://kestra.io/vs/pagerduty):** A strong tool for creating runbooks and providing self-service access to operational tasks, particularly for incident response.
+*   **[Windmill](https://kestra.io/vs/windmill):** A developer-focused platform for turning scripts into internal tools and workflows. It's geared more towards individual developer scripts than large-scale, cross-domain orchestration.
+*   **[Tines](https://kestra.io/vs/tines):** A no-code automation platform specifically designed for security and IT operations teams, with a focus on alert triage and incident response.
+
+## How to Choose the Right IT Automation Platform
+
+Selecting the right platform is a critical decision that will impact your team's productivity and your organization's ability to scale. The best choice depends on a careful evaluation of your specific needs, existing infrastructure, and long-term goals.
+
+### Aligning with Your Organizational Needs and Scale
+
+First, consider the primary users and use cases for the platform.
+
+*   **Who will build the automations?** If the primary users are platform engineers and developers, a code-centric, declarative platform like Kestra offers more power and fits naturally into their GitOps workflows. If the users are business analysts or ops teams, a visual, low-code platform like n8n or UiPath might be more appropriate.
+*   **What is the primary domain of automation?** If you need to orchestrate workflows that span infrastructure, data pipelines, and AI agents, a universal orchestrator is essential. If your focus is solely on configuration management, a specialized tool like Ansible might suffice.
+*   **What is your required scale?** Consider both the number of workflow executions and the complexity of the logic. Ensure the platform's architecture can handle your peak loads and that its pricing model aligns with your growth projections. You can compare the [Open-Source vs. Enterprise editions](https://kestra.io/docs/oss-vs-paid) of platforms like Kestra to find the right fit.
+
+### Evaluating Flexibility, Integration, and Governance
+
+Beyond the immediate use case, evaluate the platform's long-term viability and strategic fit.
+
+*   **Deployment Model:** Do you require an on-premises, air-gapped deployment for security and compliance, or is a SaaS/cloud model preferred? Look for platforms that offer flexibility in deployment.
+*   **Avoiding Vendor Lock-In:** Open-source platforms with open standards provide a safeguard against vendor lock-in. A declarative YAML-based approach also ensures that your workflow logic is portable and not tied to a proprietary interface.
+*   **Total Cost of Ownership (TCO):** Look beyond the license fee. Consider the operational overhead of managing the platform, the cost of training, and the developer productivity gains. Transparent [pricing](https://kestra.io/pricing) and a clear path from development to production are key.
+*   **Governance and Security:** As automation scales, governance becomes critical. Ensure the platform provides robust features like Role-Based Access Control (RBAC), audit trails, secrets management, and multi-tenancy to securely manage automation across different teams and environments.
+
+## Best Practices for Implementing IT Automation
+
+Successfully implementing an IT automation platform is as much about strategy and process as it is about technology. Adopting best practices can mean the difference between a successful rollout and a stalled initiative.
+
+### Strategic Adoption and Phased Rollouts
+
+Avoid a "big bang" approach where you try to automate everything at once. Instead, follow a phased rollout:
+
+1.  **Start Small:** Identify a high-impact, low-risk process as your first use case. This could be a repetitive manual report generation or a simple incident notification workflow.
+2.  **Demonstrate Value:** A quick win builds momentum and secures buy-in from stakeholders. Use the success of the initial project to justify further investment.
+3.  **Establish a Center of Excellence (CoE):** Create a central team or set of standards to guide the adoption of automation across the organization. This ensures consistency, promotes reuse of components, and prevents the creation of new automation silos.
+4.  **Iterate and Expand:** Continuously identify new opportunities for automation, building on the foundation you've established. Adhere to [flow best practices](https://kestra.io/docs/best-practices/flows) to ensure your automations are reliable and maintainable as they grow.
+
+Properly [managing environments](https://kestra.io/docs/best-practices/manage-environments) from development to production is crucial for a smooth and reliable implementation.
+
+### Measuring Impact and ROI of IT Automation
+
+To justify and sustain your automation efforts, you need to measure their impact. Track key metrics that align with business objectives:
+
+*   **Efficiency Gains:** Measure the reduction in manual hours spent on tasks that are now automated. This is the most direct measure of ROI.
+*   **Improved Reliability:** Track the reduction in human errors, the decrease in Mean Time to Resolution (MTTR) for incidents, and the improvement in system uptime.
+*   **Increased Agility:** Measure the speed at which new services can be deployed or changes can be implemented. For example, track the time it takes to provision a new development environment.
+*   **Cost Savings:** Quantify cost reductions from optimized cloud resource usage (e.g., automatically shutting down idle environments) or reduced software license costs from consolidating tools.
+
+By tying your automation initiatives to these metrics, you can clearly communicate their value to the business and build a strong case for continued investment and [performance tuning](https://kestra.io/docs/performance/performance-tuning).
+
+## The Future of IT Automation: AI and Beyond
+
+The field of IT automation is rapidly evolving, driven by advancements in AI and a push towards more integrated, autonomous systems. The next generation of automation platforms is moving beyond simple task execution to become the central nervous system of the enterprise.
+
+### AI's Evolving Role in Enhancing Automation
+
+AI is no longer just a feature; it's becoming a core component of IT automation. We are moving towards a model where AI can not only assist in building workflows but also act as an autonomous agent within them. Platforms are now providing the guardrails for [AI agents](https://kestra.io/docs/ai-tools/ai-agents) to perform complex tasks, from diagnosing production issues to optimizing infrastructure costs, all within a governed and auditable framework. This shift is turning the automation platform into the essential control plane for the AI era.
+
+### The Human Element: AI as an Enhancer, Not a Replacer
+
+Despite the rise of autonomous systems, the human element remains critical. AI is not replacing IT professionals; it's augmenting their capabilities. By handling the repetitive and predictable tasks, automation frees up engineers to focus on strategic planning, complex problem-solving, and innovation. An [AI copilot](https://kestra.io/docs/ai-tools/ai-copilot) can help an engineer write a workflow in seconds, but the engineer's expertise is still needed to validate the logic and ensure it aligns with business goals.
+
+### Emerging Trends and Next-Generation Capabilities in IT Automation
+
+Looking ahead, several key trends are shaping the future of IT automation:
+
+*   **Hyperautomation:** The concept of automating everything that can be automated, connecting not just IT systems but also business processes in a seamless fabric.
+*   **Unified Control Planes:** Organizations are moving away from siloed automation tools towards a single, universal platform that can orchestrate workflows across all domains—data, AI, infrastructure, and business applications.
+*   **Agentic Orchestration:** The future is not just about automating pre-defined workflows but about orchestrating autonomous AI agents to achieve high-level goals. The automation platform provides the necessary governance, observability, and integration layer for these agents to operate safely and effectively.
+
+As enterprises continue their digital and AI transformations, the IT automation platform will become the critical infrastructure for agility, efficiency, and innovation. As we outlined in our [Series A announcement](https://kestra.io/blogs/kestra-series-a), the goal is to build the orchestration control plane for this new era.

--- a/src/contents/resources/workflow-management/index.md
+++ b/src/contents/resources/workflow-management/index.md
@@ -1,0 +1,181 @@
+---
+title: "What is Workflow Management? Guide & Benefits"
+description: "Understand workflow management: its core definition, essential components, and how to optimize processes for efficiency. Explore modern tools and best practices for automation."
+metaTitle: "Workflow Management: Guide, Benefits & Kestra Solutions"
+metaDescription: "Understand workflow management: its core definition, essential components, and how to optimize processes for efficiency. Explore modern tools and best practices for automation."
+tag: infrastructure
+date: 2024-05-15
+faq:
+  - question: "What is meant by workflow management?"
+    answer: "Workflow management refers to the systematic organization and automation of tasks, data, and resources required to complete a business process. It involves defining steps, dependencies, and rules to ensure efficient, consistent, and trackable execution of work, from simple approvals to complex data pipelines."
+  - question: "Is workflow management a skill?"
+    answer: "Workflow management is indeed a critical skill set. It encompasses the ability to identify, analyze, design, and optimize sequences of tasks. Essential skills include process mapping, analytical thinking, problem-solving, and often technical proficiency in automation tools to improve efficiency, reduce errors, and enhance overall productivity."
+  - question: "What is the best workflow management software?"
+    answer: "The 'best' workflow management software depends on specific needs. For declarative, language-agnostic orchestration across data, AI, and infrastructure, Kestra stands out. Other popular tools include Apache Airflow for Python-centric data pipelines, Prefect for dynamic Python workflows, and n8n for no-code SaaS automation. Evaluating features like scalability, ease of use, and integration capabilities is key."
+  - question: "What is a workflow management method?"
+    answer: "A workflow management method is a structured approach to organizing and optimizing the tasks necessary to achieve specific business objectives. This typically involves defining clear steps, assigning responsibilities, establishing rules for transitions, and utilizing technology to track progress, automate actions, and gain real-time visibility into the process lifecycle."
+  - question: "What are the four types of workflows?"
+    answer: "Workflows can generally be categorized into four types: sequential (tasks follow a linear path), parallel (tasks run concurrently), conditional (paths diverge based on conditions), and state-machine (processes with discrete states and transitions). Modern workflow management systems often combine these types to handle complex, real-world scenarios."
+---
+
+In today's complex operational environments, organizations often grapple with inefficient, manual, and opaque processes. Tasks get lost, hand-offs are unclear, and bottlenecks emerge, hindering productivity and innovation. Effective workflow management is the strategic approach to bring order and efficiency to these processes.
+
+This guide delves into workflow management, defining its core concepts, exploring its essential components, and outlining the significant benefits it offers. We will also cover the skills required, different types of workflows, and best practices for design and optimization, before evaluating modern software solutions, including [Kestra's](/) declarative approach to unifying diverse orchestration needs.
+
+## What is workflow management?
+
+Workflow management is the practice of identifying, organizing, automating, and optimizing a sequence of tasks to complete a specific business process. It provides a structured framework for moving data, tasks, and information between people and systems according to predefined rules.
+
+### Defining workflow management and its core concepts
+
+At its heart, workflow management answers the question: "Who does what, when, and in what order?" To understand it fully, let's break down the key terms:
+
+- **Workflow**: A workflow is a repeatable series of steps or tasks required to achieve a specific outcome. Each step can be manual or automated. In Kestra, this is called a [Flow](https://kestra.io/docs/concepts/flow), a fundamental unit that defines a set of tasks and their execution logic.
+- **Workflow Management**: This is the overarching discipline of coordinating and supervising workflows. It involves designing the process, executing it, monitoring its performance, and continuously improving it.
+- **Workflow Management System (WFMS)**: This is the software that enables workflow management. A WFMS provides the tools to model, run, and monitor workflows, acting as the engine that automates and orchestrates the process.
+
+It's important to distinguish workflow management from project management. Project management focuses on achieving a unique, time-bound goal with specific resources (e.g., launching a new product). Workflow management, in contrast, focuses on optimizing repeatable, ongoing business processes (e.g., daily data ingestion, monthly financial reporting, or continuous infrastructure deployment). The two often intersect, but their primary focus differs. A modern, [declarative approach](https://kestra.io/blogs/declarative-from-day-one) to workflow management allows teams to define these processes as code, making them versionable, auditable, and easier to maintain.
+
+## Key components of workflow management systems
+
+A robust Workflow Management System (WFMS) is more than just a task scheduler. It's a comprehensive platform designed to handle complex, mission-critical processes.
+
+### Essential features of modern WFMS
+
+Modern systems offer a suite of capabilities to manage the entire workflow lifecycle:
+
+- **Workflow Modeling/Design**: This is the interface for defining workflows. It can be a visual drag-and-drop editor, a code-based approach using languages like Python, or a declarative format like YAML. Declarative systems allow you to define the "what" (the desired state) and let the engine figure out the "how."
+- **Execution Engine**: The core of the WFMS, responsible for interpreting the workflow definition, scheduling tasks, managing dependencies, and executing the logic.
+- **Monitoring & Analytics**: A crucial component for observability. This includes a [user interface](https://kestra.io/docs/ui) with dashboards, real-time status tracking, detailed logs, and performance metrics. This visibility helps teams identify bottlenecks and troubleshoot failures quickly.
+- **Integration Capabilities**: No workflow exists in a vacuum. A modern WFMS must connect to a wide range of external systems, databases, and APIs. This is typically achieved through a rich ecosystem of [plugins](https://kestra.io/plugins) and connectors.
+- **Scalability**: The system must be able to handle growth in both the number of workflows and the volume of executions without performance degradation. This often involves distributed architecture and efficient resource management.
+- **Error Handling and Retries**: Workflows can fail. A good WFMS provides built-in mechanisms for retries, timeouts, and error-handling branches to build resilient processes.
+- **Version Control**: As workflows become more complex, treating them as code is essential. Integration with Git for [versioning and rollbacks](https://kestra.io/docs/concepts/revision) ensures that changes are auditable and reversible. You can explore a comprehensive list of these features in Kestra's [workflow components documentation](https://kestra.io/docs/workflow-components).
+
+## Benefits of implementing workflow management
+
+Adopting a systematic approach to workflow management delivers tangible benefits across the organization, from technical teams to business stakeholders.
+
+### Streamlining operations and maximizing efficiency
+
+By automating and standardizing processes, workflow management directly addresses operational inefficiencies. Key benefits include:
+
+- **Reduced Manual Errors**: Automation eliminates the risk of human error in repetitive tasks, leading to more consistent and reliable outcomes.
+- **Increased Speed and Throughput**: Automating task hand-offs and enabling parallel execution significantly reduces the time it takes to complete a process.
+- **Cost Savings**: By optimizing resource usage and reducing manual labor, organizations can lower operational costs. As shown in Kestra's [performance benchmarks](https://kestra.io/docs/performance/benchmark), a well-tuned system can handle massive workloads efficiently.
+- **Improved Resource Allocation**: With clear visibility into processes, managers can allocate resources more effectively, ensuring that people and systems are focused on high-value work.
+
+### Enhancing productivity and collaboration
+
+Workflow management brings clarity and structure, which fosters a more productive and collaborative environment.
+
+- **Better Visibility and Transparency**: Everyone involved can see the status of a workflow in real-time. This eliminates ambiguity about who is responsible for the next step and where bottlenecks are occurring.
+- **Enhanced Compliance and Auditability**: With every action logged and every workflow versioned, creating audit trails for compliance purposes becomes straightforward.
+- **Greater Agility**: Standardized, automated workflows make it easier to adapt to changing business requirements. New processes can be designed, tested, and deployed much faster. As seen in [customer stories](https://kestra.io/use-cases/stories/23-boosted-productivity-slashed-costs-and-accelerated-delivery), this can shorten deployment cycles from weeks to minutes.
+
+Explore more [use cases](https://kestra.io/use-cases) to see how different industries leverage these benefits.
+
+## Developing workflow management skills
+
+While software provides the tools, successful implementation relies on the right human skills.
+
+### Is workflow management a skill?
+
+Absolutely. Workflow management is a critical skill set that combines analytical, technical, and interpersonal abilities. It's the capacity to see a business process not as a series of disconnected actions, but as a holistic system that can be designed, measured, and improved.
+
+### Essential abilities for successful workflow management
+
+To excel in workflow management, individuals and teams need to cultivate several key abilities:
+
+- **Analytical Thinking**: The ability to break down a complex process into its constituent parts, identify dependencies, and spot inefficiencies.
+- **Process Mapping**: Visualizing and documenting workflows to create a clear blueprint for automation.
+- **Problem-Solving**: Identifying the root cause of bottlenecks or failures and designing effective solutions.
+- **Technical Proficiency**: Comfort with the tools of the trade, whether it's scripting in [Python](https://kestra.io/docs/how-to-guides/python) or [Shell](https://kestra.io/docs/scripts/shell), or mastering a declarative language like YAML.
+- **Communication**: Collaborating with stakeholders to understand requirements and explain the logic behind workflow designs.
+- **Change Management**: Guiding teams through the transition from manual processes to automated workflows.
+
+## Types of workflows and their applications
+
+Not all workflows are created equal. Understanding the fundamental patterns is key to designing effective automation.
+
+### Understanding common workflow patterns
+
+Workflows are built from basic patterns that can be combined to model complex logic. Modern orchestration platforms provide [flowable tasks](https://kestra.io/docs/workflow-components/tasks/flowable-tasks) to implement these patterns, often allowing you to create reusable [subflows](https://kestra.io/docs/workflow-components/subflows) for common sequences.
+
+### The four types of workflows: sequential, parallel, conditional, and state-machine
+
+1.  **Sequential Workflows**: This is the simplest pattern, where tasks are executed one after another in a predefined linear order.
+    *   **Application**: A classic ETL (Extract, Transform, Load) process where data must be extracted before it can be transformed, and transformed before it's loaded.
+    ```yaml
+    id: sequential_etl
+    tasks:
+      - id: extract
+        type: io.kestra.plugin.core.http.Request
+        # ...
+      - id: transform
+        type: io.kestra.plugin.scripts.python.Script
+        # ...
+      - id: load
+        type: io.kestra.plugin.jdbc.postgresql.Query
+        # ...
+    ```
+
+2.  **Parallel Workflows**: Multiple tasks or branches are executed concurrently. This is used to improve efficiency when tasks do not depend on each other.
+    *   **Application**: Processing multiple data files from an S3 bucket simultaneously, or running independent data quality checks on different tables at the same time.
+
+3.  **Conditional Workflows**: The path of the workflow changes based on specific conditions or data. This is often implemented with "if-then-else" logic.
+    *   **Application**: An approval workflow where a request is routed to a manager only if the amount exceeds a certain threshold. In data pipelines, this could mean running a cleanup task only if data quality metrics fall below a set standard.
+
+4.  **State-Machine Workflows**: These are more complex workflows that move between different "states" based on events or triggers. The process is not necessarily linear and can loop back or jump between states.
+    *   **Application**: An order fulfillment process that moves from "Pending" to "Processing" to "Shipped" or "Cancelled" states. A CI/CD pipeline is also a state-machine, moving through states like "Building," "Testing," and "Deploying."
+
+You can find many examples of these patterns in Kestra's [Blueprints](https://kestra.io/blueprints) library.
+
+## Best practices for workflow design and optimization
+
+Building robust and maintainable workflows requires a disciplined approach that extends beyond the initial design.
+
+### Designing, documenting, and optimizing task sequences
+
+Creating effective workflows starts with a solid foundation.
+
+- **Start Simple and Iterate**: Begin with the simplest version of the workflow and add complexity gradually. This makes it easier to test and debug.
+- **Involve Stakeholders**: Collaborate with the people who actually use the process to ensure the automated workflow meets their needs and accurately reflects business logic.
+- **Thorough Documentation**: Use descriptions and labels within your workflow definitions. This makes the workflow understandable to others and easier to maintain in the future.
+- **Leverage Version Control**: Treat your workflows as code. By using [Git for version control](https://kestra.io/docs/version-control-cicd/git), you gain a full history of changes, the ability to collaborate through pull requests, and a simple mechanism for [rollbacks](https://kestra.io/docs/concepts/revision).
+
+### Monitoring and adapting workflows for continuous improvement
+
+A workflow is never truly "done." Continuous oversight and refinement are key to long-term success.
+
+- **Implement Robust Error Handling**: Design your workflows to fail gracefully. Define what should happen on failure—send an alert, run a cleanup task, or retry automatically.
+- **Continuous Monitoring**: Regularly review performance metrics, execution logs, and dashboards to identify slow-running tasks or recurring issues. Effective [monitoring](https://kestra.io/docs/administrator-guide/monitoring) is crucial for proactive management.
+- **Performance Tuning**: Analyze workflow execution to find bottlenecks. This could involve optimizing queries, increasing resources, or refactoring logic to run more tasks in parallel.
+- **Security Considerations**: Store sensitive information like passwords and API keys in a secure secrets manager, not directly in your workflow definitions.
+
+Following these [flow best practices](https://kestra.io/docs/best-practices/flows) ensures that your automated processes remain efficient, reliable, and secure over time.
+
+## Popular workflow management software and tools
+
+The market for workflow management tools is diverse, with solutions tailored to different use cases, personas, and technical environments.
+
+### Evaluating top workflow management solutions
+
+When choosing a tool, it's helpful to consider its primary focus:
+
+- **Data-Specific Orchestrators**: Tools like [Apache Airflow](https://kestra.io/vs/airflow), [Prefect](https://kestra.io/vs/prefect), and Dagster are popular in the data engineering community. They are typically Python-centric and designed for orchestrating data pipelines and ETL/ELT processes.
+- **Infrastructure & CI/CD Tools**: Solutions like Argo Workflows are Kubernetes-native and excel at orchestrating containerized tasks, often for CI/CD and MLOps.
+- **SaaS & Business Process Automation**: Platforms like n8n and Zapier are designed for connecting SaaS applications and automating business-level tasks, often with a no-code or low-code visual interface.
+
+While many tools are powerful within their niche, this specialization can lead to fragmented automation stacks where data teams use one tool, infrastructure teams another, and business users yet another. You can explore a detailed [comparison of alternatives](https://kestra.io/vs) to understand the landscape better.
+
+### Kestra: A modern, declarative alternative for unified orchestration
+
+Kestra is designed to break down these silos by providing a single, unified platform for all types of workflows. Its core differentiators make it a compelling modern alternative:
+
+- **Declarative YAML Interface**: Workflows are defined in simple, human-readable YAML. This makes them easy to create, review, and manage, even for non-programmers.
+- **Language-Agnostic**: Kestra can run any code, anywhere. Whether your scripts are in Python, R, Shell, or Node.js, or your applications are in Docker containers, Kestra orchestrates them as first-class citizens.
+- **Unified Platform**: It's built to handle [data pipelines](https://kestra.io/data), [infrastructure automation](https://kestra.io/infra-automation), and [AI/ML workflows](https://kestra.io/ai-automation) with the same set of powerful primitives. This eliminates the need for multiple specialized tools, reducing complexity and operational overhead.
+- **Event-Driven and Scalable**: With a powerful event-driven architecture, Kestra can react to triggers from various systems in real-time, enabling sophisticated, responsive automation at scale.
+
+By embracing a declarative, language-agnostic approach, Kestra provides a flexible and powerful control plane to manage the full spectrum of an organization's automated processes.


### PR DESCRIPTION
Imports 5 new content pages to the resources hub from [vfanucci/kestra-seo](https://github.com/vfanucci/kestra-seo) drafts/2026-W18.

3 pages already present in main (agentic-orchestration, agentic-workflows, ai-agent) were excluded.

**tag: ai**
- /resources/agentic-ai

**tag: data**
- /resources/automate-data-pipeline

**tag: infrastructure**
- /resources/it-automation-platform
- /resources/disaster-recovery
- /resources/workflow-management

All pages follow the existing frontmatter schema and include FAQ sections for FAQPage JSON-LD auto-generation.
Frontmatter cleaned from source drafts: `slug`, `author`, `image` stripped, tags normalized to lowercase.

cc @MartinRst for review.