### PR TITLE
seo(resources): remove broken internal links

### DIFF
--- a/src/contents/resources/alternatives-to-ansible/index.md
+++ b/src/contents/resources/alternatives-to-ansible/index.md
@@ -124,8 +124,6 @@ Jenkins is a highly extensible, open-source automation server that can be used t
 - **Weaknesses:** Jenkins can become complex to manage and scale, a phenomenon often called "Jenkins sprawl." While the `Jenkinsfile` introduces a declarative pipeline-as-code approach, the platform is not inherently designed for declarative state management of infrastructure.
 - **Best for:** Organizations with existing investments in Jenkins or those who need extreme flexibility and a vast plugin library to support their CI/CD and automation needs.
 
-Discover the differences in our [Kestra vs Jenkins breakdown](/vs/jenkins).
-
 ## 9. CFEngine: Policy-Based Configuration Management
 
 CFEngine is one of the original open-source configuration management systems, designed for large-scale, autonomous infrastructure based on policy and promise theory.

--- a/src/contents/resources/data-observability/index.md
+++ b/src/contents/resources/data-observability/index.md
@@ -175,7 +175,7 @@ While specialized data observability platforms exist, an orchestration platform 
 
 ### Building Observable Data Pipelines with Kestra's Declarative Workflows
 
-Kestra's [declarative orchestration](https://kestra.io/docs/declarative-data-orchestration) model, based on simple YAML files, makes pipelines inherently observable. Every aspect of the workflow—dependencies, tasks, triggers, and error handling—is explicitly defined, version-controlled in Git, and auditable.
+Kestra's declarative orchestration model, based on simple YAML files, makes pipelines inherently observable. Every aspect of the workflow—dependencies, tasks, triggers, and error handling—is explicitly defined, version-controlled in Git, and auditable.
 
 You can embed observability checks directly into your flows. For example, a simple task can query a table's metadata to check its row count or latest partition date, providing freshness and volume metrics with every run.
 

--- a/src/contents/resources/data-quality/index.md
+++ b/src/contents/resources/data-quality/index.md
@@ -192,7 +192,7 @@ This is achieved by:
 - **Event-Driven Automation:** Kestra can trigger validation workflows based on real-time events, such as a new file arriving in S3 or a new record in a Kafka topic. This enables you to catch quality issues at the source, before they contaminate downstream systems.
 - **Scalability and Governance:** For leading enterprises like JPMorgan Chase and Apple, maintaining data quality at a massive scale is critical. They use robust orchestration to manage complex dependencies and ensure that quality checks are consistently applied across billions of records and thousands of pipelines. At Crédit Agricole, Kestra replaced fragmented scripts with a single, governed orchestration layer, dramatically improving the reliability of their data processes.
 
-By using Kestra, you elevate data quality from a manual, reactive cleanup task to a proactive, automated, and integral part of your data operations. You can learn more about how to [integrate Kestra in the Modern Data Stack](https://kestra.io/docs/use-cases/modern-data-stack) and [why Kestra](https://kestra.io/docs/why-kestra) is designed for this level of reliability.
+By using Kestra, you elevate data quality from a manual, reactive cleanup task to a proactive, automated, and integral part of your data operations. You can learn more about [why Kestra](https://kestra.io/docs/why-kestra) is designed for this level of reliability.
 
 ## From Data Quality Theory to Practice
 

--- a/src/contents/resources/etl-pipeline-tools/index.md
+++ b/src/contents/resources/etl-pipeline-tools/index.md
@@ -146,7 +146,7 @@ Open-source software has fundamentally reshaped the data landscape, and ETL is n
 Python is the lingua franca of data engineering, and its extensive libraries make it a powerful choice for building custom ETL logic.
 *   **Pandas & Polars:** These libraries provide high-performance, easy-to-use data structures (DataFrames) and data analysis tools, making them ideal for in-memory data transformations.
 *   **Orchestration Frameworks:** Tools like **Apache Airflow** and **Prefect** allow engineers to define complex ETL workflows as Python code, managing scheduling, dependencies, and retries. You can see how Prefect compares in our [Prefect vs. Kestra](https://kestra.io/vs/prefect) guide.
-Kestra provides robust support for [running Python scripts](https://kestra.io/docs/scripts/python), enabling engineers to leverage these powerful libraries within a declarative, language-agnostic orchestration environment.
+Kestra provides robust support for running Python scripts, enabling engineers to leverage these powerful libraries within a declarative, language-agnostic orchestration environment.
 
 ### Choosing the Right Open-Source ETL Tool
 

--- a/src/contents/resources/gitops/index.md
+++ b/src/contents/resources/gitops/index.md
@@ -125,7 +125,7 @@ GitOps, on the other hand, is a "pull-based" model for continuous deployment. Th
 
 Jenkins is a powerful, general-purpose automation server often used to build traditional, imperative CI/CD pipelines. In a Jenkins-based workflow, the deployment logic is typically defined in a script (like a `Jenkinsfile`). This script dictates the steps to deploy an application.
 
-GitOps takes a declarative approach. Instead of scripting *how* to deploy, you declare *what* the end state should look like in Git. The GitOps operator handles the "how." This reduces the need for complex deployment scripts and makes the system state more transparent and auditable. While Jenkins can be part of a GitOps workflow (e.g., for the CI part), it is fundamentally different from the declarative, state-driven model of GitOps tools. For a deeper comparison, see [Kestra vs. Jenkins](https://kestra.io/vs/jenkins).
+GitOps takes a declarative approach. Instead of scripting *how* to deploy, you declare *what* the end state should look like in Git. The GitOps operator handles the "how." This reduces the need for complex deployment scripts and makes the system state more transparent and auditable. While Jenkins can be part of a GitOps workflow (e.g., for the CI part), it is fundamentally different from the declarative, state-driven model of GitOps tools.
 
 ### What is the difference between AIOps and GitOps?
 
@@ -158,9 +158,9 @@ GitOps is a versatile framework applicable across various domains, from infrastr
 
 ### Real-world applications of GitOps
 
--   **Cloud Infrastructure Provisioning**: Managing cloud resources (VPCs, databases, IAM roles) with Terraform or OpenTofu, where changes are applied via a GitOps workflow. This is a core part of modern [infrastructure automation](https://kestra.io/use-cases/infrastructure) and orchestrated [provisioning and deployment workflows](/use-cases/provisioning-and-deployment).
+-   **Cloud Infrastructure Provisioning**: Managing cloud resources (VPCs, databases, IAM roles) with Terraform or OpenTofu, where changes are applied via a GitOps workflow. This is a core part of modern infrastructure automation and orchestrated [provisioning and deployment workflows](/use-cases/provisioning-and-deployment).
 -   **Application Deployment**: The most common use case, deploying and managing the lifecycle of microservices and other applications on Kubernetes.
--   **Data Pipeline Orchestration**: Versioning and deploying [data pipelines](https://kestra.io/use-cases/data-pipelines) as code. For example, dbt models, data quality tests, and orchestration flows (like Kestra's YAML files) can be managed in Git and deployed automatically.
+-   **Data Pipeline Orchestration**: Versioning and deploying data pipelines as code. For example, dbt models, data quality tests, and orchestration flows (like Kestra's YAML files) can be managed in Git and deployed automatically.
 -   **AI Model Deployment**: Managing the deployment of machine learning models and their configurations, ensuring that a specific model version is tied to a specific Git commit for reproducibility. Kestra can orchestrate these [AI workflows](https://kestra.io/docs/ai-tools/ai-workflows) in a GitOps-native way.
 
 ### GitOps for cloud-native applications
@@ -171,4 +171,4 @@ GitOps finds its most natural home in the cloud-native ecosystem, particularly w
 
 As organizations adopt GitOps, scaling it effectively becomes crucial. This involves establishing best practices for repository structure, access control, and promotion of changes across environments. A centralized platform engineering team might manage the core GitOps tooling, while individual application teams manage their own service configurations in separate repositories.
 
-An orchestration platform like Kestra can act as a unifying control plane, providing visibility and control over diverse GitOps workflows across the organization. This allows you to [unlock GitOps superpowers](https://kestra.io/blogs/gitops-superpowers) and build a scalable, governed, and efficient [infrastructure automation platform](https://kestra.io/infra-automation).
+An orchestration platform like Kestra can act as a unifying control plane, providing visibility and control over diverse GitOps workflows across the organization. This allows you to unlock GitOps superpowers and build a scalable, governed, and efficient [infrastructure automation platform](https://kestra.io/infra-automation).

--- a/src/contents/resources/schedule-data-workflows/index.md
+++ b/src/contents/resources/schedule-data-workflows/index.md
@@ -100,7 +100,7 @@ The first step in any data workflow is accessing the data. Kestra's extensive [p
 
 ### Transforming data and building workflows
 
-Once data is accessed, you define transformation tasks. A key strength of Kestra is its language-agnostic nature; you can [run Python scripts](https://kestra.io/docs/scripts/python), execute SQL queries, or run shell commands within the same workflow. Each step is a task in your YAML file, and you can structure them to run sequentially or in parallel. This entire structure is defined in a [Flow](https://kestra.io/docs/workflow-components/flow), which is the central unit of orchestration in Kestra.
+Once data is accessed, you define transformation tasks. A key strength of Kestra is its language-agnostic nature; you can run Python scripts, execute SQL queries, or run shell commands within the same workflow. Each step is a task in your YAML file, and you can structure them to run sequentially or in parallel. This entire structure is defined in a [Flow](https://kestra.io/docs/workflow-components/flow), which is the central unit of orchestration in Kestra.
 
 ### Scheduling and monitoring execution
 
@@ -147,7 +147,7 @@ Kestra supports a wide variety of [triggers](https://kestra.io/docs/workflow-com
     - **Webhooks:** Initiating a flow via an HTTP request, perfect for API integrations.
     - **File Detection:** Starting a workflow when a new file arrives in S3, GCS, or a local filesystem.
     - **Message Queues:** Triggering a flow based on a new message in Kafka, SQS, or RabbitMQ.
-Kestra's support for [real-time triggers](https://kestra.io/blogs/realtime-triggers) enables data processing with millisecond latency, moving beyond traditional batch processing.
+Kestra's support for real-time triggers enables data processing with millisecond latency, moving beyond traditional batch processing.
 
 ### Common workflow structures
 

--- a/src/contents/resources/workflow-management/index.md
+++ b/src/contents/resources/workflow-management/index.md
@@ -90,7 +90,7 @@ To excel in workflow management, individuals and teams need to cultivate several
 - **Analytical Thinking**: The ability to break down a complex process into its constituent parts, identify dependencies, and spot inefficiencies.
 - **Process Mapping**: Visualizing and documenting workflows to create a clear blueprint for automation.
 - **Problem-Solving**: Identifying the root cause of bottlenecks or failures and designing effective solutions.
-- **Technical Proficiency**: Comfort with the tools of the trade, whether it's scripting in [Python](https://kestra.io/docs/how-to-guides/python) or [Shell](https://kestra.io/docs/scripts/shell), or mastering a declarative language like YAML.
+- **Technical Proficiency**: Comfort with the tools of the trade, whether it's scripting in [Python](https://kestra.io/docs/how-to-guides/python) or Shell, or mastering a declarative language like YAML.
 - **Communication**: Collaborating with stakeholders to understand requirements and explain the logic behind workflow designs.
 - **Change Management**: Guiding teams through the transition from manual processes to automated workflows.
 


### PR DESCRIPTION
## Summary
- Removes 11 broken internal links across 7 `/resources/*` pages (links pointing to non-existent URLs like `/docs/declarative-data-orchestration`, `/docs/scripts/python`, `/vs/jenkins`, `/blogs/realtime-triggers`, etc.).
- Per request: links removed (not replaced), with surrounding wording lightly adjusted so the prose still reads naturally.

## Files changed
- `resources/data-observability` — drop link on "declarative orchestration"
- `resources/data-quality` — drop "integrate Kestra in the Modern Data Stack" link, keep "why Kestra"
- `resources/etl-pipeline-tools` — drop link on "running Python scripts"
- `resources/schedule-data-workflows` — drop links on "run Python scripts" and "real-time triggers"
- `resources/alternatives-to-ansible` — remove the orphan "Discover the differences in our Kestra vs Jenkins breakdown" CTA (link target was the only purpose of the line)
- `resources/gitops` — drop links on "Kestra vs. Jenkins", "infrastructure automation", "data pipelines", "unlock GitOps superpowers"
- `resources/workflow-management` — drop link on "Shell"

## Test plan
- [ ] Visual check that the rewritten sentences read naturally on each page
- [ ] No remaining references to the removed URLs in the affected pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)