### PR TITLE
fix(resources): correct internal links in batch-vs-streaming-processing

### DIFF
--- a/src/contents/resources/batch-vs-streaming-processing/index.md
+++ b/src/contents/resources/batch-vs-streaming-processing/index.md
@@ -80,7 +80,7 @@ State is first-class: the processor often needs to maintain rolling aggregates, 
 
 - **Low latency**: results are available within milliseconds to seconds of the event occurring.
 - **Continuous insight**: dashboards, monitors, and reactive workflows get a live view of the system rather than periodic snapshots.
-- **Reactive workflows**: streaming enables use cases that are impossible with batch — fraud blocking, dynamic pricing, real-time recommendations, [event-driven orchestration](/resources/event-driven-orchestration) that kicks off downstream work the instant an event lands.
+- **Reactive workflows**: streaming enables use cases that are impossible with batch — fraud blocking, dynamic pricing, real-time recommendations, [event-driven orchestration](/resources/infrastructure/event-driven-orchestration) that kicks off downstream work the instant an event lands.
 
 ### Weaknesses
 
@@ -165,7 +165,7 @@ Hybrid is the default for any system that serves both analytical and operational
 - **ML training**: most training pipelines run on bounded historical data and do not benefit from streaming input.
 - **Historical backfills**: recomputing a year of aggregates is a batch job by definition, regardless of how the live pipeline is implemented.
 - **Regulatory exports**: formal deliverables to regulators on a fixed schedule.
-- **Classic ETL**: source-to-warehouse pipelines feeding BI tools that refresh hourly or daily — the core of most [data pipeline](/resources/data-pipeline) work.
+- **Classic ETL**: source-to-warehouse pipelines feeding BI tools that refresh hourly or daily — the core of most [data pipeline](/resources/data/data-pipeline) work.
 
 ### Streaming-first
 


### PR DESCRIPTION
## Summary
Fix two broken internal links (404) on the [batch-vs-streaming-processing](https://kestra.io/resources/data/batch-vs-streaming-processing) resource page.

- `/resources/event-driven-orchestration` → `/resources/infrastructure/event-driven-orchestration`
- `/resources/data-pipeline` → `/resources/data/data-pipeline`

## Test plan
- [ ] Verify the two links resolve correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)