### PR TITLE
docs(resources): 5 alternatives pages (W21 batch)

### DIFF
--- a/src/contents/resources/broadcom-dollar-universe-alternatives/index.md
+++ b/src/contents/resources/broadcom-dollar-universe-alternatives/index.md
@@ -1,0 +1,135 @@
+---
+title: "Top Broadcom Dollar Universe Alternatives for Modern Workload Automation"
+description: "Discover leading alternatives to Broadcom Dollar Universe, including Kestra, for modern workload automation. Compare features, deployment, and best fits for your enterprise needs."
+metaTitle: "Top Broadcom Dollar Universe Alternatives | Kestra"
+metaDescription: "Explore the top Broadcom Dollar Universe alternatives for workload automation. Find modern, flexible solutions for your enterprise needs and overcome legacy constraints."
+tag: infrastructure
+date: 2026-05-08
+faq:
+  - question: "Who is Broadcom's biggest competitor in workload automation?"
+    answer: "In workload automation, Broadcom's biggest competitors include vendors like BMC (with Control-M), Stonebranch, and Redwood Software. These companies offer comprehensive platforms that often compete for enterprise clients looking for robust scheduling and orchestration capabilities, particularly as organizations seek to modernize their IT operations."
+  - question: "What are AutoSys alternatives?"
+    answer: "Alternatives to Broadcom's AutoSys Workload Automation, a batch job scheduling software, include modern orchestrators like Kestra, alongside established tools such as Redwood RunMyJobs, Stonebranch, ActiveBatch, JAMS, and BMC Control-M. These alternatives offer varying degrees of flexibility, cloud-native capabilities, and broader orchestration scope."
+  - question: "What is the alternative to Broadcom Automic?"
+    answer: "Kestra offers a modern, declarative alternative to Broadcom Automic, unifying data, AI, and infrastructure workflows. Other strong alternatives include Redwood RunMyJobs and Stonebranch Universal Automation Center, which provide robust enterprise-grade solutions with different operational models and feature sets."
+  - question: "Is AutoSys a scheduling tool?"
+    answer: "Yes, AutoSys is an enterprise-level workload scheduling software designed to automate complex IT processes across various platforms. It functions as a batch job scheduling tool, providing a more streamlined approach to managing scheduled tasks compared to manual methods or older legacy schedulers."
+  - question: "Can Kestra replace Broadcom Dollar Universe?"
+    answer: "Kestra can serve as a modern replacement for Broadcom Dollar Universe, especially for organizations seeking a declarative, open-source, and polyglot orchestration platform. Kestra unifies data, AI, and infrastructure workflows, offering a flexible and cloud-native approach to automation that can coordinate existing tools and scripts, reducing operational complexity."
+---
+The landscape of enterprise workload automation is shifting, driven by the need for greater agility, cloud-native capabilities, and a unified approach to orchestrating diverse workflows. For many organizations, legacy platforms like Broadcom Dollar Universe, a cornerstone for batch job scheduling and IT process automation, have served their purpose. However, the complexities of managing these systems, coupled with evolving business demands and Broadcom's broader portfolio changes, are prompting a re-evaluation. Data and platform engineers are increasingly seeking alternatives that offer declarative definitions, multi-cloud flexibility, and seamless integration across data, AI, and infrastructure.
+
+This article explores the top alternatives to Broadcom Dollar Universe in 2026, including Kestra, Redwood RunMyJobs, Stonebranch Universal Automation Center, ActiveBatch, BMC Control-M, JAMS Scheduler, and JS7 JobScheduler. We’ll delve into why organizations are looking to move beyond traditional workload automation, the key factors to consider when choosing a new platform, and how each alternative addresses modern enterprise needs. Whether you're grappling with operational overhead, vendor lock-in, or the limitations of a domain-specific orchestrator, understanding these alternatives is crucial for future-proofing your automation strategy.
+
+## Why look for an alternative to Broadcom Dollar Universe?
+
+The search for alternatives to Dollar Universe is often driven by a combination of strategic, financial, and technical factors, many of which stem from Broadcom's acquisition of CA Technologies in 2018.
+
+*   **Broadcom's Post-Acquisition Strategy:** Following the acquisition, Broadcom implemented a strategy focused on its largest enterprise accounts. This often resulted in reduced support and account attention for smaller customers, a pattern repeated with the VMware acquisition. This shift has left many organizations feeling underserved and re-evaluating their long-term vendor relationship.
+*   **Complex Licensing and High TCO:** Many legacy workload automation tools, including those in the Broadcom portfolio, are known for their high Total Cost of Ownership (TCO). This includes complex licensing models, significant maintenance fees, and the cost of specialized talent required to operate the platform. Post-acquisition price increases and licensing restructuring have further intensified these concerns.
+*   **Limited Modernization and Innovation:** As a legacy CA product, Dollar Universe is often perceived as being outside the strategic spotlight compared to other products in the Broadcom portfolio like Automic or AutoSys. This can lead to slower innovation, particularly regarding cloud-native features and modern development practices.
+*   **Operational Complexity:** Dollar Universe and similar legacy platforms often have a steep learning curve, requiring specialized knowledge that is becoming rarer in the talent market. This complexity makes it difficult to onboard new engineers and democratize automation across teams.
+*   **Lack of Declarative, GitOps-Friendly Workflows:** Modern platform and data teams are standardizing on Infrastructure as Code (IaC) and GitOps principles. Legacy schedulers often rely on proprietary GUIs and databases for workflow definitions, making them difficult to version, review, and manage alongside other code-based assets.
+*   **Vendor Lock-In:** Relying on a single vendor's ecosystem for critical automation can create significant lock-in, reducing flexibility and making it harder to adopt best-of-breed tools from other providers. Modern alternatives often prioritize interoperability and an open architecture. For a deeper look at the [legacy scheduler landscape](https://kestra.io/blogs/2023-10-17-schedulers-landscape), see our analysis of DollarU, Control-M, and modern solutions.
+
+## How we evaluated these alternatives
+
+To provide a balanced comparison, we evaluated each alternative based on a core set of criteria relevant to modern engineering and IT operations teams. We considered the deployment model (cloud, hybrid, on-prem, Kubernetes), license type (open-source vs. proprietary), and primary use case fit. We also assessed each platform's integration ecosystem, polyglot support, operational overhead, and overall developer experience. Finally, we looked at pricing transparency and the ability to scale efficiently as workloads grow. For more on [why Kestra's architecture was chosen](https://kestra.io/docs/why-kestra), you can explore our design philosophy.
+
+## Top Broadcom Dollar Universe Alternatives
+
+### 1. Kestra: The Declarative Control Plane for All Workflows
+
+Kestra is an open-source, declarative orchestration platform that unifies data, AI, infrastructure, and business workflows. It uses a simple YAML interface to define even the most complex workflows, making them easy to version, review, and manage with GitOps principles. With a language-agnostic architecture, Kestra can run any code, script, or container, acting as a central control plane that coordinates existing tools rather than forcing a replacement.
+
+*   **Strengths:** Its event-driven architecture is ideal for real-time processing, and its highly scalable design supports everything from simple cron jobs to millions of parallel executions. With over 1,200 plugins, Kestra offers extensive connectivity across the tech stack.
+*   **Proof point:** Enterprises like Crédit Agricole use Kestra to consolidate fragmented infrastructure scripts into a single, auditable platform, while Apple leverages it for large-scale AI/ML data pipelines.
+*   **Best for:** Organizations seeking a modern, vendor-neutral control plane to manage complex, cross-domain workflows with a strong focus on developer experience and GitOps.
+*   **Honest limitation:** Kestra requires a shift to a declarative, YAML-first mindset. This can be a change for teams deeply ingrained in GUI-driven or code-heavy imperative systems, but it unlocks significant operational benefits in the long run.
+*   Explore Kestra for [infrastructure automation](https://kestra.io/infra-automation) and browse hundreds of [workflow blueprints](https://kestra.io/blueprints) to get started.
+
+### 2. Redwood RunMyJobs: Enterprise-Grade SaaS Workload Automation
+
+Redwood RunMyJobs is a cloud-native, SaaS workload automation platform that focuses on business process orchestration. It provides deep integration capabilities with a wide range of enterprise applications like SAP, Oracle, and Salesforce.
+
+*   **Best for:** Enterprises looking for a fully managed, robust WLA solution with extensive application integration, especially those migrating from legacy on-prem schedulers to a SaaS model.
+*   **Distinctive feature:** Its strong emphasis on business process automation and a large library of pre-built connectors for ERP, CRM, and major cloud services make it a powerful tool for end-to-end business workflow orchestration.
+*   **Honest limitation:** As a primarily SaaS offering, it may not be suitable for organizations with strict air-gapped or hybrid cloud requirements. Its paradigm is still rooted in traditional job scheduling, which may differ from the needs of modern, code-centric platform teams. See a detailed comparison in [Kestra vs. Redwood RunMyJobs](https://kestra.io/vs/redwood).
+
+### 3. Stonebranch Universal Automation Center: Hybrid IT Orchestration
+
+Stonebranch provides a universal automation and orchestration platform designed for hybrid IT environments. It excels at bridging the gap between traditional on-prem systems, mainframes, and modern cloud and container technologies.
+
+*   **Best for:** Large enterprises with complex hybrid IT landscapes that need to orchestrate workloads across mainframes, distributed servers, and multiple cloud providers from a single point of control.
+*   **Distinctive feature:** Its agent-based architecture allows for comprehensive reach across heterogeneous environments. It also offers strong real-time scheduling and event-driven capabilities, enabling dynamic and responsive automation.
+*   **Honest limitation:** The platform can have a significant operational footprint. Its reliance on agents for connectivity, while powerful, is a model some modern cloud-native teams prefer to avoid in favor of agentless, API-driven orchestration. Learn more about the differences in [Kestra vs. Stonebranch](https://kestra.io/vs/stonebranch).
+
+### 4. ActiveBatch: Comprehensive Workload Automation for Heterogeneous Environments
+
+ActiveBatch is a workload automation and job scheduling solution designed to integrate and automate processes across a wide range of disparate systems and applications. It offers a rich, visual workflow designer and extensive event-driven capabilities.
+
+*   **Best for:** Organizations needing to automate workflows across a highly diverse IT environment that includes legacy systems, Windows, Linux, and various cloud services.
+*   **Distinctive feature:** Its "Jobs Library" provides a vast collection of pre-built integrations and actions, reducing the need for custom scripting. The platform's event-driven architecture supports complex scheduling based on triggers like file events, emails, or API calls.
+*   **Honest limitation:** The platform can be resource-intensive to implement and manage. Its visual, low-code approach may not appeal to code-first engineering teams who prefer declarative, text-based workflow definitions that can be managed in Git.
+
+### 5. BMC Control-M: Legacy Leader with Modernization Efforts
+
+Control-M is a long-standing leader in enterprise workload automation, providing centralized scheduling, monitoring, and management for batch jobs. It is known for its robustness and reliability in mission-critical environments.
+
+*   **Best for:** Large enterprises with existing investments in the BMC ecosystem or those requiring a highly mature, proven WLA platform with extensive governance and SLA management capabilities.
+*   **Distinctive feature:** Control-M offers deep operational maturity, strong auditability, and robust SLA management. In recent years, BMC has made significant efforts to integrate it with modern cloud and DevOps toolchains.
+*   **Honest limitation:** It is often perceived as complex and costly to operate. While modernizing, its core architecture is rooted in a traditional batch processing paradigm, which can feel heavy compared to more lightweight, cloud-native orchestrators. For a direct comparison, see [Kestra vs. Control-M](https://kestra.io/vs/control-m).
+
+### 6. JAMS Scheduler: Windows-Centric Automation
+
+JAMS Scheduler is a powerful job scheduling and workload automation solution with a strong focus on the Microsoft ecosystem. It offers robust capabilities for automating tasks and managing complex workflows primarily within Windows environments.
+
+*   **Best for:** Organizations heavily invested in Microsoft technologies like Windows Server, SQL Server, and PowerShell. It provides comprehensive job scheduling and automation for Windows-based applications and infrastructure.
+*   **Distinctive feature:** Its tight integration with Windows services, PowerShell, and .NET applications provides granular control over job execution and dependencies within that ecosystem, making it a natural choice for Windows-centric IT shops.
+*   **Honest limitation:** Its primary focus on Windows environments limits its flexibility for polyglot or multi-cloud strategies that involve Linux, Kubernetes, or other non-Microsoft platforms.
+
+### 7. JS7 JobScheduler: Open-Source Cross-Platform Scheduling
+
+JS7 JobScheduler is an open-source workload automation platform from SOS GmbH, offering cross-platform scheduling with both community and commercial editions. It is the successor to the long-running JobScheduler project.
+
+*   **Best for:** Organizations seeking a proven open-source WLA solution with a more traditional, GUI-driven approach to job scheduling and complex dependency management across heterogeneous environments.
+*   **Distinctive feature:** It has a strong cross-platform agent footprint, covering Windows, Linux, and even mainframe-adjacent systems. Its free-to-use community edition makes it an accessible option for teams wanting to move away from proprietary licensing.
+*   **Honest limitation:** The platform is less developer-centric and declarative compared to Kestra. Its GUI-first workflow modeling can feel dated for modern engineering teams that have adopted [GitOps](https://kestra.io/resources/infrastructure/gitops) and YAML-as-code patterns for managing their workflows.
+
+## Comparison of Dollar Universe Alternatives
+
+| Tool | License | Deployment Model | Best for | Language/Definition | Cloud-Native Focus | Starting Price/Model |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **Kestra** | Open-Source (Apache 2.0) & Enterprise | Hybrid, Cloud, On-Prem, K8s | Unified, cross-domain orchestration (Data, AI, Infra) | YAML (Declarative) | High | Free OSS, Enterprise subscription |
+| **Redwood RunMyJobs** | Proprietary | SaaS | Enterprise business process automation | GUI, API | High (SaaS-native) | Subscription |
+| **Stonebranch UAC** | Proprietary | Hybrid, On-Prem, Cloud | Hybrid IT & mainframe orchestration | GUI, API | Medium (Agent-based) | Subscription |
+| **ActiveBatch** | Proprietary | On-Prem, Cloud | Heterogeneous IT environments | GUI (Visual) | Medium | Subscription |
+| **BMC Control-M** | Proprietary | On-Prem, Hybrid | Large-scale enterprise batch processing | GUI, JSON | Low-Medium | Subscription |
+| **JAMS Scheduler** | Proprietary | On-Prem | Windows-centric automation | GUI, PowerShell | Low | Subscription |
+| **JS7 JobScheduler** | Open-Source (GPLv3) & Commercial | On-Prem, Hybrid | Traditional open-source WLA | GUI, XML | Low | Free OSS, Commercial support |
+
+For a broader look at the landscape, explore our [Kestra vs. Alternatives](https://kestra.io/vs) hub.
+
+## How to choose the right alternative
+
+Selecting the right replacement for Dollar Universe depends on your team's primary focus and strategic goals.
+
+### For platform and IT operations teams
+
+If your goal is to establish a unified, declarative control plane for all infrastructure and IT workflows, **Kestra** is the ideal choice. Its GitOps-native approach and language-agnostic capabilities allow you to orchestrate everything from Terraform and Ansible to custom scripts and containerized services. For teams with deep roots in hybrid IT and mainframe environments, **Stonebranch** offers a powerful agent-based solution to bridge the old and the new. Explore more in our [Infrastructure Automation Resources](https://kestra.io/resources/infrastructure).
+
+### For data engineering teams
+
+If your focus is on building, scheduling, and monitoring complex data pipelines, **Kestra** provides a flexible, polyglot platform. Its ability to natively handle Python, SQL, dbt, and event-driven triggers makes it a strong foundation for a modern data stack. It allows you to orchestrate ingestion, transformation, and delivery workflows in a single, observable platform. Learn more about modern [data orchestration](https://kestra.io/resources/data/data-orchestration) and how Kestra can help build a [declarative data platform](https://kestra.io/data).
+
+### For small to mid-sized teams
+
+For smaller teams or those just beginning their automation journey, the accessibility of an open-source solution is often key. **Kestra's** open-source edition provides the full power of the orchestration engine, allowing you to start small and scale without initial licensing costs. Its Docker-based setup makes it easy to [get started](https://kestra.io/get-started) quickly. If your environment is heavily Windows-centric, **JAMS** offers a focused and powerful solution for that specific ecosystem.
+
+## Conclusion
+
+Moving away from a legacy platform like Broadcom Dollar Universe is an opportunity to modernize your entire automation strategy. The shift from traditional, imperative job schedulers to modern, declarative orchestration platforms enables greater agility, better governance, and a more unified approach to managing workflows across your organization.
+
+The best alternative depends entirely on your specific needs. For enterprises seeking a managed SaaS solution for business processes, Redwood RunMyJobs is a strong contender. For complex hybrid IT environments, Stonebranch provides extensive connectivity. However, for organizations looking to build a future-proof, vendor-neutral control plane that empowers developers and unifies data, AI, and infrastructure workflows, Kestra offers a compelling path forward.
+
+Explore Kestra to experience modern, declarative orchestration that unifies your entire workflow landscape. You can [book a demo](https://kestra.io/demo) with our team or explore the [Kestra Cloud](https://kestra.io/cloud) early adopter program.

--- a/src/contents/resources/ibm-workload-automation-alternatives/index.md
+++ b/src/contents/resources/ibm-workload-automation-alternatives/index.md
@@ -1,0 +1,135 @@
+---
+title: "Top IBM Workload Automation Alternatives for 2026"
+description: "Explore the best IBM Workload Automation alternatives for enterprises in 2026. Discover top competitors and compare features to optimize your workflows."
+metaTitle: "IBM Workload Automation Alternatives (2026) | Kestra"
+metaDescription: "Looking for IBM Workload Automation alternatives in 2026? Compare top competitors like Kestra, Control-M, and Redwood, and find the best solution for modern enterprise orchestration."
+tag: infrastructure
+date: 2026-05-09
+faq:
+  - question: "What is IBM Workload Automation?"
+    answer: "IBM Workload Automation (formerly IBM Tivoli Workload Scheduler) is a comprehensive solution designed for batch and real-time workload management. It provides centralized control and visibility over enterprise-wide IT and business processes, traditionally focused on scheduled, high-volume operations across diverse systems."
+  - question: "What is the new name of Tivoli Workload Scheduler?"
+    answer: "IBM Tivoli Workload Scheduler (TWS) was officially renamed IBM Workload Scheduler, and it is now part of the broader IBM Workload Automation suite. This rebranding reflects IBM's strategy to integrate its scheduling capabilities within a more comprehensive hybrid cloud and advanced automation offering."
+  - question: "Who are the main competitors to IBM Workload Automation?"
+    answer: "Key competitors to IBM Workload Automation in the enterprise space include legacy solutions like Control-M, Redwood RunMyJobs, ActiveBatch, and Stonebranch. Modern, developer-centric alternatives like Kestra and open-source options such as Apache Airflow also offer compelling choices, especially for cloud-native and event-driven workloads."
+  - question: "Can Kestra replace IBM Workload Automation?"
+    answer: "Kestra offers a modern, declarative alternative to IBM Workload Automation, especially for cloud-native, event-driven, and polyglot environments. While Kestra doesn't directly replace mainframe-specific legacy integrations, it excels at orchestrating hybrid workflows that integrate existing systems, APIs, and modern cloud services, providing a clear path for modernization."
+  - question: "What is the best free alternative to IBM Workload Automation?"
+    answer: "For teams seeking a free alternative to IBM Workload Automation, open-source options like Apache Airflow (for data workflows) and Kestra (for universal orchestration across data, AI, and infrastructure) are strong contenders. Kestra's open-source edition provides a full-featured engine with extensive plugin support, suitable for production use without licensing costs."
+  - question: "Is IBM Workload Automation still worth using in 2026?"
+    answer: "IBM Workload Automation remains a deeply entrenched solution for many large enterprises, particularly those with significant mainframe investments. However, its traditional architecture and cost model can be a barrier for organizations prioritizing cloud-native, developer-centric, and real-time event-driven automation in 2026. Its value depends on existing infrastructure and modernization strategy."
+---
+
+IBM Workload Automation (IBM WLA) has long been a staple in enterprise IT, managing mission-critical batch and real-time operations across diverse systems. Yet, as organizations shift towards hybrid cloud, event-driven architectures, and AI-powered workflows, the limitations of legacy workload automation platforms become increasingly apparent. Recent market signals, including shifts in the broader enterprise IT landscape, underscore the need for more agile, developer-friendly, and cost-effective orchestration solutions.
+
+This article explores the top IBM Workload Automation alternatives for 2026, offering a clear decision framework for engineering and operations teams. We'll delve into solutions that address the challenges of managing complex, cross-domain workflows, from cloud-native to traditional environments, to help you choose the right orchestrator for your modernization journey.
+
+## Understanding IBM Workload Automation and the Drive for Alternatives
+
+### What is IBM Workload Automation?
+IBM Workload Automation, a platform with roots in the mainframe era, is an enterprise-grade solution designed for managing, automating, and monitoring complex workloads. It provides centralized control over batch and real-time processes across various platforms, from mainframes to distributed and cloud environments. Its core strength lies in reliable, high-volume job scheduling and dependency management, making it a system of record for critical business operations in many large organizations.
+
+### Why Consider Alternatives to IBM Workload Automation?
+Despite its robustness, many organizations are seeking alternatives to IBM WLA due to several modern challenges:
+
+*   **Cost of Ownership:** Licensing, maintenance, and the need for specialized skills can lead to a high total cost of ownership.
+*   **Operational Complexity:** The platform's architecture, while powerful, can be complex to manage and scale in hybrid environments.
+*   **Legacy Developer Experience:** Modern engineering teams expect declarative configurations (like YAML), GitOps workflows, and polyglot support, which are not native to traditional WLA tools.
+*   **Limited Scope for Modern Use Cases:** While IBM has added cloud and container support, the platform's core design is less suited for event-driven, real-time, and AI-native workflows compared to modern alternatives.
+*   **Market Pressure:** The industry is moving towards more agile, open, and integrated platforms. Legacy, monolithic solutions face increasing pressure from cloud-native tools that offer greater flexibility and faster innovation cycles.
+
+### What is the new name of Tivoli Workload Scheduler?
+IBM Tivoli Workload Scheduler (TWS) was officially renamed IBM Workload Scheduler. It is now a key component of the broader IBM Workload Automation suite. This change reflects IBM's strategic shift to position its scheduling capabilities within a more comprehensive offering that addresses hybrid cloud and advanced automation.
+
+## How We Evaluated Top Workload Automation Alternatives
+We evaluated each alternative based on a set of criteria critical for modern enterprise orchestration. Our assessment focused on:
+
+*   **Deployment Model:** Whether the solution is SaaS, self-hosted, or hybrid.
+*   **License:** Open-source, commercial, or a combination.
+*   **Primary Use Case:** The domain where the tool excels, such as data, infrastructure, or general-purpose automation.
+*   **Developer Experience:** Support for modern practices like declarative configuration, GitOps, and multi-language scripting.
+*   **Integration Ecosystem:** The breadth and depth of available plugins and connectors.
+*   **Modernization Alignment:** How well the platform supports event-driven architectures, AI workflows, and hybrid cloud operations.
+
+## Top IBM Workload Automation Alternatives and Competitors
+
+### 1. Kestra: The Universal Orchestration Control Plane
+Kestra is an open-source, declarative orchestration platform designed to unify data, AI, infrastructure, and business workflows under a single control plane. Workflows are defined in simple YAML, making them easy to write, review, and manage with GitOps practices. Its language-agnostic architecture allows teams to run scripts in Python, Java, shell, and more, all within the same workflow.
+
+Kestra is event-driven by default, enabling it to react to real-time events from systems like Kafka, S3, or webhooks. This makes it a strong fit for modernizing legacy batch processes into more dynamic, responsive workflows. For example, financial services giant Crédit Agricole replaced fragmented infrastructure scripts and cron jobs with Kestra to create a unified, auditable orchestration layer.
+
+**Best for:** Engineering-led teams seeking a modern, declarative, and polyglot orchestration platform to manage workflows across data, AI, and [infrastructure automation]( /infra-automation). Explore available [blueprints]( /blueprints) or dive into the [documentation]( /docs/why-kestra) to learn more.
+
+### 2. Redwood RunMyJobs: SaaS Workload Automation for the Enterprise
+Redwood RunMyJobs is a fully SaaS-based workload automation platform that offers a modern alternative to traditional on-premise solutions. Its key strengths are its managed service model, which eliminates infrastructure overhead, and its extensive library of connectors, with deep integrations for SAP and other ERP systems.
+
+The trade-off for its SaaS convenience is a degree of vendor lock-in and potentially less flexibility for highly customized or code-heavy workflows. Pricing is also less transparent compared to open-source solutions.
+
+**Best for:** Enterprises prioritizing a managed SaaS WLA solution with strong, out-of-the-box ERP integration. For a detailed comparison, see [Kestra vs. Redwood]( /vs/redwood).
+
+### 3. Control-M by Broadcom: The Incumbent for Enterprise Workload Orchestration
+Control-M has been a direct competitor to IBM WLA for decades and is a mature, robust platform for enterprise-scale batch processing. It excels at managing complex job dependencies and enforcing SLAs across a wide range of legacy and modern systems. Its deep entrenchment in large enterprises makes it a common choice for organizations with significant mainframe and on-premise infrastructure.
+
+However, Control-M comes with a high price tag, significant deployment complexity, and a developer experience that can feel dated compared to cloud-native tools.
+
+**Best for:** Large enterprises with deeply embedded legacy systems and strict SLA requirements who are not yet prioritizing cloud-native agility. Learn more about how [Kestra compares to Control-M]( /vs/control-m).
+
+### 4. ActiveBatch Workload Automation: Hybrid IT Automation
+ActiveBatch is a comprehensive workload automation and job scheduling tool known for its cross-platform support and focus on hybrid IT environments. It offers a rich set of features for building and managing workflows without extensive scripting, including a graphical workflow designer and hundreds of pre-built integrations.
+
+While powerful, ActiveBatch is a proprietary solution, which can limit customization and community support. Its feature-rich environment can also introduce a steeper learning curve for teams accustomed to simpler, code-first tools.
+
+**Best for:** Organizations needing a feature-rich hybrid IT automation platform with a strong focus on job scheduling across diverse on-premise and cloud environments.
+
+### 5. Stonebranch Universal Automation Center (UAC): Modernizing Enterprise Workload Automation
+Stonebranch positions itself as a modern alternative for enterprise workload automation, with a strong emphasis on event-driven automation and real-time hybrid IT orchestration. UAC is designed to bridge the gap between legacy systems and modern cloud, container, and DevOps environments. It provides a centralized platform for managing workflows across the entire enterprise.
+
+As an enterprise-focused solution, it can come with a higher cost and a more complex setup than tools designed for smaller, more agile teams.
+
+**Best for:** Large enterprises looking to modernize their workload automation with event-driven capabilities and robust hybrid cloud support. Read our [Kestra vs. Stonebranch comparison]( /vs/stonebranch) for more details.
+
+### 6. Apache Airflow: The Open-Source Data Orchestrator
+Apache Airflow is the dominant open-source tool for [data orchestration]( /resources/data/data-orchestration). Its workflows (DAGs) are defined in Python, giving data engineers immense flexibility. It boasts a massive community and an extensive ecosystem of operators for integrating with various data sources and tools.
+
+However, Airflow's strengths are also its limitations in this context. It is primarily data-focused and less suited for universal infrastructure or business process orchestration. Its Python-only, code-first approach can be a barrier for non-Python teams, and its operational complexity requires significant infrastructure management effort.
+
+**Best for:** Python-heavy data engineering teams comfortable with defining DAGs as code and managing their own orchestration infrastructure. For a deeper dive, check out [Kestra vs. Airflow]( /vs/airflow).
+
+## Comparison Table: IBM Workload Automation Alternatives
+
+| Tool | License | Deployment | Best for | Key Differentiators | Developer Experience | Event-Driven | AI Integrations |
+|---|---|---|---|---|---|---|---|
+| **Kestra** | Open-Source (Apache 2.0) & Enterprise | Self-hosted, Cloud | Universal Orchestration | Declarative YAML, Language-Agnostic, Unified Platform | High (YAML, GitOps, API) | Native | Yes |
+| **Redwood** | Commercial | SaaS | ERP & SaaS Automation | Fully Managed SaaS, Deep SAP Integration | Medium (GUI-focused) | Yes | Limited |
+| **Control-M** | Commercial | Self-hosted, SaaS | Legacy Enterprise Batch | Mainframe Support, SLA Management | Low (Proprietary GUI) | Limited | Limited |
+| **ActiveBatch** | Commercial | Self-hosted | Hybrid Job Scheduling | Graphical Designer, Broad Platform Support | Medium (GUI-focused) | Yes | Yes |
+| **Stonebranch** | Commercial | Self-hosted, SaaS | Hybrid IT Modernization | Event-Driven Focus, Cloud Integration | Medium | Native | Yes |
+| **Airflow** | Open-Source (Apache 2.0) | Self-hosted | Data Pipelines | Python-native DAGs, Large Community | High (Python-code) | Limited | Via plugins |
+
+## Choosing the Best Workload Automation Software for Your Needs
+
+### For Data Engineering Teams
+Teams focused on data pipelines need strong integration with the modern data stack, robust dependency management, and support for transformations.
+*   **Recommendations:** **Kestra** for its ability to orchestrate polyglot data workflows alongside other systems, and **Apache Airflow** for Python-centric data teams.
+*   **Resources:** Explore [data engineering resources]( /resources/data) and how to build a [declarative data platform]( /data).
+
+### For Infrastructure & DevOps Teams
+These teams prioritize Infrastructure as Code (IaC), GitOps workflows, and the ability to automate across hybrid cloud and on-premise environments.
+*   **Recommendations:** **Kestra** provides a declarative control plane that integrates seamlessly with tools like Terraform and Ansible. **Stonebranch** and **Redwood** also offer strong hybrid capabilities.
+*   **Resources:** See our [infrastructure automation resources]( /resources/infrastructure) and learn more about Kestra for [infra-automation]( /infra-automation).
+
+### For AI & ML Platform Teams
+AI and ML workflows require orchestrating heterogeneous tasks, ensuring reproducibility, and enabling agentic workflows. A language-agnostic platform is crucial.
+*   **Recommendations:** **Kestra** is uniquely suited for this with its native AI integrations, polyglot support, and ability to manage complex, multi-step AI pipelines.
+*   **Resources:** Browse [AI orchestration resources]( /resources/ai) and see how Kestra enables [AI automation]( /ai-automation).
+
+### For Large Enterprises Modernizing from Legacy Systems
+Modernization is often a gradual process. The ideal solution should be able to orchestrate existing legacy systems while providing a clear path to cloud-native and event-driven architectures.
+*   **Recommendations:** **Kestra** can act as a strategic control plane, orchestrating legacy jobs while new, declarative workflows are built. **Redwood** and **Stonebranch** also offer strong modernization paths with their hybrid capabilities.
+
+## Conclusion: Modernizing Your Orchestration Strategy in 2026
+The shift away from traditional workload automation tools like IBM WLA is driven by the need for greater agility, developer productivity, and support for modern architectures. While incumbents like Control-M and Redwood offer established solutions, a new generation of declarative, event-driven platforms provides a more flexible and future-proof path.
+
+Kestra stands out as a universal control plane that bridges the gap between legacy and modern systems. Its declarative YAML interface, language-agnostic execution, and unified approach across data, AI, and infrastructure make it a powerful choice for any enterprise looking to build a resilient and scalable orchestration strategy for 2026 and beyond.
+
+Ready to see how a modern orchestrator can transform your workflows? [Book a demo]( /demo) to explore Kestra's capabilities.

--- a/src/contents/resources/morpheus-alternatives/index.md
+++ b/src/contents/resources/morpheus-alternatives/index.md
@@ -1,0 +1,104 @@
+---
+title: "Top Morpheus Alternatives for Enterprises in 2026"
+description: "Discover the best Morpheus alternatives for enterprise software. Compare features, pricing, and user reviews to find your ideal solution today!"
+metaTitle: "Top Morpheus Alternatives for Enterprise Software"
+metaDescription: "Explore leading HPE Morpheus alternatives for enterprises. Compare features, pricing, and deployment options to find the best cloud orchestration solution for your needs."
+tag: infrastructure
+date: 2026-05-21
+faq:
+  - question: "What is the best alternative to HPE Morpheus Enterprise Software?"
+    answer: "The best alternative depends on your primary use case. For multi-cloud governance and FinOps, Flexera Cloud Management Platform and IBM Cloudability lead the market. For workflow orchestration across data, infrastructure, and AI, Kestra is the modern open-source choice. For VMware-centric environments, VMware Aria Automation remains the most integrated option, while Platform9 Private Cloud Director offers a drop-in replacement path away from VMware."
+  - question: "Is Morpheus still a strong choice after the HPE acquisition?"
+    answer: "HPE Morpheus remains capable for hybrid cloud management, but the product split between HPE Morpheus Enterprise Software (full CMP, ~$2,500-$4,400 per socket / year) and HPE Morpheus VM Essentials (KVM-focused control plane, ~$600-$740 per socket / year) has created confusion. The per-socket licensing model also pushes some teams toward open-source or per-user alternatives."
+  - question: "What's the difference between Morpheus and orchestration platforms like Kestra?"
+    answer: "Morpheus is a hybrid cloud management platform focused on provisioning, CMDB, and cost governance. Kestra is a workflow orchestration engine that runs declarative YAML workflows across data, infrastructure, and AI tasks. They solve different problems: Morpheus answers 'how do I govern my infrastructure?', Kestra answers 'how do I orchestrate workflows across teams and systems?'. Some teams replace Morpheus with Kestra when their real need is cross-team orchestration rather than a provisioning portal."
+  - question: "What are some open-source alternatives to HPE Morpheus?"
+    answer: "For open-source alternatives, Kestra offers a declarative, language-agnostic orchestration platform that can manage infrastructure, data, and AI workflows. SUSE Rancher provides robust open-source Kubernetes cluster management. These options offer flexibility and cost control compared to proprietary solutions."
+  - question: "How does the HPE acquisition impact Morpheus Data users?"
+    answer: "The HPE acquisition of Morpheus Data in 2024 led to a product restructuring, with a focus on HPE Morpheus VM Essentials for KVM environments and broader enterprise software. This shift, coupled with per-socket licensing, has prompted many existing users to re-evaluate their cloud management and orchestration strategies."
+---
+
+The landscape of enterprise cloud management is in constant flux, and the recent acquisition of Morpheus Data by HPE in 2024 has introduced new considerations for IT and platform teams. Coupled with the ongoing ripple effects of Broadcom's acquisition of VMware and its subsequent licensing changes, many organizations are re-evaluating their infrastructure automation strategies. This article will help you navigate the top alternatives to HPE Morpheus Enterprise Software, offering a comprehensive comparison to find the ideal solution for your specific needs in 2026. From multi-cloud governance to universal workflow orchestration, we’ll explore how different tools address the evolving challenges of enterprise IT.
+
+## Quick disambiguation — HPE Morpheus software vs Morpheus8 treatment
+
+This article focuses exclusively on HPE Morpheus, an enterprise software platform for hybrid cloud management and orchestration. We will not be covering Morpheus8, which is a cosmetic microneedling treatment. All comparisons and alternatives discussed here relate to the IT and infrastructure software domain.
+
+## Why teams are looking for HPE Morpheus alternatives
+
+Several market shifts have prompted enterprises to explore alternatives to HPE Morpheus. These factors create a compelling reason to re-evaluate whether Morpheus is still the right fit for your organization.
+
+*   **The HPE Acquisition and Product Shift:** Since being acquired by HPE in 2024, the Morpheus product line has been restructured. This has led to a two-tiered offering that can be confusing for new and existing customers trying to align features with their needs.
+*   **Per-Socket Licensing Model:** HPE Morpheus employs a per-socket licensing model, which can be costly and difficult to predict. The **HPE Morpheus VM Essentials** tier, focused on VMware vSphere and KVM, is priced around **$600 to $740 per socket per year**. The full **HPE Morpheus Enterprise** platform, which includes multi-cloud orchestration and FinOps, ranges from **$2,500 to $4,400 per socket per year**, often with additional workload quotas. For larger deployments, an enterprise pack on the AWS Marketplace can cost nearly $200,000 per year.
+*   **The VMware/Broadcom Ripple Effect:** Broadcom's acquisition of VMware has caused widespread uncertainty in the virtualization market, pushing many companies to seek more vendor-neutral and flexible solutions. This has intensified the search for alternatives that are not tightly coupled to a single hypervisor ecosystem. For more on this, see our analysis of [VMware Cloud Foundation alternatives](/vs/vmware-cloud-foundation).
+
+## Top 7 Morpheus alternatives for enterprise software
+
+Navigating the landscape of [infrastructure automation resources](/resources/infrastructure) can be challenging. To simplify your evaluation, we’ve compiled a list of the top Morpheus competitors, each with its own strengths and ideal use cases. You can also [compare Kestra against other orchestration tools](/vs) for a broader view.
+
+### Comparison Table
+
+| Alternative | Best for | Pricing model | Deployment |
+|---|---|---|---|
+| **Kestra** | Universal workflow orchestration (data, infra, AI, business) | Open-source + Enterprise tier | Self-hosted / Cloud |
+| **VMware Aria Automation** | Multi-cloud automation in VMware shops | Per-CPU subscription | Self-hosted / SaaS |
+| **Flexera Cloud Management Platform** | FinOps and cost governance | Per-managed-resource | SaaS |
+| **IBM Terraform / Cloudability** | IaC + cost visibility | Per-user / consumption | SaaS |
+| **Cycloid** | Internal developer platform + FinOps | Per-user subscription | SaaS / Self-hosted |
+| **Platform9 Private Cloud Director** | VMware drop-in replacement | Per-socket | Self-hosted |
+| **SUSE Rancher** | Kubernetes cluster management | Subscription | Self-hosted / Cloud |
+
+### Kestra
+Kestra is a [universal orchestration platform](/docs/why-kestra) that unifies data, infrastructure, AI, and business workflows under a single, declarative control plane. Workflows are defined in language-agnostic YAML and can be triggered by events, schedules, or API calls. With over 1,400 [plugins](/plugins), Kestra can coordinate tools across your entire stack. It is best for teams that need to orchestrate complex, cross-domain workflows rather than just provision infrastructure. While it's a powerful orchestration engine, it is not a full-featured Cloud Management Platform (CMP) with a built-in CMDB.
+
+### VMware Aria Automation
+For organizations heavily invested in the VMware ecosystem, Aria Automation (formerly vRealize Automation) is a natural choice. It offers deep integration with vSphere and other VMware products, providing robust multi-cloud automation capabilities. However, its primary drawback is the potential for vendor lock-in and exposure to licensing changes following the Broadcom acquisition. It is best for enterprises committed to the [VMware stack](/vs/vmware-cloud-foundation).
+
+### Flexera Cloud Management Platform
+Flexera is a pure-play FinOps solution that excels at cloud cost governance and optimization. While narrower in scope than Morpheus, it provides deeper capabilities for managing cloud spend, ensuring compliance, and optimizing resource utilization. It is best for organizations where cost management and financial governance are the top priorities for their cloud operations.
+
+### IBM Terraform / Cloudability
+This combination from IBM pairs the power of Infrastructure as Code (IaC) with comprehensive cost visibility. Using Terraform for provisioning and Cloudability for financial tracking, this solution is well-suited for multi-cloud environments. It is best for teams that have standardized on Terraform for IaC and require strong cloud cost management and reporting capabilities.
+
+### Cycloid
+Cycloid positions itself as an Internal Developer Platform (IDP) with integrated FinOps. It is a direct competitor to Morpheus, focusing on streamlining developer workflows, providing self-service capabilities, and maintaining control over cloud costs. It is best for organizations looking to build an IDP that combines automation, developer experience, and financial governance.
+
+### Platform9 Private Cloud Director
+Platform9 offers a drop-in replacement for VMware, making it an attractive option for companies looking to move away from the VMware ecosystem without a complete infrastructure redesign. It focuses on simplifying private cloud management and is a strong contender for direct VMware replacement scenarios. It is best for organizations seeking a straightforward migration path from VMware for their private cloud infrastructure.
+
+### SUSE Rancher
+SUSE Rancher is a leading open-source platform for Kubernetes cluster management. If your primary need is to manage, scale, and secure Kubernetes clusters across multiple environments, Rancher is a powerful and focused solution. It is less of a general-purpose CMP and more of a specialized tool for the Kubernetes ecosystem. It is best for Kubernetes-first organizations that require robust cluster lifecycle management.
+
+## How to choose the right Morpheus alternative
+
+Selecting the right platform requires a clear understanding of your organization's needs. Follow these steps to guide your decision-making process:
+
+1.  **Identify your primary job-to-be-done:** Are you focused on VM provisioning, universal [infrastructure orchestration](/infra-automation), FinOps, or Kubernetes management? Your main goal will narrow the field. For example, if you need to coordinate [data pipelines](/data) and [AI workflows](/ai-automation) alongside infrastructure, a tool like Kestra is a better fit than a pure-play FinOps platform.
+2.  **Evaluate the licensing model:** Compare the costs and predictability of per-socket, per-user, and open-source models. Per-socket licensing can become expensive with high-density servers, while open-source solutions offer greater flexibility and cost control.
+3.  **Check for brownfield and hybrid support:** Ensure the platform can discover and manage your existing infrastructure (brownfield). If you operate in a hybrid or air-gapped environment, verify that the solution supports these deployment models.
+4.  **Test deployment friction:** Evaluate the ease of installation and setup. A solution that can be deployed with a simple Docker Compose file will have a much lower barrier to entry than one requiring a complex appliance installation.
+
+## Why Kestra is a modern alternative to Morpheus
+
+While both Kestra and Morpheus provide automation, they address different core problems. Understanding this distinction is key to choosing the right tool.
+
+Morpheus is a unified cloud management portal designed for provisioning, maintaining a CMDB, and governing costs. Its primary function is to provide a self-service catalog for infrastructure resources.
+
+Kestra, on the other hand, is a [universal orchestration engine](/docs/why-kestra). It uses declarative YAML to define and execute workflows that can span your entire technology stack. With [event-driven triggers](/docs/workflow-components/triggers) and a library of over 1,400 [plugins](/plugins), Kestra excels at coordinating complex processes. For example, a single Kestra flow can provision infrastructure with Terraform, run a dbt transformation, call a microservice API, and send a Slack notification upon completion.
+
+Teams often choose Kestra over Morpheus when their actual need is not a provisioning portal but a powerful, auditable system for cross-team orchestration. Kestra can orchestrate the tools you already use, including VMware and Ansible, as steps within a larger, more comprehensive workflow.
+
+To dive deeper into the technical differences, [see the full Kestra vs HPE Morpheus comparison](/vs/morpheus).
+
+## Frequently asked questions
+
+**What is the best alternative to HPE Morpheus Enterprise Software?**
+The best alternative depends on your primary use case. For multi-cloud governance and FinOps, Flexera Cloud Management Platform and IBM Cloudability lead the market. For workflow orchestration across data, infrastructure, and AI, Kestra is the modern open-source choice. For VMware-centric environments, VMware Aria Automation remains the most integrated option, while Platform9 Private Cloud Director offers a drop-in replacement path away from VMware.
+
+**Is Morpheus still a strong choice after the HPE acquisition?**
+HPE Morpheus remains capable for hybrid cloud management, but the product split between HPE Morpheus Enterprise Software (full CMP, ~$2,500-$4,400 per socket / year) and HPE Morpheus VM Essentials (KVM-focused control plane, ~$600-$740 per socket / year) has created confusion. The per-socket licensing model also pushes some teams toward open-source or per-user alternatives.
+
+**What's the difference between Morpheus and orchestration platforms like Kestra?**
+Morpheus is a hybrid cloud management platform focused on provisioning, CMDB, and cost governance. Kestra is a workflow orchestration engine that runs declarative YAML workflows across data, infrastructure, and AI tasks. They solve different problems: Morpheus answers "how do I govern my infrastructure?", Kestra answers "how do I orchestrate workflows across teams and systems?". Some teams replace Morpheus with Kestra when their real need is cross-team orchestration rather than a provisioning portal.
+
+For information on aesthetic treatments like Morpheus8, we recommend consulting a specialized medical or cosmetic resource, as that topic is outside the scope of this enterprise software comparison.

--- a/src/contents/resources/rundeck-alternatives/index.md
+++ b/src/contents/resources/rundeck-alternatives/index.md
@@ -1,0 +1,127 @@
+---
+title: "Rundeck Alternatives: Top Tools & Comparisons"
+description: "Explore top Rundeck alternatives and find the best fit for your automation needs. Compare features, pricing, and benefits today!"
+metaTitle: "Rundeck Alternatives: Top Tools & Comparisons"
+metaDescription: "Looking for Rundeck alternatives? Compare top open-source and commercial tools for runbook automation, IT operations, and universal workflow orchestration to find your ideal solution for 2026."
+tag: infrastructure
+date: 2026-05-20
+faq:
+  - question: "Is Rundeck owned by PagerDuty?"
+    answer: "PagerDuty acquired Rundeck in October 2020, integrating its runbook automation capabilities into the PagerDuty Process Automation platform. This acquisition highlighted Rundeck's strategic value in streamlining operational tasks and incident response workflows, enhancing PagerDuty's offerings with self-service automation."
+  - question: "Is Rundeck an orchestrator?"
+    answer: "Yes, Rundeck is primarily a workflow management and service orchestration tool. It allows users to define and execute automated tasks across various nodes, facilitating software deployment, configuration management, and operational runbooks. Its strength lies in enabling self-service automation for IT operations teams."
+  - question: "Is Rundeck free to use?"
+    answer: "Rundeck has an open-source version that is free to use and self-host. PagerDuty also offers commercial editions, PagerDuty Process Automation, which include enterprise-grade features such as enhanced security, scalability, and support, along with tighter integration into the PagerDuty platform."
+  - question: "What is the difference between Ansible Tower and Rundeck?"
+    answer: "Rundeck focuses on self-service automation, allowing ops teams to run specific commands across nodes with granular access control. Ansible Tower (now Red Hat Ansible Automation Platform) is designed for broader IT automation, including configuration management, orchestration, and centralized management of Ansible Playbooks, often with predefined workflows."
+  - question: "Who competes with PagerDuty?"
+    answer: "PagerDuty competes with incident management platforms like Opsgenie (Atlassian), Splunk On-Call (VictorOps), and xMatters. In the broader workflow and runbook automation space (where Rundeck/PagerDuty Process Automation sits), competitors include Kestra, StackStorm, Jenkins, and other IT automation platforms."
+  - question: "What language does Rundeck use?"
+    answer: "Rundeck itself is primarily built with Java and Groovy. Its workflows often involve executing scripts in various languages (Bash, Python, etc.) on target nodes. While the core platform uses Java/Groovy, it provides a language-agnostic environment for automating tasks."
+---
+
+Rundeck has long been a go-to solution for IT operations teams seeking self-service automation and runbook orchestration. However, as infrastructure grows more complex and automation needs span beyond traditional IT tasks, many organizations find themselves exploring more versatile alternatives. Whether driven by limitations in language support, operational overhead, or the desire for broader cross-domain orchestration, the market for Rundeck alternatives has matured significantly.
+
+This article will guide you through the leading alternatives to Rundeck in 2026, including Kestra, StackStorm, Jenkins, and others. We'll offer a comprehensive comparison to help you select the ideal tool for your evolving automation landscape, covering everything from open-source options to enterprise-grade platforms.
+
+## Understanding the need for Rundeck alternatives
+
+### What is Rundeck and its primary use cases?
+Rundeck, now part of PagerDuty Process Automation, is an open-source tool designed for runbook automation. Its primary strength lies in providing a secure, web-based interface for operations teams and service desk agents to execute predefined jobs (scripts, commands, workflows) on remote nodes. This enables self-service operations, reduces the need for direct server access, and provides an audit trail for actions taken. Common use cases include incident response, routine maintenance, software deployments, and diagnostic checks.
+
+### Common reasons to seek alternatives to Rundeck
+While effective for its core purpose, teams often look for alternatives when they hit certain limitations:
+*   **Operational Complexity:** Managing a large-scale Rundeck installation, including its Java-based backend and dependencies, can become cumbersome.
+*   **Limited Scope:** Rundeck is excellent for IT operations but is less suited for orchestrating workflows that cross into data engineering, AI/ML pipelines, or complex business processes.
+*   **Declarative Workflows:** Rundeck jobs are often imperative scripts. Teams adopting GitOps and Infrastructure as Code (IaC) practices may prefer a declarative, YAML-based approach to define workflows as code.
+*   **Integration Challenges:** While Rundeck has plugins, integrating it deeply into a modern, event-driven architecture can require significant custom work.
+*   **Scalability:** At enterprise scale, managing thousands of jobs and nodes can expose performance and governance challenges.
+
+## How we evaluated these alternatives
+
+We evaluated each alternative on a set of criteria designed to reflect the needs of modern platform and operations teams. Key factors include:
+*   **Deployment Model:** Can it run on-prem, in the cloud, or on Kubernetes?
+*   **License:** Is it open-source, commercial, or a hybrid model?
+*   **Primary Use Case:** Is it focused on CI/CD, configuration management, or universal orchestration?
+*   **Declarative vs. Imperative:** Are workflows defined as declarative code (e.g., YAML) or imperative scripts?
+*   **Integration Ecosystem:** How extensive is its library of plugins and connectors?
+*   **Community and Support:** How active is the community, and what are the commercial support options?
+
+## 1. Kestra
+Kestra is an open-source, event-driven orchestration platform that uses a simple, declarative YAML interface to define and manage all your workflows. Unlike tools focused on a single domain, Kestra acts as a universal control plane, capable of coordinating tasks across data pipelines, infrastructure automation, AI workflows, and business processes. Its language-agnostic architecture allows you to run scripts in Python, Shell, Go, R, and more, all within the same workflow. This makes it a powerful alternative for teams looking to consolidate their automation tools.
+
+Kestra's design emphasizes low operational overhead and seamless integration. It can orchestrate the tools you already use, such as Ansible and Terraform, adding a layer of visibility, scheduling, and event-driven capabilities on top.
+
+*   **Best for:** Teams seeking a universal, declarative orchestration control plane that integrates seamlessly with existing tools and spans multiple domains like data, infrastructure, and AI.
+*   **Learn more:** [Rundeck vs Kestra for Runbook Automation](/vs/rundeck)
+
+## 2. StackStorm
+StackStorm is an open-source, event-driven automation platform known for its "if-this-then-that" style of automation. It excels at auto-remediation and responding to events from monitoring systems, security tools, and other infrastructure components. A key feature is its integration with ChatOps, allowing teams to trigger and manage automations directly from platforms like Slack. StackStorm is highly extensible and Python-centric, making it a favorite among DevOps teams with strong Python skills.
+
+*   **Best for:** DevOps teams focused on event-driven automation, auto-remediation, and ChatOps, especially those with strong Python expertise.
+
+## 3. Jenkins
+Jenkins is one of the most established open-source automation servers in the DevOps world. While its primary use case is continuous integration and continuous delivery (CI/CD), its vast plugin ecosystem (over 1,800 plugins) allows it to be adapted for a wide range of automation tasks, including runbook execution. For organizations already heavily invested in Jenkins for their build and deploy pipelines, extending it to handle operational tasks can be a natural next step. However, its UI can feel dated, and managing its configuration ("Jenkinsfiles") can become complex.
+
+*   **Best for:** Organizations with a strong DevOps culture and existing Jenkins investment, looking to extend automation beyond CI/CD into general IT tasks.
+
+## 4. Ansible (and SaltStack)
+Ansible is a powerful open-source tool for configuration management, application deployment, and task automation. Its agentless architecture and simple YAML-based playbooks make it easy to get started. While Rundeck can be used to provide a UI for Ansible playbooks, Ansible itself (especially when paired with Red Hat Ansible Automation Platform) can be a comprehensive alternative. SaltStack offers similar capabilities but uses an agent-based model, which can provide faster execution for large-scale environments.
+
+*   **Best for:** IT operations and infrastructure teams prioritizing configuration management, desired state enforcement, and agentless automation.
+*   **Learn more:** [What is Infrastructure as Code (IaC)?](/resources/infrastructure/what-is-infrastructure-as-code)
+
+## 5. Argo Workflows
+Argo Workflows is a Kubernetes-native workflow engine. If your infrastructure and applications are built on Kubernetes, Argo provides a powerful way to orchestrate parallel jobs and complex workflows directly within your cluster. Workflows are defined as Kubernetes Custom Resource Definitions (CRDs) in YAML, aligning perfectly with cloud-native and GitOps practices. It is particularly strong for CI/CD, batch processing, and machine learning pipelines that are container-based.
+
+*   **Best for:** Kubernetes-native environments where workflows are primarily container-based and managed as part of the Kubernetes control plane.
+
+## 6. Hoop.dev
+Hoop.dev is a modern, open-source alternative that focuses on providing secure, auditable, and collaborative self-service operations. It creates a secure gateway to your production environment, allowing developers and ops teams to run commands and scripts with granular access controls and full session recording. While it shares the self-service goal with Rundeck, its emphasis is more on secure access and real-time collaboration rather than complex workflow orchestration.
+
+*   **Best for:** Teams needing granular access control, audit trails, and a secure self-service portal for running operational commands in production.
+
+## 7. Syxsense
+Syxsense is a commercial platform that combines IT management, security, and automation into a single solution. It goes beyond runbook automation to include endpoint management, patch management, vulnerability scanning, and remediation. For organizations looking to consolidate tools and manage IT and security operations from one place, Syxsense offers a compelling, unified alternative. Its automation capabilities are built into this broader context of device and security management.
+
+*   **Best for:** Organizations looking for a unified platform for IT operations, security, and automation, particularly for endpoint and patch management.
+
+## 8. Puppet
+Puppet is a long-standing leader in the configuration management space. It uses a declarative, model-driven approach to define and enforce the desired state of your infrastructure. Unlike agentless tools like Ansible, Puppet uses an agent on each managed node, which continuously ensures the system conforms to the defined state. This makes it extremely powerful for maintaining consistency across large, complex environments. While it's a configuration management tool at its core, it can be used for task automation and orchestration.
+
+*   **Best for:** Large enterprises with complex infrastructure requiring robust, agent-based configuration management and desired state enforcement.
+*   **Learn more:** [Top Puppet Alternatives for IT Automation](/resources/infrastructure/puppet-alternatives)
+
+## Comparison table
+
+| Tool | License | Deployment | Primary Use Case | Declarative Workflows | Event-Driven | Starting Price |
+|---|---|---|---|---|---|---|
+| **Kestra** | Open-Source (Apache 2.0) & Enterprise | Kubernetes, Docker, Bare Metal | Universal Orchestration | Yes (YAML) | Yes | Free |
+| **StackStorm** | Open-Source (Apache 2.0) & Enterprise | Kubernetes, Docker | Event-Driven Automation, ChatOps | Yes (YAML/JSON) | Yes | Free |
+| **Jenkins** | Open-Source (MIT) | Kubernetes, Docker, Bare Metal | CI/CD, General Automation | Yes (Groovy) | Yes (via plugins) | Free |
+| **Ansible** | Open-Source (GPLv3) & Commercial | Agentless | Configuration Management | Yes (YAML) | Limited | Free |
+| **Argo Workflows** | Open-Source (Apache 2.0) | Kubernetes | Kubernetes-Native Workflows | Yes (YAML) | Yes | Free |
+| **Hoop.dev** | Open-Source (MIT) & Enterprise | Kubernetes, Docker | Secure Self-Service Operations | No | No | Free |
+| **Syxsense** | Commercial | Cloud-based | Unified IT & Security Management | Yes | Yes | Custom |
+| **Puppet** | Open-Source (Apache 2.0) & Enterprise | Agent-based | Configuration Management | Yes (Puppet DSL) | Limited | Free |
+
+## How to choose the right alternative for your needs
+
+### Assessing your specific automation requirements
+The best choice depends entirely on your primary goal. Are you looking to replace simple runbooks, manage server configurations, or build a universal orchestration layer?
+*   **For IT operations teams** needing a modern runbook and incident response platform, tools like Kestra and StackStorm are strong contenders.
+*   **For infrastructure teams** focused on [Infrastructure as Code](/resources/infrastructure/what-is-infrastructure-as-code), Ansible, Puppet, and Terraform (orchestrated by Kestra) are the standard.
+*   **For platform teams** that need to orchestrate across multiple domains—from [data pipelines](/resources/data) to [AI workflows](/resources/ai)—a universal platform like Kestra provides the most flexibility.
+
+### Considering community support and ecosystem
+For open-source tools, the health of the community is critical. Look at GitHub activity, Slack/Discord channel engagement, and the availability of plugins. Jenkins and Ansible have massive, mature communities. Kestra has a rapidly growing community and a rich library of [blueprints](/blueprints) to accelerate development. Commercial offerings like Syxsense provide dedicated support, which can be a deciding factor for enterprise teams.
+
+### Future-proofing your automation strategy
+Avoid choosing a tool that solves today's problem but creates tomorrow's silo. A platform that is language-agnostic, event-driven, and capable of orchestrating workflows across different technology stacks will be more resilient to change. Declarative workflows defined in YAML are easier to version control, audit, and manage at scale, aligning with modern GitOps practices. Consider a solution that not only replaces Rundeck's functionality but also provides a path to a more unified and scalable automation strategy.
+
+## Conclusion
+Choosing a Rundeck alternative in 2026 means looking beyond simple runbook automation. While Rundeck excels at providing self-service access to scripts, modern platforms offer more extensive capabilities, from event-driven automation to declarative, cross-domain orchestration.
+
+For teams seeking a versatile, developer-friendly platform that unifies workflows across their entire tech stack, [Kestra offers a compelling solution](/vs/rundeck). Its declarative YAML interface, language-agnostic design, and low operational overhead make it an ideal control plane for modern infrastructure and data ecosystems.
+
+Ready to see how a universal orchestration platform can transform your automation strategy? [Get started with the open-source version](/get-started) or [book a demo](/demo) to see Kestra Enterprise in action.

--- a/src/contents/resources/stonebranch-alternatives/index.md
+++ b/src/contents/resources/stonebranch-alternatives/index.md
@@ -1,0 +1,128 @@
+---
+title: "Top Stonebranch Alternatives for Modern Automation"
+description: "Explore the leading Stonebranch alternatives for workload automation. Find modern, flexible solutions that fit your organization's evolving needs, from hybrid IT to cloud-native environments."
+metaTitle: "Stonebranch Alternatives for Workload Automation"
+metaDescription: "Explore top Stonebranch alternatives like Kestra, ActiveBatch, and Redwood RunMyJobs. Find the best workload automation solution for hybrid IT and cloud needs."
+tag: infrastructure
+date: 2026-05-06
+faq:
+  - question: "What is Stonebranch Universal Controller?"
+    answer: "Stonebranch Universal Controller (UC) is a service orchestration and automation platform offering enterprise-class features for scaling automated tasks. It's designed for IT Operations to manage workloads across various environments, from on-prem to cloud, providing centralized control over batch and event-driven processes."
+  - question: "Is Stonebranch a SaaS solution?"
+    answer: "Yes, Stonebranch offers a SaaS-based workload automation solution designed for cloud deployment. This allows organizations to quickly enable automated IT jobs, workloads, and business processes via a browser-based web interface, reducing the need for extensive on-premise infrastructure management."
+  - question: "What are the main reasons to look for Stonebranch alternatives?"
+    answer: "Organizations often seek Stonebranch alternatives due to a desire for more modern developer experiences, greater flexibility in cloud-native deployments, reduced operational overhead, different pricing models, or a need for broader orchestration capabilities beyond traditional batch processing into data, AI, and business workflows."
+  - question: "How does Kestra compare as a Stonebranch alternative?"
+    answer: "Kestra offers a declarative, YAML-based approach to orchestration, providing a modern alternative to traditional WLA tools. It supports polyglot task execution and unifies data, AI, infrastructure, and business workflows under one control plane, making it highly adaptable for hybrid and cloud-native environments compared to Stonebranch's more IT-centric model."
+  - question: "What are the best open-source Stonebranch alternatives?"
+    answer: "For open-source alternatives to Stonebranch, Kestra stands out with its Apache 2.0 licensed core, offering a declarative, event-driven engine that runs anywhere. Other open-source options like Apache Airflow are strong for data pipelines but may require more customization for cross-domain or infrastructure-specific automation."
+  - question: "Which Stonebranch alternative is best for hybrid IT environments?"
+    answer: "Many modern orchestrators excel in hybrid IT, including Kestra, which is designed to run on-prem, in the cloud, or air-gapped while coordinating tasks across diverse systems. Solutions like ActiveBatch and Redwood RunMyJobs also offer strong capabilities for managing workloads across mixed infrastructure environments."
+  - question: "What are the key considerations when migrating from Stonebranch?"
+    answer: "When migrating from Stonebranch, key considerations include assessing the new tool's learning curve, its integration capabilities with existing systems, the total cost of ownership (including operational overhead), its support for declarative configuration, and how well it aligns with modern CI/CD and GitOps practices."
+---
+
+The landscape of IT automation is constantly evolving, pushing organizations to seek solutions that offer greater agility, better developer experience, and seamless integration across hybrid IT environments. While tools like Stonebranch Universal Automation Center have long served the needs of enterprise workload automation, many teams are now evaluating alternatives that better align with cloud-native practices, declarative configuration, and broader cross-domain orchestration.
+
+The leading alternatives to Stonebranch Universal Automation Center in 2026 include Kestra, ActiveBatch, Redwood RunMyJobs, Control-M, and JAMS Scheduler, each offering distinct approaches to modern workload automation. This article will explore these options, providing a framework to help you choose the right solution for your organization's specific needs, from managing complex batch processes to orchestrating dynamic, event-driven workflows.
+
+## Why look for an alternative to Stonebranch?
+
+Organizations evaluate Stonebranch alternatives for several key reasons, often tied to the broader shift towards more agile and developer-centric IT practices. Traditional Workload Automation (WLA) tools, while powerful, can introduce operational overhead and complexity that hinder modern teams. Many are looking for solutions with more transparent pricing models to avoid vendor lock-in and better predict costs.
+
+A significant driver is the need for an improved developer experience. Teams increasingly expect to manage automation workflows like any other code, using declarative configurations (like YAML) that integrate seamlessly with DevOps and [GitOps principles](https://kestra.io/resources/infrastructure/gitops). This contrasts with proprietary interfaces that can slow down development and complicate version control.
+
+Furthermore, as businesses break down silos, the need for a single control plane to unify data, AI, and infrastructure workflows becomes critical. Many legacy tools are not built to handle this cross-domain orchestration natively. This leads teams to seek more flexible, cloud-native alternatives that can [solve orchestration problems](https://kestra.io/resources/infrastructure/orchestration-problems-complexity) without adding more complexity to their [workflow management](https://kestra.io/resources/infrastructure/workflow-management).
+
+## How we evaluated these alternatives
+
+To provide a clear comparison, we evaluated each Stonebranch alternative based on a consistent set of criteria relevant to modern IT and data teams. These criteria reflect the key decision points for organizations moving beyond traditional WLA:
+
+*   **Deployment Model:** We assessed whether the solution is primarily SaaS, self-hosted, hybrid, or cloud-native, as this impacts operational control and flexibility.
+*   **License:** We distinguished between open-source and proprietary licenses, a critical factor for customization, community support, and cost.
+*   **Primary Use Case Fit:** We identified the core strengths of each tool, whether in batch processing, event-driven automation, data pipelines, AI workflows, or infrastructure management.
+*   **Developer Experience:** We examined the authoring model—declarative YAML, code-first Python, or visual drag-and-drop—and its alignment with modern development practices.
+*   **Integration Ecosystem:** The availability and breadth of plugins, APIs, and connectors are crucial for connecting to a diverse set of tools and platforms.
+*   **Scalability and Reliability:** We considered the architecture's ability to handle enterprise-scale workloads reliably.
+*   **Pricing Transparency:** The clarity and predictability of the pricing model were evaluated.
+
+For a deeper understanding of [why Kestra](https://kestra.io/docs/why-kestra) was built with these principles in mind, you can explore our documentation on its architecture and design philosophy, including the differences between our [open-source and paid editions](https://kestra.io/docs/oss-vs-paid).
+
+## 1. Kestra: The open-source control plane for everything-as-code
+
+Kestra is a modern, open-source orchestration platform designed to unify data, AI, infrastructure, and business workflows under a single, declarative control plane. Workflows are defined as simple YAML files, making them easy to write, version-control, and integrate into CI/CD pipelines.
+
+Its language-agnostic architecture allows teams to run tasks written in any language, including Python, Shell, Go, SQL, and Docker, without being locked into a specific ecosystem. Kestra is event-driven by default, with real-time triggers that enable dynamic, responsive automation. With a core licensed under Apache 2.0, Kestra offers a powerful free tier alongside Enterprise and Cloud editions for advanced governance and scale. This flexibility makes it a strong fit for organizations looking to standardize automation with strong [GitOps integration](https://kestra.io/resources/infrastructure/gitops). For example, financial services giant Crédit Agricole replaced fragmented infrastructure scripts and cron jobs with Kestra's single, auditable orchestration layer.
+
+*   **Best for:** Organizations seeking a modern, flexible, and unified orchestration platform that supports developer-centric workflows across all domains, from cloud to on-prem.
+*   **Explore:** Get started quickly with hundreds of pre-built [Blueprints](https://kestra.io/blueprints) and connect to any tool with a vast library of [Plugins](https://kestra.io/plugins).
+*   **Learn more:** See how Kestra can manage your entire technology stack on our [Infrastructure Automation](https://kestra.io/infra-automation) page.
+
+## 2. ActiveBatch: A comprehensive workload automation engine
+
+ActiveBatch by Advanced Systems Concepts is a mature and feature-rich WLA platform known for its extensive library of pre-built job steps and integrations. It provides a centralized console for managing workflows across diverse, heterogeneous IT environments, making it a strong contender in complex enterprise settings.
+
+The platform emphasizes ease of use through a low-code, drag-and-drop interface, aiming to reduce the learning curve for IT operations teams. ActiveBatch supports a wide range of platforms and applications, from legacy systems to modern cloud services. This makes it a solid choice for organizations that need to bridge the gap between traditional and modern infrastructure.
+
+*   **Best for:** Enterprises needing a mature, feature-rich WLA solution with strong integration capabilities across diverse systems and a focus on operational efficiency.
+*   **Honest limitation:** Its approach is more aligned with traditional IT operations, which may feel less flexible for teams that have fully embraced developer-first, everything-as-code methodologies.
+*   **Learn more:** Discover how ActiveBatch compares to other solutions in our review of the [best IT automation platforms](https://kestra.io/resources/infrastructure/it-automation-platform).
+
+## 3. RunMyJobs by Redwood: Modern SaaS workload automation
+
+RunMyJobs by Redwood positions itself as a modern, cloud-native SaaS solution for workload automation and job scheduling. As a fully managed platform, it aims to reduce the operational burden on IT teams, allowing them to focus on building and managing automation rather than maintaining the underlying infrastructure.
+
+Redwood is designed to support digital transformation initiatives by providing an agile and scalable automation backbone. Its SaaS delivery model ensures that users are always on the latest version and can scale their usage up or down as needed. It offers strong capabilities for orchestrating processes across ERP systems, cloud infrastructure, and other business applications.
+
+*   **Best for:** Organizations prioritizing a managed, SaaS-delivered WLA solution for agile, cloud-centric operations.
+*   **Honest limitation:** The SaaS-only model may offer less control and flexibility for organizations with strict data residency requirements, air-gapped environments, or a preference for self-hosting.
+*   **Learn more:** For more on this tool and its competitors, see our list of [Redwood alternatives](https://kestra.io/resources/infrastructure/redwood-alternatives).
+
+## 4. Control-M: Enterprise-grade batch and service orchestration
+
+Control-M by BMC is a long-standing leader in the enterprise workload automation market. It is known for its robustness, reliability, and ability to manage complex batch processing workflows at a massive scale. Its strengths lie in SLA management, detailed auditing, and broad support for platforms spanning mainframe, distributed systems, and cloud environments.
+
+For large enterprises with mission-critical batch jobs and strict compliance requirements, Control-M provides a proven, centralized platform. It has evolved to support modern use cases like data pipelines and cloud integrations, but its core architecture is rooted in traditional enterprise IT operations.
+
+*   **Best for:** Large enterprises with existing investments in traditional batch processing and stringent SLA requirements, seeking a proven, robust solution.
+*   **Honest limitation:** Control-M can be expensive and complex to implement and operate, often presenting a steeper learning curve for developers accustomed to modern, code-centric tools.
+*   **Learn more:** See a direct comparison in our [Control-M vs. Kestra](https://kestra.io/vs/control-m) analysis and explore other [Control-M alternatives](https://kestra.io/resources/infrastructure/control-m-alternatives).
+
+## 5. JAMS Scheduler: Versatile job scheduling for Windows environments
+
+JAMS Scheduler by Fortra is a workload automation and job scheduling solution with particularly strong support for Windows-based environments. It excels at managing and monitoring jobs across a variety of platforms but is especially well-suited for organizations with a significant investment in the Microsoft technology stack, including PowerShell, .NET applications, and SQL Server.
+
+JAMS provides a centralized point of control for scheduling tasks, managing dependencies, and handling event-driven automation. Its code-driven approach to job definitions can appeal to developers, and it offers robust features for logging, auditing, and security.
+
+*   **Best for:** Windows-heavy environments needing a robust, centralized scheduler for .NET applications and PowerShell scripts.
+*   **Honest limitation:** While it supports cross-platform scheduling, its focus is less on multi-cloud, polyglot, or Linux-first environments compared to other modern alternatives.
+
+## Comparison Table
+
+| Tool | License | Deployment Model | Best for | Key Differentiator | Developer Experience |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **Kestra** | Open-Source (Apache 2.0) & Enterprise | Self-hosted, Cloud, Hybrid | Unified orchestration across data, AI, and infra | Declarative YAML, language-agnostic, event-driven | YAML as Code, GitOps, API-first |
+| **ActiveBatch** | Proprietary | Self-hosted, Cloud | Complex enterprise WLA with diverse systems | Extensive pre-built job step library | Low-code, visual drag-and-drop |
+| **RunMyJobs** | Proprietary | SaaS | Cloud-native, managed WLA for agile operations | Fully managed SaaS platform | Web-based UI, API access |
+| **Control-M** | Proprietary | Self-hosted, Cloud | Large-scale enterprise batch processing and SLAs | Mainframe and distributed system support | GUI-centric, JSON/API for developers |
+| **JAMS Scheduler**| Proprietary | Self-hosted | Windows-centric job scheduling (.NET, PowerShell) | Deep integration with the Microsoft ecosystem | Code-driven job definitions, GUI |
+
+## How to choose the right alternative
+
+Selecting the right Stonebranch alternative depends on your team's primary goals and technical environment.
+
+*   **For data engineering teams:** Your focus is on reliability, data lineage, and seamless integration with the modern data stack (e.g., dbt, Snowflake, Airbyte). You need a tool that can handle complex dependencies and execute tasks in a polyglot environment. **Recommendations: Kestra, ActiveBatch.** Kestra's [declarative orchestration for data engineers](https://kestra.io/data) offers native integrations and a flexible, code-based approach, while ActiveBatch provides a vast library of connectors for diverse data sources.
+
+*   **For infrastructure & DevOps teams:** You prioritize GitOps compatibility, Infrastructure-as-Code (IaC) integration (Terraform, Ansible), and multi-cloud capabilities. A declarative, API-first platform is essential for automating infrastructure provisioning and management. **Recommendations: Kestra, Redwood RunMyJobs.** Kestra's everything-as-code philosophy makes it a natural fit for [infrastructure automation](https://kestra.io/infra-automation), while Redwood's SaaS model offers agility for cloud-centric teams.
+
+*   **For AI & ML platform teams:** You need to orchestrate complex pipelines that combine data preprocessing, model training on GPUs, and serving. Reproducibility, agentic orchestration, and integration with LLM providers are key. **Recommendation: Kestra.** Kestra is built to [orchestrate AI pipelines](https://kestra.io/ai-automation), from RAG workflows to coordinating autonomous agents.
+
+*   **For organizations seeking modernization:** Your main goal is to move away from legacy systems, reduce operational burden, and empower developers. You need a platform with a declarative configuration, an API-first design, and a lower total cost of ownership. **Recommendations: Kestra, Redwood RunMyJobs.** Both offer modern approaches that align with agile development and cloud-native principles. To see how easy it is to start, check out our [getting started guide](https://kestra.io/get-started).
+
+## Conclusion & Next Steps
+
+Moving away from a traditional workload automation solution like Stonebranch is an opportunity to adopt a more modern, flexible, and developer-friendly approach to orchestration. The "best" alternative is the one that aligns with your organization's specific needs—whether that's the comprehensive enterprise features of ActiveBatch, the SaaS convenience of Redwood RunMyJobs, or the robust batch processing of Control-M.
+
+For teams looking for a single control plane to unify workflows across all domains—data, AI, infrastructure, and business—Kestra offers a powerful, declarative, and event-driven platform. It's designed to reduce complexity, improve developer productivity, and provide the visibility needed to manage modern IT environments at scale.
+
+Ready to experience a modern approach to workload automation? [Book a demo](https://kestra.io/demo) to see Kestra in action or join our [Kestra Cloud Early Adopter Program](https://kestra.io/cloud) to get started with a fully managed solution.


### PR DESCRIPTION
## Summary

Batch import of 5 SEO listicle pages from kestra-seo briefs (W21).

| Page | Source brief |
|---|---|
| `/resources/stonebranch-alternatives` | [vfanucci/kestra-seo#74](https://github.com/vfanucci/kestra-seo/pull/74) |
| `/resources/rundeck-alternatives` | [vfanucci/kestra-seo#73](https://github.com/vfanucci/kestra-seo/pull/73) |
| `/resources/ibm-workload-automation-alternatives` | [vfanucci/kestra-seo#72](https://github.com/vfanucci/kestra-seo/pull/72) |
| `/resources/broadcom-dollar-universe-alternatives` | [vfanucci/kestra-seo#69](https://github.com/vfanucci/kestra-seo/pull/69) |
| `/resources/morpheus-alternatives` | [vfanucci/kestra-seo#53](https://github.com/vfanucci/kestra-seo/pull/53) |

### Notes
- All pages tagged `infrastructure` to comply with the `resources` schema enum (`infrastructure | data | ai | whitepapers`)
- Removed extraneous frontmatter fields (`slug`, `author`, `image`, `hub`) not present in the resources schema
- Stripped leading ` ```yaml ` wrappers from generated drafts
- Morpheus uses slug `morpheus-alternatives` (cleaner than the brief's `top-morpheus-alternatives-for-enterprises`)
- Duplicate kestra-seo PR #77 (Morpheus, outline only) was excluded in favor of #53 (which has the full draft)

## Test plan
- [ ] Astro build passes (resources schema validation)
- [ ] All 5 pages render at their respective `/resources/<slug>` URLs
- [ ] FAQ accordions render correctly
- [ ] Internal links (`/vs/*`, `/resources/*`) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)