### PR TITLE
docs(configuration): warn about Jackson errors when injecting storage credentials via env vars

### DIFF
--- a/src/contents/docs/configuration/01.configuration-basics/index.md
+++ b/src/contents/docs/configuration/01.configuration-basics/index.md
@@ -116,6 +116,27 @@ KESTRA_STORAGE_TYPE=s3
 KESTRA_URL=https://kestra.example.com
 ```
 
+:::alert{type="warning"}
+For storage backend properties such as `kestra.storage.s3.access-key` and `kestra.storage.gcs.project-id`, prefer either the YAML form or the double-underscore env-var form. A single underscore between the last two segments can be read as a path separator by Micronaut and produce a nested object that the storage plugin's Jackson mapper rejects with `UnrecognizedPropertyException`. The two forms below are equivalent and both avoid that issue:
+
+```bash
+# double underscore preserves the literal kebab/snake separator
+KESTRA_STORAGE_S3_ACCESS__KEY=<aws-access-key-id>
+KESTRA_STORAGE_S3_SECRET__KEY=<aws-secret-access-key>
+```
+
+```yaml
+# or keep credentials in YAML and reference an env var
+kestra:
+  storage:
+    s3:
+      access-key: "${S3_ACCESS_KEY}"
+      secret-key: "${S3_SECRET_KEY}"
+```
+
+The same applies to `kestra.storage.gcs.project-id`, `kestra.storage.gcs.service-account`, and other multi-word storage properties.
+:::
+
 ## SDK default authentication
 
 SDK-based plugins can use default authentication if configured. Kestra resolves credentials in this order:

--- a/src/contents/docs/configuration/02.runtime-and-storage/index.md
+++ b/src/contents/docs/configuration/02.runtime-and-storage/index.md
@@ -274,6 +274,40 @@ kestra:
       force-path-style: false
 ```
 
+:::alert{type="warning"}
+If you inject S3 credentials through Helm `extraEnvVars` or another environment-variable source, use double underscores on multi-word property names. `KESTRA_STORAGE_S3_ACCESS_KEY` can be parsed as `kestra.storage.s3.access.key` (nested), which the storage plugin rejects with a Jackson `UnrecognizedPropertyException` at startup. Use one of the working forms instead:
+
+```yaml
+# Helm values.yaml
+extraEnvVars:
+  - name: KESTRA_STORAGE_S3_ACCESS__KEY
+    valueFrom:
+      secretKeyRef:
+        name: my-s3-secret
+        key: access_key
+  - name: KESTRA_STORAGE_S3_SECRET__KEY
+    valueFrom:
+      secretKeyRef:
+        name: my-s3-secret
+        key: secret_key
+```
+
+Or keep the keys in YAML and interpolate from simpler env vars:
+
+```yaml
+kestra:
+  storage:
+    type: s3
+    s3:
+      access-key: "${S3_ACCESS_KEY}"
+      secret-key: "${S3_SECRET_KEY}"
+      region: "<your-aws-region>"
+      bucket: "<your-s3-bucket-name>"
+```
+
+See [Environment variable conversion](../01.configuration-basics/index.md#environment-variable-conversion) for the full naming rule.
+:::
+
 If Kestra runs on EC2 or EKS with IAM roles, omit static credentials and keep only the region and bucket:
 
 ```yaml
@@ -390,6 +424,34 @@ kestra:
 ```
 
 If `service-account` is omitted, Kestra falls back to default GCP credentials, which is usually the right choice on GKE or GCE.
+
+:::alert{type="warning"}
+The same env-var caveat noted for [S3](#s3) applies to GCS. `KESTRA_STORAGE_GCS_PROJECT_ID` can be parsed as `kestra.storage.gcs.project.id` (nested) and rejected by the GCS storage plugin's Jackson mapper with `UnrecognizedPropertyException`. Use double underscores on the multi-word segment, or keep the configuration in YAML:
+
+```yaml
+# Helm values.yaml
+extraEnvVars:
+  - name: KESTRA_STORAGE_GCS_PROJECT__ID
+    value: "my-gcp-project"
+  - name: KESTRA_STORAGE_GCS_SERVICE__ACCOUNT
+    valueFrom:
+      secretKeyRef:
+        name: my-gcs-secret
+        key: service_account_json
+```
+
+```yaml
+kestra:
+  storage:
+    type: gcs
+    gcs:
+      bucket: "<bucket>"
+      project-id: "${GCS_PROJECT_ID}"
+      service-account: "${GCS_SERVICE_ACCOUNT}"
+```
+
+See [Environment variable conversion](../01.configuration-basics/index.md#environment-variable-conversion) for the full naming rule.
+:::
 
 ### Cloudflare R2
 

--- a/src/contents/docs/configuration/02.runtime-and-storage/index.md
+++ b/src/contents/docs/configuration/02.runtime-and-storage/index.md
@@ -426,7 +426,7 @@ kestra:
 If `service-account` is omitted, Kestra falls back to default GCP credentials, which is usually the right choice on GKE or GCE.
 
 :::alert{type="warning"}
-The same env-var caveat noted for [S3](#s3) applies to GCS. `KESTRA_STORAGE_GCS_PROJECT_ID` can be parsed as `kestra.storage.gcs.project.id` (nested) and rejected by the GCS storage plugin's Jackson mapper with `UnrecognizedPropertyException`. Use double underscores on the multi-word segment, or keep the configuration in YAML:
+`KESTRA_STORAGE_GCS_PROJECT_ID` can be parsed as `kestra.storage.gcs.project.id` (nested) and rejected by the GCS storage plugin's Jackson mapper with `UnrecognizedPropertyException`. Use double underscores on the multi-word segment, or keep the configuration in YAML:
 
 ```yaml
 # Helm values.yaml


### PR DESCRIPTION
## What

Adds a warning callout to three places in the Configuration docs explaining the env-var naming pitfall that affects Helm deployments of the S3 and GCS internal-storage backends:

- `configuration/01.configuration-basics/index.md` — Environment variable conversion section
- `configuration/02.runtime-and-storage/index.md` — S3 section
- `configuration/02.runtime-and-storage/index.md` — Google Cloud Storage section

## Why

Per kestra-io/kestra#15964, a user on v1.3.16 hit a fatal pod startup error when injecting `KESTRA_STORAGE_S3_ACCESS_KEY` through `extraEnvVars`:

```
Failed to create storage 's3'. Error: Unrecognized field "access"
```

The single-underscore env-var form is read by Micronaut's relaxed binding as the path `kestra.storage.s3.access.key`, producing a nested `{access: {key: ...}}` shape. The S3/GCS storage plugins then deserialize that subtree with Jackson into a flat config bean and crash with `UnrecognizedPropertyException`. The same problem affects every multi-word property under `kestra.storage.<backend>.*`.

The reporter's own workaround (double-underscore on the last hop, or YAML interpolation from a simpler env var) is shown in each callout, with a back-link from S3/GCS to the Configuration Basics rule.

## What's not changed

- The existing `KESTRA_STORAGE_S3_ACCESS_KEY=myKey` example on the Configuration Basics page is left in place because it remains correct for Micronaut's documented relaxed binding. The new callout flags the storage-plugin-specific case where Jackson observes the nested form and refuses it.
- No plugin reference pages are touched; those are auto-generated from plugin sources and live outside this repo.

## Refs

- kestra-io/kestra#15964