### PR TITLE
docs(resources): PagerDuty alternatives

### DIFF
--- a/src/contents/resources/pagerduty-alternatives/index.md
+++ b/src/contents/resources/pagerduty-alternatives/index.md
@@ -1,0 +1,158 @@
+---
+title: "Top PagerDuty Alternatives & Competitors 2026"
+description: "Explore the best PagerDuty alternatives for 2026. Compare top solutions and find the perfect fit for your incident management needs today!"
+metaTitle: "Top PagerDuty Alternatives & Competitors for 2026"
+metaDescription: "Seeking PagerDuty alternatives? Discover the leading incident management and orchestration platforms, including Kestra, for 2026. Compare features, pricing, and find your ideal solution."
+tag: infrastructure
+date: 2026-06-03
+faq:
+  - question: "Why should I consider an alternative to PagerDuty?"
+    answer: "Organizations often seek PagerDuty alternatives due to concerns about pricing, the complexity of managing on-call rotations at scale, or a desire for deeper automation capabilities. While PagerDuty excels at alerting, some teams require more flexible workflow orchestration for incident response across diverse technical stacks."
+  - question: "Is Kestra a direct replacement for PagerDuty's alerting system?"
+    answer: "Kestra is an orchestration platform that can significantly enhance incident response, but it is not a direct, standalone alerting system like PagerDuty. Kestra integrates with monitoring tools (including PagerDuty itself) to automate complex remediation workflows, trigger actions, and coordinate tasks across data, AI, and infrastructure, making it a powerful complement or a driver for automated incident resolution."
+  - question: "What are some popular open-source alternatives to PagerDuty?"
+    answer: "Popular open-source PagerDuty alternatives include Zenduty, Grafana OnCall, and GoAlert. These tools offer varying levels of on-call management, alerting, and incident response features, often appealing to teams looking for self-hosted solutions, greater customization, or cost-effective options without proprietary lock-in."
+  - question: "How does Kestra's approach to incident management differ from traditional tools?"
+    answer: "Kestra shifts the paradigm by focusing on orchestrating the *response* to incidents, rather than just alerting. It allows teams to define complex, event-driven workflows in YAML that can automatically diagnose issues, execute remediation scripts, update ITSM systems, and coordinate actions across multiple platforms, providing a governed and auditable automation layer for incident resolution."
+  - question: "Which PagerDuty alternative is best for small teams or startups?"
+    answer: "For small teams or startups, cost-effectiveness and ease of setup are key. Options like Grafana OnCall (especially if already using Grafana), Zenduty, or even Kestra's open-source edition for automating simple responses, can be excellent choices. These platforms offer essential alerting and on-call features without the enterprise-level overhead."
+  - question: "How does Kestra integrate with existing monitoring and alerting tools?"
+    answer: "Kestra integrates with existing monitoring and alerting tools (like Datadog, Splunk On-Call, or even PagerDuty) through its extensive plugin ecosystem and webhook triggers. It can listen for alerts from these systems, ingest event data, and then initiate predefined, automated workflows to address the incident, enriching the overall incident response process."
+---
+
+The incident management landscape is constantly evolving, with teams grappling with alert fatigue, complex on-call rotations, and the need for faster, more automated responses. PagerDuty has long been a leader in this space, providing robust alerting and on-call scheduling. However, as infrastructure grows more distributed and incidents become more intricate, many organizations are seeking alternatives that offer deeper automation, broader integration, or a more flexible approach to incident orchestration.
+
+This article explores the top PagerDuty alternatives and competitors for 2026, including Kestra, Opsgenie, xMatters, and several open-source options. We'll examine their strengths, trade-offs, and ideal use cases to help you find the perfect fit for your incident management and automation needs, whether you're an SRE team, a platform engineer, or a small business.
+
+## Why look for an alternative to PagerDuty?
+
+While PagerDuty is a powerful tool, several factors drive teams to explore alternatives:
+
+-   **Pricing and Cost Efficiency**: PagerDuty's pricing, often based on per-user or consumption models, can become a significant operational expense as teams and services scale. Organizations may seek more cost-effective solutions, especially open-source alternatives, to manage their budgets.
+-   **Operational Complexity**: As the number of services and integrations grows, managing on-call schedules, escalation policies, and automation rules within PagerDuty can become complex. Teams may look for tools with a more intuitive interface or a simpler configuration model to [reduce orchestration complexity](/resources/infrastructure/orchestration-problems-complexity).
+-   **Limited Workflow Orchestration**: PagerDuty excels at alerting and incident notification. However, its automation capabilities are primarily focused on the incident response lifecycle. Teams needing to orchestrate complex, cross-domain workflows—such as triggering data pipeline backfills, running infrastructure remediation scripts, and coordinating with AI models—often require a more powerful and flexible orchestration platform.
+-   **Vendor Lock-in and Flexibility**: Some organizations prefer to avoid vendor lock-in and seek open, extensible, or self-hosted solutions that offer greater control and customization. The desire for a more integrated, code-driven approach to automation (GitOps) also leads teams to platforms where workflows are managed as declarative code.
+
+## How we evaluated these alternatives
+
+We evaluated each alternative on its core incident alerting and on-call scheduling capabilities, integration ecosystem, and automation features. We also considered the deployment model (SaaS, self-hosted, open-source) and overall suitability for different team sizes and technical requirements. The primary weight for this comparison is placed on the ability to automate incident response workflows beyond simple notifications, providing a path toward more sophisticated, proactive incident resolution.
+
+## 1. Kestra: The Orchestration Control Plane for Automated Incident Response
+
+Kestra is not a like-for-like PagerDuty replacement but an orchestration control plane that fundamentally changes how teams approach incident response. Instead of just notifying a human, Kestra automates the entire remediation workflow. It is a declarative, event-driven platform that allows you to define complex, multi-step incident response runbooks as simple YAML files.
+
+With its polyglot nature, Kestra can execute tasks in any language—Python, Shell, SQL, Go—and integrate with your entire stack through a vast [plugin library](/plugins). When a monitoring tool sends an alert, Kestra can trigger a workflow that queries logs, restarts a service, runs a Terraform plan, updates a ServiceNow ticket, and notifies the on-call engineer with diagnostic data already attached. This transforms incident response from a manual, reactive process into a governed, automated, and auditable one. As demonstrated by customers like [Crédit Agricole](https://kestra.io/blogs/kestra-series-a), Kestra can unify fragmented scripts and cron jobs into a single, reliable orchestration layer.
+
+-   **Best for:** Platform engineers and SREs looking to build comprehensive, automated incident response workflows that span multiple domains, integrate diverse tools, and require GitOps-driven governance.
+-   **Limitation:** Kestra is an automation engine, not a standalone human-centric alerting and scheduling tool. It works best when integrated with an alerting source like PagerDuty, Grafana OnCall, or Datadog.
+
+Learn more about [Kestra's approach to infrastructure automation](/resources/infrastructure/automation) and [why it's built for modern engineering teams](/docs/why-kestra).
+
+## 2. Opsgenie: Best for Atlassian-Centered Teams
+
+Opsgenie, now part of Atlassian, is a leading incident management platform that provides robust alerting, on-call scheduling, and incident response coordination. Its primary strength lies in its deep and seamless integration with the Atlassian ecosystem, particularly Jira Service Management and Confluence. This allows for a smooth workflow from alert to ticket creation, resolution, and post-mortem documentation.
+
+-   **Best for:** Teams heavily invested in the Atlassian ecosystem who want a tightly integrated incident management solution that connects directly to their existing ITSM and collaboration tools.
+-   **Limitation:** Its tight coupling with Atlassian products can be a drawback for organizations that use a different set of tools, potentially limiting flexibility.
+
+## 3. xMatters: Robust Incident Management and Automation
+
+xMatters is an enterprise-grade incident management platform known for its powerful automation and communication capabilities. It's designed to not only alert the right people but also to automate the resolution process through its visual workflow builder. xMatters can trigger actions in other systems, dynamically assign responders based on skills, and manage communications across multiple channels during a critical incident.
+
+-   **Best for:** Large enterprises that require sophisticated, automated incident workflows, dynamic team assignments, and multi-channel communication for business-critical incidents.
+-   **Limitation:** The platform's extensive feature set can come with a steeper learning curve and may be overly complex for smaller teams with simpler needs.
+
+## 4. Splunk On-Call (VictorOps): Comprehensive Visibility and Collaboration
+
+Splunk On-Call (formerly VictorOps) is an incident management tool that emphasizes real-time visibility and collaboration. It provides a rich incident timeline that aggregates alerts, chats, and actions into a single view, helping teams understand the context of an outage quickly. Its deep integration with the broader Splunk observability platform allows for a seamless transition from monitoring to response.
+
+-   **Best for:** Teams already using Splunk for logging and monitoring who want an integrated incident management solution that enhances real-time collaboration and leverages their existing data.
+-   **Limitation:** The platform delivers the most value when used within the Splunk ecosystem, which could lead to vendor lock-in and may be less appealing for teams using other observability tools.
+
+## 5. Datadog: Monitoring and Incident Response in One Platform
+
+Datadog offers incident management as part of its unified observability platform. This approach allows teams to move from detection to resolution within a single interface, reducing context switching and speeding up response times. With Datadog, you can create monitors, trigger alerts, manage on-call schedules, and coordinate incident response without leaving the platform.
+
+-   **Best for:** Organizations that want a single, all-in-one platform for monitoring, logging, tracing, and incident response, especially those already committed to the Datadog ecosystem.
+-   **Limitation:** While its monitoring capabilities are top-tier, its incident management features may not be as deep or specialized as dedicated tools for teams with highly complex SRE requirements.
+
+## 6. Rootly: Best Overall PagerDuty Alternative Focused on SRE
+
+Rootly is an SRE-focused incident management platform built to automate response processes and streamline collaboration, often directly within Slack. It helps teams declare incidents, create dedicated channels, pull in the right responders, and execute automated runbooks. Rootly places a strong emphasis on generating detailed post-mortems and learning from incidents to improve overall system reliability.
+
+-   **Best for:** SRE teams that prioritize automation, structured incident processes, and continuous improvement of their reliability practices.
+-   **Limitation:** Its SRE-centric approach might introduce a learning curve for teams not already familiar with established incident command frameworks and SRE best practices.
+
+## 7. Squadcast: SRE-Focused Incident Response
+
+Squadcast is another incident management platform with a strong focus on SRE principles. It offers a comprehensive suite of features, including on-call scheduling, multi-channel alerting, incident automation, and tools for conducting post-mortems. It's known for its intuitive user interface and flexible alerting rules, making it a popular choice for teams looking for a cost-effective yet powerful solution.
+
+-   **Best for:** SRE and DevOps teams seeking a cost-effective solution with robust alerting, on-call management, and incident automation capabilities.
+-   **Limitation:** While it offers good automation features, it may not provide the same depth of cross-domain workflow orchestration as a dedicated control plane like Kestra.
+
+## 8. FireHydrant: Incident Management Platform for Reliability
+
+FireHydrant is a comprehensive platform designed to help organizations standardize their incident response processes. It enables teams to automate runbooks, manage incident communication, and track key reliability metrics like MTTR and MTTD. FireHydrant's incident command system helps structure the response process, ensuring that every incident is handled consistently and efficiently.
+
+-   **Best for:** Organizations focused on improving system reliability through structured incident response, automated runbooks, and detailed post-incident analysis.
+-   **Limitation:** The platform is primarily centered on the incident lifecycle and offers less flexibility for orchestrating broader workflows outside of incident response.
+
+## 9. OnPage: Alert and Incident Management for Critical Communications
+
+OnPage is a specialized alerting platform focused on ensuring that critical notifications are never missed. It provides persistent, high-priority alerts with advanced escalation policies, secure messaging, and detailed audit trails. This makes it ideal for environments where a missed alert can have significant consequences.
+
+-   **Best for:** Teams in industries like healthcare, IT operations, or managed services that require guaranteed, high-priority alerting and critical communication capabilities.
+-   **Limitation:** OnPage is highly specialized in alerting and lacks the broader workflow automation and incident management features found in other platforms.
+
+## 10. Zenduty: Free and Open-Source Incident Management
+
+Zenduty is an incident management platform that offers a free and open-source tier, making it an attractive option for smaller teams and startups. It provides essential features like on-call scheduling, alerting, escalation policies, and basic incident response automation. Being open-source, it offers a high degree of flexibility and customization for teams willing to self-host and manage the tool.
+
+-   **Best for:** Small teams, startups, or organizations seeking a free, self-hosted incident management solution with core features and community support.
+-   **Limitation:** The open-source version may require more setup and maintenance effort than commercial SaaS offerings, and its feature set might be less mature than enterprise-grade alternatives.
+
+## 11. Grafana OnCall: Open-Source Incident Management for Grafana Users
+
+Grafana OnCall is an open-source incident response tool that is deeply integrated into the Grafana ecosystem. It allows teams to manage on-call schedules, define escalation policies, and automatically trigger alerts from Grafana's monitoring platform. This tight integration provides a unified experience for observability and response.
+
+-   **Best for:** Teams already using Grafana for monitoring who are looking for a seamless, open-source incident management solution within their existing stack.
+-   **Limitation:** Its primary appeal is for Grafana users. Teams not using Grafana as their main monitoring tool may find other alternatives more suitable.
+
+## 12. GoAlert: Self-Hosted On-Call Scheduling and Alerting
+
+GoAlert is a simple, open-source, and self-hosted on-call scheduling and alerting system. It is designed for reliability and ease of use, focusing on the core functionalities of managing on-call rotations and delivering alerts effectively. It's a no-frills solution for teams that need a dependable alerting system without the complexity of a full incident management platform.
+
+-   **Best for:** Small to medium-sized teams that need a straightforward, self-hosted solution for on-call management without complex features or proprietary dependencies.
+-   **Limitation:** It offers a basic feature set focused on alerting and scheduling, lacking the advanced automation and collaboration tools of more comprehensive platforms.
+
+## Comparison of PagerDuty Alternatives
+
+| Tool                         | License              | Deployment                     | Best for                                            | Key Differentiator                                    |
+| ---------------------------- | -------------------- | ------------------------------ | --------------------------------------------------- | ----------------------------------------------------- |
+| Kestra                       | Apache 2.0 OSS / EE  | Hybrid (Cloud, On-prem, K8s)   | Automated, cross-domain incident response workflows | Declarative YAML, polyglot, event-driven orchestration|
+| Opsgenie                     | Proprietary          | SaaS                           | Atlassian-centric teams                             | Deep integration with Jira Service Management         |
+| xMatters                     | Proprietary          | SaaS                           | Large enterprises with complex automation           | Automated incident workflows, dynamic assignments     |
+| Splunk On-Call (VictorOps)   | Proprietary          | SaaS                           | Splunk users needing real-time visibility           | Unified incident timeline and collaboration           |
+| Datadog                      | Proprietary          | SaaS                           | Teams seeking unified observability & response      | Single platform for monitoring & incident management  |
+| Rootly                       | Proprietary          | SaaS                           | SRE teams prioritizing automation & post-mortems    | Structured incident processes and automation          |
+| Squadcast                    | Proprietary          | SaaS                           | Cost-effective SRE-focused incident response        | Intuitive UI, flexible alerting, post-incident analysis|
+| FireHydrant                  | Proprietary          | SaaS                           | Reliability-focused organizations                   | Standardized incident response, automated runbooks    |
+| OnPage                       | Proprietary          | SaaS                           | Critical communications & guaranteed alerting       | Persistent, high-priority notifications               |
+| Zenduty                      | Open-Source          | SaaS / Self-hosted             | Small teams, startups, cost-conscious users         | Free and open-source flexibility                      |
+| Grafana OnCall               | Open-Source          | SaaS / Self-hosted             | Grafana users                                       | Seamless integration with Grafana alerts              |
+| GoAlert                      | Open-Source          | Self-hosted                    | Small teams needing simple on-call                  | Simple, reliable, self-hosted on-call scheduling      |
+
+## How to choose the best PagerDuty alternative for your needs
+
+Selecting the right tool depends on your team's specific context, existing stack, and maturity level in incident response.
+
+-   **For data engineering teams**: You need a tool that understands the context of data incidents. Consider solutions that can trigger and orchestrate data quality checks, pipeline restarts, or backfills. Kestra excels here by connecting incident alerts to your data stack, allowing you to automate complex data remediation workflows. Explore Kestra for [data orchestration](/data).
+-   **For infrastructure / DevOps teams**: Your focus is on reliability, automation, and GitOps. Look for platforms that integrate with your IaC tools like Terraform and Ansible. Kestra provides a powerful control plane to automate infrastructure diagnostics and remediation, all defined as code in your Git repository. See how Kestra enables [infrastructure automation](/infra-automation).
+-   **For AI / ML platform teams**: Incidents in AI/ML can range from model drift to data pipeline failures. You need an orchestrator that can trigger model retraining jobs, data validation pipelines, or even coordinate with AI agents for diagnostics. Kestra's AI-native features provide a unified platform for these tasks. Discover [AI automation with Kestra](/ai-automation).
+-   **For small teams getting started**: If you're just starting with on-call, prioritize simplicity and cost-effectiveness. Open-source tools like Grafana OnCall or GoAlert, or the free tiers of commercial products, can provide the essential alerting and scheduling you need without a large investment.
+
+Ultimately, the best choice is one that not only solves your immediate alerting needs but also provides a path toward a more automated and resilient incident management practice.
+
+While many tools can tell you when something is broken, a true orchestration platform can help you fix it automatically. If your goal is to move beyond manual response and build a governed, automated system for incident resolution, Kestra offers a flexible and powerful foundation.
+
+Ready to see how orchestration can transform your incident response? [Get started with Kestra](/get-started) and explore our blueprints for automated workflows.


### PR DESCRIPTION
## Summary
- New `/resources/pagerduty-alternatives` SEO listicle page
- Covers leading incident management and orchestration platforms as PagerDuty alternatives
- Imported from [vfanucci/kestra-seo#68](https://github.com/vfanucci/kestra-seo/pull/68)

## Test plan
- [ ] Astro build passes (resources schema validation)
- [ ] Page renders at `/resources/pagerduty-alternatives`
- [ ] FAQ structured data renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)