### PR TITLE
fix(website): restore legal pages (privacy-policy, cookie-policy, ...) returning 404

### DIFF
--- a/src/pages/[item].astro
+++ b/src/pages/[item].astro
@@ -1,5 +1,0 @@
----
-export const prerender = false
-if (!Astro.params.item || Astro.params.item !== "404")
-    return Astro.rewrite("/404")
----


### PR DESCRIPTION
## Summary

- All [legal pages](https://github.com/kestra-io/docs/tree/main/src/contents/legal) (`/privacy-policy`, `/cookie-policy`, `/data-processing-agreement`, `/cloud-license-agreement`, `/enterprise-license-agreement`, `/kestra-cloud-tos`, `/master-software-licence-agreement`) currently return **HTTP 404** in production.
- Root cause: [`src/pages/[item].astro`](https://github.com/kestra-io/docs/blob/main/src/pages/%5Bitem%5D.astro) is a SSR catch-all (`prerender = false`) that rewrites every single-segment URL to `/404`. It shadows the prerendered routes from [`[legal].astro`](https://github.com/kestra-io/docs/blob/main/src/pages/%5Blegal%5D.astro).
- The prerendered HTML actually exists on the edge: `curl https://kestra.io/privacy-policy/index.html` returns **200**, but `curl https://kestra.io/privacy-policy` returns **404** because the worker SSR catch-all wins over the static asset since [#4547](https://github.com/kestra-io/docs/pull/4547) / commit `21de23dff` changed `run_worker_first` from `true` to a restricted pattern.
- Fix: delete `[item].astro`. Astro's native `404.astro` already handles unmatched routes, so the catch-all is redundant.

## Test plan

- [ ] After deploy, `curl -I https://kestra.io/privacy-policy` returns 200
- [ ] Same for `/cookie-policy`, `/data-processing-agreement`, `/cloud-license-agreement`, `/enterprise-license-agreement`, `/kestra-cloud-tos`, `/master-software-licence-agreement`
- [ ] An unknown URL like `/this-does-not-exist` still returns the custom 404 page (served by `404.astro`)
- [ ] Other top-level pages (`/about-us`, `/contact-us`, ...) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)