### PR TITLE
perf(mermaid): lazy-load mermaid only on pages that use it

### DIFF
--- a/src/scripts/mermaid.ts
+++ b/src/scripts/mermaid.ts
@@ -1,8 +1,8 @@
-import mermaid from "mermaid"
-
 document.addEventListener("astro:page-load", async () => {
     const diagrams = document.querySelectorAll<HTMLElement>(".mermaid:not([data-processed])")
     if (!diagrams.length) return
+
+    const { default: mermaid } = await import("mermaid")
 
     const dark = document.documentElement.classList.contains("dark")
     mermaid.initialize({


### PR DESCRIPTION
## Problem

`src/scripts/mermaid.ts` does a static top-level `import mermaid from "mermaid"`. Vite/Rollup therefore bundles the full mermaid runtime (~144 KB brotli, ~600 KB unminified) into the `layout-6` chunk on **every** page. The `if (!diagrams.length) return` guard runs in the listener — after the bundle has already been downloaded and parsed.

Site-wide audit:
- ~1500+ pages include `layout.astro` → all pay the 144 KB cost
- Only ~2 markdown files actually use ```` ```mermaid ```` blocks
- → 99.9% of page loads download mermaid for nothing

## Fix

Move the import **inside** the listener, **after** the presence check, as a dynamic import. Vite will then code-split mermaid into its own chunk that only loads on demand.

```diff
-import mermaid from "mermaid"
-
 document.addEventListener("astro:page-load", async () => {
     const diagrams = document.querySelectorAll<HTMLElement>(".mermaid:not([data-processed])")
     if (!diagrams.length) return

+    const { default: mermaid } = await import("mermaid")
+
     const dark = document.documentElement.classList.contains("dark")
```

## Expected impact

| Page type | Before (`layout-6.js`) | After |
|---|---|---|
| `/blueprints/*` (311 pages, no diagrams) | 144 KB br | ~300 B |
| `/plugins/*` (~1100 pages, no diagrams) | 144 KB br | ~300 B |
| `/docs/*` with mermaid blocks (~2 pages) | 144 KB br on critical path | ~300 B + lazy chunk loaded after `astro:page-load` (non-blocking) |

Estimated mobile gain on ~1500 pages: **−144 KB transfer**, **−150-200 ms TBT/INP** (mermaid embarks d3, dagre, parser).

## Test plan

- [ ] `npm run build` and verify in `dist/_astro/`:
  - `layout-6` chunk drops from ~144 KB to ~hundreds of bytes
  - A new chunk (~140 KB) appears for the mermaid runtime
- [ ] `npm run preview` → `/blueprints/data-engineering-pipeline` → DevTools Network filter "mermaid" → no request
- [ ] Open a page that contains a ```` ```mermaid ```` block → diagram renders, mermaid chunk is fetched after `astro:page-load`
- [ ] SPA navigation: navigate from a no-mermaid page to a mermaid page via ClientRouter → loader still triggers (the listener is in `astro:page-load` which fires on SPA transitions)
- [ ] Toggle dark/light theme on a mermaid page → no regression
- [ ] Lighthouse mobile before/after on `/blueprints/data-engineering-pipeline` → CLS unchanged, TBT/transfer-size lower

## Notes

- Mermaid v11 is ESM-only; the `{ default: mermaid }` destructure handles the default export correctly.
- Independent follow-up: assets under `/_astro/*` ship `cache-control: public, max-age=0, must-revalidate` despite being fingerprinted/immutable. Fixing that to `max-age=31536000, immutable` would compound the gain on repeat visits across the whole site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)