### PR TITLE
feat(seo): add SoftwareApplication schema on homepage and /pricing

### DIFF
--- a/src/components/layout.astro
+++ b/src/components/layout.astro
@@ -85,6 +85,7 @@ const randomAiQuestions = getRandomAiQuestions()
 const annonces = parsedAnnonces.filter((a: { id: number }) => a.id !== 0)
 
 const isHomepage = Astro.url.pathname === "/"
+const isPricingPage = Astro.url.pathname === "/pricing" || Astro.url.pathname === "/pricing/"
 const hasAnnounce = isHomepage && annonces.length > 0
 
 const websiteSchema = isHomepage
@@ -96,6 +97,37 @@ const websiteSchema = isHomepage
           "name": "Kestra",
           "description":
               "Open-source declarative orchestration platform for data, AI, and infrastructure workflows",
+      }
+    : null
+
+const softwareApplicationSchema = (isHomepage || isPricingPage)
+    ? {
+          "@context": "https://schema.org",
+          "@type": "SoftwareApplication",
+          "@id": "https://kestra.io/#software",
+          "name": "Kestra",
+          "applicationCategory": "DeveloperApplication",
+          "applicationSubCategory": "Workflow Orchestration",
+          "operatingSystem": "Linux, macOS, Windows, Docker, Kubernetes",
+          "url": "https://kestra.io",
+          "downloadUrl": "https://github.com/kestra-io/kestra",
+          "license": "https://www.apache.org/licenses/LICENSE-2.0",
+          "isAccessibleForFree": true,
+          "publisher": { "@id": "https://kestra.io/#organization" },
+          "offers": [
+              {
+                  "@type": "Offer",
+                  "name": "Open Source",
+                  "price": "0",
+                  "priceCurrency": "USD",
+                  "url": "https://github.com/kestra-io/kestra",
+              },
+              {
+                  "@type": "Offer",
+                  "name": "Enterprise Edition",
+                  "url": "https://kestra.io/pricing",
+              },
+          ],
       }
     : null
 
@@ -229,6 +261,7 @@ const organizationSchema = {
 
         <script type="application/ld+json" set:html={JSON.stringify(organizationSchema)}></script>
         {websiteSchema && <script type="application/ld+json" set:html={JSON.stringify(websiteSchema)}></script>}
+        {softwareApplicationSchema && <script type="application/ld+json" set:html={JSON.stringify(softwareApplicationSchema)}></script>}
 
         <slot name="head" />
 


### PR DESCRIPTION
## Summary

Adds a `SoftwareApplication` JSON-LD block on the homepage and `/pricing` — the two top-funnel pages where Kestra is presented as a product.

- `applicationCategory`: `DeveloperApplication`
- `applicationSubCategory`: `Workflow Orchestration`
- `operatingSystem`: Linux, macOS, Windows, Docker, Kubernetes
- `publisher`: linked to existing `Organization` via shared `@id` anchor
- Two `offers`: Open Source (free, GitHub) + Enterprise Edition (links to `/pricing`)

## Context

Plugin pages already had their own `SoftwareApplication` blocks (one per plugin, #4656). This PR adds the **parent** block for the Kestra product itself, so Google recognizes the brand entity as software rather than just a website.

Identified in the May 13, 2026 SEO follow-up audit (§5.2) — last remaining HIGH-priority schema gap from the April action plan.

## Test plan

- [ ] Build the site locally and verify the JSON-LD block appears on `/` and `/pricing` only
- [ ] Validate the structured data via [Schema.org validator](https://validator.schema.org/) and [Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Verify no JSON-LD block appears on `/docs`, `/blogs`, plugin pages (existing SoftwareApplication on plugins should remain untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)