### PR TITLE
fix(blueprints): sanitize pagination params to eliminate 501 errors

### DIFF
--- a/src/pages/blueprints/index.astro
+++ b/src/pages/blueprints/index.astro
@@ -8,29 +8,59 @@ import BlueprintCard from "~/components/layout/BlueprintCard.astro"
 import BlueprintLists from "~/components/blueprints/BlueprintLists.vue"
 import BlueprintSearch from "~/components/blueprints/BlueprintSearch.vue"
 
-const page = Astro.url.searchParams.get("page") ?? 1
-const size = Astro.url.searchParams.get("size") ?? 24
+// Sanitize pagination params so unexpected query strings (e.g. tracking-injected
+// `clid=`, malformed `size=99999`) cannot reach the upstream API and trigger 501s.
+// See PR description for the production incident this guards against.
+const PAGE_DEFAULT = 1
+const SIZE_DEFAULT = 24
+const SIZE_MAX = 48
+const PAGE_MAX = 1000
+
+const parsePositiveInt = (raw: string | null, fallback: number, max: number) => {
+    if (!raw) return fallback
+    const n = Number.parseInt(raw, 10)
+    if (!Number.isFinite(n) || n < 1) return fallback
+    return Math.min(n, max)
+}
+
+const page = parsePositiveInt(Astro.url.searchParams.get("page"), PAGE_DEFAULT, PAGE_MAX)
+const size = parsePositiveInt(Astro.url.searchParams.get("size"), SIZE_DEFAULT, SIZE_MAX)
 const q = Astro.url.searchParams.get("q") ?? undefined
 const sort = Astro.url.searchParams.get("sort") ?? "A-Z"
 const tagsSelected = Astro.url.searchParams.get("tags") ?? undefined
 
-const tags = await $fetchApiCached<BlueprintTag[]>(
-    `/blueprints/versions/latest/tags`,
-)
+let tags: BlueprintTag[] = []
+try {
+    tags = await $fetchApiCached<BlueprintTag[]>(
+        `/blueprints/versions/latest/tags`,
+    )
+} catch (e) {
+    console.error("[blueprints] failed to fetch tags", e)
+}
 
 const tagsForFilter = tagsSelected
     ? tags.find((tag) => tag.name.toLowerCase() === tagsSelected.toLowerCase())
           ?.id
     : undefined
 
-const { results: blueprintsData = [], total = 0 } = (await $fetchApiCached<{
-    results: Blueprint[]
-    total: number
-}>(
-    `/blueprints/versions/latest?size=${size}&page=${page}` +
-        (tagsForFilter ? `&tags=${tagsForFilter}` : "") +
-        (q ? `&q=${encodeURIComponent(q)}` : ""),
-)) ?? { results: [], total: 0 }
+let blueprintsData: Blueprint[] = []
+let total = 0
+try {
+    const data = await $fetchApiCached<{
+        results: Blueprint[]
+        total: number
+    }>(
+        `/blueprints/versions/latest?size=${size}&page=${page}` +
+            (tagsForFilter ? `&tags=${tagsForFilter}` : "") +
+            (q ? `&q=${encodeURIComponent(q)}` : ""),
+    )
+    if (data) {
+        blueprintsData = data.results ?? []
+        total = data.total ?? 0
+    }
+} catch (e) {
+    console.error("[blueprints] failed to fetch blueprint list", e)
+}
 
 const blueprints = blueprintsData.sort((a, b) => {
     if (sort === "A-Z") {

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -9,10 +9,7 @@ const disabled = import.meta.env.DEV || envField.PREVIEW
 
 User-agent: *
 Disallow: ${disabled ? "*" : "/slack"}
-${disabled ? "" : `# Block the /blueprints pagination bug (critical - 501 errors)
-Disallow: /blueprints?*clid=*
-Disallow: /blueprints?*size=*
-# Build assets — CSS, JS, fonts accessible for robots rendering
+${disabled ? "" : `# Build assets — CSS, JS, fonts accessible for robots rendering
 Allow: /_astro/
 Disallow: /_nuxt/
 Disallow: /__nuxt_content/


### PR DESCRIPTION
## Summary

Root-cause fix for the recurring `/blueprints?…` 501 errors that have been masked since April via robots.txt `Disallow` rules.

The page passed `page` and `size` query string values raw into the upstream API. Malformed values (`size=99999`, `page=abc`, or unexpected tracking params injected by ad networks) caused the API to return 501, which in turn produced a hard render failure on `/blueprints` rather than a degraded page.

**Two protections introduced:**

1. **Validate and clamp pagination params**
   - `page`: positive integer, capped at 1000 (default `1`)
   - `size`: positive integer, capped at 48 (default `24`)
   - Non-numeric or out-of-range values silently fall back to defaults

2. **Graceful degradation on API failure**
   - Both API calls (tags + blueprint list) are now wrapped in `try/catch`
   - If the upstream API is unreachable, the page renders the search UI with an empty result set instead of crashing

**Also removes the temporary robots.txt workaround:**
```diff
- # Block the /blueprints pagination bug (critical - 501 errors)
- Disallow: /blueprints?*clid=*
- Disallow: /blueprints?*size=*
```
The `/blueprints` listing becomes fully crawlable again with malformed query strings handled defensively at the source.

## Context

Identified in the May 13, 2026 SEO follow-up audit (§2.1 and §11.2 — the only remaining Critical-tier item alongside the empty CSP value). The robots.txt workaround was in place since April and has been blocking legitimate crawls for ~30 days.

## Test plan

- [ ] Local build, then verify the following URLs all return 200 with a rendered page:
  - `/blueprints`
  - `/blueprints?page=1&size=24` (normal)
  - `/blueprints?size=99999` (clamped to 48)
  - `/blueprints?page=abc&size=-5` (falls back to defaults)
  - `/blueprints?clid=fb_test_id` (ignored unknown param)
- [ ] Verify search and pagination still work normally
- [ ] Confirm `/robots.txt` no longer contains the two `/blueprints?*` Disallow rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)