### PR TITLE
seo(resources): add 5 new AI resource pages

### DIFF
--- a/src/contents/resources/kubernetes/index.md
+++ b/src/contents/resources/kubernetes/index.md
@@ -1,0 +1,269 @@
+---
+title: "Kubernetes: Automating Containerized Applications"
+description: "Explore Kubernetes: understand its core concepts, architecture, and benefits for managing containerized applications. Learn how Kestra simplifies Kubernetes orchestration."
+metaTitle: "Kubernetes: Automating Containerized Applications"
+metaDescription: "Understand Kubernetes, its architecture, and benefits for containerized apps. Discover how Kestra enhances Kubernetes orchestration with declarative workflows."
+tag: "infrastructure"
+date: 2026-05-02
+slug: "kubernetes"
+faq:
+  - question: "Is Kubernetes the same as Docker?"
+    answer: "No, Kubernetes and Docker are distinct but complementary technologies. Docker is a platform for building, running, and managing individual containers, while Kubernetes is an orchestration system designed to manage and automate the deployment, scaling, and operation of multiple containerized applications, often including Docker containers, across a cluster of machines."
+  - question: "Is Netflix using Kubernetes?"
+    answer: "While Netflix is known for its pioneering work in cloud infrastructure, they primarily use their custom-built orchestration platform, Titus, which is similar in concept to Kubernetes but tailored to their specific needs. However, many other major companies and cloud providers heavily rely on Kubernetes for their container orchestration."
+  - question: "Is Kubernetes still relevant in 2026?"
+    answer: "Yes, Kubernetes remains highly relevant in 2026 as the de-facto standard for container orchestration. Its widespread adoption, robust ecosystem, and continuous development ensure its critical role in cloud-native application deployment, even as new tools and paradigms emerge to complement its capabilities."
+  - question: "Is Kubernetes easy to learn?"
+    answer: "Kubernetes has a reputation for a steep learning curve due to its extensive feature set and complex concepts. While mastering it takes time and practice, starting with foundational concepts and hands-on tutorials can make the learning journey manageable for developers and operations professionals."
+  - question: "Why are people moving away from Kubernetes?"
+    answer: "Some organizations explore alternatives or complementary tools to Kubernetes due to its inherent operational complexity, high resource consumption, and the specialized expertise required for effective management at scale. For specific use cases, simpler or more opinionated solutions can offer better results with less overhead."
+  - question: "Can I learn Kubernetes in 2 days?"
+    answer: "Learning Kubernetes in just two days is challenging due to its breadth and depth. While you can grasp basic concepts and deploy a simple application, a comprehensive understanding and practical proficiency typically require more time and consistent hands-on experience. Bootcamps and intensive workshops can provide a solid foundation."
+---
+
+In the world of modern application development, managing containerized workloads at scale presents significant challenges. Teams grapple with ensuring high availability, seamless scaling, and efficient resource utilization across distributed environments. Without a robust orchestration layer, these tasks quickly become a source of operational complexity and manual toil, hindering agility and increasing the risk of downtime.
+
+This article dives deep into Kubernetes, the open-source platform that has become the standard for automating container deployment and management. We'll explore its fundamental concepts, architectural components, and how it empowers organizations to run resilient, scalable applications. Furthermore, we'll examine how Kestra integrates with and extends Kubernetes, offering a declarative, polyglot orchestration control plane that streamlines complex workflows across your entire stack.
+
+## What is Kubernetes?
+
+Kubernetes is an open-source platform designed to automate the deployment, scaling, and management of containerized applications. Often abbreviated as "K8s" (K, 8 characters, s), it groups application containers into logical units for easy discovery and management, providing a robust framework for running distributed systems resiliently.
+
+### Kubernetes definition and core concepts
+
+At its core, Kubernetes is a container orchestrator. It takes a collection of physical or virtual machines and turns them into a unified, powerful computing resource. Developers can then deploy their applications without needing to worry about the underlying individual machines. Kubernetes handles critical tasks like resource allocation, load balancing, self-healing (restarting failed containers), and scaling applications up or down based on demand.
+
+The platform operates on a declarative model. You define the desired state of your application—for example, "I want three instances of my web server running with this container image"—and Kubernetes works continuously to maintain that state. This approach aligns perfectly with modern [Infrastructure as Code (IaC)](/resources/infrastructure/what-is-infrastructure-as-code) and broader [infrastructure automation](/resources/infrastructure/automation) practices.
+
+### The history and evolution of Kubernetes
+
+Kubernetes has its roots in Google's internal cluster management system, Borg. For over a decade, Google ran its production workloads, including services like Gmail and Search, on Borg. In 2014, leveraging the experience gained from Borg, Google open-sourced the Kubernetes project.
+
+The project was donated to the newly formed Cloud Native Computing Foundation (CNCF) in 2015, where it quickly became the flagship project. This move to a neutral, vendor-agnostic foundation fueled its rapid adoption across the industry. Today, Kubernetes is one of the most active and largest open-source projects in the world, with contributions from thousands of individuals and major tech companies.
+
+### Key features and components of Kubernetes
+
+Kubernetes has a rich set of components and abstractions that work together to manage containerized applications. Understanding these is key to using the platform effectively.
+
+*   **Cluster**: The foundation of Kubernetes. A cluster consists of a set of worker machines, called Nodes, that run containerized applications. Every cluster has at least one worker node.
+*   **Nodes**: A worker machine in a Kubernetes cluster, which can be either a virtual or a physical machine. Each node is managed by the control plane and contains the services necessary to run Pods.
+*   **Control Plane**: The set of components that manages the overall state of the cluster. It makes global decisions about the cluster (e.g., scheduling) and detects and responds to cluster events.
+*   **Pod**: The smallest and simplest unit in the Kubernetes object model that you create or deploy. A Pod represents a single instance of a running process in your cluster and can contain one or more containers.
+*   **Deployment**: A resource object that provides declarative updates for Pods and ReplicaSets. You describe a desired state in a Deployment, and the Deployment Controller changes the actual state to the desired state at a controlled rate.
+*   **Service**: An abstract way to expose an application running on a set of Pods as a network service. Services provide a stable endpoint (IP address and DNS name) for a group of Pods.
+*   **Namespace**: A way to divide cluster resources between multiple users or teams. This concept is similar to [Kestra's namespaces](/docs/workflow-components/namespace), which help organize and secure workflows.
+
+## How does Kubernetes work?
+
+Kubernetes operates on a client-server architecture, with a central control plane (often called the master) managing a fleet of worker nodes. This distributed design ensures high availability and scalability.
+
+### Understanding Kubernetes architecture: clusters, nodes, and pods
+
+A Kubernetes cluster is composed of two main types of components: the control plane and the worker nodes.
+
+**The Control Plane components include:**
+*   **kube-apiserver**: The front end for the Kubernetes control plane. It exposes the Kubernetes API, which is how users, management devices, and other cluster components communicate.
+*   **etcd**: A consistent and highly-available key-value store used as Kubernetes' backing store for all cluster data.
+*   **kube-scheduler**: Watches for newly created Pods that have no node assigned and selects a node for them to run on based on resource requirements and other constraints.
+*   **kube-controller-manager**: Runs controller processes. These controllers watch the state of the cluster through the API server and make changes to move the current state towards the desired state.
+
+**Worker Node components include:**
+*   **kubelet**: An agent that runs on each node in the cluster. It ensures that containers are running in a Pod.
+*   **kube-proxy**: A network proxy that runs on each node, maintaining network rules and enabling communication to your Pods from network sessions inside or outside of your cluster.
+*   **Container Runtime**: The software responsible for running containers, such as containerd or Docker.
+
+### Container orchestration with Kubernetes
+
+Container orchestration is the automated process of managing the lifecycle of containers. Kubernetes excels at this by providing powerful automation features:
+
+*   **Scheduling**: Automatically places containers on nodes based on their resource needs and other constraints, while not sacrificing availability.
+*   **Self-healing**: Restarts containers that fail, replaces and reschedules containers when nodes die, and kills containers that don't respond to user-defined health checks.
+*   **Load Balancing**: If traffic to a container is high, Kubernetes can load balance and distribute the network traffic to ensure the deployment is stable.
+*   **Automated Rollouts and Rollbacks**: You can progressively roll out changes to your application or its configuration, while monitoring application health to ensure it doesn't kill all your instances at the same time. If something goes wrong, Kubernetes will roll back the change for you.
+
+### Deployment, scaling, and management of applications
+
+Managing applications in Kubernetes is done declaratively. You create manifest files (typically in YAML) that describe your application's components—Deployments, Services, ConfigMaps, etc. This declarative approach is central to [GitOps principles](/resources/infrastructure/gitops), where the desired state of the system is version-controlled in Git.
+
+*   **Deployments and ReplicaSets**: A Deployment ensures that a specified number of pod "replicas" are running at any given time. A ReplicaSet, managed by the Deployment, is responsible for maintaining this stable set of replica Pods.
+*   **Scaling**: The Horizontal Pod Autoscaler (HPA) automatically scales the number of pods in a replication controller, deployment, or replica set based on observed CPU utilization or other custom metrics.
+*   **Stateful Applications**: For applications that require stable network identifiers and persistent storage, Kubernetes provides **StatefulSets**.
+*   **Node-level workloads**: For tasks that need to run on every node in the cluster, such as log collectors or monitoring agents, **DaemonSets** are used.
+
+## Kubernetes vs. other container technologies
+
+The container ecosystem is vast, and it's important to understand where Kubernetes fits in, especially in relation to Docker.
+
+### Is Kubernetes the same as Docker?
+
+No, Kubernetes and Docker are not the same, but they work very well together. Docker is a platform for creating, shipping, and running individual containers. It provides the tooling to build a container image and a runtime to execute it.
+
+Kubernetes, on the other hand, is an orchestrator for containers. It doesn't build or run containers itself; it manages them at scale across a cluster of machines. You can think of it this way: Docker provides the car (the container), while Kubernetes provides the traffic control system, highways, and mechanics to manage a whole fleet of cars. Most Kubernetes deployments use Docker (or more accurately, containerd, which originated from Docker) as the underlying container runtime. Kestra's own [Docker plugin](/plugins/plugin-docker) allows for direct interaction with the Docker engine for building and running containers within a workflow.
+
+### Kubernetes and container runtimes
+
+Kubernetes is designed to be pluggable and supports various container runtimes through the Container Runtime Interface (CRI). While Docker was the original runtime, the ecosystem has evolved. Today, **containerd** is the most common runtime used in Kubernetes clusters. Others like CRI-O are also popular. This flexibility allows Kubernetes to remain independent of any single containerization technology.
+
+### When to use Kubernetes vs. alternative solutions
+
+Kubernetes is powerful, but its complexity means it's not always the right tool for every job.
+
+*   **Single Host / Local Development**: For running a few containers on a single machine, Docker Compose is often a simpler and more efficient choice.
+*   **Simple Multi-Host Orchestration**: Docker Swarm offers a less complex alternative to Kubernetes for basic container orchestration across multiple hosts.
+*   **Serverless Containers**: For workloads where you don't want to manage the underlying cluster infrastructure, services like AWS Fargate, Google Cloud Run, or Azure Container Instances are excellent options. They allow you to run containers without provisioning or managing servers.
+
+The decision often comes down to scale and complexity. If you are managing a microservices architecture with dozens or hundreds of services that need to scale independently and communicate reliably, Kubernetes is the industry standard. For simpler applications, the overhead of managing a Kubernetes cluster might not be justified. Kestra's architecture reflects this flexibility, offering various [task runner types](/docs/task-runners/types) that can execute tasks on Docker, in local processes, or as Kubernetes pods.
+
+## Benefits of using Kubernetes
+
+Organizations adopt Kubernetes for a range of strategic advantages that go beyond simple container management. It provides a common platform that bridges development and operations, accelerating software delivery and improving system reliability.
+
+### Why organizations adopt Kubernetes
+
+The primary driver for Kubernetes adoption is the need to manage complexity at scale. As companies move to microservices architectures, the number of deployable components explodes. Kubernetes provides a unified API and a consistent operational model to manage this complexity, leading to:
+*   **Increased Agility**: Teams can deploy applications faster and more frequently.
+*   **Improved Reliability**: Self-healing and automated rollouts reduce downtime.
+*   **Better Resource Utilization**: Kubernetes efficiently packs containers onto nodes, optimizing infrastructure costs.
+*   **Developer Productivity**: A consistent platform across development, testing, and production environments streamlines the developer workflow.
+
+### Scalability and high availability
+
+Kubernetes is designed from the ground up for scale and resilience. The Horizontal Pod Autoscaler can automatically increase or decrease the number of application instances based on real-time metrics like CPU or memory usage. This ensures that applications can handle traffic spikes without manual intervention.
+
+High availability is achieved through redundancy. By running multiple instances of application pods across different nodes, Kubernetes can tolerate node failures. If a node goes down, the pods running on it are automatically rescheduled to healthy nodes, ensuring continuous service availability.
+
+### Portability across different environments
+
+One of the most significant benefits of Kubernetes is its portability. It provides a consistent abstraction layer over the underlying infrastructure, whether it's on-premises data centers, public clouds, or a hybrid combination. This allows organizations to build applications that can run anywhere without modification. This is a key enabler for [multi-cloud orchestration](/resources/infrastructure/multi-cloud-orchestration) and [hybrid cloud automation](/resources/infrastructure/hybrid-cloud-automation), preventing vendor lock-in and giving businesses the flexibility to choose the best infrastructure for their needs.
+
+## Real-world applications and use cases
+
+Kubernetes is used by thousands of organizations, from startups to large enterprises, to run their most critical applications. For example, Apple's ML team uses Kestra to orchestrate large-scale data pipelines, which often run in containerized environments managed by systems like Kubernetes to handle the massive scale. Leading enterprises in finance and resources, such as JPMorgan Chase and BHP, leverage Kestra for complex infrastructure and cybersecurity workflows, which frequently involve orchestrating tasks across Kubernetes clusters and other systems.
+
+### Is Netflix using Kubernetes?
+
+This is a common question, given Netflix's influence on cloud-native architecture. While Netflix was a pioneer in microservices and containerization, they developed their own in-house container orchestration platform called Titus. Titus serves a similar purpose to Kubernetes but is deeply integrated with the AWS ecosystem and tailored to Netflix's specific scale and requirements. So, while they don't use Kubernetes directly for their core streaming services, their work on Titus has contributed valuable insights to the broader container orchestration community.
+
+## How Kestra approaches Kubernetes orchestration
+
+While Kubernetes is a powerful platform for running applications, orchestrating the complex, multi-step, polyglot workflows *around* those applications often requires a higher-level control plane. This is where Kestra excels. Kestra acts as a universal orchestration layer that can manage not only Kubernetes resources but also the data, infrastructure, and business processes that interact with them.
+
+Kestra simplifies Kubernetes operations by allowing you to define and manage complex workflows using declarative YAML. Instead of writing brittle shell scripts or custom operators, you can use Kestra's rich set of plugins and flow-control logic to automate tasks like:
+*   Deploying applications using the [kubectl plugin](/plugins/plugin-kubernetes/kubectl).
+*   Running [long-running, resource-intensive tasks](/docs/how-to-guides/long-running-intensive-tasks) as isolated pods.
+*   Automating the entire [lifecycle of a pod](/blueprints/k8-pod-lifecycle), from creation to cleanup.
+*   Implementing [AI-powered incident monitoring](/blueprints/k8s-ai-incident-monitor) for your cluster.
+
+A key feature is the **[Kubernetes Task Runner](/docs/task-runners/types/kubernetes-task-runner)**, which allows any Kestra task—be it Python, SQL, or a shell script—to be executed as a dedicated Kubernetes pod. This provides ultimate isolation, resource management, and scalability for your workflows.
+
+Furthermore, the **[Kestra Kubernetes Operator](/docs/version-control-cicd/cicd/kubernetes-operator)** brings GitOps to your workflows. You can manage your Kestra flows, templates, and namespace files as Kubernetes Custom Resources, allowing you to version-control your entire orchestration layer alongside your application and infrastructure code.
+
+Here is a simple example of a Kestra flow that uses the `PodCreate` task from the [Kubernetes plugin](/plugins/plugin-kubernetes) to launch an Nginx pod:
+
+```yaml
+id: kubernetes-pod-create-example
+namespace: company.team
+
+tasks:
+  - id: create-nginx-pod
+    type: io.kestra.plugin.kubernetes.core.PodCreate
+    namespace: default
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25.3
+          ports:
+            - containerPort: 80
+```
+
+This declarative workflow is easy to read, version, and reuse. By combining Kestra and Kubernetes, you can [simplify provisioning and deployment](/use-cases/provisioning-and-deployment) and build a robust, auditable control plane for all your [infrastructure automation needs](/infra-automation). You can explore more patterns in our dedicated [infrastructure resources](/resources/infrastructure).
+
+## Learning Kubernetes and future relevance
+
+As Kubernetes has become a foundational technology for cloud-native computing, understanding its concepts and future direction is crucial for developers and operations professionals.
+
+### Is Kubernetes easy to learn?
+
+Kubernetes has a reputation for being complex, and its learning curve can be steep. The platform encompasses a wide range of concepts, from networking and storage to security and scheduling. However, its modular design allows you to learn it incrementally. Starting with core concepts like Pods, Deployments, and Services, and then gradually exploring more advanced features, makes the learning process manageable. Abundant documentation, tutorials, and a vibrant community provide extensive support for newcomers.
+
+### Can I learn Kubernetes in 2 days?
+
+While it's possible to grasp the basic concepts and deploy a simple application within a couple of days, achieving proficiency with Kubernetes takes longer. A two-day bootcamp can provide a strong conceptual foundation, but true mastery comes from sustained, hands-on experience: deploying real applications, troubleshooting issues, and managing clusters in production-like environments.
+
+### Is Kubernetes still relevant in 2026?
+
+Absolutely. In 2026, Kubernetes remains the de-facto standard for container orchestration. Its adoption is widespread across all major cloud providers and a vast number of enterprises. The ecosystem around Kubernetes continues to grow, with new tools and platforms being built on top of it. While other technologies like serverless and WebAssembly are emerging, they often complement Kubernetes rather than replace it. Kubernetes is a mature, stable, and evolving platform that will continue to be a critical part of the cloud-native landscape for the foreseeable future.
+
+### Why are people moving away from Kubernetes?
+
+While Kubernetes adoption is still growing, some teams and organizations are exploring alternatives for specific use cases. The primary reasons for this shift are complexity and operational overhead. Managing a Kubernetes cluster requires specialized expertise and can be resource-intensive, especially for smaller teams or simpler applications. In these scenarios, managed container platforms (like AWS Fargate), Platform-as-a-Service (PaaS) offerings, or even simpler orchestrators may provide a better trade-off between control and convenience. The trend is not a mass exodus from Kubernetes but rather a maturation of the market, where organizations choose the right tool for the job.
+
+## Getting started with Kubernetes
+
+Starting your journey with Kubernetes involves setting up a local environment and learning the basic commands to interact with a cluster.
+
+### Essential tools and prerequisites
+
+Before you begin, you'll need a few key tools:
+*   **A container runtime**: Docker Desktop is a popular choice as it includes Docker, containerd, and a single-node Kubernetes cluster.
+*   **kubectl**: The command-line tool for interacting with the Kubernetes API. You use it to deploy applications, inspect and manage cluster resources, and view logs.
+*   **A local Kubernetes cluster**: Tools like **minikube** or **kind** allow you to run a lightweight, single-node Kubernetes cluster on your local machine for development and testing.
+
+### Setting up your first Kubernetes cluster
+
+For local development, `minikube start` or `kind create cluster` are the quickest ways to get a cluster running. These tools create a virtual machine or Docker container on your laptop that acts as a Kubernetes node.
+
+For more production-like environments, all major cloud providers offer managed Kubernetes services:
+*   **Amazon Elastic Kubernetes Service (EKS)**
+*   **Google Kubernetes Engine (GKE)**
+*   **Azure Kubernetes Service (AKS)**
+
+These services handle the complexity of managing the control plane, allowing you to focus on your applications. You can [deploy Kestra on any of these Kubernetes distributions](/docs/installation/kubernetes) using our official Helm chart.
+
+### Deploying an application on Kubernetes
+
+Deploying an application typically involves writing a YAML manifest file. Here's a minimal example for a Deployment that runs two Nginx replicas:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.25.3
+        ports:
+        - containerPort: 80
+```
+
+You would save this as `deployment.yaml` and apply it to your cluster with the command: `kubectl apply -f deployment.yaml`. Kubernetes will then create the pods and ensure two instances are always running.
+
+## Advanced Kubernetes concepts
+
+Once you've mastered the basics, Kubernetes offers a rich set of advanced features for managing complex applications, enhancing security, and improving observability.
+
+### Service meshes and networking
+
+As microservice architectures grow, managing communication between services becomes complex. A service mesh, such as Istio or Linkerd, is an infrastructure layer that handles service-to-service communication. It provides features like traffic management, security (mTLS), and observability (metrics, tracing) without requiring changes to the application code. Kubernetes also has powerful built-in networking concepts like NetworkPolicies for controlling traffic flow between pods and Ingress for managing external access to services.
+
+### Security best practices in Kubernetes
+
+Securing a Kubernetes cluster is a multi-faceted task. Key best practices include:
+*   **Role-Based Access Control (RBAC)**: Use RBAC to define granular permissions for users and services interacting with the Kubernetes API.
+*   **Pod Security Standards**: Enforce security policies on pods to restrict their capabilities, such as preventing them from running as root.
+*   **Network Segmentation**: Use NetworkPolicies to isolate workloads and limit the blast radius of a potential compromise.
+*   **Secret Management**: Avoid storing secrets directly in manifests. Use Kubernetes Secrets, or integrate with an external secrets manager like HashiCorp Vault. Kestra's own [secret management capabilities](/docs/concepts/secret) can be used to securely inject credentials into workflows that interact with Kubernetes.
+
+### Monitoring and logging solutions
+
+Effective monitoring and logging are critical for operating applications on Kubernetes. The de-facto standard for monitoring is **Prometheus**, an open-source tool that scrapes metrics from cluster components and applications, paired with **Grafana** for visualization. For logging, a common pattern is to use a combination of Fluentd to collect logs from nodes and ship them to a centralized backend like Elasticsearch or Loki. Adopting a standardized observability framework like [OpenTelemetry](/docs/administrator-guide/open-telemetry) can provide a unified way to collect traces, metrics, and logs from your applications. You can also explore Kestra's guides on [monitoring and alerting](/docs/administrator-guide/monitoring) for your orchestration platform.

--- a/src/contents/resources/model-deployment/index.md
+++ b/src/contents/resources/model-deployment/index.md
@@ -1,0 +1,163 @@
+---
+title: "What is Model Deployment? Process & Strategies"
+description: "Understand what model deployment entails, its importance, and key strategies. Learn to successfully deploy your machine learning models today with robust orchestration."
+metaTitle: "Model Deployment: Process, Strategies & Orchestration"
+metaDescription: "Learn the essential processes and strategies for machine learning model deployment. Understand its importance, common challenges, and how orchestration platforms streamline your MLOps."
+tag: "ai"
+date: 2026-05-07
+slug: "model-deployment"
+faq:
+  - question: "What is model deployment in machine learning?"
+    answer: "Model deployment is the process of integrating a trained machine learning model into a production environment, making it available for real-world use to generate predictions or insights. It bridges the gap between model development and practical application, ensuring that the model can interact with live data and deliver business value."
+  - question: "What is the difference between model deployment and model serving?"
+    answer: "Model deployment refers to the entire process of preparing a trained model for use in a production environment, including packaging, configuration, and integration. Model serving, on the other hand, is the specific act of making the deployed model accessible to users or applications, typically via an API or a web service, to receive input data and return predictions."
+  - question: "What are the 4 stages of model deployment?"
+    answer: "While specific stages can vary, a common framework for model deployment includes four key phases: model training and validation, model packaging and versioning, infrastructure provisioning and deployment, and continuous monitoring and maintenance. These stages ensure the model is robust, reproducible, and performs reliably in production."
+  - question: "What is 'modal deployment'?"
+    answer: "'Modal deployment' is often a misspelling or misunderstanding of 'model deployment.' There is a separate, unrelated concept of 'Modal deployments' in the context of Modal Labs, which creates and persists applications and their objects for grouped function executions, aiding observability."
+  - question: "Why is model deployment crucial for AI projects?"
+    answer: "Model deployment is crucial because it translates the theoretical insights from model development into tangible business value. Without effective deployment, even the most accurate models remain in a research environment, unable to impact real-world decisions, automate processes, or enhance user experiences."
+  - question: "What are common strategies for deploying machine learning models?"
+    answer: "Common model deployment strategies include batch deployment for offline predictions on large datasets, real-time (or online) deployment for low-latency predictions via APIs, and containerization (using Docker and Kubernetes) to ensure portability, scalability, and reproducibility across different environments."
+---
+
+Building a powerful machine learning model is only half the battle. The true value of AI emerges when those models move beyond the data scientist's notebook and into a production environment, making real-time predictions or automating critical business processes. This transition, known as model deployment, is often where the most significant challenges arise.
+
+This article will demystify model deployment, explaining its core concepts, why it's a critical stage in the machine learning lifecycle, and the key strategies involved. We'll explore common pitfalls and demonstrate how a robust orchestration platform can streamline the entire process, ensuring your models deliver consistent value.
+
+## What is Model Deployment?
+
+Model deployment is a key discipline within [Machine Learning Operations (MLOps)](/resources/ai/what-is-mlops) that focuses on integrating a trained and validated model into a live production system. This process makes the model's predictive capabilities available to other software applications, business processes, or end-users.
+
+### Defining Machine Learning Model Deployment
+
+At its core, model deployment is the mechanism for bridging the gap between development and production. It involves packaging the model, its dependencies, and any necessary pre-processing code into a format that can be executed reliably and efficiently in a real-world environment. This isn't a one-time event but a continuous process that includes updates, monitoring, and maintenance to ensure the model performs as expected over time. The ultimate goal is to operationalize the model so it can generate predictions on new, unseen data and deliver tangible business value.
+
+### Model Deployment vs. Model Serving
+
+The terms "model deployment" and "model serving" are often used interchangeably, but they represent distinct concepts:
+- **Model Deployment** is the entire end-to-end process of preparing and releasing a model. It includes steps like packaging the model artifacts, configuring the serving infrastructure, and versioning the model for reproducibility. It's the "how" of getting a model into production.
+- **Model Serving** is the specific runtime component of this process. It refers to making the deployed model accessible, typically by exposing it through an API endpoint. When an application sends a request with input data to this endpoint, the serving layer processes it through the model and returns a prediction. It's the "what" of making predictions available.
+
+In short, deployment is the setup; serving is the execution.
+
+### Model Deployment vs. Modal Deployment (Addressing Common Confusion)
+
+A common point of confusion arises from the term "modal deployment," which is often a typo for "model deployment." However, "Modal Deployment" is also a specific concept related to Modal Labs, a serverless compute platform. In that context, a Modal deployment creates and persists an application and its objects, helping to group function executions for better observability. This is a platform-specific feature and is distinct from the general practice of machine learning model deployment.
+
+## Why is Model Deployment Crucial for AI Success?
+
+Without a robust deployment process, even the most accurate and innovative machine learning models remain isolated experiments, unable to influence business outcomes.
+
+### Bridging the Gap Between Development and Production
+
+Many organizations suffer from a "model graveyard," where promising models developed by data science teams are never successfully operationalized. A structured deployment process provides the path to production, ensuring that the investment in model development yields a return. It's the final, critical stage of the [AI pipeline](/resources/ai/ai-pipeline) that turns theoretical insights into practical, automated actions.
+
+### Real-World Impact of Deployed Models
+
+Deployed models are what power modern applications and drive business value. From fraud detection systems that analyze transactions in milliseconds to recommendation engines that personalize user experiences, the impact is tangible. Effective deployment enables businesses to automate complex decisions, optimize operations, and create new revenue streams, making it a cornerstone of any successful AI strategy for [data engineers](/use-cases/data-engineers) and ML teams alike.
+
+## The Key Stages of Model Deployment
+
+A successful deployment relies on a structured, repeatable process. While specifics can vary, the lifecycle generally follows four key stages.
+
+### The 4 Stages of Deployment Explained
+
+1.  **Training & Validation:** The model is trained on historical data and rigorously validated to ensure its performance meets predefined accuracy and fairness metrics.
+2.  **Packaging & Versioning:** The validated model, along with its dependencies (libraries, frameworks) and any pre- or post-processing code, is packaged into a deployable artifact, such as a container image. This artifact is versioned to ensure reproducibility and enable rollbacks.
+3.  **Infrastructure Provisioning & Deployment:** The necessary compute, storage, and networking resources are provisioned in the target environment (e.g., cloud, on-prem). The packaged model is then deployed to this infrastructure, making it ready to serve predictions.
+4.  **Monitoring & Maintenance:** Once live, the model is continuously monitored for performance, latency, and drift. This stage includes setting up alerts, logging inference data, and establishing pipelines for periodic retraining.
+
+These stages are central to the discipline of [MLOps](/resources/ai/what-is-mlops), which applies DevOps principles to the machine learning lifecycle.
+
+### Pre-Deployment Considerations
+
+Before deploying, several factors must be addressed to ensure a smooth transition:
+- **Environment Parity:** Staging and production environments should mirror each other as closely as possible to catch issues before they impact users.
+- **Dependency Management:** All software dependencies must be explicitly defined and packaged with the model to avoid runtime errors.
+- **Infrastructure as Code (IaC):** Using tools like Terraform and applying [GitOps principles](/resources/infrastructure/gitops) ensures that infrastructure is provisioned consistently and declaratively.
+- **Robust Testing:** The deployment pipeline should include automated unit, integration, and performance tests to validate both the model and the serving infrastructure.
+
+### Monitoring and Maintenance Post-Deployment
+
+Deployment is the beginning, not the end. Continuous [monitoring](/docs/administrator-guide/monitoring) is essential to track model performance and detect issues like:
+- **Data Drift:** The statistical properties of the live data diverge from the training data.
+- **Concept Drift:** The relationship between input features and the target variable changes over time.
+
+A comprehensive [LLM evaluation](/resources/ai/llm-evaluation) and monitoring strategy includes automated alerting and triggers for retraining pipelines to keep the model accurate and relevant.
+
+## Common Model Deployment Strategies
+
+The choice of deployment strategy depends on the use case, particularly latency and throughput requirements.
+
+### Batch Deployment
+
+In batch deployment, the model makes predictions on a large volume of data at scheduled intervals. This offline process is suitable for use cases where real-time predictions are not required, such as generating daily reports, updating customer segments, or scoring leads. This strategy aligns well with traditional [batch processing](/resources/data/batch-vs-streaming-processing) workflows.
+
+### Real-Time and Online Deployment
+
+For applications requiring immediate predictions, real-time (or online) deployment is used. The model is exposed as an API endpoint, often through a [webhook trigger](/docs/workflow-components/triggers/webhook-trigger), that applications can call to get predictions with low latency. This is common in fraud detection, product recommendations, and dynamic pricing. Kestra's [real-time triggers](/docs/workflow-components/triggers/realtime-trigger) are designed to support these event-driven use cases.
+
+### Containerization for Flexible Deployment
+
+Containerization, using technologies like Docker and Kubernetes, has become a standard for model deployment. It packages the model and all its dependencies into a portable container image. This approach ensures consistency across environments, simplifies dependency management, and enables automated scaling and management of serving infrastructure. Teams can [deploy on Kubernetes](/docs/installation/kubernetes) and use [custom Docker images](/docs/scripts/custom-docker-image) to create reproducible and isolated execution environments for their models.
+
+## Challenges in Machine Learning Model Deployment
+
+Deploying models to production introduces a unique set of technical and operational challenges.
+
+### Ensuring Scalability and Reliability
+
+Production systems must handle variable loads, from a few requests to thousands per second. The deployment architecture needs to be scalable to meet this demand without compromising performance or reliability. This requires careful [infrastructure sizing and scaling](/docs/performance/sizing-and-scaling-infrastructure) and designing for fault tolerance.
+
+### Managing Model Drift and Retraining
+
+Models are not static; their performance can degrade over time due to drift. Building an automated [AI pipeline](/resources/ai/ai-pipeline) to monitor for drift, validate data quality, and trigger retraining is complex but necessary for maintaining model accuracy and business value.
+
+### Security and Compliance Considerations
+
+Deployed models often handle sensitive data, making security paramount. This includes securing API endpoints, managing access control, and ensuring that data handling complies with regulations like GDPR. Maintaining detailed [audit logs](/docs/enterprise/governance/audit-logs) of model predictions and updates is often a compliance requirement.
+
+## Orchestrating Model Deployment with Kestra
+
+A robust orchestration platform like Kestra can unify and automate the entire model deployment lifecycle, from data preparation and model training to deployment and monitoring. By defining the entire MLOps workflow as declarative YAML, Kestra ensures reproducibility, version control, and collaboration.
+
+```yaml
+id: ml-model-deployment
+namespace: production.mlops
+
+tasks:
+  - id: train_and_validate
+    type: io.kestra.plugin.scripts.python.Script
+    docker:
+      image: my-ml-image:latest
+    script: |
+      python train.py --output-path /kestra/outputs/model.pkl
+
+  - id: package_model
+    type: io.kestra.plugin.docker.Build
+    from: "{{ outputs.train_and_validate.uri }}"
+    image: my-registry/my-model-api:{{ flow.id }}
+
+  - id: deploy_to_staging
+    type: io.kestra.plugin.kubernetes.kubectl.Apply
+    namespace: staging
+    spec: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: model-api-staging
+      spec:
+        replicas: 1
+        template:
+          spec:
+            containers:
+            - name: model-api
+              image: my-registry/my-model-api:{{ flow.id }}
+```
+
+Kestra's polyglot nature allows teams to use the best tools for the job—whether it's Python for training, Docker for packaging, or Terraform for infrastructure. Its event-driven architecture is ideal for triggering retraining pipelines or handling real-time inference requests. As shown by a leading tech company like **Apple, whose ML team orchestrates large-scale data pipelines with Kestra**, a powerful orchestration layer is key to managing complexity at scale.
+
+By leveraging a central control plane, you can streamline your deployment processes, reduce manual errors, and accelerate the delivery of AI-powered applications.
+
+Explore Kestra's [AI plugins](/plugins/plugin-ai) and ready-to-use [blueprints](/blueprints) to see how you can simplify your MLOps workflows. To learn more, browse our [AI orchestration resources](/resources/ai) or see how you can [stop writing glue code around your AI pipelines](/ai-automation).

--- a/src/contents/resources/multi-agent-collaboration-evolving-orchestration/index.md
+++ b/src/contents/resources/multi-agent-collaboration-evolving-orchestration/index.md
@@ -1,0 +1,132 @@
+---
+title: "Multi-Agent Collaboration via Evolving Orchestration"
+description: "Explore multi-agent collaboration via evolving orchestration. Learn how dynamic orchestrators improve AI agent systems. Optimize your LLM agents now!"
+metaTitle: "Multi-Agent Collaboration & Evolving AI Orchestration"
+metaDescription: "Explore how multi-agent collaboration with evolving orchestration enhances AI agent systems. Discover dynamic orchestrators for LLM agents to optimize performance and adaptability."
+tag: "ai"
+date: 2026-05-09
+slug: "multi-agent-collaboration-evolving-orchestration"
+faq:
+  - question: "What does multi-agent orchestration mean?"
+    answer: "Multi-agent orchestration involves coordinating multiple AI agents to work together towards a common goal. It manages their interactions, task delegation, and overall workflow to achieve complex objectives more effectively than individual agents."
+  - question: "What is the key mechanism that enables effective collaboration between multiple AI agents?"
+    answer: "Effective collaboration in multi-agent systems is often enabled by a centralized orchestrator employing a 'puppeteer-style paradigm.' This orchestrator dynamically directs agents, assigning specialized roles and adapting their sequence and priority, often through mechanisms like reinforcement learning."
+  - question: "Why is an orchestrator important in multi-agent systems?"
+    answer: "An orchestrator is crucial for the smooth operation of multi-agent systems by providing task delegation, coordination, and overall governance. It assigns work to specialized agents based on predefined rules, real-time signals, and workload awareness, ensuring efficient execution and problem-solving."
+  - question: "What is multi-model orchestration?"
+    answer: "Multi-model orchestration refers to integrating and managing several distinct AI models that collaborate on related tasks. Instead of relying on a single model, workflows strategically leverage different models, each chosen for its unique strengths to optimize specific outputs."
+  - question: "What is the difference between agent and orchestration?"
+    answer: "Agents provide capabilities and execute tasks, while orchestration provides the control and coordination layer. Agents often operate iteratively and in parallel within a multi-agent system, and the orchestrator manages their collective behavior rather than a linear input-to-output flow."
+  - question: "What is an example of a multi-agent system?"
+    answer: "A multi-agent system could be a customer service bot that uses specialized AI agents for different tasks: one agent for intent recognition, another for retrieving knowledge base articles, a third for escalating to a human, and a fourth for logging interactions. The orchestrator directs these agents based on the user's query and interaction flow."
+---
+
+The promise of AI agents working together autonomously has long captivated technologists. Yet, transforming this vision into reliable, production-ready systems often hits a wall of complexity: how do you coordinate multiple intelligent agents, each with its own capabilities, without sacrificing control or visibility? Static, predefined workflows quickly falter in the face of dynamic, unpredictable AI interactions.
+
+This is where evolving orchestration steps in. Far beyond simple task sequencing, evolving orchestration introduces a dynamic layer that learns and adapts to the nuanced needs of multi-agent collaboration. This article will explore how such a "puppeteer-style paradigm" can unlock the full potential of LLM-based multi-agent systems, and how a platform like Kestra provides the declarative control plane to govern these adaptive workflows.
+
+## Understanding multi-agent collaboration and evolving orchestration
+
+### What does multi-agent orchestration mean?
+
+Multi-agent orchestration is the practice of coordinating multiple, often specialized, [AI agents](https://kestra.io/resources/ai/ai-agent) to achieve a common goal. Unlike single-agent systems that handle a task from start to finish, a multi-agent system breaks down a complex problem into sub-tasks, each handled by an agent best suited for the job.
+
+This collaborative approach offers significant benefits:
+*   **Efficiency:** Specialized agents perform their tasks more effectively than a single generalist agent.
+*   **Scalability:** New agents can be added to the system to handle new tasks or increase capacity without redesigning the entire architecture.
+*   **Complex Problem-Solving:** By combining the capabilities of diverse agents, the system can tackle problems that are too complex for any single agent to solve alone. This is a core concept in the field of [agentic AI](https://kestra.io/resources/ai/agentic-ai).
+
+### Why is an orchestrator important in multi-agent systems?
+
+In a multi-agent system, the [orchestrator](https://kestra.io/resources/data/orchestrator) acts as the central coordinator. Without it, agents would operate in silos, unable to collaborate effectively. An orchestrator provides the essential governance layer that manages task delegation, coordination, error handling, and resource allocation.
+
+Static approaches, where the interaction flow is rigidly predefined, often fail because they cannot adapt to the dynamic nature of AI. An evolving orchestrator, however, can adjust its strategy based on real-time feedback and changing conditions. This dynamic control is fundamental to successful [agentic orchestration](https://kestra.io/resources/ai/agentic-orchestration).
+
+## The puppeteer paradigm for LLM-based multi-agent systems
+
+### What is the key mechanism that enables effective collaboration between multiple AI agents?
+
+A key mechanism for effective multi-agent collaboration is the "puppeteer-style paradigm." In this model, a centralized orchestrator acts as a "puppeteer," dynamically directing a team of specialized "puppet" agents. This approach moves beyond static, linear workflows and introduces a more adaptive and intelligent control layer.
+
+The orchestrator’s role includes:
+*   **Role-Based Specialization:** Assigning tasks to agents based on their unique capabilities, often in a "manager-worker" dynamic where one agent supervises and delegates.
+*   **Adaptive Sequencing:** Determining the best order of agent execution based on the evolving context of the problem.
+*   **Dynamic Prioritization:** Re-prioritizing tasks and agents in real-time to optimize for the desired outcome.
+
+This paradigm allows for a flexible and powerful way to manage complex [AI workflows](https://kestra.io/docs/ai-tools/ai-workflows) and is a foundational concept for building robust systems of [AI agents](https://kestra.io/docs/ai-tools/ai-agents).
+
+### Adapting agents with reinforcement learning
+
+To make the puppeteer paradigm truly "evolving," the orchestrator needs a mechanism to learn and improve its strategies over time. Reinforcement Learning (RL) is a powerful technique for this. By receiving feedback on the outcomes of its decisions, the orchestrator can learn which sequences and priorities lead to the best results.
+
+It's important to distinguish between the orchestration platform and the learning mechanism. A platform like Kestra doesn't use RL for its internal logic; instead, it provides the framework to orchestrate workflows that *include* RL training steps. For example, a Kestra workflow could trigger an RL training job for an orchestrator model, then deploy the updated model to control a team of [AI agents](https://kestra.io/plugins/plugin-ai/tool/io.kestra.plugin.ai.tool.aiagent) in a production environment.
+
+## Architectures for dynamic AI agent systems
+
+### Multi-team collaboration with cross-team orchestration
+
+Dynamic AI agent systems are rarely built by a single team. Data engineers, ML scientists, platform engineers, and business analysts all have a role to play. A unified orchestration platform is essential for breaking down silos and enabling effective collaboration.
+
+With a central control plane, different teams can contribute their expertise without friction. For instance, a data team can manage the data pipelines that feed the agents, while an ML team focuses on the models themselves. This approach is similar to patterns seen in [multi-cloud orchestration](https://kestra.io/resources/infrastructure/multi-cloud-orchestration), where a single platform coordinates resources across different environments. It also allows for clear [separation of concerns between business units](https://kestra.io/docs/best-practices/business-unit-separation).
+
+### Exploring the Evolving Agents Toolkit (EAT)
+
+Building evolving agent systems requires a toolkit that supports modularity, reusability, and integration. While "Evolving Agents Toolkit" is a conceptual term, the principles behind it are crucial. An effective toolkit should provide:
+*   **Modular Components:** The ability to define agents and their capabilities as reusable blocks. In Kestra, these are often implemented as [plugins](https://kestra.io/docs/workflow-components/plugins) or version-controlled scripts.
+*   **Reusable Logic:** The ability to encapsulate common patterns of agent interaction into templates or [subflows](https://kestra.io/docs/workflow-components/subflows) that can be easily composed into larger, more complex systems.
+*   **Integration Capabilities:** A rich ecosystem of integrations to connect agents with various data sources, APIs, and external tools.
+
+## Comparing agent roles and orchestration strategies
+
+### What is the difference between agent and orchestration?
+
+The distinction between agents and orchestration is fundamental: **agents provide capability, while orchestration provides control.** An [AI agent](https://kestra.io/resources/ai/ai-agent) is an entity that can perceive its environment and act upon it to achieve goals. It has skills, such as calling an API, running a script, or querying a database.
+
+[Agentic orchestration](https://kestra.io/resources/ai/agentic-orchestration), on the other hand, is the system that coordinates these agents. It defines the rules of engagement, manages the flow of information between them, and makes high-level decisions about strategy. In a multi-agent system, the behavior is often iterative and parallel, and the orchestrator is responsible for managing this complex dance.
+
+### What is an example of a multi-agent system?
+
+Consider an automated incident response system for a production application. This system could be composed of several specialized agents orchestrated by a central workflow:
+
+1.  **Monitoring Agent:** Detects an anomaly from system logs or metrics.
+2.  **Triage Agent:** Analyzes the alert to determine its severity and potential root cause.
+3.  **Remediation Agent:** Executes a predefined runbook, such as restarting a service or rolling back a deployment.
+4.  **Communication Agent:** Updates the status page, posts a message in the team's Slack channel, and creates a Jira ticket.
+5.  **Reporting Agent:** Summarizes the incident, actions taken, and resolution for a post-mortem report. You can see a similar, simpler pattern in this [text summarizer blueprint](https://kestra.io/blueprints/agent-text-summarizer).
+
+Each of these agents could be a separate script, API call, or even another LLM. The orchestrator defines the logic that determines when each agent is called, what data is passed between them, and how to handle failures. This entire system can be defined declaratively, as shown in blueprints like this one for [AI agent-driven automation](https://kestra.io/blueprints/ai-agent-calling-flows).
+
+## Advanced orchestration techniques for AI agents
+
+### What is multi-model orchestration?
+
+Multi-model orchestration is the practice of using multiple, different AI models within a single workflow. Instead of relying on a single, general-purpose model, this approach leverages the unique strengths of various specialized models. For example, a workflow might use:
+
+*   **Anthropic's Claude 3.5 Sonnet** for its reasoning capabilities to analyze a complex problem.
+*   **OpenAI's GPT-4o** for its code generation abilities to write a remediation script.
+*   A smaller, fine-tuned open-source model for a simple classification task to reduce costs.
+
+A flexible orchestration platform with a rich plugin ecosystem makes this possible, allowing you to seamlessly integrate models from providers like [OpenAI](https://kestra.io/plugins/plugin-ai/provider/io.kestra.plugin.ai.provider.openai) and [Anthropic](https://kestra.io/plugins/plugin-ai/provider/io.kestra.plugin.ai.provider.anthropic) into a single, cohesive workflow.
+
+### Building flexible and evolvable collective reasoning
+
+The ultimate goal of evolving orchestration is to build systems that exhibit collective reasoning—where the whole is smarter than the sum of its parts. This requires a flexible architecture that can be easily refined and improved over time.
+
+Declarative orchestration, where workflows are defined as code (e.g., YAML), is a key enabler. By treating your orchestration logic as code, you can apply [GitOps principles](https://kestra.io/resources/infrastructure/gitops) to manage its evolution. This means you can:
+*   Version control your agent strategies.
+*   Review changes through pull requests.
+*   A/B test different orchestration logics.
+*   Easily roll back to a previous version if a new strategy underperforms, using features like [flow revisions](https://kestra.io/docs/concepts/revision).
+
+## Kestra: The Declarative Control Plane for Evolving Orchestration
+
+Building, managing, and evolving complex multi-agent systems requires a robust control plane. Kestra provides this layer through its declarative, language-agnostic, and unified platform.
+
+Here’s why Kestra is uniquely suited for evolving orchestration:
+*   **Declarative YAML:** Workflows are defined in simple, auditable YAML, making it easy to version, review, and manage the evolution of your agent strategies.
+*   **Polyglot Execution:** Agents can be written in any language—Python, Go, Node.js, or even as simple shell scripts—and orchestrated seamlessly.
+*   **Native AI Capabilities:** With a built-in [AI Copilot](https://kestra.io/docs/ai-tools/ai-copilot) and native AI agent plugins, Kestra is designed for the modern AI stack.
+*   **Unified Platform:** Orchestrate data pipelines, infrastructure, and AI workflows from a single control plane, providing end-to-end visibility.
+*   **GitOps-Ready:** Full integration with Git allows for CI/CD, version control, and auditable rollbacks of your orchestration logic.
+
+By providing a flexible and governable foundation, Kestra empowers teams to move from experimenting with individual agents to deploying reliable, evolving multi-agent systems in production. Explore Kestra's [AI automation capabilities](https://kestra.io/ai-automation) to see how you can build the next generation of intelligent systems. For more details on Kestra's philosophy, see [Why Kestra](https://kestra.io/docs/why-kestra).

--- a/src/contents/resources/rag-architecture/index.md
+++ b/src/contents/resources/rag-architecture/index.md
@@ -1,0 +1,196 @@
+---
+title: "RAG Architecture: Enhance Your LLM Applications"
+description: "Explore RAG architecture with our comprehensive guide. Optimize large language models with external knowledge sources. Learn how RAG works!"
+metaTitle: "RAG Architecture for LLMs | Kestra Orchestration"
+metaDescription: "Master RAG architecture to enhance LLM applications. This guide covers core components, types, and practical implementation with Kestra's orchestration."
+tag: "ai"
+date: 2026-05-06
+slug: "rag-architecture"
+faq:
+  - question: "What is RAG architecture?"
+    answer: "Retrieval-Augmented Generation (RAG) is an AI framework that enhances Large Language Models (LLMs) by giving them access to external, up-to-date knowledge bases. Instead of relying solely on their pre-trained knowledge, RAG models retrieve relevant information from a specified source (like documents or databases) and use it to inform their generated responses, leading to more accurate, relevant, and grounded outputs."
+  - question: "What is the difference between RAG and LLM?"
+    answer: "An LLM (Large Language Model) is a standalone generative model trained on vast datasets, capable of understanding and generating human-like text. RAG (Retrieval-Augmented Generation) is an architecture that *enhances* an LLM. It adds a retrieval step before generation, allowing the LLM to fetch real-time or specific external information to improve its responses, addressing limitations like hallucinations or outdated knowledge."
+  - question: "Is ChatGPT a RAG model?"
+    answer: "Is ChatGPT a RAG model by default? No, ChatGPT is fundamentally a Generative Pre-trained Transformer (GPT), which is a type of Large Language Model (LLM). It only becomes a 'RAG system' when it uses features like 'Browse with Bing' to access external web data or when you upload files to a custom GPT for specific context, effectively adding a retrieval step."
+  - question: "Who typically uses RAG architecture?"
+    answer: "Common RAG use cases include customer support chatbots, internal knowledge search, and augmented search experiences that answer questions directly from company documents. Data engineers, ML engineers, and platform engineers often implement RAG to build reliable AI applications that require up-to-date, domain-specific, and verifiable information."
+  - question: "How does RAG improve LLM accuracy?"
+    answer: "RAG improves LLM accuracy by providing specific, verifiable context from external sources at the time of query. This reduces the LLM's tendency to 'hallucinate' or generate incorrect information based solely on its training data. By grounding responses in factual, up-to-date documents, RAG ensures that the generated output is more precise, relevant, and trustworthy for users."
+  - question: "What are the core components of a RAG system?"
+    answer: "A RAG system primarily consists of two core components: the retriever and the generator. The retriever is responsible for searching and fetching relevant documents from a knowledge base based on the user's query. The generator then takes this retrieved information, combines it with the original query, and feeds it to a Large Language Model (LLM) to produce an informed and coherent response."
+  - question: "When should I choose RAG for my AI projects?"
+    answer: "You should choose RAG for AI projects when your LLM applications need to access dynamic, proprietary, or highly specialized information that wasn't part of the LLM's original training data. It's ideal for use cases requiring factual accuracy, reduced hallucinations, and the ability to cite sources, without the high cost and complexity of continuous LLM fine-tuning."
+---
+
+Large Language Models (LLMs) have revolutionized how we interact with information, yet they often face challenges like generating outdated or fabricated responses—a phenomenon known as hallucination. Relying solely on an LLM's pre-trained knowledge can limit its utility, especially for applications requiring real-time, accurate, or domain-specific information. This is where Retrieval-Augmented Generation (RAG) architecture steps in.
+
+RAG enhances LLMs by equipping them with the ability to retrieve relevant information from external knowledge sources before generating a response. This guide will explore the intricacies of RAG architecture, from its core components to various implementation patterns, and demonstrate how platforms like Kestra can orchestrate these complex systems to build more reliable and intelligent AI applications.
+
+## What is RAG Architecture?
+
+RAG architecture is an AI framework that connects a Large Language Model to an external, authoritative knowledge base. This connection allows the LLM to access fresh, relevant information that was not part of its original training data, leading to more accurate and context-aware responses.
+
+### Defining Retrieval-Augmented Generation (RAG)
+
+Retrieval-Augmented Generation (RAG) is a two-step process that enhances the output of an LLM. First, it retrieves relevant data from a specified knowledge source based on a user's query. Second, it augments the user's prompt with this retrieved data and passes it to the LLM to generate a response. This process effectively "grounds" the LLM in a set of facts, significantly reducing the chances of hallucination and providing answers that are current and verifiable. A typical [RAG pipeline](https://kestra.io/resources/ai/rag-pipeline) involves data ingestion, indexing, retrieval, and generation stages.
+
+### How RAG Enhances Large Language Models (LLMs)
+
+LLMs are trained on static datasets, which means their knowledge has a cutoff date and lacks specific, proprietary information. RAG overcomes these limitations by providing a mechanism to inject real-time, external context into the generation process. Instead of just "remembering" information from its training, the LLM can now "read" relevant documents on the fly. This makes it possible to build applications that can answer questions about recent events, internal company documents, or specialized technical manuals. The core components of this system often rely on a [vector database](https://kestra.io/resources/ai/vector-database) to efficiently store and retrieve information.
+
+### Is ChatGPT a RAG Model?
+
+By default, ChatGPT is a standard LLM, not a RAG model. It generates responses based on the patterns and information present in its training data. However, it incorporates RAG-like capabilities through features such as "Browse with Bing," which allows it to retrieve live information from the web to answer queries. Similarly, when you upload documents to a custom GPT, you are creating a temporary RAG system where the model retrieves information from your provided files. These functionalities layer a retrieval mechanism on top of the base LLM, turning it into a RAG system for that specific interaction. This is similar to how developers build applications with [AI agents](https://kestra.io/resources/ai/ai-agent) that can access external tools and data sources.
+
+## Core Components of RAG Architecture
+
+A RAG system is composed of two main phases, each with its own set of components. Understanding these parts is key to designing and implementing an effective RAG architecture.
+
+### The Retrieval Phase: Accessing External Knowledge
+
+The retrieval phase is responsible for finding and fetching the most relevant information from a knowledge base to answer a user's query. This process typically involves:
+- **Data Ingestion and Indexing:** Documents are loaded, split into manageable chunks, and converted into numerical representations (embeddings) using an embedding model. These embeddings are then stored and indexed in a [vector database](https://kestra.io/resources/ai/vector-database).
+- **Querying:** When a user submits a query, it is also converted into an embedding. The system then performs a similarity search in the vector database to find the document chunks with embeddings closest to the query embedding.
+- **Knowledge Sources:** The external knowledge can come from various sources, including text documents, PDFs, database records, or even web pages. Proper management of these [data storage components](https://kestra.io/docs/architecture/data-components) is crucial for a robust RAG system.
+
+### The Generation Phase: Crafting Informed Responses
+
+Once the relevant document chunks are retrieved, the generation phase begins. This phase uses the power of an LLM to synthesize an answer.
+- **Prompt Augmentation:** The retrieved text is combined with the original user query to form an augmented prompt. This prompt provides the LLM with the necessary context to generate a factually grounded response.
+- **LLM Generation:** The augmented prompt is sent to an LLM (e.g., GPT-4, Claude 3). The model uses the provided context to craft a coherent, human-like answer that directly addresses the user's question. This is a core part of building [RAG workflows](https://kestra.io/docs/ai-tools/ai-rag-workflows) and can be enhanced with autonomous [AI agents](https://kestra.io/docs/ai-tools/ai-agents).
+
+### Key Benefits of RAG in AI
+
+Implementing a RAG architecture offers several significant advantages:
+- **Improved Accuracy and Reduced Hallucinations:** By grounding responses in external data, RAG minimizes the risk of the LLM inventing information.
+- **Access to Up-to-Date Information:** RAG systems can provide current answers by connecting to knowledge bases that are continuously updated, overcoming the static nature of LLMs.
+- **Transparency and Verifiability:** Since the model's responses are based on retrieved documents, it's possible to cite sources, allowing users to verify the information.
+- **Cost-Effectiveness:** Updating a knowledge base is significantly cheaper and faster than retraining or fine-tuning an entire LLM.
+
+## Why RAG Architecture Matters
+
+RAG architecture is more than just a technical enhancement; it represents a fundamental shift in how we build reliable and scalable AI applications. It directly addresses the inherent weaknesses of LLMs, making them more suitable for enterprise and mission-critical use cases.
+
+### Addressing LLM Limitations with RAG
+
+LLMs, despite their impressive capabilities, have well-known limitations. Their knowledge is frozen at the time of training, they can be prone to factual inaccuracies (hallucinations), and they lack domain-specific expertise unless explicitly trained on it. RAG provides an elegant solution by offloading the "knowledge" part to an external, easily updatable database, allowing the LLM to focus on its core strengths: reasoning, summarization, and language generation.
+
+### Improving Accuracy and Relevance in Generative AI
+
+In a business context, trust is paramount. RAG improves the reliability of generative AI applications by ensuring that their outputs are based on verified, company-approved data. This is crucial for applications like customer support bots that must provide accurate product information or internal knowledge systems that employees rely on for correct procedures. This move towards verifiable, tool-using AI is a key component of [agentic AI](https://kestra.io/resources/ai/agentic-ai).
+
+### Who Typically Uses RAG Architecture?
+
+RAG is used by a wide range of professionals to build sophisticated AI applications.
+- **Data Engineers and ML Engineers** build and maintain the data pipelines and infrastructure that power RAG systems, from data ingestion and embedding to model deployment and monitoring. This often involves complex [agentic orchestration](https://kestra.io/resources/ai/agentic-orchestration) and a solid understanding of [MLOps](https://kestra.io/resources/ai/what-is-mlops).
+- **Software Developers** integrate RAG capabilities into user-facing applications, such as intelligent search engines, chatbots, and content creation tools.
+- **Business Analysts and Product Managers** leverage RAG to create internal tools that provide quick, data-driven answers from internal knowledge bases, reports, and dashboards.
+
+## Types and Patterns of RAG Architecture
+
+As the field of generative AI matures, RAG architecture has evolved from a simple, single-step process to a variety of sophisticated patterns designed to handle more complex queries and improve performance.
+
+### Simple vs. Advanced RAG Implementations
+
+- **Simple RAG:** This is the foundational pattern where a query retrieves a set of documents, which are then fed to the LLM in a single pass. It's effective for straightforward question-answering tasks.
+- **Advanced RAG:** This involves more complex logic to enhance the quality of retrieval and generation. Techniques include:
+    - **Query Rewriting:** The initial user query is refined or expanded by an LLM to be more effective for retrieval.
+    - **Re-ranking:** After an initial retrieval, a secondary, more lightweight model re-ranks the documents for relevance before passing them to the main LLM.
+    - **Multi-hop Retrieval:** For complex questions that require synthesizing information from multiple sources, the system performs several rounds of retrieval, using the output of one step to inform the next. This is a form of [prompt chaining](https://kestra.io/resources/ai/prompt-chaining-llm-guide).
+
+### Exploring Different RAG Architectural Patterns
+
+Beyond simple and advanced implementations, different architectural patterns can be employed. A **sequential pattern** follows the standard retrieve-then-generate flow. A **parallel pattern** might retrieve from multiple knowledge sources simultaneously and then consolidate the results. An **iterative pattern** refines the query and retrieval process multiple times until a satisfactory context is built, which is common in [multi-agent systems](https://kestra.io/resources/ai/multi-agent-system).
+
+### Real-World Applications of RAG
+
+The applications of RAG extend far beyond simple chatbots. In the legal field, RAG systems can analyze thousands of case documents to provide summaries and precedents. In scientific research, they can sift through vast libraries of academic papers to help researchers find relevant studies. In finance, RAG can power tools that analyze market reports and financial filings to provide real-time insights to traders and analysts.
+
+## RAG vs. Traditional LLM Approaches
+
+To fully appreciate the value of RAG, it's helpful to compare it with other methods of customizing LLM behavior, such as fine-tuning.
+
+### What is the Difference Between RAG and LLM?
+
+An LLM is the core generative engine, while RAG is an architectural framework built around it. The key difference lies in how they access knowledge. A standard LLM relies on the implicit knowledge encoded in its parameters during training. A RAG system, however, uses explicit knowledge retrieved from an external source at inference time. This makes RAG more dynamic and easier to update. In contrast, fine-tuning adapts the LLM's internal parameters to a specific domain, which is a more static and computationally expensive process.
+
+### When to Choose RAG for Your AI Projects
+
+You should choose RAG when your application requires:
+- **Up-to-date information:** If the knowledge base changes frequently, RAG is ideal.
+- **Domain-specific context:** RAG excels at providing answers based on proprietary documents or specialized knowledge.
+- **Verifiability:** When users need to know the source of the information, RAG can provide citations.
+- **Cost-efficiency and speed:** Updating a vector database is much faster and cheaper than fine-tuning an LLM.
+
+### Future Trends in RAG Development
+
+The RAG landscape is rapidly evolving. Future trends include **multi-modal RAG**, which can retrieve and process information from images, audio, and video, not just text. We are also seeing the rise of **self-improving RAG systems** that use feedback to refine their retrieval strategies over time. The tight integration of RAG with [agentic AI workflows](https://kestra.io/docs/ai-tools/ai-workflows) and [autonomous agents](https://kestra.io/docs/ai-tools/ai-agents) is also pushing the boundaries of what's possible.
+
+## Implementing RAG Architecture in Practice
+
+Building a production-ready RAG system involves careful design choices, selecting the right tools, and establishing a robust evaluation framework.
+
+### Designing a RAG Solution: Best Practices
+
+A successful RAG implementation depends on several key decisions:
+- **Data Preprocessing:** Raw documents must be cleaned and split into optimal-sized chunks. Small chunks provide more precise context, while larger chunks can capture more background information.
+- **Embedding Model Selection:** The choice of embedding model affects the quality of the retrieval. Models should be chosen based on the specific domain and language of the documents.
+- **Vector Store Choice:** Different vector databases offer various trade-offs in terms of scalability, performance, and features.
+- **LLM Selection:** The generator LLM should be chosen based on its reasoning capabilities, context window size, and cost.
+
+### Tools and Platforms for RAG Deployment
+
+The ecosystem of tools for building RAG systems is growing. Frameworks like LangChain and LlamaIndex provide abstractions to simplify development. Vector databases such as Pinecone, Chroma, and Weaviate are popular choices for indexing. For deployment, many teams rely on cloud services and containerization technologies like [Kubernetes](https://kestra.io/docs/installation/kubernetes). The overall [system architecture](https://kestra.io/docs/architecture) must be designed for scalability and reliability.
+
+### Evaluating RAG System Performance
+
+Evaluating a RAG system is a multi-faceted task. Key metrics include:
+- **Retrieval Metrics:** Precision and recall measure how well the retriever finds relevant documents.
+- **Generation Metrics:** Fluency, coherence, and factual consistency assess the quality of the LLM's output.
+- **End-to-End Evaluation:** Ultimately, the system's success is measured by its ability to provide answers that are relevant, accurate, and helpful to the end-user.
+
+## Orchestrating RAG Workflows with Kestra
+
+A production-grade RAG system is not a single application but a complex pipeline of interconnected components that must be automated, monitored, and scaled. This is where an orchestration platform like Kestra becomes essential. Leading enterprises like Apple, JPMorgan Chase, and Toyota use Kestra to manage their complex data and AI pipelines at scale.
+
+### Declarative YAML for RAG Pipeline Definition
+
+Kestra allows you to define your entire [RAG workflow](https://kestra.io/docs/ai-tools/ai-rag-workflows) as a simple, declarative YAML file. This brings GitOps principles to your AI pipelines, enabling version control, code reviews, and automated deployments. You can define every step, from data ingestion and chunking to embedding and indexing, in a single, auditable file.
+
+```yaml
+id: simple-rag-pipeline
+namespace: production.ai
+tasks:
+  - id: ingest_documents
+    type: io.kestra.plugin.scripts.python.Script
+    script: |
+      # Python code to fetch and chunk documents
+      ...
+  - id: create_embeddings
+    type: io.kestra.plugin.ai.provider.openai
+    action: EMBEDDING
+    input: "{{ outputs.ingest_documents.uri }}"
+  - id: index_in_weaviate
+    type: io.kestra.plugin.weaviate.BatchCreate
+    className: "MyDocs"
+    input: "{{ outputs.create_embeddings.uri }}"
+triggers:
+  - id: on_new_data
+    type: io.kestra.plugin.aws.s3.Trigger
+    bucket: my-knowledge-base
+```
+
+### Polyglot Execution and Plugin Ecosystem
+
+RAG pipelines often involve a mix of technologies. Kestra's language-agnostic approach means you can use Python for data processing, shell scripts for CLI tools, and SQL for database interactions, all within the same workflow. With a rich ecosystem of [AI plugins](https://kestra.io/plugins/plugin-ai) and database connectors like the one for [Postgres](https://kestra.io/plugins/plugin-jdbc-postgres), you can easily integrate with any LLM provider, vector database, or data source your architecture requires. You can explore hundreds of blueprints for common patterns, from [generating book summaries](https://kestra.io/blueprints/ai-book-summary-perplexity) to building a [GDPR-compliant RAG system](https://kestra.io/blueprints/ai-gdpr-dpia-assistant).
+
+### End-to-End Automation and Observability
+
+Kestra provides the tools to fully automate and monitor your RAG system. You can use event-driven triggers to automatically update your vector database whenever new documents are added. Robust error handling and retry mechanisms ensure your pipelines are resilient. Detailed logs and a visual topology view give you complete observability into every execution, making it easy to debug issues and optimize performance as you scale.
+
+## Conclusion: The Future of Informed AI
+
+RAG architecture has emerged as a critical pattern for building reliable, accurate, and context-aware generative AI applications. By separating knowledge from reasoning, it overcomes the inherent limitations of LLMs and unlocks their true potential for enterprise use.
+
+As these systems grow in complexity, the need for a robust orchestration layer becomes clear. Kestra provides a declarative control plane to manage the entire lifecycle of your RAG workflows, from data ingestion to generation, enabling you to build and scale informed AI solutions with confidence. To learn more, explore our [AI automation](https://kestra.io/ai-automation) platform or browse our other [AI resources](https://kestra.io/resources/ai).

--- a/src/contents/resources/what-is-a-machine-learning-pipeline/index.md
+++ b/src/contents/resources/what-is-a-machine-learning-pipeline/index.md
@@ -1,0 +1,180 @@
+---
+title: "What is a Machine Learning Pipeline?"
+description: "Demystify the machine learning pipeline concept. Learn how ML pipelines automate model building, training, and deployment for efficiency."
+metaTitle: "What is a Machine Learning Pipeline? Kestra Explained"
+metaDescription: "Explore the machine learning pipeline concept and its core stages, from data prep to model deployment. Learn how Kestra simplifies and automates ML workflows with declarative YAML."
+tag: "ai"
+date: 2026-05-15
+slug: "what-is-a-machine-learning-pipeline"
+faq:
+  - question: "What is a machine learning pipeline?"
+    answer: "A machine learning (ML) pipeline is a structured, automated workflow that manages the entire lifecycle of an ML model, from data ingestion and preparation through model training, evaluation, and deployment. It streamlines the development process, ensuring reproducibility, scalability, and efficient model management in production."
+  - question: "What are the basic steps in an ML pipeline?"
+    answer: "The basic steps typically include data ingestion, data preparation (cleaning, transformation), feature engineering, model training, model evaluation, and model deployment. Each step builds upon the previous one, with automation ensuring smooth transitions and consistent execution."
+  - question: "What are the 4 pipeline stages?"
+    answer: "While specific models vary, a common four-stage view includes: data collection/preparation, model training/validation, model deployment, and continuous monitoring/feedback. This holistic approach ensures models remain effective and adapt to new data over time."
+  - question: "What are the 4 types of machine learning models?"
+    answer: "Machine learning models generally fall into four types: supervised learning (learning from labeled data), unsupervised learning (finding patterns in unlabeled data), semi-supervised learning (combining labeled and unlabeled data), and reinforcement learning (learning through trial and error with rewards)."
+  - question: "What is the 80/20 rule in machine learning?"
+    answer: "The 80/20 rule, or Pareto Principle, in machine learning suggests that roughly 80% of results come from 20% of effort. Applied to ML, this means focusing on the most impactful aspects like robust data preprocessing, careful feature engineering, and selecting appropriate core algorithms to achieve significant results efficiently."
+  - question: "What are the 4 pillars of ML?"
+    answer: "Some perspectives categorize the four pillars of ML as predictions, decisions, discovery, and generation. These represent the core capabilities and applications of machine learning, from forecasting future outcomes to creating new data or insights."
+---
+```
+
+Building and deploying machine learning models in production is rarely a straightforward task. From raw data to a deployed model, the journey involves numerous complex, interconnected steps that demand precision, reproducibility, and efficient management. Without a structured approach, teams often grapple with inconsistent results, slow deployments, and operational overhead.
+
+This is where machine learning pipelines become indispensable. An ML pipeline is an automated, systematic workflow designed to streamline the entire ML lifecycle. This article will demystify the concept of ML pipelines, explore their core stages and architectures, and highlight how Kestra's declarative orchestration platform provides a robust, unified control plane for managing these critical AI workflows.
+
+## Understanding the machine learning pipeline
+
+A machine learning pipeline is an automated workflow that manages the entire lifecycle of an ML model. It sequences a series of interconnected steps, from initial data collection to model deployment and monitoring, ensuring that each phase is executed consistently and efficiently. Think of it as an assembly line for machine learning: raw data enters at one end, and a production-ready model emerges at the other, with every step automated and auditable.
+
+This structured approach is crucial for building a foundation for MLOps and moving beyond ad-hoc model development. By automating the workflow, ML pipelines ensure reproducibility, allowing teams to recreate results reliably. They provide the consistency needed for scalable AI operations, making it possible to manage hundreds or even thousands of models in production. For more information on AI pipelines, you can explore our [AI Orchestration Resources](https://kestra.io/resources/ai).
+
+The key benefits of implementing ML pipelines include:
+- **Efficiency:** Automation reduces manual intervention, freeing up data scientists and engineers to focus on model improvement rather than operational tasks.
+- **Reduced Errors:** By standardizing processes, pipelines minimize the risk of human error in data preparation, training, and deployment.
+- **Faster Deployment Cycles:** Automated testing and deployment processes accelerate the time-to-market for new models and updates.
+- **Improved Resource Utilization:** Pipelines can be optimized to run on specific hardware or cloud instances, managing costs and compute resources effectively.
+- **Auditability and Governance:** Each step in the pipeline is logged and versioned, creating a clear audit trail for compliance and debugging.
+
+## Core stages of a typical ML pipeline
+
+While the specifics can vary, most ML pipelines consist of a set of core stages that transform raw data into a functional, monitored model.
+
+### Data ingestion and preparation in ML pipelines
+
+This initial stage focuses on gathering raw data from various sources and preparing it for use. It involves collecting data from databases, APIs, or streaming platforms. Once collected, the data undergoes cleaning to handle missing values, correct inconsistencies, and remove duplicates. Transformation and validation steps ensure the data conforms to the required schema and quality standards, a critical step detailed in guides on [data ingestion best practices](https://kestra.io/resources/data/what-is-data-ingestion).
+
+### Feature engineering and selection techniques
+
+In this stage, raw data is transformed into features that better represent the underlying patterns for the model. This can involve creating new features from existing ones (e.g., extracting the day of the week from a timestamp) or transforming variables (e.g., log transformation). Feature selection techniques are then used to identify and retain the most relevant features, reducing model complexity and improving performance.
+
+### Model training and optimization
+
+This is where the machine learning algorithm learns from the prepared data. The process involves selecting an appropriate algorithm, feeding it the feature set, and tuning its hyperparameters to achieve the best performance. Techniques like cross-validation are often used to ensure the model generalizes well to unseen data. For large datasets, this stage may involve distributed training across multiple machines.
+
+### Model evaluation and validation
+
+Once trained, the model's performance must be rigorously evaluated. This is done using a holdout dataset that the model has not seen during training. Key metrics such as accuracy, precision, recall, F1-score, or AUC are calculated to assess its effectiveness. A/B testing can also be employed to compare the new model's performance against a currently deployed version.
+
+### Model deployment and monitoring
+
+After validation, the model is deployed into a production environment where it can make predictions on new data. This often involves packaging the model into a standard format (like ONNX or PMML), containerizing it, and exposing it via an API endpoint. Post-deployment, continuous monitoring is essential to track performance, detect data drift, and ensure the model remains accurate over time, a practice central to [data observability](https://kestra.io/resources/data/data-observability).
+
+### What are the basic steps in an ML pipeline?
+
+The basic steps of an ML pipeline are data ingestion, data preparation, feature engineering, model training, model evaluation, and model deployment. These sequential steps form the core workflow for taking a model from concept to production.
+
+### What are the 4 pipeline stages?
+
+A common high-level view simplifies the ML pipeline into four primary stages: data collection and preparation, model training and validation, model deployment, and continuous monitoring and feedback. This cyclical view emphasizes the iterative nature of MLOps, where production feedback informs future model improvements.
+
+## Types of machine learning pipeline architectures
+
+ML pipelines can be designed with different architectures to suit various use cases, primarily differing in how they process data.
+
+### Batch processing pipelines
+
+Batch processing pipelines are the most common type, designed to process large volumes of data on a scheduled basis (e.g., daily or weekly). They are ideal for offline model training, where models are retrained periodically on new data. This architecture is well-suited for applications that do not require real-time predictions, such as generating weekly sales forecasts or monthly customer churn analysis.
+
+### Streaming pipelines for real-time applications
+
+Streaming pipelines are built for low-latency, real-time applications. They process data continuously as it arrives, enabling immediate predictions. This is essential for use cases like fraud detection, real-time bidding, and dynamic pricing. These pipelines are often event-driven, triggering actions as soon as new data points are received. Understanding the trade-offs between [batch vs. streaming processing](https://kestra.io/resources/data/batch-vs-streaming-processing) is key to choosing the right architecture.
+
+### Hybrid ML pipeline approaches
+
+Many modern systems use a hybrid approach that combines the strengths of both batch and streaming architectures. In this model, a batch pipeline is used for model training and periodic re-training on large historical datasets, while a streaming pipeline uses the trained model for real-time inference on live data. This allows organizations to build robust, accurate models with historical data while still serving low-latency predictions. This pattern often relies on a robust [event-driven orchestration](https://kestra.io/resources/infrastructure/event-driven-orchestration) system.
+
+## Implementing machine learning pipelines in Python
+
+Python is the dominant language for machine learning, and it offers a rich ecosystem of libraries for building pipelines.
+
+### Popular Python libraries for ML pipelines
+
+- **Scikit-learn:** Its `Pipeline` module is a cornerstone for creating simple, sequential pipelines that chain transformers and estimators.
+- **Pandas:** The go-to library for data manipulation and preparation, used extensively in the initial stages of a pipeline.
+- **NumPy:** Essential for numerical operations and handling multi-dimensional arrays.
+- **TensorFlow/PyTorch:** Used for building and training deep learning models within a pipeline.
+- **MLflow:** An open-source platform for managing the end-to-end machine learning lifecycle, including experiment tracking and model versioning.
+
+### Step-by-step guide to building a simple pipeline
+
+Building a basic `pipeline in machine learning with scikit-learn` typically involves these conceptual steps:
+1.  **Load Data:** Use Pandas to load your dataset from a CSV file or database.
+2.  **Define Preprocessing Steps:** Create transformers for data cleaning, such as an `imputer` for missing values and a `scaler` for numerical features.
+3.  **Define the Model:** Choose a machine learning algorithm, like a `RandomForestClassifier`.
+4.  **Chain Steps with `Pipeline`:** Use Scikit-learn's `Pipeline` class to chain the preprocessing steps and the model into a single object.
+5.  **Train and Evaluate:** Fit the pipeline on your training data and evaluate its performance on a test set.
+
+This modular approach ensures that the same preprocessing steps are applied consistently to both training and prediction data.
+
+### Best practices for Python ML pipeline development
+
+- **Modularity:** Break down your pipeline into reusable components or tasks.
+- **Code Versioning:** Use Git to track changes to your pipeline code, data, and models.
+- **Testing:** Implement unit and integration tests to validate each component of your pipeline.
+- **Dependency Management:** Use tools like `pip`, `uv`, or `conda` to manage package dependencies and ensure a reproducible environment.
+- **Environment Isolation:** Use containers (e.g., Docker) to isolate your pipeline's execution environment. Kestra makes it easy to [orchestrate Python workflows](https://kestra.io/docs/use-cases/python-workflows) with built-in dependency management and containerization.
+
+## Tools and platforms for ML pipeline orchestration
+
+Orchestration tools are essential for managing, scheduling, and monitoring complex ML pipelines in production.
+
+### Overview of managed ML pipeline services
+
+Major cloud providers offer managed services that simplify pipeline creation and management. Examples include **Google Cloud Vertex AI Pipelines**, **AWS Step Functions for ML**, and **Azure ML Pipelines**. While powerful, these services often tie you to a specific cloud ecosystem. **Databricks Workflows** are another popular option for teams working within the Databricks lakehouse environment.
+
+### Open-source tools for pipeline management
+
+For greater flexibility and control, many teams turn to open-source tools. **Kubeflow Pipelines** and **Argo Workflows** are popular choices for Kubernetes-native environments. **Kestra** stands out as a declarative, language-agnostic, and event-driven orchestration platform. Its YAML-based workflows make it easy to define, version, and manage complex pipelines that span data, AI, and infrastructure tasks.
+
+### Choosing the right tool for your ML workflow
+
+When selecting a tool, consider factors like scalability, language support, integration with your existing stack, and deployment flexibility. Platforms like Kestra offer a vendor-agnostic control plane, allowing you to [stop writing glue code around your AI pipelines](https://kestra.io/ai-automation) and coordinate tools across hybrid and multi-cloud environments. This avoids lock-in and provides a unified solution for orchestrating more than just ML tasks.
+
+## Advanced concepts in ML pipeline design
+
+As ML systems mature, pipelines must incorporate more advanced concepts to ensure reliability and continuous improvement.
+
+### CI/CD for machine learning (MLOps)
+
+MLOps applies DevOps principles to machine learning, and pipelines are its backbone. A CI/CD pipeline for ML automates the testing and deployment of not just code, but also data and models. This ensures that every change is validated before reaching production, a core practice in [modern MLOps](https://kestra.io/resources/ai/what-is-mlops).
+
+### Automated re-training and model versioning
+
+Models in production can become stale as new data emerges. Advanced pipelines include triggers for automated re-training based on performance degradation or data drift. Every trained model, along with its corresponding data and code, should be versioned as an artifact, allowing for easy rollbacks and auditability. Kestra's support for [version control and CI/CD](https://kestra.io/docs/version-control-cicd) makes this process seamless.
+
+### Addressing data drift and concept drift
+
+Data drift occurs when the statistical properties of the input data change over time, while concept drift happens when the relationship between input and output variables changes. Pipelines must include monitoring components to detect these drifts and trigger alerts or automated re-training to maintain model accuracy.
+
+### What is the 80/20 rule in machine learning?
+
+The 80/20 rule, or Pareto Principle, suggests that about 80% of results come from 20% of the effort. In machine learning, this means focusing on the most critical aspects—like high-quality data preprocessing, robust feature engineering, and selecting the right core algorithms—can yield the most significant performance gains efficiently.
+
+## Common challenges and solutions in ML pipelines
+
+Building robust ML pipelines comes with its own set of challenges.
+
+### Managing data dependencies
+
+Pipelines rely on specific versions of datasets, schemas, and features. Without proper management, changes in upstream data can break the pipeline. Solutions include data versioning tools, schema registries, and robust [data lineage](https://kestra.io/resources/data/data-lineage) tracking to understand dependencies.
+
+### Ensuring reproducibility and auditability
+
+To trust a model's output, you must be able to reproduce its training process exactly. Declarative workflow definitions, like Kestra's YAML, are crucial for this. By defining the entire pipeline as code and managing it with GitOps practices, every execution becomes a reproducible and auditable event.
+
+### Scaling ML pipelines efficiently
+
+As data volumes and model complexity grow, pipelines must scale. This requires tools that support distributed computing and dynamic resource allocation. Kestra's architecture, with its support for [Task Runners and Worker Groups](https://kestra.io/docs/task-runners), allows tasks to be offloaded to dedicated compute environments, ensuring pipelines can scale horizontally without overwhelming the core orchestration engine.
+
+## Unifying and Governing ML Pipelines with Kestra
+
+Machine learning pipelines are fundamental to modern AI, but their complexity demands a powerful and flexible orchestration layer. Kestra provides a unified control plane that addresses the core challenges of building, deploying, and managing ML workflows at scale.
+
+With its declarative YAML interface, Kestra ensures that every pipeline is reproducible, versionable, and auditable. Its polyglot nature allows teams to use the best tool for each task—whether it's Python for model training, SQL for data transformation, or Bash for infrastructure setup—all within a single, cohesive workflow. This versatility is backed by an ecosystem of over 1,200 plugins, enabling seamless integration across your entire stack.
+
+Kestra is also built for the future of AI with native features for [agentic orchestration](https://kestra.io/resources/ai/agentic-orchestration). The [AI Copilot](https://kestra.io/docs/ai-tools/ai-copilot) accelerates development by translating natural language into production-ready YAML, while [AI Agents](https://kestra.io/docs/ai-tools/ai-agents) can execute complex, multi-step tasks autonomously. This allows organizations like Apple and JPMorgan Chase to orchestrate large-scale AI and data pipelines with robust governance, including human-in-the-loop approvals for critical operations.
+


### PR DESCRIPTION
## Summary

Publishes 5 new AI resource pages drafted in [vfanucci/kestra-seo](https://github.com/vfanucci/kestra-seo):

| Slug | Source PR |
|------|-----------|
| `rag-architecture` | [kestra-seo#49](https://github.com/vfanucci/kestra-seo/pull/49) |
| `model-deployment` | [kestra-seo#48](https://github.com/vfanucci/kestra-seo/pull/48) |
| `what-is-a-machine-learning-pipeline` | [kestra-seo#47](https://github.com/vfanucci/kestra-seo/pull/47) |
| `kubernetes` | [kestra-seo#46](https://github.com/vfanucci/kestra-seo/pull/46) |
| `multi-agent-collaboration-evolving-orchestration` | [kestra-seo#45](https://github.com/vfanucci/kestra-seo/pull/45) |

Frontmatter adjustments applied to satisfy the `resources` collection schema:
- `tag` normalized to lowercase enum values (`ai` / `infrastructure`)
- removed unresolved `image: /images/blogs/rag-architecture/cover.png` reference on `rag-architecture`

## Test plan

- [ ] CI passes (content collection schema validation)
- [ ] All 5 pages render at `/resources/<slug>` with FAQ section
- [ ] Internal links resolve (links use absolute `https://kestra.io/resources/...` URLs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)