### PR TITLE
docs(resources): VMware Aria Automation alternatives

### DIFF
--- a/src/contents/resources/vmware-aria-automation-alternatives/index.md
+++ b/src/contents/resources/vmware-aria-automation-alternatives/index.md
@@ -1,0 +1,124 @@
+---
+title: "Top VMware Aria Automation Alternatives for Modern Infrastructure"
+description: "Explore leading VMware Aria Automation alternatives, comparing features, deployment models, and costs. Find the best solution for your cloud infrastructure and IT automation needs."
+metaTitle: "VMware Aria Automation Alternatives"
+metaDescription: "Discover top VMware Aria Automation alternatives. Compare features, pricing, and user reviews to find the best solution for your needs today!"
+tag: infrastructure
+date: 2026-05-15
+faq:
+  - question: "What is the old name for VMware Aria Automation?"
+    answer: "VMware Aria Automation was formerly known as vRealize Automation. VMware rebranded its entire cloud management portfolio under the 'Aria' family in 2022, consolidating various products for multi-cloud management."
+  - question: "What is replacing ESXi?"
+    answer: "While ESXi is still widely used, organizations seeking alternatives often consider open-source hypervisors like Proxmox or commercial solutions like Nutanix AHV. The shift is often driven by cost, vendor lock-in concerns, or a move towards container-native and cloud-agnostic infrastructure."
+  - question: "Is VMware Aria the same as vRealize?"
+    answer: "Yes, VMware Aria is the rebranded suite of products that previously fell under the vRealize portfolio. For instance, vRealize Automation became Aria Automation, and vRealize Operations became Aria Operations, reflecting a broader focus on multi-cloud management."
+  - question: "What is VMware Aria Automation used for?"
+    answer: "VMware Aria Automation is used to automate the delivery and management of applications and infrastructure, primarily in private and hybrid cloud environments. It provides capabilities for self-service provisioning, governance, and release pipeline management for DevOps teams."
+  - question: "Why is VMware falling?"
+    answer: "Recent changes, particularly the acquisition by Broadcom, have led to user concerns about pricing increases, uncertainty regarding product roadmaps, and potential changes in support quality. This has prompted many organizations to explore alternative solutions to mitigate vendor risk."
+  - question: "What are Aria Operations called now?"
+    answer: "VMware Aria Operations retains its name as of the latest branding. It functions as the intelligence layer for visibility, automation, and performance optimization across virtual infrastructure and multi-cloud environments."
+---
+
+The landscape of cloud infrastructure automation is in flux, with many organizations re-evaluating their strategies following recent changes to VMware's portfolio and business model. VMware Aria Automation, previously known as vRealize Automation, has long been a staple for private and hybrid cloud infrastructure delivery. It empowers IT teams with self-service provisioning, governance, and release pipeline management, making it a powerful tool for complex environments. However, the shift towards a more consolidated product offering under Broadcom has introduced uncertainties regarding pricing, support, and long-term strategic alignment for many users.
+
+This evolving environment has spurred a significant search for viable alternatives. The leading alternatives to VMware Aria Automation in 2026 include Kestra, Red Hat Ansible Automation Platform, HPE Morpheus Enterprise Software, Quali Torque, AWS Step Functions, and HashiCorp Terraform Cloud. Each offers distinct approaches to infrastructure automation, ranging from declarative orchestration to comprehensive cloud management and platform engineering. This article will delve into why exploring these alternatives is crucial now, how we evaluated them, and provide a detailed comparison to help you choose the best fit for your organization's unique needs.
+
+## Why explore alternatives to VMware Aria Automation?
+
+The primary catalyst for seeking alternatives is the industry disruption following Broadcom's acquisition of VMware. This event has created significant uncertainty, with users reporting concerns over substantial price increases, shifts in product bundling, and questions about the future quality of support. For many, the predictable, long-term partnership they had with VMware is now in question, making it a prudent time to assess the market for more stable, cost-effective, and flexible solutions.
+
+Beyond the business context, technical drivers are also pushing teams to look elsewhere. Modern engineering practices favor vendor-agnostic, multi-cloud strategies to avoid lock-in and leverage the best services from each provider. Platforms that are deeply tied to a single vendor's ecosystem, like Aria Automation is to VMware, can hinder this flexibility. Furthermore, many organizations are moving towards declarative, GitOps-driven workflows that treat infrastructure and automation as code. This requires tools that are API-first, developer-friendly, and integrate seamlessly with CI/CD pipelines, a paradigm where some legacy platforms can feel cumbersome. Evaluating modern [alternatives to VMware's automation suite](https://kestra.io/vs/vmware-cloud-foundation) is now a strategic necessity for future-proofing infrastructure operations.
+
+## How we evaluated these alternatives
+
+To provide a clear comparison, we evaluated each alternative based on a core set of criteria relevant to modern platform and DevOps teams. These criteria include:
+
+*   **Deployment Model:** Can the tool be self-hosted, consumed as a managed service, or deployed in a hybrid model?
+*   **License:** Is the core offering open-source, commercial, or a mix?
+*   **Primary Use Case:** Is the tool a general-purpose orchestrator, a specialized configuration management tool, or a cloud management platform?
+*   **Multi-cloud Support:** Does the platform operate agnostically across AWS, Azure, GCP, and on-premises environments?
+*   **Integration Ecosystem:** How well does it connect with the broader ecosystem of IaC tools, CI/CD systems, and ITSM platforms?
+*   **Declarative vs. Imperative:** Is the workflow defined by *what* you want (declarative) or *how* to do it (imperative)?
+*   **Developer Experience:** Does the platform align with GitOps principles and provide a strong developer-first workflow?
+
+## 1. Kestra: Declarative Orchestration for the AI Era
+
+Kestra is an open-source, event-driven orchestration platform that uses a declarative YAML interface to define and manage workflows. Unlike tools focused solely on infrastructure, Kestra acts as a universal control plane, capable of coordinating tasks across infrastructure, data pipelines, AI/ML models, and business processes from a single platform.
+
+Its language-agnostic architecture allows you to orchestrate the tools you already use, whether it's Terraform, Ansible, Python scripts, or shell commands. This makes it a powerful choice for unifying disparate automation scripts and cron jobs into a governed, auditable system. Workflows are managed as code, aligning perfectly with [GitOps principles for infrastructure automation](https://kestra.io/resources/infrastructure/what-is-infrastructure-as-code).
+
+At global mining leader BHP, Kestra replaced VMware vRA, reducing infrastructure provisioning times from six months to just six days. This demonstrates its capacity to handle complex, enterprise-grade automation with greater speed and flexibility. Kestra can be deployed anywhere—on Kubernetes, VMs, or even air-gapped environments—providing true multi-cloud and hybrid flexibility.
+
+**Best for:** Organizations seeking a unified, vendor-agnostic control plane to orchestrate infrastructure, data, and AI workflows with a developer-first, declarative approach. Explore the [Kestra infrastructure automation platform](https://kestra.io/infra-automation) to learn more.
+
+## 2. Red Hat Ansible Automation Platform: Enterprise-Grade IT Automation
+
+Red Hat Ansible Automation Platform (AAP) is the enterprise-grade solution for scaling and governing Ansible-based automation. It builds on the popular open-source Ansible project, adding features like a centralized UI, role-based access control (RBAC), and certified content collections.
+
+Its core strength lies in agentless configuration management, application deployment, and IT process automation. For teams already standardized on Ansible playbooks, AAP provides the necessary control and visibility for production environments. However, it remains primarily focused on the infrastructure domain. While it can trigger external systems, it's less natural as a universal orchestrator for complex, cross-domain workflows involving data pipelines or AI model training. Its approach, while using YAML, is fundamentally imperative—defining the steps to execute rather than the desired end state.
+
+**Best for:** Teams heavily invested in Ansible for configuration management, patching, and IT operations who need enterprise support, governance, and scalability. See how it compares directly in our [Kestra vs. Ansible Automation Platform analysis](https://kestra.io/vs/ansible-automation-platform).
+
+## 3. HPE Morpheus Enterprise Software: Hybrid Cloud Management Platform
+
+Morpheus is a comprehensive hybrid cloud management platform (CMP) that offers a unified interface for managing infrastructure and applications across multiple clouds and on-premises environments. It excels at providing a self-service catalog, enabling users to provision VMs, containers, and applications on demand while enforcing governance and cost controls.
+
+Its capabilities extend beyond simple provisioning to include cost management, monitoring, and security compliance. This makes it a strong contender for enterprises looking to centralize control over a sprawling, heterogeneous IT landscape. The trade-off is that Morpheus is a heavyweight platform, more aligned with the traditional CMP model than with lightweight, declarative workflow orchestration. For teams that just need to automate specific tasks, it may be more complex than necessary.
+
+**Best for:** Enterprises needing a unified portal for hybrid cloud consumption, governance, and cost optimization, especially those with diverse cloud and on-premises footprints.
+
+## 4. Quali Torque: Platform Engineering for Dynamic Environments
+
+Quali Torque is an Environment-as-a-Service (EaaS) platform designed to help organizations implement platform engineering principles. Its primary focus is on providing developers with on-demand, self-service access to application environments for development, testing, and production.
+
+Torque allows platform teams to create reusable blueprints of complex environments, which can include infrastructure, applications, and data. This approach helps standardize environments, control costs, and accelerate the development lifecycle. While it integrates with IaC tools like Terraform, its scope is narrower than a general-purpose orchestrator. It is purpose-built for the "environment" lifecycle, not for orchestrating broader operational or data-centric workflows.
+
+**Best for:** DevOps and platform engineering teams looking to provide on-demand, self-service environments for development and testing, with strong cost governance and an emphasis on the developer experience.
+
+## 5. AWS Step Functions: Serverless Workflow Orchestration on AWS
+
+AWS Step Functions is a serverless workflow service designed to coordinate components of distributed applications and microservices using visual workflows. It integrates deeply with the entire AWS ecosystem, making it a natural choice for orchestrating AWS Lambda functions, ECS tasks, and other native services.
+
+Its main advantages are its managed nature, state management capabilities, and event-driven architecture, which are ideal for building resilient, scalable applications entirely within AWS. The significant limitation, however, is vendor lock-in. Step Functions is not designed for multi-cloud or hybrid environments, and its workflow definitions are specific to the AWS platform. This makes it a poor fit for organizations committed to a vendor-agnostic strategy.
+
+**Best for:** AWS-native organizations building serverless applications and microservices that primarily interact within the AWS ecosystem. For a deeper look, see our [Kestra vs. AWS Step Functions comparison](https://kestra.io/vs/aws-step-functions).
+
+## 6. HashiCorp Terraform Cloud / Enterprise: IaC Lifecycle Management
+
+Terraform has become the industry standard for defining [infrastructure as code](https://kestra.io/resources/infrastructure/what-is-infrastructure-as-code). Terraform Cloud and Enterprise are HashiCorp's managed offerings that provide a collaborative environment for teams using Terraform at scale. They offer features like remote state management, a private module registry, policy-as-code with Sentinel, and collaborative run workflows.
+
+These platforms are excellent for what they do: governing the Terraform lifecycle. However, they are not general-purpose orchestrators. Their role ends once the infrastructure is provisioned. They do not manage the application deployment, data pipelines, or operational tasks that run on top of that infrastructure. They are a critical component of a modern automation stack, but not a complete replacement for a workflow automation platform.
+
+**Best for:** Teams standardizing on [Terraform for infrastructure as code](https://kestra.io/docs/terraform) who require advanced governance, collaboration, and a managed service for their IaC workflows.
+
+## Comparison Table
+
+| Tool                               | License                 | Deployment                | Best For                               | Multi-Cloud Support | Declarative? |
+| ---------------------------------- | ----------------------- | ------------------------- | -------------------------------------- | ------------------- | ------------ |
+| **Kestra**                         | Apache 2.0 + Enterprise | Hybrid (Self-hosted/Cloud)    | Unified Orchestration (Infra, Data, AI) | Full                | Yes          |
+| **Red Hat Ansible Automation Platform** | Commercial              | Hybrid (Self-hosted/Cloud)    | Enterprise IT Automation               | Full                | No (Imperative) |
+| **HPE Morpheus Enterprise Software** | Commercial              | Hybrid (Self-hosted)      | Hybrid Cloud Management (CMP)          | Full                | No           |
+| **Quali Torque**                   | Commercial              | Hybrid (Self-hosted/Cloud)    | Environment-as-a-Service (EaaS)        | Full                | No           |
+| **AWS Step Functions**             | Commercial              | Managed (AWS Only)        | AWS-Native Serverless Workflows        | Partial (AWS Only)  | Yes          |
+| **HashiCorp Terraform Cloud**      | Freemium + Commercial   | Managed                   | IaC Lifecycle Management               | Full                | Yes          |
+
+## How to choose the right alternative
+
+Choosing the right platform depends on your team's primary focus and long-term strategic goals.
+
+*   **For infrastructure and DevOps teams,** the key considerations are GitOps alignment, IaC integration, and multi-cloud support. Tools like Kestra, Ansible Automation Platform, and Terraform Cloud are strong contenders. Kestra stands out for its ability to orchestrate multi-tool workflows (e.g., Terraform *then* Ansible) within a single, declarative framework, providing a unified control plane for all infrastructure operations. You can find more resources on the [Kestra for Infrastructure Automation](https://kestra.io/infra-automation) page.
+
+*   **For data engineering teams,** the priority is orchestrating complex, multi-step data pipelines. While Aria was not a primary data tool, a replacement should be. A platform with declarative, polyglot, and event-driven capabilities is essential. Kestra excels here, as it was built to handle data-intensive workflows alongside infrastructure tasks. More details can be found on the [Kestra for Data Orchestration](https://kestra.io/data) page.
+
+*   **For AI and ML platform teams,** the need is for a language-agnostic platform that can orchestrate heterogeneous tasks, from data preparation to GPU-based model training and serving. Kestra's ability to run any code in any container, combined with its new agentic orchestration features, makes it a future-proof choice for the [AI automation stack](https://kestra.io/ai-automation).
+
+*   **For small teams getting started,** ease of deployment and a strong open-source community are key. Kestra's Apache 2.0 open-source edition can be spun up quickly with Docker, offering a fast path to value without initial license costs.
+
+## Conclusion
+
+The shift in the VMware ecosystem has created a compelling reason to evaluate the broader infrastructure automation market. While VMware Aria Automation has been a powerful tool, modern alternatives offer greater flexibility, vendor neutrality, and alignment with developer-centric practices.
+
+Platforms like Kestra provide a path forward by offering a single, declarative control plane that unifies not just infrastructure, but also the data, AI, and business workflows that run on it. By choosing a solution that is open, flexible, and built for the future of multi-cloud and AI-driven operations, you can turn a moment of market uncertainty into a strategic advantage for your organization.
+
+Ready to see how a declarative approach can simplify your automation challenges? [Get started with Kestra](https://kestra.io/get-started) or [book a demo](https://kestra.io/demo) to see the platform in action.


### PR DESCRIPTION
## Summary
- New `/resources/vmware-aria-automation-alternatives` SEO listicle page
- Covers Kestra, Red Hat AAP, HPE Morpheus, Quali Torque, AWS Step Functions, Terraform Cloud as alternatives to VMware Aria Automation (vRA)
- Imported from [vfanucci/kestra-seo#76](https://github.com/vfanucci/kestra-seo/pull/76)

## Test plan
- [ ] Astro build passes (resources schema validation)
- [ ] Page renders at `/resources/vmware-aria-automation-alternatives`
- [ ] FAQ structured data renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)