### PR TITLE
docs(resources): Temporal alternatives

### DIFF
--- a/src/contents/resources/temporal-alternatives/index.md
+++ b/src/contents/resources/temporal-alternatives/index.md
@@ -1,0 +1,212 @@
+---
+title: "Temporal Alternatives: Find Your Workflow Orchestrator"
+description: "Explore the top Temporal alternatives for workflow orchestration. Discover options for enterprise, self-hosted, and specific use cases. Try Kestra today!"
+metaTitle: "Top Temporal Alternatives for Workflow Orchestration"
+metaDescription: "Seeking Temporal alternatives? Compare leading workflow orchestrators for enterprise, self-hosted, and specialized needs. Discover Kestra and more."
+tag: infrastructure
+date: 2026-05-06
+faq:
+  - question: "Why do teams look for alternatives to Temporal?"
+    answer: "Teams often seek Temporal alternatives due to its steep learning curve, code-centric workflow definition (requiring Java/Go/Python SDKs), and the operational overhead of managing its infrastructure. While powerful for durable microservices orchestration, some find it less flexible for polyglot data, AI, or infrastructure-focused workflows."
+  - question: "Is Kestra a good alternative to Temporal?"
+    answer: "Yes, Kestra is a strong alternative, especially for teams seeking a declarative, language-agnostic, and event-driven orchestrator. Unlike Temporal's code-first approach, Kestra defines workflows in YAML, simplifying version control and enabling broader team collaboration. It unifies data, AI, and infrastructure workflows on a single platform."
+  - question: "What are some lightweight and self-hosted Temporal alternatives?"
+    answer: "For lightweight and self-hosted alternatives, options like Kestra, Windmill, and Trigger.dev offer flexibility. Kestra's single-binary deployment and Helm charts simplify self-hosting, while supporting polyglot execution. Windmill focuses on internal tools and scripts, and Trigger.dev provides durable execution for app developers with self-hosting options."
+  - question: "How does Apache Airflow compare to Temporal?"
+    answer: "Airflow, like Temporal, is code-first but primarily targets batch data pipelines with Python DAGs. Temporal focuses on durable microservices orchestration. While Airflow has a vast operator ecosystem, it shares some of Temporal's operational complexity. Kestra unifies both data and application logic with a declarative approach."
+  - question: "What should I consider when choosing a Temporal alternative?"
+    answer: "Key considerations include the primary use case (data, AI, infra, microservices), preferred workflow definition (code vs. declarative YAML), deployment model (managed vs. self-hosted), language support, developer experience, and the need for advanced features like event-driven triggers, fault tolerance, and observability."
+  - question: "Are there cloud-native alternatives to Temporal?"
+    answer: "Yes, cloud providers offer native alternatives like AWS Step Functions and Google Cloud Workflows, which are well-suited for orchestrating services within their respective ecosystems. Netflix Conductor is another cloud-native option, often self-hosted, for microservices. However, these often lead to vendor lock-in, which Kestra avoids."
+  - question: "Can I migrate existing Temporal workflows to Kestra?"
+    answer: "Migrating from Temporal to Kestra involves translating existing workflow logic from code-based SDKs (Java, Go, Python) into Kestra's declarative YAML. Kestra's polyglot execution capabilities mean that the core logic of your tasks (e.g., Python scripts) can often be reused directly, simplifying the transition process."
+---
+
+Temporal has established itself as a powerful platform for orchestrating long-running, fault-tolerant microservice workflows, enabling developers to build resilient applications with durable execution guarantees. However, its code-centric approach and operational overhead can present challenges for teams seeking broader orchestration capabilities across data, AI, and infrastructure domains, or those preferring a more declarative model. The leading alternatives to Temporal in 2026, including Kestra, Akka, Camunda, AWS Step Functions, Netflix Conductor, Inngest, Apache Airflow, Prefect, Dagster, Windmill, and Trigger.dev, each offer distinct advantages tailored to various use cases, from enterprise process automation to lightweight self-hosted deployments. This article explores these alternatives, providing a framework to help you choose the ideal workflow orchestrator for your specific needs.
+
+## Understanding Temporal and the need for alternatives
+
+Temporal is an open-source, durable execution system. It enables developers to write workflow logic in general-purpose programming languages like Go, Java, Python, and TypeScript using SDKs. Its core strength lies in its ability to maintain workflow state over long periods, automatically handling retries and recovering from failures. This makes it a strong choice for complex, stateful application backends, such as financial transactions, e-commerce order processing, and subscription management.
+
+However, several factors drive teams to look for alternatives:
+*   **Code-Centric Workflow Definition:** Workflows are defined entirely in code, which can be a strength for application developers but a barrier for data, operations, or business teams. This approach can make workflows harder to visualize, version, and audit compared to declarative models.
+*   **Steep Learning Curve:** Mastering Temporal's concepts—workers, activities, signals, queries—requires a significant investment, especially for teams not already deep in distributed systems engineering.
+*   **Operational Complexity:** Self-hosting Temporal involves managing a cluster of services, including a database (like PostgreSQL or Cassandra) and often Elasticsearch for visibility. This infrastructure overhead can be substantial.
+*   **Narrow Focus:** While excellent for microservices, Temporal is not purpose-built for the specific needs of data engineering, AI/ML pipelines, or infrastructure automation, which often require different integration patterns and execution models.
+
+For a direct comparison of how Kestra addresses these points, see our in-depth analysis of [Kestra vs. Temporal](https://kestra.io/vs/temporal).
+
+## How we evaluated these alternatives
+
+To provide a balanced comparison, we evaluated each Temporal alternative against a consistent set of criteria relevant to modern engineering teams. These include the deployment model (managed, self-hosted, hybrid), licensing (open-source vs. proprietary), primary use case fit, and the workflow definition paradigm (code-first, declarative YAML, or visual). We also considered language support, developer experience, observability, fault tolerance, pricing transparency, and the health of the community for open-source tools.
+
+## 1. Kestra: Declarative Orchestration for the Modern Enterprise
+
+Kestra is an open-source, event-driven orchestration control plane designed to unify workflows across an entire organization. Unlike Temporal's application-centric, code-first model, Kestra uses a declarative YAML interface to define and manage workflows. This approach makes orchestration accessible to a broader range of roles, from platform engineers to data analysts, while enforcing GitOps best practices.
+
+**Key Differentiators:**
+*   **Declarative YAML:** Workflows are structured, versionable, and auditable configuration files, not complex application code.
+*   **Language-Agnostic:** Kestra can run tasks in any language, including Python, Shell, SQL, R, and Node.js, often without requiring custom SDKs or containerization.
+*   **Unified Platform:** It seamlessly orchestrates data pipelines, AI/ML workflows, infrastructure operations, and business processes on a single platform. For instance, Crédit Agricole uses Kestra to unify and replace fragmented infrastructure scripts and cron jobs with a single, governed orchestration layer.
+
+**Best for:** Teams seeking a unified, polyglot, and declarative orchestrator that integrates with their existing stack and spans multiple domains. Kestra is ideal for organizations adopting platform engineering and GitOps principles for all their workflows.
+
+**Limitations:** For teams deeply committed to a purely code-as-workflow paradigm and building logic directly into their application services, the shift to a declarative YAML model requires a change in mindset.
+
+Explore Kestra's [documentation](https://kestra.io/docs/why-kestra) to learn more about its architecture and how to define your first [workflow](https://kestra.io/docs/workflow-components/flow).
+
+## 2. Akka: Building Reactive Systems
+
+Akka is a toolkit and runtime for building highly concurrent, distributed, and resilient message-driven applications on the JVM. It is not a direct workflow orchestrator in the same category as Temporal, but it provides the foundational components for building similar systems.
+
+**One-liner:** A toolkit for building highly concurrent, distributed, and resilient message-driven applications on the JVM.
+
+**Best for:** JVM-centric application teams building reactive microservices that require high concurrency and fault tolerance from the ground up.
+
+**Distinctive Feature:** Its core is the actor model, which provides a powerful abstraction for managing state and concurrency without locks, making it excellent for high-throughput systems.
+
+**Limitation:** Akka is a library, not a platform. It requires significant development effort to build a complete workflow management system. It's primarily suited for Scala and Java developers and has a steep learning curve.
+
+## 3. Camunda: Universal Process Orchestration with BPMN
+
+Camunda is a universal process orchestrator that excels at modeling and executing end-to-end business processes, particularly those involving human-in-the-loop tasks.
+
+**One-liner:** An open-source universal process orchestrator with strong BPMN/DMN modeling for end-to-end business processes.
+
+**Best for:** Organizations with formal business processes that need to be visually modeled, automated, and monitored, such as loan applications, insurance claims, or customer onboarding.
+
+**Distinctive Feature:** Its native support for BPMN (Business Process Model and Notation) and DMN (Decision Model and Notation) allows business analysts and developers to collaborate using a shared visual language.
+
+**Limitation:** The BPMN-centric model can be overly complex and rigid for purely technical workflows, such as data pipelines or infrastructure automation, where a simpler, code- or configuration-based approach is often more efficient.
+
+## 4. AWS Step Functions: Serverless Orchestration in the Cloud
+
+AWS Step Functions is a fully managed, serverless workflow service that makes it easy to orchestrate AWS services, microservices, and APIs.
+
+**One-liner:** A serverless workflow service for orchestrating AWS services and microservices.
+
+**Best for:** Teams deeply invested in the AWS ecosystem who need to coordinate multiple AWS services (like Lambda, S3, ECS, and Glue) into a cohesive application.
+
+**Distinctive Feature:** Its deep, native integration with the AWS ecosystem is unparalleled. It offers a visual workflow designer and handles state, retries, and error handling for AWS services automatically.
+
+**Limitation:** The primary drawback is vendor lock-in. Workflows are tied to the AWS platform, making [multi-cloud orchestration](https://kestra.io/resources/infrastructure/multi-cloud-orchestration) or hybrid deployments difficult. For a detailed breakdown, see our comparison of [Kestra vs. AWS Step Functions](https://kestra.io/vs/aws-step-functions).
+
+## 5. Netflix Conductor: Microservice Orchestration at Scale
+
+Originally developed at Netflix, Conductor is an open-source platform for orchestrating workflows across microservices. It is architecturally similar to Temporal in its focus on coordinating distributed systems.
+
+**One-liner:** An open-source microservices orchestration platform for coordinating distributed systems.
+
+**Best for:** Large-scale organizations building internal developer platforms that need to manage complex, long-running workflows across hundreds of microservices.
+
+**Distinctive Feature:** It uses a JSON-based DSL for workflow definitions, which provides a declarative way to chain tasks. It also features a UI for visualizing and debugging workflows. Orkes offers a fully managed cloud version of Conductor.
+
+**Limitation:** Like Temporal, it requires significant operational effort to self-host and is primarily designed for microservice choreography, offering less out-of-the-box support for data or infrastructure use cases.
+
+## 6. Inngest: Developer-First Durable Execution
+
+Inngest is a developer-focused platform for building reliable background jobs, serverless functions, and event-driven workflows with durable execution.
+
+**One-liner:** A developer-first platform for building reliable background jobs and workflows with durable execution, often for web applications.
+
+**Best for:** Application developers who need to add durable, long-running tasks to their applications (e.g., user onboarding flows, data processing, API integrations) with a modern developer experience.
+
+**Distinctive Feature:** It allows developers to define workflows directly in their TypeScript or Python codebase with minimal boilerplate. It automatically handles retries, concurrency, and state management.
+
+**Limitation:** It is primarily application-centric and not designed for heavy-duty data engineering or complex infrastructure orchestration tasks.
+
+## 7. Apache Airflow: Data Pipeline Orchestration
+
+Apache Airflow is the most widely adopted open-source platform for authoring, scheduling, and monitoring batch-oriented data pipelines.
+
+**One-liner:** The dominant open-source data orchestrator, defining workflows as Python DAGs.
+
+**Best for:** Python-heavy data engineering teams with a primary focus on scheduled ETL/ELT jobs and a large catalog of existing data-related operators. It's one of the key [enterprise Airflow alternatives](https://kestra.io/blogs/enterprise-airflow-alternatives).
+
+**Distinctive Feature:** Its massive ecosystem of community-contributed operators and its "workflow-as-code" paradigm, where DAGs are defined in Python.
+
+**Limitation:** Airflow's model is less suited for event-driven or application-level workflows. It also carries significant operational overhead and its Python-centricity can be a constraint for polyglot teams. See our [Airflow vs. Kestra comparison](https://kestra.io/vs/airflow) for more details.
+
+## 8. Prefect: Pythonic Workflow Automation
+
+Prefect is a modern workflow orchestration platform that also embraces the "workflow-as-code" paradigm, with a strong focus on the Python ecosystem and dynamic, data-intensive workflows.
+
+**One-liner:** A Pythonic orchestrator focused on developer experience and dynamic data workflows.
+
+**Best for:** Python-only data and ML teams looking for a more flexible and modern alternative to Airflow, especially for workflows that are highly dynamic or event-driven.
+
+**Distinctive Feature:** Its use of Python decorators and a hybrid execution model (cloud-managed control plane, self-managed workers) offers a great developer experience for Pythonistas.
+
+**Limitation:** Its reliance on Python makes it less suitable for polyglot teams or for orchestrating non-Python-based infrastructure. Read the full [Prefect vs. Kestra comparison](https://kestra.io/vs/prefect).
+
+## 9. Dagster: Asset-Centric Data Orchestration
+
+Dagster is a data orchestrator that shifts the focus from tasks to the data assets they produce. It provides strong typing, testing capabilities, and excellent data lineage.
+
+**One-liner:** An asset-centric orchestrator with strong typing, data lineage, and a software-engineering approach to data.
+
+**Best for:** Analytics engineering teams who think in terms of data assets (tables, files, models) and require strong observability and lineage, particularly in dbt-heavy environments.
+
+**Distinctive Feature:** The asset graph is its core abstraction, allowing teams to visualize dependencies between data assets, not just tasks.
+
+**Limitation:** The asset-centric paradigm, while powerful for data, can be a clunky fit for general-purpose or infrastructure workflows. It is also Python-only. See our [Dagster vs. Kestra comparison](https://kestra.io/vs/dagster) for more.
+
+## 10. Windmill: Open-Source Dev Platform for Internal Tools
+
+Windmill is an open-source developer platform designed for quickly building internal tools, automations, and light-duty workflows.
+
+**One-liner:** An open-source developer platform for building internal tools, scripts, and workflows quickly, with self-hosting capabilities.
+
+**Best for:** Teams needing to rapidly automate internal processes, build simple UIs on top of scripts, and run multi-language scripts (Python, TypeScript, Go) in a self-hosted environment.
+
+**Distinctive Feature:** It combines a low-code UI builder with a robust script execution engine, making it easy for developers to create and share internal tools.
+
+**Limitation:** While versatile, it is not specialized for high-throughput data processing or complex, stateful microservice orchestration at the level of Kestra or Temporal. Check out the [Kestra vs. Windmill comparison](https://kestra.io/vs/windmill).
+
+## 11. Trigger.dev: Open-Source Background Jobs for Developers
+
+Trigger.dev is an open-source framework that helps developers create reliable background jobs and long-running workflows directly within their codebase.
+
+**One-liner:** An open-source framework for building background jobs and long-running workflows with durable execution in code (TypeScript/Python).
+
+**Best for:** Developers working with modern web frameworks (like Next.js, Remix, or SvelteKit) who need to add resilient, long-running jobs without leaving their development environment.
+
+**Distinctive Feature:** Its tight integration with popular web frameworks and its focus on a simple, code-first developer experience for creating durable tasks.
+
+**Limitation:** It is highly focused on the application layer and is not designed for orchestrating external data or infrastructure resources.
+
+## Comparison table
+
+| Tool | License | Deployment | Primary Focus | Workflow Definition | Language Support | Best for |
+|---|---|---|---|---|---|---|
+| Kestra | Apache 2.0 OSS / EE / Cloud | Self-hosted, Hybrid, Cloud | Unified Orchestration (Data, AI, Infra, App) | Declarative YAML | Polyglot (Python, Shell, SQL, Go, R, Node.js, etc.) | Universal orchestration across domains, GitOps |
+| Akka | Open Source / Commercial | Self-hosted, Hybrid | Reactive Microservices | Code (Scala, Java) | JVM-based | High-concurrency, resilient app backends on JVM |
+| Camunda | Open Source / Enterprise | Self-hosted, Cloud | Business Process Automation | BPMN/DMN | Java, Node.js, Python SDKs | Formal business processes, human-in-the-loop |
+| AWS Step Functions | Proprietary | AWS Cloud | AWS Service Orchestration | Visual (JSON/YAML) | AWS Lambda runtimes | AWS-native serverless applications |
+| Netflix Conductor | Apache 2.0 OSS / Commercial | Self-hosted, Hybrid | Microservices Orchestration | JSON | Polyglot (SDKs) | Large-scale microservice architectures |
+| Inngest | Commercial (OSS core) | Cloud-managed | Developer-First Durable Jobs | Code (TypeScript, Python) | TypeScript, Python | App developers needing durable background jobs |
+| Apache Airflow | Apache 2.0 OSS | Self-hosted, Managed | Data Pipeline Orchestration | Code (Python DAGs) | Python | Python-heavy batch data pipelines |
+| Prefect | Apache 2.0 OSS / Cloud | Self-hosted, Cloud | Pythonic Data & AI Workflows | Code (Python) | Python | Python-centric dynamic data/ML workflows |
+| Dagster | Apache 2.0 OSS / Cloud | Self-hosted, Cloud | Asset-Centric Data Orchestration | Code (Python) | Python | Analytics engineering, data lineage, dbt |
+| Windmill | AGPLv3 OSS / Cloud | Self-hosted, Cloud | Internal Tools, Scripts & Workflows | Code (Python, TS, Go, SQL) | Polyglot | Building internal tools and automations quickly |
+| Trigger.dev | MIT OSS / Cloud | Self-hosted, Cloud | Developer Background Jobs | Code (TypeScript, Python) | TypeScript, Python | Resilient background jobs for web apps |
+
+## How to choose the right alternative
+
+Choosing the right orchestrator depends entirely on your team's primary use case and technical culture.
+
+*   **For microservices & application teams:** If your core need is durable execution embedded within your application logic, tools like **Inngest**, **Trigger.dev**, and **Netflix Conductor** are strong contenders. They prioritize SDKs and a code-first experience.
+*   **For data engineering teams:** If your world revolves around ETL/ELT, data quality, and transformation, platforms like **Kestra**, **Airflow**, **Prefect**, and **Dagster** are purpose-built for data pipelines. The choice between them often comes down to code-first Python vs. declarative YAML.
+*   **For infrastructure & DevOps teams:** When orchestrating IaC tools, cloud services, and CI/CD processes, a language-agnostic and API-driven orchestrator is key. **Kestra** is designed for this, allowing you to coordinate tools like Terraform and Ansible within a larger workflow.
+*   **For AI / ML platform teams:** Orchestrating ML pipelines requires handling diverse tasks from data prep to model training and deployment. **Kestra** and **Prefect** offer the flexibility to manage these complex, multi-step processes.
+*   **For small teams & self-hosted needs:** If low operational overhead and ease of deployment are critical, **Kestra**, **Windmill**, and **Trigger.dev** offer straightforward self-hosting options with transparent open-source licenses.
+
+Ultimately, the best choice is a platform that not only solves today's problem but also provides a path to unify orchestration as your organization's needs grow and diversify.
+
+## Conclusion
+
+The search for a Temporal alternative is often a search for a different approach to orchestration—one that might be more declarative, more data-aware, or less operationally intensive. While Temporal excels at durable execution for microservices, the modern landscape offers a wide array of tools tailored to specific needs.
+
+Platforms like Airflow, Prefect, and Dagster serve the Python-native data world, while Inngest and Trigger.dev focus on a modern developer experience for application backends. Kestra stands out by offering a unified, declarative control plane that bridges all these domains. By defining workflows in YAML and executing tasks in any language, Kestra provides a scalable and collaborative foundation for orchestrating everything from data pipelines and AI agents to infrastructure automation.
+
+If you're looking for an orchestrator that can grow with you, we encourage you to [get started with Kestra](https://kestra.io/get-started) or [book a demo](https://kestra.io/demo) to see how it can simplify your complex workflows.


### PR DESCRIPTION
## Summary
- New `/resources/temporal-alternatives` SEO listicle page
- Compares Kestra and other workflow orchestrators against Temporal
- Imported from [vfanucci/kestra-seo#75](https://github.com/vfanucci/kestra-seo/pull/75)

## Test plan
- [ ] Astro build passes (resources schema validation)
- [ ] Page renders at `/resources/temporal-alternatives`
- [ ] FAQ structured data renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)