### PR TITLE
fix: use direct venv pip path instead of source activation (fixes #8540)

### DIFF
--- a/src/contents/docs/06.concepts/12.caching/index.md
+++ b/src/contents/docs/06.concepts/12.caching/index.md
@@ -84,8 +84,7 @@ tasks:
           type: io.kestra.plugin.core.runner.Process
         beforeCommands:
           - python -m venv venv
-          - source venv/bin/activate
-          - pip install pandas
+          - ./venv/bin/pip install pandas
         script: |
           import pandas as pd
           print(pd.__version__)


### PR DESCRIPTION
source command is not available in Kestra's sh shell environment. Using ./venv/bin/pip directly works reliably across all shells.

Fixes https://github.com/kestra-io/kestra/issues/8540.