### PR TITLE
docs(resources): HP Orchestration alternatives

### DIFF
--- a/src/contents/resources/hp-orchestration-alternatives/index.md
+++ b/src/contents/resources/hp-orchestration-alternatives/index.md
@@ -1,0 +1,124 @@
+---
+title: "HP Orchestration Alternatives: Top Platforms for Modern IT Automation"
+description: "Explore modern alternatives to HP Operations Orchestrator. Discover top platforms for data, process, and IT automation to elevate your strategy."
+metaTitle: "HP Orchestration Alternatives: Top Platforms for Modern IT"
+metaDescription: "Explore modern alternatives to HP Operations Orchestrator. Discover top platforms for data, process, and IT automation to elevate your strategy."
+tag: infrastructure
+date: 2026-05-13
+faq:
+  - question: "What is HP Operations Orchestration used for?"
+    answer: "HP Operations Orchestration (HP OO) is a legacy IT operations management (ITOM) tool designed for automating IT processes, managing runbooks, and orchestrating tasks across various IT systems. It helps standardize operational procedures and reduce manual intervention in complex IT environments."
+  - question: "Why should I consider alternatives to HP Operations Orchestration?"
+    answer: "Many organizations seek HP OO alternatives due to its legacy architecture, high operational overhead, limited cloud-native capabilities, and difficulty integrating with modern data, AI, and developer-centric toolchains. Newer platforms offer greater flexibility, scalability, and cost-effectiveness."
+  - question: "Is Kestra a suitable alternative to HP Operations Orchestration?"
+    answer: "Yes, Kestra is a highly suitable alternative to HP Operations Orchestration, offering a modern, open-source, and declarative platform. It unifies data, AI, and infrastructure workflows, supports polyglot execution, and integrates seamlessly with cloud-native practices, making it ideal for modernizing IT automation."
+  - question: "How do open-source tools compare to HP Operations Orchestration?"
+    answer: "Open-source tools like Kestra, Apache Airflow, and Ansible offer greater flexibility, community support, and often lower total cost of ownership compared to proprietary legacy solutions like HP OO. They are typically more aligned with modern development practices, cloud-native deployments, and polyglot environments."
+  - question: "What are the key features to look for in an HP OO alternative?"
+    answer: "Key features include scalability for cloud and hybrid environments, extensive integration capabilities, declarative workflow definitions (YAML), support for multiple programming languages, event-driven architecture, robust observability, and a strong community or vendor ecosystem."
+  - question: "Can cloud-native platforms replace HP Operations Orchestration?"
+    answer: "Yes, cloud-native platforms such as AWS Step Functions and Azure Data Factory can replace parts of HP OO's functionality, especially for workloads within their respective cloud ecosystems. However, a universal orchestrator like Kestra offers broader cross-cloud and hybrid capabilities, coordinating diverse systems."
+---
+
+For decades, traditional IT operations orchestration tools like HP Operations Orchestration (HP OO) have been the backbone of enterprise automation. However, as IT landscapes evolve towards multi-cloud, hybrid infrastructures, and data-intensive workflows, the limitations of these legacy platforms become increasingly apparent. Teams are seeking more agile, scalable, and developer-friendly solutions that can unify diverse automation needs across data, infrastructure, and AI. This article will explore why modern enterprises are looking for HP OO alternatives and provide a comprehensive guide to the top platforms available today, helping you choose the right tool to elevate your automation strategy.
+
+## Understanding HP Operations Orchestration and the Need for Alternatives
+
+### What is HP Operations Orchestration?
+HP Operations Orchestration (HP OO), now part of Micro Focus, is a traditional IT Operations Management (ITOM) platform. Its primary function is runbook automation, allowing IT teams to design, orchestrate, and automate routine operational tasks and processes. It typically uses a graphical interface to build flows that execute pre-defined actions across servers, networks, and applications. For many years, it has been a staple in large enterprises for standardizing IT processes like server patching, incident response, and system provisioning, particularly in on-premises data centers. Many government and public sector agencies have historically relied on such tools for their IT automation.
+
+### Why Seek Alternatives to HP Operations Orchestration?
+The shift to cloud-native architectures and DevOps practices has exposed the limitations of legacy tools like HP OO. Modern engineering teams often seek alternatives for several key reasons:
+*   **Operational Burden:** HP OO can be complex to manage, requiring specialized knowledge and significant infrastructure, which can [increase orchestration complexity](//resources/infrastructure/orchestration-problems-complexity) rather than reduce it.
+*   **Lack of Cloud-Native Capabilities:** It was designed for a pre-cloud era. Integrating with modern cloud services, container orchestration platforms like Kubernetes, and serverless functions can be cumbersome.
+*   **Limited Integration:** While it has a library of integrations, connecting to modern data and AI stacks, SaaS APIs, and developer-centric tools is often not as seamless as with newer platforms.
+*   **Cost and Vendor Lock-in:** Proprietary licensing models can be expensive and create dependency on a single vendor, hindering flexibility.
+*   **Developer Experience:** The platform's model is often at odds with modern developer workflows that favor declarative, code-based definitions (like YAML or Python) and GitOps practices.
+
+## Key Features to Look for in Orchestration Alternatives
+When evaluating replacements for HP OO, it's essential to look for features that address the shortcomings of legacy systems and align with modern engineering practices. Key capabilities include:
+*   **Scalability and Performance:** The ability to handle a high volume of workflows across hybrid and multi-cloud environments without performance degradation.
+*   **Integration Ecosystem:** A rich and extensible library of plugins to connect seamlessly with databases, cloud services, messaging systems, and modern SaaS applications.
+*   **Declarative Workflows:** Defining workflows as code (e.g., YAML) enables version control, automated testing, and GitOps practices, making automation more reliable and auditable.
+*   **Polyglot Execution:** Support for multiple programming languages (Python, Shell, SQL, Node.js, etc.) and containerized environments (Docker, Kubernetes) to accommodate diverse teams and use cases.
+*   **Event-Driven Capabilities:** The ability to trigger workflows based on real-time events from various sources, enabling more responsive and dynamic automation.
+*   **Observability:** Comprehensive logging, monitoring, and alerting to ensure visibility into workflow performance and facilitate rapid troubleshooting.
+*   **Cost-Effectiveness:** A transparent pricing model, often with an open-source core, that provides a lower total cost of ownership (TCO).
+
+## The Alternatives
+
+### 1. Kestra: A Modern Open-Source Orchestrator
+Kestra is an open-source, declarative orchestration platform designed to unify workflows across an entire organization. Unlike specialized tools, Kestra provides a single control plane for data, AI, infrastructure, and business processes. Workflows are defined in simple, auditable YAML files, making them accessible to both technical and non-technical users.
+
+Its language-agnostic architecture allows you to run scripts in Python, Shell, R, or any other language, execute SQL queries, and run containerized tasks with Docker. This flexibility makes Kestra a powerful replacement for fragmented scripts and legacy tools. For example, Crédit Agricole used Kestra to replace a collection of disparate scripts with a single, governed orchestration layer. Kestra is event-driven by default, enabling real-time automation that legacy schedulers struggle with. While its YAML-first approach is a strength for engineering teams, organizations seeking a purely no-code, drag-and-drop interface for simple SaaS integrations might find other tools have a lower initial learning curve.
+
+**Kestra is best for organizations seeking a unified, declarative, and polyglot orchestration control plane that spans data, AI, and infrastructure workflows, offering high scalability and robust governance.**
+
+### 2. Apache Airflow: A Popular Workflow Management System
+Apache Airflow is the most widely adopted open-source workflow management system, particularly for data engineering. Its core strength lies in its "DAGs-as-code" paradigm, where workflows are defined in Python. This provides immense flexibility for Python-savvy teams and is supported by a massive ecosystem of pre-built operators for various data sources and services.
+
+However, this Python-centricity is also its main limitation when considered as an HP OO alternative. It's less suited for teams with polyglot requirements or for orchestrating infrastructure tasks that don't fit neatly into a Python operator. Furthermore, managing Airflow at scale can be operationally complex, requiring careful configuration of schedulers, workers, and metadata databases.
+
+**Airflow is best for Python-centric data engineering teams with existing investment in the ecosystem and a focus on batch data pipelines.**
+
+### 3. Prefect: Dataflow Automation for Data Engineers
+Prefect is another popular open-source data orchestrator that competes closely with Airflow. It distinguishes itself with a strong focus on developer experience, particularly for Python developers. Prefect's API is designed to be intuitive and "Pythonic," making it easy to convert existing Python scripts into managed workflows. It excels at handling dynamic, parameterized dataflows where the structure of the workflow can change at runtime.
+
+Its hybrid execution model, where a central cloud control plane manages self-hosted workers, offers a balance of convenience and security. However, like Airflow, Prefect is primarily a tool for data engineers. Its capabilities for broader IT and infrastructure automation are less developed, making it a specialized, rather than universal, alternative to HP OO.
+
+**Prefect is best for Python-only data teams looking for a modern, developer-friendly data orchestrator with strong dynamic flow capabilities.**
+
+### 4. AWS Step Functions: Serverless Workflow Orchestration
+For organizations heavily invested in the Amazon Web Services ecosystem, AWS Step Functions offers a powerful, serverless orchestration service. It allows you to coordinate multiple AWS services into workflows using a visual editor or by defining state machines in JSON. As a fully managed service, it eliminates the operational overhead of managing infrastructure.
+
+Its deep integration with services like AWS Lambda, S3, and Glue makes it an excellent choice for building resilient, event-driven applications and data processing pipelines within AWS. The primary drawback is vendor lock-in. Step Functions are not portable, and their utility is limited outside of the AWS environment, making them unsuitable for hybrid or multi-cloud strategies.
+
+**AWS Step Functions is best for organizations deeply invested in the AWS ecosystem seeking serverless, managed orchestration for application and microservice workflows.**
+
+### 5. Azure Data Factory: Cloud-Based Data Integration
+Azure Data Factory (ADF) is Microsoft's cloud-native ETL and data integration service. It provides a visual interface for building and managing data pipelines that move and transform data at scale. With a vast library of managed connectors, ADF excels at ingesting data from various sources into the Azure ecosystem, particularly Azure Synapse Analytics and Azure Blob Storage.
+
+While powerful for data-centric workloads within Azure, ADF is not a general-purpose orchestrator. Its capabilities for infrastructure automation or non-data business processes are limited. Like AWS Step Functions, it ties you to a specific cloud provider, making it a strategic choice for Azure-first organizations but less viable for those with multi-cloud or hybrid requirements.
+
+**Azure Data Factory is best for Azure-centric data teams needing a managed, cloud-based data integration service with visual authoring capabilities.**
+
+## Other Notable Automation and Orchestration Tools
+
+Beyond the top five, several other categories of tools can serve as alternatives or complements, depending on your specific needs.
+
+### Process Orchestration Software (BPM, iPaaS)
+Tools like [Camunda](https://kestra.io/vs/camunda) and Workato focus on business process management (BPM) and integration Platform as a Service (iPaaS). They excel at orchestrating complex business workflows that involve human-in-the-loop tasks, approvals, and integrations between SaaS applications like Salesforce and ServiceNow.
+
+### Cloud Orchestrators
+Each major cloud provider offers orchestration tools beyond those mentioned, such as [Google Cloud Workflows](https://kestra.io/vs/google-workflows). Additionally, enterprise ITOM suites from vendors like IBM, Huawei, and Nokia offer integrated solutions for telecommunications and large-scale IT management, though they often share the same legacy constraints as HP OO.
+
+### Open-Source Infrastructure Automation
+For teams focused purely on infrastructure, tools like [Ansible Automation Platform](https://kestra.io/vs/ansible-automation-platform), [Puppet](https://kestra.io/vs/puppet), and [Apache NiFi](https://kestra.io/vs/apache-nifi) provide powerful capabilities. Ansible excels at configuration management and IT automation, Puppet at declarative configuration, and NiFi at visual data flow management. These tools often work best when coordinated by a higher-level orchestrator like Kestra.
+
+## Comparison Table
+
+| Tool | License | Deployment | Best for | Key Differentiator |
+|---|---|---|---|---|
+| Kestra | Apache 2.0 OSS / EE | Hybrid (Docker, K8s, VM, Cloud) | Unified data, AI, infra, business workflows | Declarative YAML, polyglot, event-driven, cross-domain |
+| Apache Airflow | Apache 2.0 OSS | Self-hosted / Managed | Python-centric batch data pipelines | Mature ecosystem of Python operators |
+| Prefect | Apache 2.0 OSS / Cloud | Hybrid (Cloud-managed workers) | Python-native data and AI workflows | Developer-friendly Python API, dynamic workflows |
+| AWS Step Functions | Proprietary | AWS Cloud | AWS-native serverless application workflows | Deep AWS service integration, managed serverless |
+| Azure Data Factory | Proprietary | Azure Cloud | Azure-centric data integration and ETL | Visual ETL/ELT, extensive Azure connectors |
+
+## How to Choose the Right Orchestration Tool for Your Business
+
+Selecting the right alternative depends on your team's primary use cases and technical expertise.
+
+### For Infrastructure and DevOps Teams
+Your focus should be on [Infrastructure as Code (IaC)](https://kestra.io/resources/infrastructure/what-is-infrastructure-as-code) principles. Look for a tool with strong integrations for Terraform and Ansible, robust GitOps capabilities, and the flexibility to manage hybrid and multi-cloud environments. A declarative approach is critical for auditability and reliability. Explore how Kestra can help you [automate your infrastructure](https://kestra.io/infra-automation).
+
+### For Data Engineering Teams
+Prioritize platforms that can handle large-scale [data orchestration](https://kestra.io/resources/data/data-orchestration) and integrate seamlessly with your data stack. Key features include support for dbt, robust data lineage tracking, and the ability to connect to a wide range of data sources and destinations. See how Kestra can serve your [data teams](https://kestra.io/data).
+
+### For AI/ML Platform Teams
+AI and MLOps workflows require orchestrating diverse tasks, from data preprocessing to model training and deployment. Look for a platform that supports GPU-enabled workers, integrates with ML frameworks and experiment tracking tools, and can manage complex, multi-step [agentic workflows](https://kestra.io/resources/ai/agentic-orchestration). Discover Kestra for [AI automation](https://kestra.io/ai-automation).
+
+### For Organizations Modernizing from Legacy Systems
+If you are moving away from tools like HP OO, Control-M, or Autosys, prioritize a platform that simplifies migration. A declarative, YAML-based approach provides a clear, auditable definition of workflows that is easier to manage than legacy graphical interfaces. Strong community and vendor support are also crucial for ensuring long-term success and a smooth transition.
+
+Modernizing your orchestration strategy means moving beyond the constraints of legacy tools like HP Operations Orchestration. The alternatives discussed—from Kestra's unified, declarative approach to specialized cloud-native and open-source platforms—offer distinct advantages for different needs. By carefully evaluating factors like scalability, integration, ease of use, and future-proofing, you can select a platform that empowers your teams and streamlines your operations. Explore the [full range of Kestra alternatives](https://kestra.io/vs) and see how it can serve as your central control plane for all your automation needs.


### PR DESCRIPTION
## Summary
- New `/resources/hp-orchestration-alternatives` SEO listicle page
- Covers modern alternatives to HP Operations Orchestrator (HP OO)
- Imported from [vfanucci/kestra-seo#71](https://github.com/vfanucci/kestra-seo/pull/71)

## Test plan
- [ ] Astro build passes (resources schema validation)
- [ ] Page renders at `/resources/hp-orchestration-alternatives`
- [ ] FAQ structured data renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)