### PR TITLE
seo(resources): internal linking to /use-cases/* pages

### DIFF
--- a/src/contents/resources/automation/index.md
+++ b/src/contents/resources/automation/index.md
@@ -148,7 +148,7 @@ tasks:
     payload: '{"text": "✅ {{ inputs.environment }} environment provisioned"}'
 ```
 
-Terraform for provisioning, Ansible for configuration, an HTTP call for CMDB registration, a notification at the end — all coordinated with retries, error handling, and audit logging built into the orchestration layer.
+Terraform for provisioning, Ansible for configuration, an HTTP call for CMDB registration, a notification at the end — all coordinated with retries, error handling, and audit logging built into the orchestration layer. The same backbone powers Kestra's broader [CI/CD automation use cases](/use-cases/ci-cd) when the trigger is a Git push instead of an input.
 
 ## Implementing Infrastructure Automation
 
@@ -189,4 +189,4 @@ The last category is where many organizations under-invest — and where the mos
 
 Infrastructure automation works when there's a clear hierarchy: IaC at the bottom, configuration management on top of it, and an orchestration layer tying everything together. Skipping the orchestration layer is where most automation programs stall — provisioning gets automated, configuration gets automated, but the end-to-end workflow stays manual.
 
-For teams evaluating orchestration for infrastructure workflows, Kestra is open-source, self-hostable, and integrates natively with Terraform, Ansible, Kubernetes, and cloud APIs. Start with the [infrastructure automation hub](/infra-automation), try the [getting-started blueprint](/blueprints/infrastructure-automation), or read the broader [declarative infrastructure approach](/blogs/infra-automation).
+For teams evaluating orchestration for infrastructure workflows, Kestra is open-source, self-hostable, and integrates natively with Terraform, Ansible, Kubernetes, and cloud APIs. Start with the [infrastructure automation hub](/infra-automation), try the [getting-started blueprint](/blueprints/infrastructure-automation), explore how [platform engineers use Kestra](/use-cases/platform-engineers) as a unified control plane, or read the broader [declarative infrastructure approach](/blogs/infra-automation).

--- a/src/contents/resources/batch-vs-streaming-processing/index.md
+++ b/src/contents/resources/batch-vs-streaming-processing/index.md
@@ -80,7 +80,7 @@ State is first-class: the processor often needs to maintain rolling aggregates, 
 
 - **Low latency**: results are available within milliseconds to seconds of the event occurring.
 - **Continuous insight**: dashboards, monitors, and reactive workflows get a live view of the system rather than periodic snapshots.
-- **Reactive workflows**: streaming enables use cases that are impossible with batch — fraud blocking, dynamic pricing, real-time recommendations, [event-driven orchestration](/resources/infrastructure/event-driven-orchestration) that kicks off downstream work the instant an event lands.
+- **Reactive workflows**: streaming enables use cases that are impossible with batch — fraud blocking, dynamic pricing, real-time recommendations, [real-time pipelines for the automotive industry](/use-cases/automotive), and [event-driven orchestration](/resources/infrastructure/event-driven-orchestration) that kicks off downstream work the instant an event lands.
 
 ### Weaknesses
 

--- a/src/contents/resources/change-data-capture/index.md
+++ b/src/contents/resources/change-data-capture/index.md
@@ -74,7 +74,7 @@ The most transformative benefit of CDC is its ability to power real-time analyti
 
 ## Use cases for change data capture
 
-CDC is a versatile technique applicable to a wide range of data integration challenges. Its ability to provide low-latency, reliable data streams makes it invaluable in many modern architectures.
+CDC is a versatile technique applicable to a wide range of data integration challenges. Its ability to provide low-latency, reliable data streams makes it invaluable in many modern architectures — see the dedicated [Change Data Capture use cases](/use-cases/change-data-capture) page for the patterns Kestra teams run in production.
 
 ### Data warehousing and ETL processes
 
@@ -82,7 +82,7 @@ CDC is a key enabler for efficient data warehousing. Instead of performing full 
 
 ### Database replication and migration
 
-When migrating from one database system to another, minimizing downtime is critical. CDC facilitates zero-downtime migrations by allowing the new database to be synchronized with the old one in real time. Once the initial data load is complete, CDC keeps the target database up-to-date with any changes occurring on the source. The cutover can then be performed with minimal disruption to applications.
+When migrating from one database system to another, minimizing downtime is critical. CDC facilitates zero-downtime migrations by allowing the new database to be synchronized with the old one in real time. Once the initial data load is complete, CDC keeps the target database up-to-date with any changes occurring on the source. The cutover can then be performed with minimal disruption to applications — a common scenario in broader [database management workflows](/use-cases/databases-management).
 
 ### Auditing and compliance
 
@@ -90,7 +90,7 @@ For industries with strict regulatory requirements, maintaining a detailed audit
 
 ### What is an example of change data capture?
 
-A classic example of CDC is in an e-commerce platform. When a customer places an order, a new record is inserted into the `orders` table in the transactional database.
+A classic example of CDC is in an e-commerce platform — a pattern that sits at the core of modern [retail data workflows](/use-cases/retail). When a customer places an order, a new record is inserted into the `orders` table in the transactional database.
 1.  A log-based CDC tool like Debezium reads this `INSERT` event from the database's transaction log.
 2.  The change event is published to a message broker like Kafka.
 3.  Multiple downstream services can consume this event in real time:

--- a/src/contents/resources/data-lineage/index.md
+++ b/src/contents/resources/data-lineage/index.md
@@ -134,7 +134,7 @@ A hospital needs to report patient admission rates to a public health agency. Ac
 4.  **Aggregation:** The anonymized records are loaded into a secure data mart, where they are aggregated by day, demographic group, and diagnosis code.
 5.  **Reporting:** A reporting tool generates the final admission rate report from the aggregated data.
 
-Data lineage here is crucial for auditing. It proves that the PII was correctly removed and that the aggregation logic matches the agency's specifications. This is a common pattern in many [data pipeline use cases](https://kestra.io/docs/use-cases/data-pipelines) where compliance and accuracy are non-negotiable.
+Data lineage here is crucial for auditing. It proves that the PII was correctly removed and that the aggregation logic matches the agency's specifications. This is a common pattern in many [data pipeline use cases](https://kestra.io/docs/use-cases/data-pipelines) — and a baseline expectation for [healthcare orchestration workflows](/use-cases/healthcare) — where compliance and accuracy are non-negotiable.
 
 ## The Tangible Benefits of Robust Data Lineage
 

--- a/src/contents/resources/data-observability/index.md
+++ b/src/contents/resources/data-observability/index.md
@@ -40,7 +40,7 @@ At its core, data observability is an orchestration challenge. It requires coord
 
 Without data observability, data teams operate with blind spots. A pipeline might complete successfully, but the data it delivers could be incomplete, stale, or incorrectly formatted. These "silent failures" are particularly insidious because they undermine the most valuable asset a data team has: trust.
 
-When business stakeholders can no longer rely on the dashboards and reports they use for critical decisions, the value of the entire data platform diminishes. Data observability addresses this by:
+When business stakeholders can no longer rely on the dashboards and reports they use for critical decisions, the value of the entire data platform diminishes — a particularly acute risk for [financial services orchestration workflows](/use-cases/financial-services), where every reconciliation depends on trustworthy pipelines. Data observability addresses this by:
 
 -   **Building Confidence:** Providing verifiable proof that data is fresh, accurate, and complete.
 -   **Reducing Time-to-Resolution:** Enabling data engineers to quickly pinpoint the root cause of an issue, from source to consumption.
@@ -89,7 +89,7 @@ Adopting a data observability strategy yields significant returns, transforming 
 
 ### Minimizing Data Downtime and Errors
 
-Data downtime refers to periods when data is missing, inaccurate, or otherwise erroneous. By providing early warnings of potential issues, data observability significantly reduces the duration and impact of this downtime. Instead of discovering a problem hours or days later from an angry end-user, teams are alerted in near real-time. This proactive stance allows for faster root cause analysis and resolution, often before the business is even aware of an issue. Implementing robust [error handling and observability](https://kestra.io/blueprints/error-logs) within your orchestration workflows is a first step toward minimizing this downtime.
+Data downtime refers to periods when data is missing, inaccurate, or otherwise erroneous. By providing early warnings of potential issues, data observability significantly reduces the duration and impact of this downtime. Instead of discovering a problem hours or days later from an angry end-user, teams are alerted in near real-time. This proactive stance allows for faster root cause analysis and resolution, often before the business is even aware of an issue — the same proactive posture that anchors Kestra's [pipeline monitoring use cases](/use-cases/monitoring). Implementing robust [error handling and observability](https://kestra.io/blueprints/error-logs) within your orchestration workflows is a first step toward minimizing this downtime.
 
 ### Improving Data Quality and Reliability at Scale
 

--- a/src/contents/resources/data-pipeline/index.md
+++ b/src/contents/resources/data-pipeline/index.md
@@ -100,7 +100,7 @@ Batch pipelines run on a fixed schedule — typically hourly, daily, or weekly. 
 
 ### Streaming Pipelines
 
-Streaming pipelines process data continuously, one record (or micro-batch) at a time, as it arrives. Latency drops from hours to seconds or milliseconds. Tools like Kafka, Flink, and Spark Streaming power this pattern. Use cases: fraud detection, real-time personalization, operational dashboards.
+Streaming pipelines process data continuously, one record (or micro-batch) at a time, as it arrives. Latency drops from hours to seconds or milliseconds. Tools like Kafka, Flink, and Spark Streaming power this pattern. Use cases: fraud detection, real-time personalization, operational dashboards, and [connected-vehicle data pipelines in the automotive industry](/use-cases/automotive).
 
 ### Event-Driven Pipelines
 

--- a/src/contents/resources/data-quality/index.md
+++ b/src/contents/resources/data-quality/index.md
@@ -61,17 +61,17 @@ High-quality data is not just a technical requirement; it's a strategic business
 On a daily basis, business operations rely on accurate data to function. Poor data quality can cause tangible problems:
 - **Supply Chain:** Incorrect inventory levels lead to stockouts or overstocking.
 - **Customer Service:** Inaccurate customer histories frustrate support agents and customers alike.
-- **Finance:** Flawed transaction data results in billing errors and compliance issues.
+- **Finance:** Flawed transaction data results in billing errors and compliance issues — a defining concern for [financial services data workflows](/use-cases/financial-services).
 - **Marketing:** Incomplete customer profiles lead to ineffective campaigns and wasted ad spend.
 
-By improving data quality, organizations can streamline these processes, reduce manual corrections, and enhance overall operational efficiency.
+By improving data quality, organizations can streamline these processes, reduce manual corrections, and enhance overall operational efficiency. The same imperative drives [public services data orchestration](/use-cases/public-services), where citizen-facing systems can't afford to act on stale or contradictory records.
 
 ### Reducing Risks and Improving Decision-Making
 
 Every business decision carries a degree of risk, but decisions based on poor data are gambles. High-quality data provides a solid foundation for strategic planning, financial forecasting, and market analysis. It mitigates several types of risk:
 - **Financial Risk:** Accurate financial data is essential for budgeting and reporting.
 - **Reputational Risk:** Errors like sending marketing materials to deceased customers can damage brand perception.
-- **Compliance Risk:** Regulations like GDPR and CCPA impose strict requirements on the accuracy and management of personal data.
+- **Compliance Risk:** Regulations like GDPR, HIPAA, and CCPA impose strict requirements on the accuracy and management of personal data — non-negotiable for [healthcare orchestration workflows](/use-cases/healthcare) where every record affects patient care.
 
 Ultimately, trustworthy data empowers leaders to make confident, evidence-based decisions that drive growth and innovation.
 

--- a/src/contents/resources/disaster-recovery/index.md
+++ b/src/contents/resources/disaster-recovery/index.md
@@ -98,7 +98,7 @@ A robust DR plan is a cornerstone of business continuity, ensuring that an organ
 
 ### Preventing data loss and system downtime
 
-Downtime can have severe consequences, including direct financial losses from lost revenue, reputational damage that erodes customer trust, and potential legal or compliance penalties. A well-executed DR plan minimizes these impacts by restoring services quickly and ensuring data integrity. Effective [infrastructure monitoring](https://kestra.io/use-cases/monitoring) is a key part of this, providing early warnings of potential issues.
+Downtime can have severe consequences, including direct financial losses from lost revenue, reputational damage that erodes customer trust, and potential legal or compliance penalties — stakes that are especially high in [financial services orchestration workflows](/use-cases/financial-services) where settlement windows and regulatory SLAs leave no margin for unplanned downtime. A well-executed DR plan minimizes these impacts by restoring services quickly and ensuring data integrity. Effective [infrastructure monitoring](https://kestra.io/use-cases/monitoring) is a key part of this, providing early warnings of potential issues.
 
 ### Ensuring operational resilience
 

--- a/src/contents/resources/event-driven-orchestration/index.md
+++ b/src/contents/resources/event-driven-orchestration/index.md
@@ -55,7 +55,7 @@ With event-driven orchestration, the order creation event (a new message on an `
 
 ### Real-time responsiveness
 
-Schedules are a poor fit when data arrival is unpredictable. An hourly cron that processes files from S3 adds up to an hour of latency on every upload. An event-driven trigger starts the workflow the moment the file lands, keeping end-to-end latency in the seconds.
+Schedules are a poor fit when data arrival is unpredictable. An hourly cron that processes files from S3 adds up to an hour of latency on every upload. An event-driven trigger starts the workflow the moment the file lands, keeping end-to-end latency in the seconds. The same pattern powers high-throughput verticals — including event-driven orchestration for [automotive and connected-vehicle workloads](/use-cases/automotive) where telemetry must be processed as it streams in.
 
 ### Decoupling without losing visibility
 
@@ -220,7 +220,7 @@ Event-driven orchestration shows up in three recurring patterns worth recognizin
 
 **Data pipeline automation.** File lands in S3 or GCS, orchestrator picks it up, runs validation, loads into the warehouse, triggers dbt, and notifies stakeholders. This replaces the classic "scheduled every hour, hope the data is there" pattern.
 
-**Microservice coordination.** An order event triggers a workflow that calls payment, inventory, shipping, and notification services in a defined sequence, with compensating actions on failure. The orchestrator acts as a saga coordinator.
+**Microservice coordination.** An order event triggers a workflow that calls payment, inventory, shipping, and notification services in a defined sequence, with compensating actions on failure. The orchestrator acts as a saga coordinator — see how teams approach [microservices orchestration](/use-cases/microservices-orchestration) end-to-end.
 
 **Infrastructure automation.** A webhook from a monitoring system triggers a remediation workflow: scale a cluster, rotate credentials, run a diagnostic, open an incident. The orchestrator ties together the cloud APIs, scripts, and notifications.
 

--- a/src/contents/resources/gitops/index.md
+++ b/src/contents/resources/gitops/index.md
@@ -99,7 +99,7 @@ flowchart LR
 3.  **Merge**: Once approved, the change is merged into the main branch.
 4.  **CI Pipeline**: The merge triggers a Continuous Integration (CI) pipeline that builds, tests, and packages the application (e.g., as a Docker image) and pushes it to a container registry. The pipeline then updates a deployment manifest (e.g., a Kubernetes YAML file) in the configuration repository with the new image tag.
 5.  **Reconciliation**: The GitOps operator running in the production environment detects the change in the configuration repository. It pulls the updated manifest and compares the desired state with the actual state of the cluster.
-6.  **Deployment**: The operator applies the necessary changes to reconcile the cluster's state with the desired state, such as deploying the new container image. This entire process can be managed and validated with [Kestra's CI/CD capabilities](https://kestra.io/docs/version-control-cicd/cicd).
+6.  **Deployment**: The operator applies the necessary changes to reconcile the cluster's state with the desired state, such as deploying the new container image. This entire process can be managed and validated with [Kestra's CI/CD capabilities](https://kestra.io/docs/version-control-cicd/cicd) — see how teams build end-to-end [CI/CD orchestration with Kestra](/use-cases/ci-cd).
 
 ### Migrating to a GitOps model
 
@@ -158,7 +158,7 @@ GitOps is a versatile framework applicable across various domains, from infrastr
 
 ### Real-world applications of GitOps
 
--   **Cloud Infrastructure Provisioning**: Managing cloud resources (VPCs, databases, IAM roles) with Terraform or OpenTofu, where changes are applied via a GitOps workflow. This is a core part of modern [infrastructure automation](https://kestra.io/use-cases/infrastructure).
+-   **Cloud Infrastructure Provisioning**: Managing cloud resources (VPCs, databases, IAM roles) with Terraform or OpenTofu, where changes are applied via a GitOps workflow. This is a core part of modern [infrastructure automation](https://kestra.io/use-cases/infrastructure) and orchestrated [provisioning and deployment workflows](/use-cases/provisioning-and-deployment).
 -   **Application Deployment**: The most common use case, deploying and managing the lifecycle of microservices and other applications on Kubernetes.
 -   **Data Pipeline Orchestration**: Versioning and deploying [data pipelines](https://kestra.io/use-cases/data-pipelines) as code. For example, dbt models, data quality tests, and orchestration flows (like Kestra's YAML files) can be managed in Git and deployed automatically.
 -   **AI Model Deployment**: Managing the deployment of machine learning models and their configurations, ensuring that a specific model version is tied to a specific Git commit for reproducibility. Kestra can orchestrate these [AI workflows](https://kestra.io/docs/ai-tools/ai-workflows) in a GitOps-native way.

--- a/src/contents/resources/hybrid-cloud-automation/index.md
+++ b/src/contents/resources/hybrid-cloud-automation/index.md
@@ -57,7 +57,7 @@ The biggest source of outages in hybrid environments isn't technology — it's i
 
 ### Security and Compliance
 
-Regulated industries often keep sensitive workloads on-prem while using public cloud for everything else. Automation makes compliance auditable: every change is logged, every approval is captured, every credential is rotated on schedule. Compliance shifts from a quarterly scramble to a continuous property of the system.
+Regulated industries often keep sensitive workloads on-prem while using public cloud for everything else — a defining constraint behind many [public services orchestration use cases](/use-cases/public-services). Automation makes compliance auditable: every change is logged, every approval is captured, every credential is rotated on schedule. Compliance shifts from a quarterly scramble to a continuous property of the system.
 
 ## Common Use Cases for Hybrid Cloud Automation
 
@@ -69,7 +69,7 @@ Moving workloads between environments — cloud to on-prem for cost, on-prem to 
 
 ### Disaster Recovery and Business Continuity
 
-DR plans that exist only as runbooks fail when the incident actually happens. Hybrid cloud automation turns DR into a workflow that can be tested regularly — failing over from on-prem to cloud, validating the failover, then failing back — until it becomes routine rather than a once-a-year fire drill.
+DR plans that exist only as runbooks fail when the incident actually happens. Hybrid cloud automation turns DR into a workflow that can be tested regularly — failing over from on-prem to cloud, validating the failover, then failing back — until it becomes routine rather than a once-a-year fire drill. This is one of the most common [disaster recovery use cases](/use-cases/disaster-recovery) Kestra teams put into production.
 
 ### Development and Testing Environments
 

--- a/src/contents/resources/it-automation-platform/index.md
+++ b/src/contents/resources/it-automation-platform/index.md
@@ -103,7 +103,7 @@ Choosing the right IT automation platform involves understanding the strengths a
 *   **Unified Platform:** Kestra bridges the gap between different domains. The same platform can orchestrate a Terraform deployment, run a dbt data transformation, and coordinate an AI agent workflow, eliminating tool sprawl.
 *   **Scalable and Enterprise-Ready:** Built on a robust JVM-based architecture, Kestra is designed for high-throughput workloads. The [Enterprise Edition](https://kestra.io/enterprise) adds features like RBAC, SSO, audit logs, and multi-tenancy for secure, governed automation at scale.
 
-Kestra is the right choice for organizations looking for a single, flexible platform to manage complex, cross-domain workflows with an engineering-first, code-adjacent approach. You can learn more about its philosophy in the [Why Kestra documentation](https://kestra.io/docs/why-kestra).
+Kestra is the right choice for organizations looking for a single, flexible platform to manage complex, cross-domain workflows with an engineering-first, code-adjacent approach — including [software providers and ISVs](/use-cases/software-providers) embedding orchestration into their own products. You can learn more about its philosophy in the [Why Kestra documentation](https://kestra.io/docs/why-kestra).
 
 ### UiPath: RPA and AI-Driven Transformation for Business Processes
 

--- a/src/contents/resources/lakehouse-architecture/index.md
+++ b/src/contents/resources/lakehouse-architecture/index.md
@@ -47,7 +47,7 @@ A typical lakehouse architecture is built on several key components working in c
 - **Processing Engines:** A variety of engines can access the data directly. Apache Spark is the most common for large-scale data processing, while query engines like [DuckDB](/blogs/2024-03-14-duck-db) and Trino enable high-performance SQL analytics.
 - **Governance and Access Control:** Tools for managing security, access control, data quality, and lineage are integrated across the platform.
 
-This unified structure directly addresses the limitations of maintaining separate data lakes and data warehouses.
+This unified structure directly addresses the limitations of maintaining separate data lakes and data warehouses, and increasingly sits at the heart of the [modern data stack](/use-cases/modern-data-stack) Kestra customers operate.
 
 
 ## Lakehouse vs. Data Warehouse vs. Data Lake: Key Differentiators

--- a/src/contents/resources/multi-cloud-orchestration/index.md
+++ b/src/contents/resources/multi-cloud-orchestration/index.md
@@ -50,7 +50,7 @@ Without a shared orchestration layer, multi-cloud operations devolve into a patc
 
 ### Improved Resource Management and Scalability
 
-A unified orchestration layer lets teams provision, scale, and decommission resources across clouds based on workload demand rather than contractual lock-in. Workloads can shift to cheaper regions, fail over to a secondary provider, or scale out burst capacity — without rewriting the automation each time.
+A unified orchestration layer lets teams provision, scale, and decommission resources across clouds based on workload demand rather than contractual lock-in. Workloads can shift to cheaper regions, fail over to a secondary provider, or scale out burst capacity — without rewriting the automation each time. Cross-cloud failover is also the backbone of most modern [disaster recovery use cases](/use-cases/disaster-recovery).
 
 ### Optimizing Costs and Governance
 
@@ -145,4 +145,4 @@ Five practices that separate functional multi-cloud orchestration from theatrica
 
 Multi-cloud orchestration works when there's a single control plane that treats every environment equally — and breaks down when each cloud gets its own orchestrator bolted together at the edges. Picking the orchestration layer is the most consequential decision in a multi-cloud strategy.
 
-For teams evaluating options, Kestra is open-source, self-hostable, and runs natively across AWS, Azure, GCP, and on-prem from a single YAML-defined workflow layer. Start with the [multi-cloud deployment blueprint](/blueprints/multi-cloud-deployment), explore the [infrastructure automation hub](/infra-automation), or read the deeper case for [vendor-neutral orchestration](/blogs/kestra-series-a).
+For teams evaluating options, Kestra is open-source, self-hostable, and runs natively across AWS, Azure, GCP, and on-prem from a single YAML-defined workflow layer. Start with the [multi-cloud deployment blueprint](/blueprints/multi-cloud-deployment), explore the [infrastructure automation hub](/infra-automation), see how [software providers and ISVs](/use-cases/software-providers) embed this orchestration layer, or read the deeper case for [vendor-neutral orchestration](/blogs/kestra-series-a).

--- a/src/contents/resources/orchestrator/index.md
+++ b/src/contents/resources/orchestrator/index.md
@@ -40,7 +40,7 @@ An AI orchestrator coordinates the components of an AI system — retrieval, emb
 
 ### In container and cloud systems
 
-Container orchestrators (Kubernetes, Nomad, Amazon ECS) manage the lifecycle of containerized applications — scheduling containers across nodes, scaling replicas, recovering from failures. Cloud orchestrators (AWS Step Functions, Azure Logic Apps) coordinate cloud service calls into workflows. These are related to but distinct from workflow orchestration — they handle the runtime infrastructure rather than the workflow logic.
+Container orchestrators (Kubernetes, Nomad, Amazon ECS) manage the lifecycle of containerized applications — scheduling containers across nodes, scaling replicas, recovering from failures. Cloud orchestrators (AWS Step Functions, Azure Logic Apps) coordinate cloud service calls into workflows. These are related to but distinct from workflow orchestration — they handle the runtime infrastructure rather than the workflow logic. For the workflow-logic side of that boundary, see Kestra's [microservices orchestration use cases](/use-cases/microservices-orchestration).
 
 ## What Does a Technology Orchestrator Actually Do?
 

--- a/src/contents/resources/patch-management-automation/index.md
+++ b/src/contents/resources/patch-management-automation/index.md
@@ -134,7 +134,7 @@ errors:
     payload: '{"text": "🚨 Patch workflow failed — triggering rollback"}'
 ```
 
-Approval gates between rings, health checks at each stage, compliance evidence generated automatically, and failure handling built in. That's what "automated" looks like in practice — not fire-and-forget, but governed end-to-end.
+Approval gates between rings, health checks at each stage, compliance evidence generated automatically, and failure handling built in. That's what "automated" looks like in practice — not fire-and-forget, but governed end-to-end. Many teams reuse the same primitives for their broader [provisioning and deployment workflows](/use-cases/provisioning-and-deployment) and run patching inside their existing [CI/CD pipelines](/use-cases/ci-cd).
 
 ## Common Tools for Automated Patch Management
 

--- a/src/contents/resources/reverse-etl/index.md
+++ b/src/contents/resources/reverse-etl/index.md
@@ -41,7 +41,7 @@ This shift has profound implications:
 - **Informed Sales Outreach:** Sales representatives can see a customer's product usage, recent support tickets, and lead score directly in their CRM before making a call.
 - **Proactive Customer Support:** Support teams can be alerted to product usage patterns that indicate a customer might be at risk of churning, allowing for proactive intervention.
 
-By closing the loop between data analysis and business action, Reverse ETL transforms the data warehouse from a passive reporting tool into an active, operational hub that drives intelligent business decisions across the entire organization.
+By closing the loop between data analysis and business action, Reverse ETL transforms the data warehouse from a passive reporting tool into an active, operational hub that drives intelligent business decisions across the entire organization. Mature teams typically pair this with [Change Data Capture pipelines](/use-cases/change-data-capture) so warehouse syncs reflect upstream changes within seconds rather than hours.
 
 ## Reverse ETL vs. ETL: Key Differences and Complementary Roles
 
@@ -88,7 +88,7 @@ The true power of Reverse ETL is realized when it's applied to solve real-world 
 ### Streamlining Operations and Customer Service
 
 - **Proactive Support:** Identify customers exhibiting at-risk behaviors (e.g., failed payments, low feature adoption) and automatically create a ticket in Zendesk or Intercom for a customer success manager to follow up.
-- **Inventory and Supply Chain Management:** Sync sales forecasts and demand models from the warehouse to an ERP system to optimize stock levels and prevent shortages.
+- **Inventory and Supply Chain Management:** Sync sales forecasts and demand models from the warehouse to an ERP system to optimize stock levels and prevent shortages — a foundational pattern for [retail data activation use cases](/use-cases/retail).
 - **Enhanced Fraud Detection:** Feed real-time transaction and user behavior models into payment or security systems to identify and flag suspicious activity instantly.
 
 ## How Reverse ETL Platforms Work: From Warehouse to Application

--- a/src/contents/resources/schedule-data-workflows/index.md
+++ b/src/contents/resources/schedule-data-workflows/index.md
@@ -41,7 +41,7 @@ A workflow schedule is the automated execution plan for a data workflow. Instead
 ### Different types of data workflows
 
 Data workflows are not a monolith; they serve various purposes within the data lifecycle. Common types include:
-- **Data Integration:** Moving data between systems, such as extracting from APIs and loading into a data warehouse. A classic example is an [ETL workflow](https://kestra.io/resources/data/etl-workflow).
+- **Data Integration:** Moving data between systems, such as extracting from APIs and loading into a data warehouse, or scheduling recurring jobs across [database management workflows](/use-cases/databases-management). A classic example is an [ETL workflow](https://kestra.io/resources/data/etl-workflow).
 - **Data Transformation:** Cleaning, standardizing, and enriching raw data to make it usable for analysis. This often involves running scripts or dbt models.
 - **Data Analysis:** Preparing aggregated datasets for business intelligence and reporting tools.
 - **Machine Learning:** Orchestrating the steps to train, evaluate, and deploy machine learning models.

--- a/src/contents/resources/what-is-data-ingestion/index.md
+++ b/src/contents/resources/what-is-data-ingestion/index.md
@@ -43,7 +43,7 @@ Batch data ingestion involves collecting and transferring data in large, discret
 
 Real-time ingestion involves moving data from source to target continuously, as soon as it is generated. Streaming is a specific type of real-time ingestion where data is processed as a continuous flow of events. This approach ensures that the target system is always up-to-date with the latest information.
 
-- **Use Cases:** This method is essential for applications that require immediate insights, such as fraud detection in financial transactions, real-time analytics for e-commerce websites, monitoring IoT sensor data, and personalizing user experiences on the fly. An example is using an [event-driven ingestion pattern for AWS S3](https://kestra.io/blueprints/ingest-to-datalake-event-driven).
+- **Use Cases:** This method is essential for applications that require immediate insights, such as fraud detection in financial transactions, real-time analytics for e-commerce websites, monitoring IoT sensor data, [Change Data Capture pipelines](/use-cases/change-data-capture) that stream every row-level change downstream, and personalizing user experiences on the fly. An example is using an [event-driven ingestion pattern for AWS S3](https://kestra.io/blueprints/ingest-to-datalake-event-driven).
 - **Characteristics:** The primary benefits are extremely low latency and the ability to act on data in the moment. However, these systems are typically more complex to design and maintain. Modern orchestration platforms simplify this by providing native [`Realtime Triggers`](https://kestra.io/docs/workflow-components/triggers/realtime-trigger) that can listen to message queues like Kafka, SQS, or Pulsar.
 
 For a deeper dive into different ingestion methods, explore this [guide to cloud data warehouse integration and ingestion](https://kestra.io/blogs/2024-03-06-guide-integration-ingestion).
@@ -63,7 +63,7 @@ A robust data ingestion system is composed of several key elements working in co
 
 ### Key Elements Involved
 
-- **Data Sources:** Where the data originates. This can include databases (SQL, NoSQL), APIs, log files, message queues, IoT devices, and flat files (CSV, JSON, Parquet).
+- **Data Sources:** Where the data originates. This can include databases (SQL, NoSQL) — see how Kestra fits into broader [database management workflows](/use-cases/databases-management) — APIs, log files, message queues, IoT devices, and flat files (CSV, JSON, Parquet).
 - **Connectors/Agents:** Software components that connect to data sources and extract the data. These can be API clients, database drivers, or specialized agents. A platform with a rich ecosystem of [plugins](https://kestra.io/plugins) can connect to virtually any source.
 - **Ingestion Layer:** The transport mechanism that moves the data. For real-time ingestion, this is often a message broker like Apache Kafka or AWS SQS. For batch, it might be a direct transfer protocol.
 - **Staging Area:** An intermediate storage location, such as a data lake or cloud storage (e.g., S3, GCS), where raw data is landed before further processing.
@@ -91,7 +91,7 @@ As businesses grow, so does their data. Ingestion systems must be scalable to ha
 
 ### Security and Compliance Considerations
 
-Data is a valuable and sensitive asset. During ingestion, it must be protected both in transit and at rest through encryption. Access control mechanisms like RBAC are crucial to ensure only authorized users and systems can interact with the data. Furthermore, organizations must adhere to regulatory standards like GDPR and HIPAA, which requires features like detailed [audit logs](https://kestra.io/docs/enterprise/governance/audit-logs) for compliance.
+Data is a valuable and sensitive asset. During ingestion, it must be protected both in transit and at rest through encryption. Access control mechanisms like RBAC are crucial to ensure only authorized users and systems can interact with the data. Furthermore, organizations must adhere to regulatory standards like GDPR and HIPAA — a hard requirement for [healthcare data ingestion workflows](/use-cases/healthcare) — which requires features like detailed [audit logs](https://kestra.io/docs/enterprise/governance/audit-logs) for compliance.
 
 ## Best Practices for Effective Data Ingestion
 

--- a/src/contents/resources/what-is-infrastructure-as-code/index.md
+++ b/src/contents/resources/what-is-infrastructure-as-code/index.md
@@ -39,7 +39,7 @@ IaC is built on a set of foundational principles that ensure its effectiveness:
 
 ## Why Infrastructure as Code is Essential for Modern IT
 
-Adopting IaC is no longer a niche practice; it's a critical component of modern DevOps and platform engineering. The benefits extend beyond simple automation, impacting speed, reliability, and cost.
+Adopting IaC is no longer a niche practice; it's a critical component of modern DevOps and [platform engineering](/use-cases/platform-engineers). The benefits extend beyond simple automation, impacting speed, reliability, and cost.
 
 - **Consistency and Reliability:** IaC eliminates configuration drift by ensuring that every environment is provisioned from the same source of truth. This consistency drastically reduces bugs and deployment failures caused by environment-specific discrepancies.
 - **Speed and Efficiency:** Automation accelerates the entire lifecycle of infrastructure management. Provisioning new environments, from a single server to a complex multi-cloud setup, can be reduced from days or weeks to minutes.
@@ -66,7 +66,7 @@ This GitOps model provides a clear history of all infrastructure modifications, 
 
 ### What are examples of Infrastructure as Code?
 IaC can be applied to a wide range of scenarios:
-- **Cloud Environment Setup:** Provisioning virtual machines, networks, storage, and IAM policies on AWS, Azure, or GCP.
+- **Cloud Environment Setup:** Provisioning virtual machines, networks, storage, and IAM policies on AWS, Azure, or GCP — see Kestra's [provisioning and deployment use cases](/use-cases/provisioning-and-deployment) for end-to-end orchestration of these flows.
 - **Web Application Deployment:** Defining the entire stack for an application, including servers, load balancers, databases, and CDN configurations.
 - **Multi-Cloud Deployments:** Using a single set of configurations to deploy infrastructure consistently across different cloud providers.
 - **CI/CD Pipelines:** Automatically creating and destroying testing and staging environments as part of the software delivery pipeline.

--- a/src/contents/resources/workflow-management/index.md
+++ b/src/contents/resources/workflow-management/index.md
@@ -46,7 +46,7 @@ Modern systems offer a suite of capabilities to manage the entire workflow lifec
 
 - **Workflow Modeling/Design**: This is the interface for defining workflows. It can be a visual drag-and-drop editor, a code-based approach using languages like Python, or a declarative format like YAML. Declarative systems allow you to define the "what" (the desired state) and let the engine figure out the "how."
 - **Execution Engine**: The core of the WFMS, responsible for interpreting the workflow definition, scheduling tasks, managing dependencies, and executing the logic.
-- **Monitoring & Analytics**: A crucial component for observability. This includes a [user interface](https://kestra.io/docs/ui) with dashboards, real-time status tracking, detailed logs, and performance metrics. This visibility helps teams identify bottlenecks and troubleshoot failures quickly.
+- **Monitoring & Analytics**: A crucial component for observability. This includes a [user interface](https://kestra.io/docs/ui) with dashboards, real-time status tracking, detailed logs, and performance metrics. This visibility helps teams identify bottlenecks and troubleshoot failures quickly — see Kestra's [workflow monitoring use cases](/use-cases/monitoring) for production patterns.
 - **Integration Capabilities**: No workflow exists in a vacuum. A modern WFMS must connect to a wide range of external systems, databases, and APIs. This is typically achieved through a rich ecosystem of [plugins](https://kestra.io/plugins) and connectors.
 - **Scalability**: The system must be able to handle growth in both the number of workflows and the volume of executions without performance degradation. This often involves distributed architecture and efficient resource management.
 - **Error Handling and Retries**: Workflows can fail. A good WFMS provides built-in mechanisms for retries, timeouts, and error-handling branches to build resilient processes.
@@ -127,7 +127,7 @@ Workflows are built from basic patterns that can be combined to model complex lo
     *   **Application**: An approval workflow where a request is routed to a manager only if the amount exceeds a certain threshold. In data pipelines, this could mean running a cleanup task only if data quality metrics fall below a set standard.
 
 4.  **State-Machine Workflows**: These are more complex workflows that move between different "states" based on events or triggers. The process is not necessarily linear and can loop back or jump between states.
-    *   **Application**: An order fulfillment process that moves from "Pending" to "Processing" to "Shipped" or "Cancelled" states. A CI/CD pipeline is also a state-machine, moving through states like "Building," "Testing," and "Deploying."
+    *   **Application**: An order fulfillment process that moves from "Pending" to "Processing" to "Shipped" or "Cancelled" states — a canonical [microservices orchestration pattern](/use-cases/microservices-orchestration). A CI/CD pipeline is also a state-machine, moving through states like "Building," "Testing," and "Deploying," which is why [software engineers adopt Kestra](/use-cases/software-engineers) as a workflow backbone.
 
 You can find many examples of these patterns in Kestra's [Blueprints](https://kestra.io/blueprints) library.
 


### PR DESCRIPTION
## Summary

- Adds **38 new internal links** from 21 `/resources/*` pages toward the 16 `/use-cases/*` pages that were under-linked in the GSC export (data-engineers already had 5 inbound and was intentionally left untouched).
- Each target use-case page now has **exactly 3 inbound links** from the resources hub, respecting the 1–3 cap requested by the SEO team.
- Anchors mix **exact-match** (e.g. "Change Data Capture use cases", "disaster recovery orchestration") and **semi-optimized** variants (e.g. "real-time pipelines for the automotive industry"), placed inside existing editorial paragraphs — no footer-style related-link blocks.

## Distribution per use-case (new links added)

| Use-case | Existing | Added | Total |
|---|---:|---:|---:|
| automotive | 0 | 3 | 3 |
| change-data-capture | 0 | 3 | 3 |
| ci-cd | 0 | 3 | 3 |
| databases-management | 0 | 3 | 3 |
| disaster-recovery | 1 | 2 | 3 |
| financial-services | 0 | 3 | 3 |
| healthcare | 0 | 3 | 3 |
| microservices-orchestration | 0 | 3 | 3 |
| modern-data-stack | 2 | 1 | 3 |
| monitoring | 1 | 2 | 3 |
| platform-engineers | 1 | 2 | 3 |
| provisioning-and-deployment | 0 | 3 | 3 |
| public-services | 1 | 2 | 3 |
| retail | 1 | 2 | 3 |
| software-engineers | 2 | 1 | 3 |
| software-providers | 1 | 2 | 3 |
| **Total** | **10** | **38** | **48** |

## Source

Mapping derived from the GSC export `GSC - resources - SF Crawl - 1805.csv` and the linking plan documented in `kestra-internal-linking-resources-to-use-cases.md`.

## Test plan

- [ ] Visual diff on each modified resource page — links render inline, ancres lisibles
- [ ] No broken links (all `/use-cases/*` targets exist under `src/pages/use-cases/`)
- [ ] Build passes
- [ ] Post-merge: monitor GSC for impressions/position lift on the 16 target use-case pages over 4–6 weeks

🤖 Generated with [Claude Code](https://claude.com/claude-code)