### PR TITLE
feat(plugins): sort by first release date and usage count

### DIFF
--- a/src/components/plugins/PluginsLists.vue
+++ b/src/components/plugins/PluginsLists.vue
@@ -111,6 +111,8 @@
     const sortOptions = [
         { value: "A-Z", label: "Name A-Z" },
         { value: "Z-A", label: "Name Z-A" },
+        { value: "newest", label: "Newest" },
+        { value: "most-used", label: "Most used" },
     ]
 
     const props = defineProps<{
@@ -126,7 +128,7 @@
 
     const SEARCHABLE_FIELDS: (keyof CardPlugin)[] = ["title", "description", "name", "classes"]
 
-    const sortPlugins = (plugins: CardPlugin[], ascending: boolean, query: string) => {
+    const sortPlugins = (plugins: CardPlugin[], sort: string, query: string) => {
         const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
         const matchesAll = (value: string | undefined) =>
             tokens.length > 0 && tokens.every((t) => value?.toLowerCase().includes(t))
@@ -138,12 +140,21 @@
                 if (aStrong !== bStrong) return aStrong ? -1 : 1
             }
 
-            const aCore = a.group === "io.kestra.plugin.core" && !a.subGroup
-            const bCore = b.group === "io.kestra.plugin.core" && !b.subGroup
-            if (aCore !== bCore) return aCore ? -1 : 1
+            if (sort === "newest") {
+                const aDate = a.firstReleasedAt ? new Date(a.firstReleasedAt).getTime() : 0
+                const bDate = b.firstReleasedAt ? new Date(b.firstReleasedAt).getTime() : 0
+                if (aDate !== bDate) return bDate - aDate   // newest first
+            } else if (sort === "most-used") {
+                const bCmp = (b.usageCount ?? 0) - (a.usageCount ?? 0)
+                if (bCmp !== 0) return bCmp
+            } else {
+                const aCore = a.group === "io.kestra.plugin.core" && !a.subGroup
+                const bCore = b.group === "io.kestra.plugin.core" && !b.subGroup
+                if (aCore !== bCore) return aCore ? -1 : 1
+            }
 
             const comparison = a.title.toLowerCase().localeCompare(b.title.toLowerCase())
-            return ascending ? comparison : -comparison
+            return sort === "Z-A" ? -comparison : comparison
         })
     }
 
@@ -176,7 +187,7 @@
     )
 
     const pluginsSlice = computed(() =>
-        sortPlugins(categoryFilteredPlugins.value, sortBy.value === "A-Z", searchQuery.value).slice(
+        sortPlugins(categoryFilteredPlugins.value, sortBy.value, searchQuery.value).slice(
             (currentPage.value - 1) * itemsPerPage.value,
             currentPage.value * itemsPerPage.value,
         ),

--- a/src/components/plugins/PluginsLists.vue
+++ b/src/components/plugins/PluginsLists.vue
@@ -112,7 +112,6 @@
         { value: "A-Z", label: "Name A-Z" },
         { value: "Z-A", label: "Name Z-A" },
         { value: "newest", label: "Newest" },
-        { value: "recently-updated", label: "Recently updated" },
         { value: "most-used", label: "Most used" },
     ]
 
@@ -142,10 +141,6 @@
             }
 
             if (sort === "newest") {
-                const aDate = a.firstReleasedAt ? new Date(a.firstReleasedAt).getTime() : 0
-                const bDate = b.firstReleasedAt ? new Date(b.firstReleasedAt).getTime() : 0
-                if (aDate !== bDate) return bDate - aDate
-            } else if (sort === "recently-updated") {
                 const aDate = a.lastReleasedAt ? new Date(a.lastReleasedAt).getTime() : 0
                 const bDate = b.lastReleasedAt ? new Date(b.lastReleasedAt).getTime() : 0
                 if (aDate !== bDate) return bDate - aDate

--- a/src/components/plugins/PluginsLists.vue
+++ b/src/components/plugins/PluginsLists.vue
@@ -112,6 +112,7 @@
         { value: "A-Z", label: "Name A-Z" },
         { value: "Z-A", label: "Name Z-A" },
         { value: "newest", label: "Newest" },
+        { value: "recently-updated", label: "Recently updated" },
         { value: "most-used", label: "Most used" },
     ]
 
@@ -143,7 +144,11 @@
             if (sort === "newest") {
                 const aDate = a.firstReleasedAt ? new Date(a.firstReleasedAt).getTime() : 0
                 const bDate = b.firstReleasedAt ? new Date(b.firstReleasedAt).getTime() : 0
-                if (aDate !== bDate) return bDate - aDate   // newest first
+                if (aDate !== bDate) return bDate - aDate
+            } else if (sort === "recently-updated") {
+                const aDate = a.lastReleasedAt ? new Date(a.lastReleasedAt).getTime() : 0
+                const bDate = b.lastReleasedAt ? new Date(b.lastReleasedAt).getTime() : 0
+                if (aDate !== bDate) return bDate - aDate
             } else if (sort === "most-used") {
                 const bCmp = (b.usageCount ?? 0) - (a.usageCount ?? 0)
                 if (bCmp !== 0) return bCmp

--- a/src/utils/plugins/pruneForClient.ts
+++ b/src/utils/plugins/pruneForClient.ts
@@ -14,6 +14,8 @@ export type CardPlugin = {
     blueprints?: number
     isEnterprise?: boolean
     classes?: string
+    firstReleasedAt?: string
+    usageCount?: number
 }
 
 export function prunePluginsForCards(
@@ -44,6 +46,8 @@ export function prunePluginsForCards(
             blueprints: info.blueprints,
             isEnterprise: p.group?.includes('.ee.') ?? false,
             classes,
+            firstReleasedAt: info.firstReleasedAt as string | undefined,
+            usageCount: info.usageCount as number | undefined,
         }
     })
 }

--- a/src/utils/plugins/pruneForClient.ts
+++ b/src/utils/plugins/pruneForClient.ts
@@ -14,7 +14,6 @@ export type CardPlugin = {
     blueprints?: number
     isEnterprise?: boolean
     classes?: string
-    firstReleasedAt?: string
     lastReleasedAt?: string
     usageCount?: number
 }
@@ -47,7 +46,6 @@ export function prunePluginsForCards(
             blueprints: info.blueprints,
             isEnterprise: p.group?.includes('.ee.') ?? false,
             classes,
-            firstReleasedAt: info.firstReleasedAt as string | undefined,
             lastReleasedAt: info.lastReleasedAt as string | undefined,
             usageCount: info.usageCount as number | undefined,
         }

--- a/src/utils/plugins/pruneForClient.ts
+++ b/src/utils/plugins/pruneForClient.ts
@@ -15,6 +15,7 @@ export type CardPlugin = {
     isEnterprise?: boolean
     classes?: string
     firstReleasedAt?: string
+    lastReleasedAt?: string
     usageCount?: number
 }
 
@@ -47,6 +48,7 @@ export function prunePluginsForCards(
             isEnterprise: p.group?.includes('.ee.') ?? false,
             classes,
             firstReleasedAt: info.firstReleasedAt as string | undefined,
+            lastReleasedAt: info.lastReleasedAt as string | undefined,
             usageCount: info.usageCount as number | undefined,
         }
     })


### PR DESCRIPTION
## Summary

- Removes the temporary version-based "Newest" sort and the `version` field from `CardPlugin`
- "Newest" now uses `firstReleasedAt` (ISO date from API, populated from Maven Central / Google Artifact Registry)
- "Most used" now uses `usageCount` (BigQuery aggregate over last 90 days)
- Both fields are nullable — plugins without data sort to the bottom

## Changes

- `src/utils/plugins/pruneForClient.ts`: replaced `version?: string` with `firstReleasedAt?: string` and `usageCount?: number` in `CardPlugin`; updated `prunePluginsForCards` to read `info.firstReleasedAt` and `info.usageCount` instead of `p.version`
- `src/components/plugins/PluginsLists.vue`: removed `compareVersions` helper; updated `sortPlugins` to use `firstReleasedAt` for the "newest" sort and `usageCount` for "most-used"

## Test plan

- [ ] Verify the plugins list page loads without errors
- [ ] Sort by "Newest" — plugins with a `firstReleasedAt` date should appear first, most recently released at top
- [ ] Sort by "Most used" — plugins with higher `usageCount` should appear first
- [ ] Plugins without `firstReleasedAt` / `usageCount` should fall back to alphabetical within their tier
- [ ] "Name A-Z" and "Name Z-A" sorts are unaffected

Part-of: https://github.com/kestra-io/kestra-ee/issues/7925