### PR TITLE
build(deps): add commit-message prefix to npm dependabot section

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,10 @@ updates:
   # Maintain dependencies for NPM modules
   - package-ecosystem: "npm"
     directory: "/"
+    commit-message:
+      prefix: "build(deps)"
+      prefix-development: "build(deps)"
+      include: "scope"
     schedule:
       interval: "weekly"
       day: "wednesday"


### PR DESCRIPTION
## Summary

- Adds `commit-message` prefix to the npm Dependabot section to match the convention introduced across other Kestra repos
- All Dependabot npm PRs will now be prefixed with `build(deps):`