### PR TITLE
chore(seo): add immutable Cache-Control on /_astro/* assets

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -3,3 +3,6 @@
 
 /.well-known/mcp
   Content-Type: application/json
+
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Context

Astro bundles static assets (JS, CSS, fonts, SVG) into `/_astro/*` with a content hash in the filename (e.g. `Close.80W_Cjbn.js`). These files are immutable by construction — any change produces a new filename.

However, Astro currently serves them with `Cache-Control: public, max-age=0, must-revalidate`, which forces browsers and Googlebot to revalidate every asset on every request.

This is a known Astro issue, see [withastro/astro#9106](https://github.com/withastro/astro/issues/9106). The Astro maintainer's recommended fix is to add a `public/_headers` file (Cloudflare convention) overriding the directive for `/_astro/*`.

## Change

Add a rule to `public/_headers`:

```
/_astro/*
  Cache-Control: public, max-age=31536000, immutable
```

The file is copied to `dist/_headers` at build time and honored by Cloudflare Workers static-assets binding (already used here for `/api/feeds` and `/.well-known/mcp`).

## Expected impact

**User-facing perf**
- Browser cache works properly on repeat visits → faster navigation
- Improved Core Web Vitals (LCP, INP) for returning users

**SEO**
- Reduced Googlebot crawl budget spent on `/_astro/*` (-10 to -25% est.)
- Better signals on asset stability

**Not affected**
- HTML caching is **unchanged** — only `/_astro/*` is targeted
- Dynamic content (GitHub star counters, etc.) keeps working as before
- API routes (`/api/feeds`) and `/.well-known/mcp` rules preserved

## Rollback

Remove the `/_astro/*` block from `public/_headers`. No build or code change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)