### PR TITLE
fix(resources): correct version control and CI/CD link in gitops page

### DIFF
--- a/src/contents/resources/gitops/index.md
+++ b/src/contents/resources/gitops/index.md
@@ -30,7 +30,7 @@ The entire system is managed declaratively, with Git serving as the guaranteed s
 
 ### Key principles of GitOps
 
-The GitOps methodology is guided by four fundamental principles that ensure consistency, reliability, and auditability. These principles form the foundation of any successful GitOps implementation and are crucial for effective [version control and CI/CD](https/kestra.io/docs/version-control-cicd).
+The GitOps methodology is guided by four fundamental principles that ensure consistency, reliability, and auditability. These principles form the foundation of any successful GitOps implementation and are crucial for effective [version control and CI/CD](https://kestra.io/docs/version-control-cicd).
 
 1.  **Declarative Configuration**: The entire system state must be described declaratively in a format like YAML or JSON. This description defines the desired state of all components, including infrastructure, applications, and configurations. By defining your system declaratively, as you would with [Kestra flows](https://kestra.io/docs/workflow-components/flow), you create a clear, unambiguous target for your automation.
 


### PR DESCRIPTION
## Summary
- The internal link with anchor "version control and CI/CD" on https://kestra.io/resources/infrastructure/gitops was malformed (`https/kestra.io/...` — missing colon), making it a broken link.
- Fixed the URL to `https://kestra.io/docs/version-control-cicd`.

## Test plan
- [ ] Verify the rendered page links to https://kestra.io/docs/version-control-cicd

🤖 Generated with [Claude Code](https://claude.com/claude-code)