### PR TITLE
docs(resources): Chef alternatives

### DIFF
--- a/src/contents/resources/chef-alternatives/index.md
+++ b/src/contents/resources/chef-alternatives/index.md
@@ -1,0 +1,208 @@
+---
+title: "Chef Alternatives: Automate Your Workflow"
+description: "Explore top Chef alternatives for IT automation. Discover Kestra, Ansible, Puppet, and SaltStack for declarative, agentless, and event-driven infrastructure management."
+metaTitle: "Top Chef Alternatives for IT Automation in 2026"
+metaDescription: "Explore the best Chef alternatives for IT automation. Discover Kestra, Ansible, Puppet, and SaltStack for declarative, agentless, and event-driven infrastructure management."
+tag: infrastructure
+date: 2026-05-13
+faq:
+  - question: "Which is better, Chef or Ansible?"
+    answer: "The choice between Chef and Ansible depends on your team's needs. Chef excels in robust, agent-based configuration management, using a Ruby DSL for complex setups. Ansible, conversely, offers agentless automation with simpler YAML playbooks, making it faster to get started and manage for many teams, especially when moving towards more declarative, GitOps-driven approaches."
+  - question: "Can Kestra replace Chef for infrastructure automation?"
+    answer: "Kestra can serve as a modern orchestration control plane that integrates with and orchestrates tools like Chef, or manage automation that Chef previously handled. While Chef focuses on configuration management, Kestra provides a higher-level, event-driven, and polyglot framework to coordinate infrastructure tasks, data pipelines, and even AI workflows from a single declarative YAML definition."
+  - question: "What is the best open-source alternative to Chef?"
+    answer: "Leading open-source alternatives to Chef include Ansible, known for its agentless architecture and YAML-based playbooks; SaltStack, for high-speed, event-driven automation; and Kestra, which offers a declarative, language-agnostic platform to orchestrate infrastructure, data, and AI workflows."
+  - question: "What can I do instead of being a chef?"
+    answer: "If you're considering a career change from being a chef, many roles leverage organizational, creative, and leadership skills. Options include restaurant management, food styling, culinary instruction, food writing, catering, or even transitioning into project management or operations in other industries."
+  - question: "How to transition out of being a chef?"
+    answer: "Transitioning out of a chef career often involves identifying transferable skills like project management, team leadership, problem-solving, and attention to detail. Networking, seeking mentorship, and potentially pursuing further education or certifications in a new field can help facilitate a smooth career change."
+---
+Chef has long been a cornerstone of IT automation, empowering DevOps teams with its powerful agent-based configuration management and Ruby DSL. For over a decade, it has helped organizations define infrastructure as code, ensuring consistency and repeatability across complex environments. However, as infrastructure ecosystems evolve, many platform engineers and DevOps professionals are re-evaluating their orchestration stack. The shift towards agentless architectures, simpler declarative languages, and unified control planes for diverse workloads is driving a search for more agile and operationally lightweight alternatives.
+
+The leading alternatives to Chef for modern IT automation in 2026 include Kestra, Ansible, Puppet, SaltStack, and GitLab CI/CD, each offering distinct approaches to configuration management, deployment, and infrastructure as code. This article will explore why teams are seeking these alternatives, detail the key features and trade-offs of each, and provide a framework for choosing the right tool to automate your infrastructure, deployment, and operational workflows in today's dynamic IT landscape.
+
+## Why look for an alternative to Chef?
+
+While Chef is a powerful and mature tool, several factors contribute to the search for alternatives. These challenges often relate to complexity, operational overhead, and a philosophical shift in how modern infrastructure is managed.
+
+- **Complexity of Ruby DSL:** Chef uses a Ruby-based Domain-Specific Language (DSL) for its "cookbooks." While powerful, this presents a steep learning curve for teams not already proficient in Ruby. This can slow down onboarding and make collaboration more difficult in polyglot engineering organizations.
+- **Agent-based Model Overhead:** Chef requires a client agent to be installed and running on every managed node. This agent periodically checks in with the Chef server to pull the latest configurations. Managing, updating, and securing this agent fleet across hundreds or thousands of servers adds a layer of operational complexity.
+- **Operational Burden:** Running a full Chef deployment involves managing Chef servers, workstations, cookbooks, and environments. This infrastructure requires maintenance, backups, and expertise to operate at scale, contributing to the total cost of ownership.
+- **Shift Towards Modern Automation Patterns:** The industry is increasingly adopting agentless, declarative, and event-driven automation. Tools that align with [GitOps principles](https://kestra.io/resources/infrastructure/gitops) and use simple, human-readable formats like YAML are gaining traction. This shift favors tools that are easier to integrate into CI/CD pipelines and that treat [infrastructure as code](https://kestra.io/resources/infrastructure/what-is-infrastructure-as-code) as a first-class citizen.
+
+## How we evaluated these alternatives
+
+To provide a clear comparison, we evaluated each Chef alternative based on a core set of criteria relevant to modern DevOps and platform engineering teams. Understanding these criteria is key to solving common [orchestration problems and reducing complexity](https://kestra.io/resources/infrastructure/orchestration-problems-complexity).
+
+- **Deployment Model:** We examined whether the tool is agentless or requires an agent on each managed node, as this significantly impacts operational overhead.
+- **Configuration Language:** We assessed the language used for defining automation (e.g., YAML, Ruby DSL, Python), considering its learning curve and readability.
+- **Primary Use Case:** We identified the tool's core strength, whether it's configuration management, application deployment, CI/CD, or universal orchestration.
+- **Operational Overhead:** We considered the effort required to install, manage, and scale the tool and its components.
+- **Ecosystem & Community:** We looked at the size and health of the community, as well as the availability of pre-built modules, plugins, and integrations.
+
+## The Alternatives
+
+### 1. Kestra: The Universal Orchestration Control Plane
+
+Kestra is an open-source, declarative orchestration platform that unifies data, AI, infrastructure, and business workflows under a single control plane. Instead of focusing solely on configuration management, Kestra orchestrates the end-to-end processes that involve multiple tools and systems.
+
+Workflows in Kestra are defined in simple YAML, making them easy to write, review, and version control. Its language-agnostic architecture allows you to run tasks in Python, Bash, Go, SQL, or any other language, all within the same workflow. This makes it a powerful control plane that can sit *above* tools like Ansible or Terraform, coordinating their execution alongside other tasks like database queries, API calls, and notifications. For example, financial institutions like Crédit Agricole have used Kestra to replace fragmented infrastructure scripts and cron jobs with a single, auditable orchestration layer.
+
+**Best for:** Platform engineering teams seeking a unified, event-driven control plane to orchestrate workflows across their entire stack, from data pipelines to infrastructure automation, using a declarative, GitOps-friendly approach. Explore how Kestra can manage your [infrastructure automation](https://kestra.io/docs/use-cases/infrastructure) and enable [version control for all your workflows](https://kestra.io/docs/version-control-cicd/git).
+
+### 2. Ansible: Agentless Simplicity and Playbooks
+
+Ansible is one of the most popular IT automation tools, known for its agentless architecture and human-readable YAML playbooks. It communicates with managed nodes over standard SSH, eliminating the need to install and maintain client agents. This simplicity makes it incredibly fast to get started with and easy to integrate into existing environments.
+
+Ansible excels at application deployment, configuration management, and ad-hoc task execution. Its vast ecosystem of modules allows it to manage a wide range of systems, from cloud providers and network devices to on-premises servers. While highly effective for executing procedural tasks, Ansible is less suited for complex, long-running, or event-driven orchestration that spans multiple domains. For a deeper dive, see our [Ansible vs. Kestra comparison](https://kestra.io/vs/ansible-automation-platform).
+
+**Best for:** Teams prioritizing agentless configuration management, straightforward application deployments, and ad-hoc automation tasks with a minimal learning curve.
+
+### 3. Puppet: Robust Configuration Management for Enterprises
+
+Puppet is a mature, agent-based configuration management tool that has been a staple in large enterprise environments for years. It uses a declarative, model-driven approach, where you define the desired state of your infrastructure in Puppet's Ruby-based DSL, and the Puppet agent enforces that state on each node.
+
+Puppet's strengths lie in its scalability, robust reporting, and strong compliance features, making it ideal for managing large, complex, and heterogeneous server fleets. However, it comes with the operational overhead of managing a Puppet master and agents, and its DSL can be complex for newcomers. While powerful for maintaining a desired state, it is less agile for procedural tasks or event-driven workflows compared to other tools. For more details, see our comparison of [Puppet alternatives](https://kestra.io/resources/infrastructure/puppet-alternatives).
+
+**Best for:** Large enterprises with established investments in Puppet, requiring robust, agent-based configuration management and deep compliance reporting across extensive infrastructure.
+
+### 4. SaltStack: Event-Driven Automation and Speed
+
+SaltStack (often referred to as Salt) is a powerful, Python-based automation tool built for high-speed data transfer and event-driven infrastructure management. It typically uses a master-minion (agent-based) architecture with a persistent connection, allowing for near-instantaneous command execution across thousands of minions.
+
+Salt's core feature is its event bus, which enables reactive, event-driven automation. This makes it excellent for real-time monitoring and automated remediation in response to system events. While it supports both imperative remote execution and declarative configuration management, its architecture can be more complex to set up and manage compared to agentless tools.
+
+**Best for:** Organizations managing large-scale server environments that require high-speed, event-driven automation and real-time remote execution capabilities.
+
+### 5. GitLab CI/CD: Integrated DevOps Platform
+
+GitLab is a comprehensive DevOps platform that provides a single application for the entire software development and delivery lifecycle. Its built-in CI/CD capabilities allow teams to build, test, and deploy applications directly from their source code repository.
+
+While primarily a CI/CD tool, GitLab CI/CD can also be used for infrastructure automation through its pipeline definitions (`.gitlab-ci.yml`). By integrating with tools like Terraform or Ansible, it can manage infrastructure as part of the software delivery process, promoting a strong GitOps workflow. However, its primary focus remains on the CI/CD pipeline, and it lacks the broader, event-driven orchestration capabilities of a dedicated platform like Kestra. See how to [integrate GitLab CI with Kestra](https://kestra.io/docs/version-control-cicd/cicd/gitlab).
+
+**Best for:** Teams already using GitLab for source code management who want to consolidate their toolchain and manage infrastructure provisioning and application deployment within a single, integrated DevOps platform.
+
+## Comparison Table
+
+| Tool | License | Deployment Model | Configuration Language | Best for | Starting Price |
+|---|---|---|---|---|---|
+| **Kestra** | Open-Source (Apache 2.0) & Enterprise | Agentless | YAML | Universal orchestration across data, AI, and infra | Free (Open-Source) |
+| **Ansible** | Open-Source (GPLv3) & Enterprise | Agentless | YAML | Agentless configuration management & deployment | Free (Community) |
+| **Puppet** | Open-Source (Apache 2.0) & Enterprise | Agent-based | Ruby DSL | Enterprise-scale, model-driven configuration | Free (Open-Source) |
+| **SaltStack** | Open-Source (Apache 2.0) & Enterprise | Agent-based | YAML & Python | High-speed, event-driven infrastructure automation | Free (Community) |
+| **GitLab CI/CD** | Open-Source (MIT) & Enterprise | Runner-based | YAML | Integrated CI/CD and DevOps workflows | Free tier available |
+
+## How to choose the right alternative
+
+Selecting the best Chef alternative depends on your team's specific needs, existing stack, and long-term goals. Here’s a quick guide to help you decide:
+
+- **For platform engineers building a unified control plane:** If your goal is to orchestrate workflows across different domains (data, AI, infrastructure) and tools (Terraform, Ansible, Kubernetes) from a single, declarative platform, **Kestra** is the ideal choice. Its event-driven, language-agnostic approach provides maximum flexibility. Explore our [blueprints](https://kestra.io/blueprints) for examples.
+- **For teams prioritizing simplicity and speed:** If you need an easy-to-learn, agentless tool for configuration management and application deployment, **Ansible** offers the fastest path to value.
+- **For large enterprises with deep configuration needs:** If you manage a massive, heterogeneous fleet of servers and require robust, state-enforced configuration with strong compliance features, **Puppet** remains a powerful, enterprise-grade solution.
+- **For high-speed, reactive automation:** If your use case involves real-time event processing and requires near-instantaneous execution across thousands of nodes, **SaltStack**'s event bus is a key differentiator.
+- **For consolidating your DevOps toolchain:** If your organization is heavily invested in GitLab for source control, using **GitLab CI/CD** for infrastructure tasks can streamline workflows and reduce tool sprawl.
+
+Ultimately, the choice is about finding the right tool for the job. You can explore a wide range of [Kestra alternatives and comparisons](https://kestra.io/vs) to see how different tools stack up for various use cases.
+
+## Conclusion
+
+Moving away from Chef is not just about replacing one tool with another; it's an opportunity to align your automation strategy with modern DevOps principles. Whether you prioritize the agentless simplicity of Ansible, the enterprise control of Puppet, the speed of SaltStack, or the integrated experience of GitLab, each alternative offers a distinct path forward.
+
+For teams looking beyond traditional configuration management, a universal orchestration platform like Kestra provides a powerful control plane to unify all your workflows. By embracing a declarative, event-driven, and language-agnostic approach, you can build resilient, scalable, and auditable automation for your entire technology stack.
+
+Ready to modernize your IT automation and unify your workflows? Explore Kestra's [infrastructure automation capabilities](https://kestra.io/infra-automation) and see how declarative orchestration can streamline your operations.
+
+## Structured data
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://kestra.io"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Resources",
+      "item": "https://kestra.io/resources"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Infrastructure Automation Resources",
+      "item": "https://kestra.io/resources/infrastructure"
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "name": "Chef Alternatives: Automate Your Workflow",
+      "item": "https://kestra.io/resources/infrastructure/chef-alternatives"
+    }
+  ]
+}
+```
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Top Chef Alternatives for IT Automation",
+  "description": "A list of the best alternatives to Chef for infrastructure automation and configuration management.",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Kestra",
+        "url": "https://kestra.io/vs/chef",
+        "description": "A universal orchestration control plane that unifies data, AI, and infrastructure workflows with declarative YAML."
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Ansible",
+        "url": "https://www.ansible.com/",
+        "description": "An agentless IT automation tool that uses YAML playbooks for configuration management and application deployment."
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Puppet",
+        "url": "https://www.puppet.com/",
+        "description": "An agent-based, declarative configuration management platform for large-scale enterprise environments."
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "SaltStack",
+        "url": "https://saltproject.io/",
+        "description": "A high-speed, event-driven infrastructure automation tool using a master-minion architecture."
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 5,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "GitLab CI/CD",
+        "url": "https://about.gitlab.com/stages-devops-lifecycle/continuous-integration/",
+        "description": "An integrated DevOps platform with built-in CI/CD for building, testing, and deploying applications and infrastructure."
+      }
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Summary
- New `/resources/chef-alternatives` SEO listicle page
- Covers Kestra, Ansible, Puppet, SaltStack, and GitLab CI/CD as alternatives to Chef
- Imported from [vfanucci/kestra-seo#70](https://github.com/vfanucci/kestra-seo/pull/70)

## Test plan
- [ ] Astro build passes (resources schema validation)
- [ ] Page renders at `/resources/chef-alternatives`
- [ ] FAQ + JSON-LD structured data renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)