### PR TITLE
feat(plugins): extract first heading from longDescription for TOC entry

### DIFF
--- a/src/components/plugins/PluginsIndexWrapper.vue
+++ b/src/components/plugins/PluginsIndexWrapper.vue
@@ -2,8 +2,8 @@
     import { onMounted, onUnmounted, ref } from "vue"
     import { navigate } from "astro:transitions/client"
 
-    import { type Plugin, type PluginMetadata } from "@kestra-io/ui-libs"
-    import PluginIndex from "@kestra-io/ui-libs/src/components/plugins/PluginIndex.vue"
+    import { type Plugin, type PluginMetadata } from "@kestra-io/design-system"
+    import { KsPluginIndex as PluginIndex } from "@kestra-io/design-system"
 
     import MDCParserAndRenderer from "../MDCParserAndRenderer.vue"
 

--- a/src/utils/plugins/buildPluginPageProps.ts
+++ b/src/utils/plugins/buildPluginPageProps.ts
@@ -151,6 +151,9 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
 
     const tocEntry = (id: string, text: string): TocLink => ({ id, depth: TOC_DEPTH, text })
 
+    const extractFirstHeading = (markdown: string): string | undefined =>
+        markdown.match(/^#{1,6}\s+(.+)$/m)?.[1]?.trim()
+
     const generateTocForPluginElements = (wrapper: Plugin): TocLink[] =>
         Object.entries(wrapper)
             .filter(([key]) => isEntryAPluginElementPredicate(key, wrapper[key as keyof Plugin]))
@@ -238,7 +241,7 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
         return [
             ...baseTocLinks,
             ...(isRootView && rootPlugin?.longDescription
-                ? [tocEntry("how-to-use-this-plugin", "How to use this plugin")]
+                ? [tocEntry("how-to-use-this-plugin", extractFirstHeading(rootPlugin.longDescription) ?? "How to use this plugin")]
                 : []),
             ...(isRootView && currentPluginVideos?.length > 0
                 ? [tocEntry("see-it-in-action", "See it in action")]


### PR DESCRIPTION
## Summary

- Adds `extractFirstHeading` helper in `buildPluginPageProps.ts` that parses the first `#` heading from the plugin's markdown content
- Uses that heading text as the right-sidebar TOC label instead of the hardcoded `"How to use this plugin"` string
- Falls back to `"How to use this plugin"` when the markdown has no heading (backwards-compatible for plugins that haven't added an H1 yet)

## Test plan

- [ ] `/plugins/plugin-aws` right-sidebar TOC shows "How to Use the AWS Plugin" (from the plugin's H1)
- [ ] A plugin whose markdown has no heading still shows "How to use this plugin" in the TOC
- [ ] TOC anchor `#how-to-use-this-plugin` still scrolls to the correct section (anchor is on the wrapper div via the ui-libs change)

Part-of: https://github.com/kestra-io/docs/issues/4688