### PR TITLE
seo(docs): use absolute links in section index pages to fix 18 404s

### DIFF
--- a/src/contents/docs/07.enterprise/03.auth/sso/index.md
+++ b/src/contents/docs/07.enterprise/03.auth/sso/index.md
@@ -41,8 +41,8 @@ For more configuration details, refer to the [Micronaut OIDC configuration guide
 ## Provider guides
 
 Check out our guides for specific SSO providers:
-- [Google](./google-oidc/index.md)
-- [Microsoft](./microsoft-oidc/index.md)
-- [Keycloak](./keycloak/index.md)
-- [Okta](./okta/index.md)
-- [authentik](./authentik/index.md)
+- [Google](/docs/enterprise/auth/sso/google-oidc)
+- [Microsoft](/docs/enterprise/auth/sso/microsoft-oidc)
+- [Keycloak](/docs/enterprise/auth/sso/keycloak)
+- [Okta](/docs/enterprise/auth/sso/okta)
+- [authentik](/docs/enterprise/auth/sso/authentik)

--- a/src/contents/docs/07.enterprise/index.mdx
+++ b/src/contents/docs/07.enterprise/index.mdx
@@ -24,7 +24,7 @@ While Kestra Cloud is fully managed, it differs from Kestra Enterprise in severa
 | ------------------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | **Infrastructure Control**            | Fully managed by Kestra for simplicity and reliability                                                         | Full control and customization                                              |
 | **Backend Technology**                | PostgreSQL JDBC only                                                                                           | Customizable Kafka, PostgreSQL, MySQL, H2 (testing)                         |
-| **Workers**                           | Managed worker pools sized for stability                                                                       | Remote [Worker Groups](./04.scalability/worker-group/index.md), autoscaling |
+| **Workers**                           | Managed worker pools sized for stability                                                                       | Remote [Worker Groups](/docs/enterprise/scalability/worker-group), autoscaling |
 | **Custom Internal Storage & Secrets** | No instance-level control, **tenant/namespace-level only** backends                                            | Fully customizable backends                                                 |
 | **Network Configuration**             | Secure access over public Internet                                                                             | Private networking (self-hosted, VPC peering, etc.)                         |
 | **Backup Access**                     | Automatic backups handled by Kestra                                                                            | Customer-controlled backups                                                 |
@@ -32,10 +32,10 @@ While Kestra Cloud is fully managed, it differs from Kestra Enterprise in severa
 | **Identity Providers (IdP)**          | Built-in Google, Microsoft, or Basic Authentication                                                            | Custom SSO/SCIM supported                                                   |
 | **Log Retention**                     | Automatic retention protocol managed by Kestra                                                                 | Unlimited (based on customer setup)                                         |
 | **Deployment Regions**                | US & EU (Belgium) on GCP                                                                                       | Any cloud, any region                                                       |
-| **Task Runners**                      | Compatible with most, [Process Task Runner](../task-runners/04.types/01.process-task-runner/index.md) excluded | Compatible with all task runners                                            |
+| **Task Runners**                      | Compatible with most, [Process Task Runner](/docs/task-runners/types/process-task-runner) excluded | Compatible with all task runners                                            |
 
 This section describes those features in detail and explains how to configure them.
 
-If you're interested to learn more, check the [Open-Source and Enterprise Edition comparison](../oss-vs-paid/index.md), explore our [Pricing](/pricing), and [get in touch](/demo) to discuss your requirements.
+If you're interested to learn more, check the [Open-Source and Enterprise Edition comparison](/docs/oss-vs-paid), explore our [Pricing](/pricing), and [get in touch](/demo) to discuss your requirements.
 
 <ChildCard />

--- a/src/contents/docs/16.scripts/index.mdx
+++ b/src/contents/docs/16.scripts/index.mdx
@@ -28,7 +28,7 @@ There are dedicated plugins for `Python`, `R`, `Julia`, `Ruby`, `Node.js`, `Powe
 
 By default, these tasks run in individual Docker containers (taskRunner type: `io.kestra.plugin.scripts.runner.docker.Docker`). You can overwrite that default behavior if you prefer that your scripts run in a local process (taskRunner type: `io.kestra.plugin.core.runner.Process`) instead.
 
-If you use the [Enterprise Edition](../07.enterprise/index.mdx), you can also run your scripts on [dedicated remote workers](../07.enterprise/04.scalability/worker-group/index.md) by specifying a `workerGroup` property or using other [Task Runner types](../task-runners/04.types/index.mdx) for AWS, GCP, Azure, and Kubernetes.
+If you use the [Enterprise Edition](/docs/enterprise), you can also run your scripts on [dedicated remote workers](/docs/enterprise/scalability/worker-group) by specifying a `workerGroup` property or using other [Task Runner types](/docs/task-runners/types) for AWS, GCP, Azure, and Kubernetes.
 
 The following pages dive into details of each task runner, supported programming languages, and how to manage dependencies.
 

--- a/src/contents/docs/task-runners/index.mdx
+++ b/src/contents/docs/task-runners/index.mdx
@@ -19,8 +19,8 @@ Many data processing tasks are **computationally intensive** and require a lot o
 All you have to do to offload your task execution to a remote environment is to specify the `taskRunner` type in your task configuration. Each `type` of a task runner is a **plugin** with its own schema. The built-in code editor provides documentation, autocompletion, and syntax validation for all task runner plugin properties to ensure correctness, standardization, and consistency.
 
 :::alert{type="info"}
-Some task runner plugins are available only in the [Enterprise Edition](../07.enterprise/index.mdx). If you want to try them out, please [reach out](/demo).
-See [Open Source vs Enterprise](../oss-vs-paid/index.md) to compare editions.
+Some task runner plugins are available only in the [Enterprise Edition](/docs/enterprise). If you want to try them out, please [reach out](/demo).
+See [Open Source vs Enterprise](/docs/oss-vs-paid) to compare editions.
 :::
 
 <div class="video-container">

--- a/src/contents/docs/version-control-cicd/cicd/index.md
+++ b/src/contents/docs/version-control-cicd/cicd/index.md
@@ -14,7 +14,7 @@ Continous integration and deliver (CI/CD) pipelines enable teams to deploy updat
 This section covers multiple approaches to building a CI/CD pipeline for Kestra — from using the CLI and GitHub Actions to integrating with Terraform.
 
 :::alert{type="info"}
-When flows are deployed through CI/CD, add the [`system.readOnly`](../../06.concepts/system-labels/index.md#systemreadonly) label set to `"true"` so the UI editor is disabled and production configurations stay immutable. This is especially recommended for critical production flows:
+When flows are deployed through CI/CD, add the [`system.readOnly`](/docs/concepts/system-labels#systemreadonly) label set to `"true"` so the UI editor is disabled and production configurations stay immutable. This is especially recommended for critical production flows:
 
 ```yaml
 labels:
@@ -39,7 +39,7 @@ Kestra supports several approaches for automating flow validation and deployment
 
 ### Kestra CLI
 
-The [Kestra CLI](./04.helpers/index.md) includes built-in commands for validating and deploying your flows.
+The [Kestra CLI](/docs/version-control-cicd/cicd/helpers) includes built-in commands for validating and deploying your flows.
 
 #### Validate and deploy a single flow
 
@@ -52,7 +52,7 @@ The [Kestra CLI](./04.helpers/index.md) includes built-in commands for validatin
 ```
 
 :::alert{type="info"}
-The `--api-token` flag is available in the [Enterprise Edition](../../07.enterprise/03.auth/api-tokens/index.md).
+The `--api-token` flag is available in the [Enterprise Edition](/docs/enterprise/auth/api-tokens).
 In the open-source edition, use basic authentication with the `--user` flag:
 
 ```bash
@@ -158,7 +158,7 @@ https://kestra_host_url/api/v1/main/executions/webhook/namespace/flow_id/webhook
 
 ### Deploy flows with GitHub Actions
 
-Kestra provides [official GitHub Actions](./01.github-action/index.md) to validate and deploy flows.
+Kestra provides [official GitHub Actions](/docs/version-control-cicd/cicd/github-action) to validate and deploy flows.
 
 1. **Validate** flows and templates — [Validate Action](https://github.com/marketplace/actions/kestra-validate-action)
 2. **Deploy** flows and templates — [Deploy Action](https://github.com/marketplace/actions/kestra-deploy-action)
@@ -207,7 +207,7 @@ jobs:
 ```
 
 :::alert{type="info"}
-You can also authenticate using an [API token](../../07.enterprise/03.auth/api-tokens/index.md) instead of username and password:
+You can also authenticate using an [API token](/docs/enterprise/auth/api-tokens) instead of username and password:
 
 ```yaml
 with:
@@ -221,7 +221,7 @@ with:
 ### Deploy flows with GitLab CI/CD
 
 GitLab CI/CD uses a similar approach to GitHub Actions.
-See the [GitLab guide](./02.gitlab/index.md) for examples and configuration details.
+See the [GitLab guide](/docs/version-control-cicd/cicd/gitlab) for examples and configuration details.
 
 ---
 


### PR DESCRIPTION
## Summary

A Screaming Frog crawl of kestra.io surfaced **18 distinct 404s** stemming from the same root cause: the remark link-rewrite plugin (`src/markdown/remark/link-rewrite.ts`, configured in `astro.config.mjs`) transforms relative markdown links inside `index.md`/`index.mdx` files in a way that only works when the page is hit at its canonical (no trailing slash) URL.

When the same page is requested with a trailing slash (e.g. `/docs/version-control-cicd/cicd/` instead of the canonical `/docs/version-control-cicd/cicd`), every relative href in the body resolves to a different, non-existent path:

| Source page (with trailing slash) | Rendered href | Resolves to | Status |
|---|---|---|---|
| `/docs/version-control-cicd/cicd/` | `cicd/helpers` | `/docs/version-control-cicd/cicd/cicd/helpers` | 404 |
| `/docs/version-control-cicd/cicd/` | `./../enterprise/auth/api-tokens` | `/docs/version-control-cicd/enterprise/auth/api-tokens` | 404 |
| `/docs/enterprise/auth/sso/` | `sso/okta` | `/docs/enterprise/auth/sso/sso/okta` | 404 |
| ... | ... | ... | ... |

## What this PR does

Replaces the affected relative markdown links with **absolute `/docs/...` paths** in 5 section index files. The rewriter only acts on URLs starting with `.`, so absolute hrefs pass through untouched and resolve correctly regardless of trailing-slash form.

### Files touched

- `src/contents/docs/version-control-cicd/cicd/index.md` — 6 links (fixes 5 404s)
- `src/contents/docs/07.enterprise/index.mdx` — 3 links (fixes 3 404s)
- `src/contents/docs/07.enterprise/03.auth/sso/index.md` — 5 links (fixes 5 404s)
- `src/contents/docs/task-runners/index.mdx` — 2 links (fixes 2 404s)
- `src/contents/docs/16.scripts/index.mdx` — 3 links (fixes 3 404s)

### 404s eliminated

```
/docs/version-control-cicd/cicd/cicd/github-action
/docs/version-control-cicd/cicd/cicd/gitlab
/docs/version-control-cicd/cicd/cicd/helpers
/docs/version-control-cicd/concepts/system-labels
/docs/version-control-cicd/enterprise/auth/api-tokens
/docs/enterprise/enterprise/scalability/worker-group
/docs/enterprise/oss-vs-paid
/docs/enterprise/task-runners/types/process-task-runner
/docs/enterprise/auth/sso/sso/authentik
/docs/enterprise/auth/sso/sso/google-oidc
/docs/enterprise/auth/sso/sso/keycloak
/docs/enterprise/auth/sso/sso/microsoft-oidc
/docs/enterprise/auth/sso/sso/okta
/docs/task-runners/enterprise
/docs/task-runners/oss-vs-paid
/docs/scripts/enterprise
/docs/scripts/enterprise/scalability/worker-group
/docs/scripts/task-runners/types
```

## Note on root cause

This PR is a **surgical surface fix**. The underlying bug lives in the index-file branch of the `replacer` function in `astro.config.mjs` (the dirname prepending + the partial `../` → `./` rewrite). A root-cause fix would either:
- correct the rewriter to produce hrefs that work under both slash and no-slash forms, or
- enforce a single trailing-slash policy (`trailingSlash: "never"` with a redirect).

Both are more invasive and worth a separate discussion — this PR keeps blast radius minimal while clearing the user-visible 404s.

## Test plan

- [ ] `npm run build` succeeds
- [ ] Visit each affected page locally and confirm the previously-broken links now navigate to a 200 page
- [ ] Spot-check the 18 URLs above on the preview deploy return 200
- [ ] Sidebar navigation on the touched pages still works (sidebar uses absolute URLs already, so should be unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)