### PR TITLE
seo(robots): disallow /t/ and /flags/

### DIFF
--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -9,7 +9,9 @@ const disabled = import.meta.env.DEV || envField.PREVIEW
 
 User-agent: *
 Disallow: ${disabled ? "*" : "/slack"}
-${disabled ? "" : `# Block the /blueprints pagination bug (critical - 501 errors)
+${disabled ? "" : `Disallow: /t/
+Disallow: /flags/
+# Block the /blueprints pagination bug (critical - 501 errors)
 Disallow: /blueprints?*clid=*
 Disallow: /blueprints?*size=*
 # Build assets — CSS, JS, fonts accessible for robots rendering


### PR DESCRIPTION
## Summary
- Add `Disallow: /t/` and `Disallow: /flags/` to the production `robots.txt` output in [src/pages/robots.txt.ts](src/pages/robots.txt.ts).

## Test plan
- [ ] Visit `/robots.txt` on a preview/prod deploy and confirm both `Disallow: /t/` and `Disallow: /flags/` appear under `User-agent: *`.
- [ ] Confirm DEV/PREVIEW output is unchanged (still blanket `Disallow: *`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)