### PR TITLE
feat(topology): migrate to @kestra-io/topology package and fix theming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@cloudflare/workers-types": "^4.20260413.1",
         "@gtm-support/vue-gtm": "^3.2.0",
         "@iconify-json/mdi": "^1.2.3",
+        "@kestra-io/topology": "^0.0.2",
         "@kestra-io/ui-libs": "^0.0.299",
         "@popperjs/core": "^2.11.8",
         "@types/aos": "^3.0.7",
@@ -1456,6 +1457,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/@element-plus/icons-vue": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@element-plus/icons-vue/-/icons-vue-2.3.2.tgz",
+      "integrity": "sha512-OzIuTaIfC8QXEPmJvB4Y4kw34rSXdCJzxcD1kFStBvr8bK6X1zQAYDo0CNMjojnfTqRQCJ0I7prlErcoRiET2A==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
@@ -2003,6 +2014,34 @@
       "dependencies": {
         "@expressive-code/core": "^0.41.7"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@gtm-support/core": {
       "version": "3.0.1",
@@ -2588,15 +2627,15 @@
       }
     },
     "node_modules/@intlify/core-base": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.3.0.tgz",
-      "integrity": "sha512-NNX5jIwF4TJBe7RtSKDMOA6JD9mp2mRcBHAwt2X+Q8PvnZub0yj5YYXlFu2AcESdgQpEv/5Yx2uOCV/yh7YkZg==",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.4.2.tgz",
+      "integrity": "sha512-7fpuCcVmeLv2T9qHsARqGvh8xt+sV2fH+Q+gMHFwB/rPXzo85DpbJFKn7dBH1L5p0c2cSh2DW+2h/64EKrISmA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@intlify/devtools-types": "11.3.0",
-        "@intlify/message-compiler": "11.3.0",
-        "@intlify/shared": "11.3.0"
+        "@intlify/devtools-types": "11.4.2",
+        "@intlify/message-compiler": "11.4.2",
+        "@intlify/shared": "11.4.2"
       },
       "engines": {
         "node": ">= 16"
@@ -2606,14 +2645,14 @@
       }
     },
     "node_modules/@intlify/devtools-types": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.3.0.tgz",
-      "integrity": "sha512-G9CNL4WpANWVdUjubOIIS7/D2j/0j+1KJmhBJxHilWNKr9mmt3IjFV3Hq4JoBP23uOoC5ynxz/FHZ42M+YxfGw==",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.4.2.tgz",
+      "integrity": "sha512-3u8EN1kB6EMSi96KXs5k7a8y2X2g4+h3X6iwVZU47cP4n+mTuq//WMjG588BzSp/2XQ/dTXo2BLUXX+XS+PNfA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@intlify/core-base": "11.3.0",
-        "@intlify/shared": "11.3.0"
+        "@intlify/core-base": "11.4.2",
+        "@intlify/shared": "11.4.2"
       },
       "engines": {
         "node": ">= 16"
@@ -2623,13 +2662,13 @@
       }
     },
     "node_modules/@intlify/message-compiler": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.3.0.tgz",
-      "integrity": "sha512-RAJp3TMsqohg/Wa7bVF3cChRhecSYBLrTCQSj7j0UtWVFLP+6iEJoE2zb7GU5fp+fmG5kCbUdzhmlAUCWXiUJw==",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.4.2.tgz",
+      "integrity": "sha512-a6CDSGSMTGrg0BjD97x8TBYPf7qQMDlZipJ6UDfv/pd4OIym8TMlHu3MsH0bTNnRdAG2D6EFEykIgiQPqvtTkA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@intlify/shared": "11.3.0",
+        "@intlify/shared": "11.4.2",
         "source-map-js": "^1.0.2"
       },
       "engines": {
@@ -2640,9 +2679,9 @@
       }
     },
     "node_modules/@intlify/shared": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.3.0.tgz",
-      "integrity": "sha512-LC6P/uay7rXL5zZ5+5iRJfLs/iUN8apu9tm8YqQVmW3Uq3X4A0dOFUIDuAmB7gAC29wTHOS3EiN/IosNSz0eNQ==",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.4.2.tgz",
+      "integrity": "sha512-NzpHbguRCsOHDwxmlBa9qu/imc+/QWgsYUaK6FZeNC0wK8QfAbhqrktEp/haVzxU1aikH8IX4ytD+mfFEMi/9A==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -2707,6 +2746,70 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@kestra-io/design-system": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@kestra-io/design-system/-/design-system-0.1.4.tgz",
+      "integrity": "sha512-/RU9sBzP5f406zWjYAKMxSyGIzlrwLbZfYpBHXakB4DNdA2IrNOzZ2t/pRnWG0H6oG7sy5khN3EScRYhxuwROA==",
+      "peer": true,
+      "dependencies": {
+        "echarts": ">=5.4.0",
+        "element-plus": ">=2.13.5",
+        "humanize-duration": "^3.33.2",
+        "js-yaml": "^4.1.1",
+        "mermaid": "^11.14.0",
+        "moment": "^2.30.1",
+        "moment-timezone": "^0.5.48",
+        "remark-directive": "^4.0.0",
+        "remark-frontmatter": "^5.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "shiki": "^4.0.2",
+        "unified": ">=11.0.0",
+        "vue-echarts": ">=7.0.0",
+        "xss": "^1.0.15"
+      },
+      "peerDependencies": {
+        "@vueuse/core": ">=11.0.0",
+        "bootstrap": "^5.3.8",
+        "echarts": ">=5.4.0",
+        "element-plus": ">=2.13.5",
+        "moment": "^2.30.1",
+        "moment-timezone": "^0.5.48",
+        "vue": "^3.5.0",
+        "vue-i18n": "^11.3.0",
+        "vue-material-design-icons": "^5.3.1",
+        "vue-router": ">=4.0.0",
+        "yaml": "^2.8.2"
+      }
+    },
+    "node_modules/@kestra-io/topology": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@kestra-io/topology/-/topology-0.0.2.tgz",
+      "integrity": "sha512-ZfAArCeVdVKik1VKOZUctlblz8y8TC9HG7XQu1y7a/gL5XiAcHMng1iKMiQ7fE5XFhSniSIWa1n4clM5oNd8+A==",
+      "dependencies": {
+        "dagre": "^0.8.5",
+        "html-to-image": "^1.11.13",
+        "js-yaml": "^4",
+        "vue-material-design-icons": "^5.3.1",
+        "yaml": "^2"
+      },
+      "peerDependencies": {
+        "@kestra-io/design-system": "*",
+        "@vue-flow/background": "^1.3.2",
+        "@vue-flow/controls": "^1.1.2",
+        "@vue-flow/core": "^1.48.2",
+        "lodash": "^4",
+        "moment": "^2.30.1",
+        "moment-timezone": "^0.5.48",
+        "vue": "^3.5.0",
+        "vue-i18n": "^11.4.2"
+      },
+      "peerDependenciesMeta": {
+        "vue-i18n": {
+          "optional": true
+        }
       }
     },
     "node_modules/@kestra-io/ui-libs": {
@@ -5725,6 +5828,23 @@
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "license": "MIT"
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -6006,7 +6126,6 @@
       "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.2.tgz",
       "integrity": "sha512-h9t4ArDdniO9ekYHAD95t9AZcAbb19lEGK+26iAjUODOIJKmObDNBSe4+6ELQAA3vtYiFPPBtHh7+cQCKi3Dng==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@vue/compiler-sfc": "^3.5.22",
         "ast-kit": "^2.1.2",
@@ -6358,7 +6477,6 @@
       "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
       "integrity": "sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "pathe": "^2.0.3"
@@ -6375,7 +6493,6 @@
       "resolved": "https://registry.npmjs.org/ast-walker-scope/-/ast-walker-scope-0.8.3.tgz",
       "integrity": "sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@babel/parser": "^7.28.4",
         "ast-kit": "^2.1.3"
@@ -6504,6 +6621,13 @@
       "peerDependencies": {
         "astro": "^4.0.0 || ^5.0.0 || ^6.0.0"
       }
+    },
+    "node_modules/async-validator": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-4.2.5.tgz",
+      "integrity": "sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -7225,6 +7349,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/csso": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
@@ -7758,7 +7889,6 @@
       "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
       "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graphlib": "^2.1.8",
         "lodash": "^4.17.15"
@@ -8086,11 +8216,102 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/echarts": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
+      "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.328",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
       "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
       "license": "ISC"
+    },
+    "node_modules/element-plus": {
+      "version": "2.13.7",
+      "resolved": "https://registry.npmjs.org/element-plus/-/element-plus-2.13.7.tgz",
+      "integrity": "sha512-XdHATFZOyzVFL1DaHQ90IOJQSg9UnSAV+bhDW+YB5UoZ0Hxs50mwqjqfwXkuwpSag+VXXizVcErBR6Movo5daw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ctrl/tinycolor": "^4.2.0",
+        "@element-plus/icons-vue": "^2.3.2",
+        "@floating-ui/dom": "^1.0.1",
+        "@popperjs/core": "npm:@sxzz/popperjs-es@^2.11.7",
+        "@types/lodash": "^4.17.20",
+        "@types/lodash-es": "^4.17.12",
+        "@vueuse/core": "12.0.0",
+        "async-validator": "^4.2.5",
+        "dayjs": "^1.11.19",
+        "lodash": "^4.17.23",
+        "lodash-es": "^4.17.23",
+        "lodash-unified": "^1.0.3",
+        "memoize-one": "^6.0.0",
+        "normalize-wheel-es": "^1.2.0",
+        "vue-component-type-helpers": "^3.2.4"
+      },
+      "peerDependencies": {
+        "vue": "^3.3.0"
+      }
+    },
+    "node_modules/element-plus/node_modules/@types/web-bluetooth": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/element-plus/node_modules/@vueuse/core": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.0.0.tgz",
+      "integrity": "sha512-C12RukhXiJCbx4MGhjmd/gH52TjJsc3G0E0kQj/kb19H3Nt6n1CA4DRWuTdWWcaFRdlTe0npWDS942mvacvNBw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.20",
+        "@vueuse/metadata": "12.0.0",
+        "@vueuse/shared": "12.0.0",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/element-plus/node_modules/@vueuse/metadata": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.0.0.tgz",
+      "integrity": "sha512-Yzimd1D3sjxTDOlF05HekU5aSGdKjxhuhRFHA7gDWLn57PRbBIh+SF5NmjhJ0WRgF3my7T8LBucyxdFJjIfRJQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/element-plus/node_modules/@vueuse/shared": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.0.0.tgz",
+      "integrity": "sha512-3i6qtcq2PIio5i/vVYidkkcgvmTjCqrf26u+Fd4LhnbBmIT6FN8y6q/GJERp8lfcB9zVEfjdV0Br0443qZuJpw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
     },
     "node_modules/emojilib": {
       "version": "2.4.0",
@@ -8508,6 +8729,20 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fault": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -8617,6 +8852,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/fsevents": {
@@ -8756,7 +9000,6 @@
       "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
       "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.15"
       }
@@ -9773,6 +10016,18 @@
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
+    "node_modules/lodash-unified": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/lodash-unified/-/lodash-unified-1.0.3.tgz",
+      "integrity": "sha512-WK9qSozxXOD7ZJQlpSqOT+om2ZfcT4yO+03FuzAHD0wF6S0l0090LRPDx3vhTTLZ8cFKpBn+IOcVXK6qOcIlfQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/lodash-es": "*",
+        "lodash": "*",
+        "lodash-es": "*"
+      }
+    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -9818,7 +10073,6 @@
       "resolved": "https://registry.npmjs.org/magic-string-ast/-/magic-string-ast-1.0.3.tgz",
       "integrity": "sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "magic-string": "^0.30.19"
       },
@@ -9953,6 +10207,25 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
+      "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10218,6 +10491,13 @@
       "integrity": "sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ==",
       "license": "MIT"
     },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/mermaid": {
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
@@ -10340,6 +10620,23 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
+      "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -11132,9 +11429,9 @@
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.6.1.tgz",
-      "integrity": "sha512-1B9lmAhB9D9/sHaPC1N7wLFEVUoFldxOpOO96lOD1PvJ43vCd0ozDPbu0FEL3++VvawOlDkq8YD373tJmP5JHw==",
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -11163,8 +11460,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
       "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -11310,6 +11606,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/normalize-wheel-es": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/normalize-wheel-es/-/normalize-wheel-es-1.2.0.tgz",
+      "integrity": "sha512-Wj7+EJQ8mSuXr2iWfnujrimU35R2W4FAErEyTmJoJ7ucwTn2hOUSsRehMb5RSYkxXGTM7Y9QpvPmp++w5ftoJw==",
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -12525,6 +12828,23 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/remark-frontmatter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
+      "integrity": "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-frontmatter": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {
@@ -14315,16 +14635,34 @@
         }
       }
     },
+    "node_modules/vue-component-type-helpers": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.2.8.tgz",
+      "integrity": "sha512-9689efAXhN/EV86plgkL/XFiJSXhGtWPG6JDboZ+QnjlUWUUQrQ0ILKQtw4iQsuwIwu5k6Aw+JnehDe7161e7A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/vue-echarts": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/vue-echarts/-/vue-echarts-8.0.1.tgz",
+      "integrity": "sha512-23rJTFLu1OUEGRWjJGmdGt8fP+8+ja1gVgzMYPIPaHWpXegcO1viIAaeu2H4QHESlVeHzUAHIxKXGrwjsyXAaA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "echarts": "^6.0.0",
+        "vue": "^3.3.0"
+      }
+    },
     "node_modules/vue-i18n": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.3.0.tgz",
-      "integrity": "sha512-1J+xDfDJTLhDxElkd3+XUhT7FYSZd2b8pa7IRKGxhWH/8yt6PTvi3xmWhGwhYT5EaXdatui11pF2R6tL73/zPA==",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.4.2.tgz",
+      "integrity": "sha512-sADDeKXqAGsPX6tK3t3y2ZiMpbVWN12tG+MhTiJ06rVoh58eGtM4wFyw3uWGbVkXByVp9Ne/AP+nSSzI+J9OAQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@intlify/core-base": "11.3.0",
-        "@intlify/devtools-types": "11.3.0",
-        "@intlify/shared": "11.3.0",
+        "@intlify/core-base": "11.4.2",
+        "@intlify/devtools-types": "11.4.2",
+        "@intlify/shared": "11.4.2",
         "@vue/devtools-api": "^6.5.0"
       },
       "engines": {
@@ -14348,7 +14686,6 @@
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.4.tgz",
       "integrity": "sha512-lCqDLCI2+fKVRl2OzXuzdSWmxXFLQRxQbmHugnRpTMyYiT+hNaycV0faqG5FBHDXoYrZ6MQcX87BvbY8mQ20Bg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@babel/generator": "^7.28.6",
         "@vue-macros/common": "^3.1.1",
@@ -14394,7 +14731,6 @@
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.1.tgz",
       "integrity": "sha512-bsDMJ07b3GN1puVwJb/fyFnj/U2imyswK5UQVLZwVl7O05jDrt6BHxeG5XffmOOdasOj/bOmIjxJvGPxU7pcqw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@vue/devtools-kit": "^8.1.1"
       }
@@ -14404,7 +14740,6 @@
       "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
       "integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
         "picomatch": "^4.0.3",
@@ -15183,6 +15518,30 @@
         "repeat-string": "^1.5.2"
       }
     },
+    "node_modules/xss": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
+      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/xss/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
@@ -15272,6 +15631,23 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/zrender": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
+      "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@cloudflare/workers-types": "^4.20260413.1",
     "@gtm-support/vue-gtm": "^3.2.0",
     "@iconify-json/mdi": "^1.2.3",
+    "@kestra-io/topology": "^0.0.2",
     "@kestra-io/ui-libs": "^0.0.299",
     "@popperjs/core": "^2.11.8",
     "@types/aos": "^3.0.7",

--- a/src/assets/styles/vendor.scss
+++ b/src/assets/styles/vendor.scss
@@ -24,7 +24,17 @@
 @import "vue-material-design-icons/styles.css";
 @import "vanilla-cookieconsent/dist/cookieconsent.css";
 @import "medium-zoom/dist/style.css";
-@import "@vue-flow/core/dist/style.css";
-@import "@vue-flow/core/dist/theme-default.css";
-@import "@vue-flow/controls/dist/style.css";
 @import "vue3-carousel/carousel.css";
+@import "@kestra-io/topology/style.css";
+
+.el-popper {
+    border-radius: 8px;
+    padding: 0.25rem 0.5rem;
+    font-size: $font-size-xs;
+    white-space: nowrap;
+    word-wrap: break-word;
+    pointer-events: none;
+    background: var(--ks-background-body);
+    border: 1px solid var(--ks-border-secondary);
+    color: var(--ks-content-primary);
+}

--- a/src/components/blueprints/Topology.client.vue
+++ b/src/components/blueprints/Topology.client.vue
@@ -14,7 +14,7 @@
 
 <script setup lang="ts">
     import { getCurrentInstance, nextTick, onBeforeUnmount, onMounted, ref } from "vue"
-    import { Topology } from "@kestra-io/ui-libs"
+    import { Topology } from "@kestra-io/topology"
     import { useVueFlow } from "@vue-flow/core"
     import TaskIcon from "~/components/common/TaskIcon.vue"
 
@@ -120,9 +120,5 @@
 
     :deep(.bg-white) {
         background-color: var(--ks-background-body) !important;
-    }
-
-    :deep(.text-color) {
-        color: var(--ks-content-primary) !important;
     }
 </style>


### PR DESCRIPTION
**Migration to `@kestra-io/topology`:**

* Added `@kestra-io/topology` as a dependency in `package.json` and removed imports of `@vue-flow` styles in `vendor.scss`.
* Updated the `Topology.client.vue` component to import `Topology` from `@kestra-io/topology` instead of `@kestra-io/ui-libs`, aligning it with the new package. 

**Styling updates:**

* Imported the new `@kestra-io/topology/style.css` stylesheet and removed obsolete `@vue-flow` styles from `vendor.scss`. Also, added custom styles for `.el-popper` to improve tooltip appearance. 
* Removed `.text-color` style override from `Topology.client.vue` to clean up CSS. 