### PR TITLE
docs: update python cached dependencies example to use --target=./deps

### DIFF
--- a/src/contents/docs/06.concepts/12.caching/index.md
+++ b/src/contents/docs/06.concepts/12.caching/index.md
@@ -68,7 +68,7 @@ tasks:
 
 ### Python example
 
-Below is an example of a flow that installs the `pandas` package before running a Python script. The `venv` folder is cached for one day.
+Below is an example of a flow that installs the `pandas` package before running a Python script. The `deps` folder is cached for one day.
 
 ```yaml
 id: python_cached_dependencies
@@ -83,14 +83,15 @@ tasks:
         taskRunner:
           type: io.kestra.plugin.core.runner.Process
         beforeCommands:
-          - python -m venv venv
-          - ./venv/bin/pip install pandas
+          - pip install --target=./deps pandas
+        env:
+          PYTHONPATH: "./deps"
         script: |
           import pandas as pd
           print(pd.__version__)
     cache:
       patterns:
-        - venv/**
+        - deps/**
       ttl: PT24H
 ```
 

--- a/src/contents/docs/14.best-practices/4.managing-pip-dependencies/index.md
+++ b/src/contents/docs/14.best-practices/4.managing-pip-dependencies/index.md
@@ -87,9 +87,9 @@ tasks:
 
 ## Using cache files
 
-In a `WorkingDirectory` task, you can create a virtual environment using the [Process Task Runner](../../task-runners/04.types/01.process-task-runner/index.md), install all required `pip` dependencies, and cache the `venv` folder. This ensures the dependencies are reused in subsequent executions, eliminating the need for repeated installations. For more details, see the [caching](../../06.concepts/12.caching/index.md) page.
+In a `WorkingDirectory` task, you can install all required `pip` dependencies into a local `deps` folder using the [Process Task Runner](../../task-runners/04.types/01.process-task-runner/index.md), and cache that folder. This ensures the dependencies are reused in subsequent executions, eliminating the need for repeated installations. For more details, see the [caching](../../06.concepts/12.caching/index.md) page.
 
-The example below demonstrates how to cache the `venv` folder:
+The example below demonstrates how to cache the `deps` folder:
 
 ```yaml
 id: python_cached_dependencies
@@ -104,15 +104,15 @@ tasks:
         taskRunner:
           type: io.kestra.plugin.core.runner.Process
         beforeCommands:
-          - python -m venv venv
-          - . venv/bin/activate
-          - pip install pandas
+          - pip install --target=./deps pandas
+        env:
+          PYTHONPATH: "./deps"
         script: |
           import pandas as pd
           print(pd.__version__)
     cache:
       patterns:
-        - venv/**
+        - deps/**
       ttl: PT24H
 ```
 


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/8540

Replace the venv-based approach with `pip install --target=./deps` and `PYTHONPATH` so the cached dependencies example does not rely on shell activation of a virtualenv.