### PR TITLE
build(deps): clean up dependabot npm section comment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
     open-pull-requests-limit: 50
     labels: ["dependency-upgrade", "area/devops"]
 
-  # Maintain dependencies for NPM modules
+  # Maintain dependencies for NPM modules (core UI)
   - package-ecosystem: "npm"
     directory: "/"
     commit-message:


### PR DESCRIPTION
## Summary

- Minor comment cleanup in `.github/dependabot.yml` to align with OSS/EE formatting.