### PR TITLE
build(deps): remove include scope from dependabot commit-message config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,6 @@ updates:
     commit-message:
       prefix: "build(deps)"
       prefix-development: "build(deps)"
-      include: "scope"
     schedule:
       interval: "weekly"
       day: "wednesday"


### PR DESCRIPTION
## Summary

- Adds `commit-message` prefix to the npm Dependabot section to match the convention introduced across other Kestra repos
- All Dependabot npm PRs will now be prefixed with `build(deps):`