### PR TITLE
feat(resources): add change-data-capture page

### DIFF
--- a/src/contents/resources/change-data-capture/index.md
+++ b/src/contents/resources/change-data-capture/index.md
@@ -1,0 +1,277 @@
+---
+title: "What is Change Data Capture (CDC)?"
+description: "Change Data Capture (CDC) is a crucial technique for modern data architectures. This guide explores what CDC is, its operational mechanisms, and how it ensures real-time data synchronization across systems."
+metaTitle: "What is Change Data Capture (CDC)? Kestra Guide"
+metaDescription: "Learn what change data capture (CDC) is, how it works, and its benefits for data synchronization across modern data architectures."
+tag: data
+date: 2026-05-02
+faq:
+  - question: "What is the difference between ETL and CDC?"
+    answer: "Change Data Capture (CDC) focuses on tracking and extracting only the modifications (inserts, updates, deletes) in a source system. Traditional ETL often involves batch processing of entire datasets. CDC provides a more granular, efficient approach, reducing the load on source systems and enabling near real-time data synchronization, often complementing or enhancing an ETL pipeline."
+  - question: "What is IBM change data capture?"
+    answer: "IBM Change Data Capture refers to IBM's suite of solutions that identify and record data change events from various sources, including relational and non-relational databases. These solutions integrate with IBM's data platforms to facilitate data synchronization, warehousing, and analytics. Kestra can orchestrate these vendor-specific CDC tools as part of a broader workflow."
+  - question: "What is an example of change data capture?"
+    answer: "A common example of CDC is in retail. When a customer places an order, the transaction is recorded in an operational database. A CDC system captures this specific 'insert' event in real-time. This change can then trigger downstream processes, such as updating inventory, sending a confirmation email, or feeding a real-time analytics dashboard, ensuring immediate data consistency."
+  - question: "Does change data capture affect performance?"
+    answer: "The performance impact of CDC depends heavily on the method used. Trigger-based CDC can introduce overhead as it runs database triggers for every data modification. Log-based CDC, however, generally has minimal impact on source database performance as it reads transaction logs asynchronously, offloading the processing to a separate system. Proper implementation and monitoring are key to minimizing any performance degradation."
+  - question: "Will ETL be replaced by AI?"
+    answer: "AI is transforming ETL, not replacing it. While AI can automate parts of the ETL process, such as data mapping, quality checks, and anomaly detection, the core principles of data extraction, transformation, and loading remain. AI-powered tools enhance efficiency and intelligence, allowing engineers to focus on more complex tasks. CDC itself can feed real-time data into AI-driven ETL processes."
+  - question: "Is Excel an ETL tool?"
+    answer: "While Excel, especially with features like Power Query, can perform basic data extraction, transformation, and loading for small-scale tasks, it is not considered a robust enterprise-grade ETL tool. Its limitations in scalability, automation, error handling, and governance make it unsuitable for complex, high-volume, or mission-critical data integration pipelines. Dedicated ETL or orchestration tools are required for such scenarios."
+---
+
+In the dynamic landscape of modern data architectures, keeping disparate systems synchronized and data consistently up-to-date is a perpetual challenge. Traditional batch processing often introduces latency, making real-time insights a distant goal. This is where Change Data Capture (CDC) emerges as a critical technique, fundamentally altering how organizations manage and react to data modifications.
+
+This comprehensive guide will demystify Change Data Capture, exploring its core mechanisms, diverse methods, and profound benefits. We'll delve into how CDC empowers real-time analytics, streamlines migrations, and enhances operational efficiency, alongside a deep dive into how Kestra, a declarative orchestration platform, can seamlessly integrate and manage your CDC pipelines, turning raw data changes into actionable insights.
+
+## What is Change Data Capture (CDC)?
+
+Change Data Capture (CDC) is a set of software design patterns used to identify and track changes to data in a source database. Instead of extracting an entire dataset, CDC captures only the incremental changes—inserts, updates, and deletes—and makes them available in real time. This process allows other systems to respond to these changes as they happen, ensuring data consistency and enabling a wide range of real-time applications.
+
+The primary purpose of CDC is to maintain synchronization between different data stores with minimal impact on the source system. By capturing only the deltas, CDC avoids the resource-intensive overhead of full table scans and large batch transfers. This makes it a cornerstone of modern data integration, supporting everything from real-time analytics to zero-downtime database migrations. In an era where business decisions depend on the freshest possible data, CDC provides the mechanism to move from periodic batch updates to a continuous, event-driven flow of information. For more on this topic, explore our [resources for data articles](/resources/data).
+
+## How change data capture works
+
+At its core, CDC operates by monitoring a source database for modifications and then streaming those changes to consumers. The implementation details can vary, but the goal remains the same: to provide a reliable, low-latency stream of change events.
+
+### CDC mechanisms and techniques
+
+Several techniques exist for implementing CDC, each with its own trade-offs in terms of performance, reliability, and complexity. The most common methods include:
+- **Log-based CDC:** Reads the database's native transaction log (e.g., PostgreSQL's WAL, MySQL's binlog) to capture changes. This is often the most efficient and reliable method.
+- **Trigger-based CDC:** Uses database triggers on source tables to record changes into a separate changelog table. This method is database-agnostic but can add overhead to the source system.
+- **Timestamp-based CDC:** Relies on a `last_updated` column in each table to identify recently modified rows. This approach is simpler to implement but has limitations, such as being unable to capture `DELETE` operations reliably.
+
+### Batch processing vs. real-time CDC
+
+The distinction between batch and real-time processing is crucial in understanding the value of CDC.
+- **Batch Processing:** Traditionally, data is extracted in large chunks at scheduled intervals (e.g., nightly). This creates data latency, meaning the target system is always out of sync with the source.
+- **Real-time CDC:** CDC systems capture changes as they occur and stream them immediately. This approach minimizes latency, allowing target systems to reflect the source's state within seconds or milliseconds. While batch processing is suitable for historical analysis, real-time CDC is essential for operational analytics, fraud detection, and other time-sensitive applications.
+
+### Does change data capture affect performance?
+
+A common concern with CDC is its potential impact on the performance of the source database. The effect varies significantly based on the chosen method.
+- **Trigger-based CDC** can have a noticeable performance impact. Because triggers are executed synchronously with every `INSERT`, `UPDATE`, or `DELETE` operation, they add overhead to each transaction, potentially slowing down the application.
+- **Timestamp-based CDC** requires queries to scan tables for new or updated records, which can be resource-intensive, especially on large tables without proper indexing.
+- **Log-based CDC** generally has the lowest performance impact. It reads the transaction log asynchronously, meaning it doesn't interfere with the database's primary workload. The process of reading the log is offloaded from the main database engine, making it a non-intrusive and highly efficient method for capturing changes.
+
+### End-to-end CDC architecture
+
+The diagram below illustrates how a typical log-based CDC pipeline flows — from a row-level change in the source database, through capture and streaming, to the downstream consumers that react to each event in real time. Kestra sits at the orchestration layer, coordinating the workflow and triggering downstream tasks as change events arrive.
+
+```mermaid
+flowchart LR
+    subgraph SRC["Source database"]
+        APP[Application<br/>INSERT / UPDATE / DELETE]
+        TXLOG[(Transaction log<br/>WAL / binlog)]
+        APP -->|writes| TXLOG
+    end
+
+    subgraph CDC["CDC capture layer"]
+        DEBEZIUM[Debezium connector<br/>log reader]
+    end
+
+    subgraph STREAM["Streaming layer"]
+        KAFKA[Message broker<br/>Kafka / Pulsar]
+    end
+
+    subgraph ORCH["Orchestration — Kestra"]
+        TRIGGER[Real-time trigger<br/>on change event]
+        FLOW[Kestra flow<br/>transform &amp; route]
+    end
+
+    subgraph DOWN["Downstream consumers"]
+        DWH[(Data warehouse<br/>Snowflake / BigQuery)]
+        ANALYTICS[Real-time<br/>analytics]
+        MICRO[Microservices<br/>inventory, shipping...]
+        NOTIF[Notifications<br/>Slack / email]
+    end
+
+    TXLOG -->|tails log| DEBEZIUM
+    DEBEZIUM -->|publishes events| KAFKA
+    KAFKA -->|consumes events| TRIGGER
+    TRIGGER --> FLOW
+    FLOW --> DWH
+    FLOW --> ANALYTICS
+    FLOW --> MICRO
+    FLOW --> NOTIF
+```
+
+This event-driven topology is what makes CDC so powerful: a single row change in the source can fan out to every system that needs it, without coupling those systems to the source database. The next sections explore the concrete benefits this architecture unlocks.
+
+## Benefits of implementing change data capture
+
+Implementing CDC offers significant advantages for data management and analytics, moving organizations toward a more agile, data-driven operational model.
+
+### Data synchronization and consistency
+
+CDC ensures that data across multiple systems remains consistent and up-to-date. By propagating changes in real time, it eliminates the data silos and inconsistencies that arise from delayed batch updates. This is critical for microservices architectures, where different services might own their data but need a consistent view of related data from other services.
+
+### Improved operational efficiency
+
+By capturing only incremental changes, CDC dramatically reduces the volume of data that needs to be transferred and processed. This minimizes network bandwidth usage, reduces the load on both source and target systems, and lowers overall compute costs. The efficiency gains are particularly pronounced in large-scale environments with high transaction volumes.
+
+### Enabling real-time analytics and reporting
+
+The most transformative benefit of CDC is its ability to power real-time analytics. When change events are streamed as they happen, they can be fed directly into analytics platforms, data warehouses, or business intelligence dashboards. This allows businesses to monitor operations, detect anomalies, and make informed decisions based on the most current data available, rather than relying on outdated snapshots from the previous day.
+
+## Use cases for change data capture
+
+CDC is a versatile technique applicable to a wide range of data integration challenges. Its ability to provide low-latency, reliable data streams makes it invaluable in many modern architectures.
+
+### Data warehousing and ETL processes
+
+CDC is a key enabler for efficient data warehousing. Instead of performing full extracts in a traditional [ETL workflow](/resources/data/etl-workflow), CDC allows for incremental updates to the data warehouse. This reduces the time and resources required for the ETL process, shortens the data refresh cycle, and provides analysts with more current data. This approach is foundational to building a modern, responsive [data pipeline](/resources/data/create-data-pipeline).
+
+### Database replication and migration
+
+When migrating from one database system to another, minimizing downtime is critical. CDC facilitates zero-downtime migrations by allowing the new database to be synchronized with the old one in real time. Once the initial data load is complete, CDC keeps the target database up-to-date with any changes occurring on the source. The cutover can then be performed with minimal disruption to applications.
+
+### Auditing and compliance
+
+For industries with strict regulatory requirements, maintaining a detailed audit trail of all data changes is essential. CDC provides a complete, ordered history of every modification made to the data, including what changed, who changed it, and when. This immutable log of events can be used for auditing, compliance reporting, and historical analysis.
+
+### What is an example of change data capture?
+
+A classic example of CDC is in an e-commerce platform. When a customer places an order, a new record is inserted into the `orders` table in the transactional database.
+1.  A log-based CDC tool like Debezium reads this `INSERT` event from the database's transaction log.
+2.  The change event is published to a message broker like Kafka.
+3.  Multiple downstream services can consume this event in real time:
+    - The inventory service decrements the stock count.
+    - The shipping service initiates the fulfillment process.
+    - The analytics platform updates a real-time sales dashboard.
+    - A marketing automation tool sends an order confirmation email.
+
+This event-driven architecture, powered by CDC, ensures that all parts of the system are synchronized instantly without tightly coupling them to the orders database.
+
+## Change data capture methods and tools
+
+Choosing the right CDC method and tool is critical for a successful implementation. Each approach has distinct characteristics that make it suitable for different scenarios.
+
+### Log-based CDC
+
+Log-based CDC is widely considered the gold standard. It works by reading the database's transaction log, which is an ordered, append-only record of all changes.
+- **How it works:** A CDC agent tails the transaction log, parses the binary log entries, and converts them into structured change events.
+- **Pros:** Minimal performance impact on the source database, captures all changes (including deletes and schema changes), and guarantees data consistency.
+- **Cons:** Can be complex to set up, as it requires deep integration with the specific database's log format.
+- **Tools:** [Debezium](https://kestra.io/docs/how-to-guides/debezium) is the leading open-source platform for log-based CDC, with connectors for databases like [MySQL](/plugins/plugin-debezium-mysql), [PostgreSQL](https://kestra.io/blogs/2022-04-05-debezium-without-kafka-connect), [SQL Server](/plugins/plugin-debezium-sqlserver), [Oracle](/plugins/plugin-debezium-oracle), and [DB2](/plugins/plugin-debezium-db2).
+
+### Trigger-based CDC
+
+This method uses standard database triggers to capture changes.
+- **How it works:** For each table being tracked, `INSERT`, `UPDATE`, and `DELETE` triggers are created. When a change occurs, the trigger fires and writes a record of the change to a separate "shadow" or "changelog" table.
+- **Pros:** It's database-agnostic and relatively straightforward to implement.
+- **Cons:** It adds transactional overhead to the source database, which can impact application performance. Triggers can also be complex to manage and maintain at scale.
+
+### Timestamp-based CDC
+
+Also known as query-based CDC, this method relies on columns in the source tables to identify changes.
+- **How it works:** It requires tables to have a column like `last_modified_timestamp`. The CDC process periodically queries the tables to find rows with a timestamp later than the last extraction time.
+- **Pros:** Simple to implement and doesn't require special database permissions or features.
+- **Cons:** It cannot reliably capture `DELETE` operations (since the row is gone), can miss changes that occur between queries, and puts additional query load on the source database.
+
+### Comparison of CDC strategies
+
+| Strategy | Performance Impact | Reliability | Complexity | Captures Deletes? |
+| --- | --- | --- | --- | --- |
+| **Log-based** | Low | High | High | Yes |
+| **Trigger-based** | Medium-High | High | Medium | Yes |
+| **Timestamp-based**| Medium | Low | Low | No |
+
+## CDC vs. ETL: understanding the differences
+
+While CDC and ETL are both data integration techniques, they serve different purposes and operate on different principles.
+
+### What is the difference between ETL and CDC?
+
+- **ETL (Extract, Transform, Load):** Typically a batch-oriented process that extracts large volumes of data (often entire tables), transforms it into a specific format, and loads it into a target system like a data warehouse. It operates on data in bulk at scheduled intervals.
+- **CDC (Change Data Capture):** A process that identifies and captures individual data changes (row-level inserts, updates, deletes) as they happen. It operates on a continuous stream of events, not on bulk data.
+
+### When to use CDC instead of ETL
+
+CDC is preferable when:
+- **Real-time data is required:** For applications that need up-to-the-second data.
+- **Source system impact must be minimized:** Log-based CDC is less intrusive than large batch extracts.
+- **Network bandwidth is a concern:** Sending only changes is far more efficient than sending full datasets.
+
+### How CDC complements ETL
+
+CDC and ETL are not mutually exclusive; they often work together. CDC can serve as the "Extract" phase in a modern, real-time ETL or ELT (Extract, Load, Transform) pipeline. Instead of a batch extract job, a CDC process continuously streams changes from the source, which are then transformed and loaded into the target system. This creates a more efficient, low-latency data pipeline.
+
+## Exploring IBM and Microsoft's CDC solutions
+
+Major database vendors often provide native or integrated CDC solutions to support data integration within their ecosystems.
+
+### What is IBM change data capture?
+
+IBM offers a suite of data replication and integration products under its InfoSphere brand, often referred to as IBM Change Data Capture. These tools are designed for enterprise environments and support a wide range of sources, including Db2, Oracle, and SQL Server. They provide log-based capture capabilities and are tightly integrated with other IBM products like DataStage for ETL and Cognos for analytics.
+
+### Microsoft SQL Server change data capture
+
+Microsoft SQL Server includes a built-in CDC feature. When enabled on a database and specific tables, it automatically creates changelog tables and capture jobs that populate them with row-level changes. This native functionality provides a reliable way to track modifications without relying on custom triggers. The change data is then accessible via table-valued functions, which can be queried by downstream applications and integration tools.
+
+For both IBM and Microsoft solutions, an orchestration platform like Kestra can be used to manage the end-to-end workflow, triggering downstream processes based on the captured changes and integrating them with the broader data ecosystem.
+
+## Orchestrating Change Data Capture with Kestra
+
+While CDC tools like Debezium are excellent at capturing change events, they are just one piece of the puzzle. A robust orchestration platform is needed to manage the entire workflow that follows. This is where Kestra excels, providing a declarative, language-agnostic control plane for your CDC pipelines.
+
+With Kestra, you can define your entire data flow in a simple YAML file. This includes configuring the CDC process, reacting to change events with real-time triggers, and orchestrating the downstream tasks that process the data. Kestra's extensive library of [plugins](/plugins) allows you to connect to any source or destination, from message queues like Kafka to data warehouses like Snowflake.
+
+For example, you can create a Kestra workflow that is triggered in real time by a change in a PostgreSQL database, captured via the Debezium plugin. The workflow could then transform the data using a Python script, load it into a data warehouse, and send a Slack notification upon completion.
+
+Here is an example of a Kestra flow that listens for changes in a PostgreSQL database using Debezium and processes each change event:
+
+```yaml
+id: debezium-postgres-listener
+namespace: company.team.production
+
+tasks:
+  - id: postgres-changes
+    type: io.kestra.plugin.debezium.postgres.Trigger
+    description: "Listen for CDC events from the customers table."
+    hostname: "{{ secret('POSTGRES_HOST') }}"
+    port: "{{ secret('POSTGRES_PORT') }}"
+    username: "{{ secret('POSTGRES_USER') }}"
+    password: "{{ secret('POSTGRES_PASSWORD') }}"
+    database: "sales"
+    tableWhitelist:
+      - "public.customers"
+
+  - id: process-event
+    type: io.kestra.plugin.scripts.python.Script
+    description: "Process the captured change event."
+    script: |
+      from kestra import Kestra
+      import json
+
+      event = json.loads('{{ trigger.data }}')
+      change_type = event['payload']['op']
+      customer_id = event['payload']['after']['id']
+      
+      print(f"Detected change '{change_type}' for customer ID: {customer_id}")
+      Kestra.outputs({'customerId': customer_id, 'changeType': change_type})
+```
+
+This declarative approach makes CDC pipelines easier to build, manage, and scale. You can find more examples in our [Blueprints library](/blueprints/listen-debezium).
+
+## Best practices for change data capture
+
+To ensure your CDC implementation is robust, scalable, and secure, consider the following best practices.
+
+### Monitoring and error handling
+
+A CDC pipeline is a critical piece of infrastructure. Implement comprehensive [monitoring](/docs/administrator-guide/monitoring) to track latency, throughput, and error rates. Kestra provides built-in observability features, allowing you to set up alerts for failed tasks and configure automatic retries to handle transient issues, ensuring the reliability of your data flows.
+
+### Scalability considerations
+
+As data volumes grow, your CDC pipeline must be able to scale. Choose tools and architectures that support distributed processing. For log-based CDC, this might involve deploying multiple connectors in parallel. In Kestra, you can use worker groups to distribute the processing load across multiple nodes, ensuring your pipeline can handle high-throughput data streams without bottlenecks.
+
+### Security implications
+
+CDC pipelines often handle sensitive data. It's crucial to secure the data both in transit and at rest. Use encryption for connections to databases and message brokers. Manage credentials and other sensitive information using a secure secrets management system. Kestra offers built-in [secrets management](/docs/best-practices/secrets-management) and integrates with external vaults to ensure that your data remains protected throughout the pipeline.
+
+## Conclusion
+
+Change Data Capture is no longer a niche technique but a fundamental component of modern data engineering. By moving from inefficient batch processing to real-time event streams, CDC enables organizations to build more responsive, efficient, and data-driven systems. Whether you are synchronizing microservices, migrating databases, or powering real-time analytics, CDC provides the foundation for a truly agile data architecture.
+
+By combining powerful CDC tools like Debezium with a declarative orchestration platform like Kestra, [data engineers](/use-cases/data-engineers) can build, manage, and scale complex data pipelines with unprecedented ease and reliability. To see how Kestra can transform your [data orchestration](/data), explore our platform and get started today.


### PR DESCRIPTION
## Summary

Imports the *Change Data Capture (CDC)* SEO article as a resource page, following the format introduced in [docs#4637](https://github.com/kestra-io/docs/pull/4637), [docs#4646](https://github.com/kestra-io/docs/pull/4646), and [docs#4695](https://github.com/kestra-io/docs/pull/4695).

- **/resources/data/change-data-capture** — *What is Change Data Capture (CDC)?*

The page uses the resources collection frontmatter (`title`, `description`, `metaTitle`, `metaDescription`, `tag`, `date`, `faq`). FAQ schema is generated from frontmatter, so the trailing `## FAQ` and `## Structured data` sections from the source draft are not included.

## Test plan

- [ ] Page builds without schema errors
- [ ] Page renders at expected route (/resources/data/change-data-capture)
- [ ] Internal links resolve
- [ ] FAQ schema renders from frontmatter
- [ ] Mermaid diagram renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)