### PR TITLE
[Preview only] /resources/it-automation-platform-v2 — W19 draft

### DIFF
--- a/src/contents/resources/it-automation-platform-v2/index.md
+++ b/src/contents/resources/it-automation-platform-v2/index.md
@@ -1,0 +1,63 @@
+---
+title: "What is an IT Automation Platform?"
+description: "Learn what an IT automation platform is, its core components, real-world use cases, and how to evaluate platforms for your team."
+metaTitle: "What is an IT Automation Platform?"
+metaDescription: "Learn what an IT automation platform is, its core components, real-world use cases, and how to evaluate platforms for your team."
+tag: infrastructure
+date: 2026-05-08
+---
+
+## Introduction
+
+IT automation has moved from a nice-to-have to a core capability for modern engineering teams. As infrastructure grows in complexity and the pressure to ship faster increases, manual operations simply do not scale. An IT automation platform addresses this by providing a unified layer to orchestrate, schedule, and monitor automated tasks across systems, tools, and environments.
+
+This guide walks through what an IT automation platform is, the components that make one effective, and how to evaluate platforms for your team.
+
+## Key Components of a Modern Automation Platform
+
+
+<figure>
+  <img src="https://kestra.io/cdn-cgi/image/onerror=redirect,width=1200,height=790,format=webp/_astro/architecture.NkV9Ai1a.png" alt="Kestra architecture diagram showing webserver, scheduler, executor, worker, and queue components" loading="lazy" />
+  <figcaption>Kestra architecture diagram showing webserver, scheduler, executor, worker, and queue components</figcaption>
+</figure>
+
+A modern IT automation platform is built on six core components that work together to deliver reliable, scalable automation:
+
+- Triggers and events: webhooks, schedules, message queues, and file events that initiate workflows
+- Workflow definition: declarative YAML or DSL that describes the automation logic, ideally version-controlled
+- Orchestration engine: the brain that schedules, executes, and monitors workflows
+- Execution engine: runs the actual tasks in containers or processes, polyglot by design
+- Plugin ecosystem: pre-built integrations with cloud providers, databases, SaaS tools, and APIs
+- Observability: logs, metrics, and audit trails for debugging and compliance
+
+The strength of a platform comes from how tightly these components integrate and how well they handle scale.
+
+## Real-World Examples of IT Automation
+
+IT automation platforms are used across a wide range of operational scenarios. Three of the most common include automated incident response, server provisioning and configuration, and compliance and audit reporting. These examples show how automation moves operational work from reactive firefighting to proactive, predictable execution.
+
+## Kestra: The Declarative Control Plane
+
+
+<figure>
+  <img src="https://kestra.io/cdn-cgi/image/onerror=redirect,width=1200,height=675,format=webp/_astro/dashboard.QEuuo7qi.jpg" alt="Kestra dashboard showing workflow executions, real-time metrics, and system overview" loading="lazy" />
+  <figcaption>Kestra dashboard showing workflow executions, real-time metrics, and system overview</figcaption>
+</figure>
+
+Kestra is a declarative orchestration platform purpose-built for IT automation at scale. Unlike code-first tools that lock teams into a specific language, Kestra uses a YAML-based approach that makes workflows readable, version-controllable, and accessible to both developers and operators.
+
+Key advantages of Kestra for IT automation include polyglot execution (Python, Bash, SQL, R, Node, and more, all in one workflow), 600+ plugins covering AWS, GCP, Azure, Kubernetes, databases, and SaaS tools, built-in scheduling and event triggers, and enterprise features for governance, RBAC, and audit logging.
+
+Kestra fits naturally as the control plane that sits above existing automation tools, coordinating them rather than replacing them.
+
+## Conclusion
+
+
+<figure>
+  <img src="https://kestra.io/cdn-cgi/image/onerror=redirect,width=1200,height=675,format=webp/_astro/plugins.CQMFn5So.png" alt="Kestra plugin ecosystem with hundreds of integrations across cloud, data, and SaaS tools" loading="lazy" />
+  <figcaption>Kestra plugin ecosystem with hundreds of integrations across cloud, data, and SaaS tools</figcaption>
+</figure>
+
+An IT automation platform is no longer optional for teams that want to scale operations without scaling headcount. The right platform combines reliable orchestration, a rich plugin ecosystem, and strong observability, all wrapped in a developer experience that does not get in the way.
+
+If you are evaluating platforms, focus on declarative workflow definition, polyglot execution, and a plugin ecosystem that matches your stack. These three factors will determine whether the platform becomes a force multiplier or another tool to maintain.


### PR DESCRIPTION
**Preview-only PR — do not merge.**

Imports the W19 draft `it-automation-platform.test-v2.md` from [vfanucci/kestra-seo](https://github.com/vfanucci/kestra-seo/blob/main/drafts/2026-W19/it-automation-platform.test-v2.md) under a distinct slug `it-automation-platform-v2` so the existing `/resources/it-automation-platform` page (PR #4704) is untouched.

Goal: render the draft on Netlify preview to review formatting and `<figure>` rendering before deciding whether to replace the existing page or iterate further.

Frontmatter cleaned: `slug`, `author`, `image`, `images`, `category` stripped; `tags` → `tag` (singular, lowercase); `metaTitle` / `metaDescription` added.