### PR TITLE
seo(resources): publish W22 batch — 11 new resource pages

### DIFF
--- a/src/contents/resources/airflow-alternatives/index.md
+++ b/src/contents/resources/airflow-alternatives/index.md
@@ -3,7 +3,7 @@ title: "Airflow Alternatives: Top Workflow Orchestrators for Modern Stacks"
 description: "Explore the best alternatives to Airflow, including Kestra, Prefect, and Dagster. Find modern, lightweight, and event-driven workflow orchestrators that address common Airflow pain points."
 metaTitle: "Airflow Alternatives: Top Workflow Orchestrators"
 metaDescription: "Explore top alternatives to Airflow for data orchestration. Find the best lightweight workflow tools that beat Airflow at its own game."
-tag: "data orchestration"
+tag: "data"
 date: 2026-05-27
 slug: "airflow-alternatives"
 faq:

--- a/src/contents/resources/airflow-alternatives/index.md
+++ b/src/contents/resources/airflow-alternatives/index.md
@@ -1,0 +1,192 @@
+---
+title: "Airflow Alternatives: Top Workflow Orchestrators for Modern Stacks"
+description: "Explore the best alternatives to Airflow, including Kestra, Prefect, and Dagster. Find modern, lightweight, and event-driven workflow orchestrators that address common Airflow pain points."
+metaTitle: "Airflow Alternatives: Top Workflow Orchestrators"
+metaDescription: "Explore top alternatives to Airflow for data orchestration. Find the best lightweight workflow tools that beat Airflow at its own game."
+tag: "data orchestration"
+date: 2026-05-27
+slug: "airflow-alternatives"
+faq:
+  - question: "Is there anything better than Airflow for modern data orchestration?"
+    answer: "Yes, for many modern use cases, alternatives like Kestra, Prefect, or Dagster offer significant advantages. Kestra, for instance, provides a declarative YAML-based approach, polyglot task execution, and native event-driven capabilities, reducing operational complexity and enabling broader workflow orchestration across data, AI, and infrastructure."
+  - question: "Is Kestra a better alternative to Airflow?"
+    answer: "Kestra offers several advantages over Airflow, especially for teams seeking a more modern, flexible, and unified orchestration platform. Its declarative YAML definition simplifies version control and collaboration, while native event-driven triggers and polyglot execution support a wider range of workloads beyond Python-centric data pipelines. Kestra also provides a lower operational overhead for large-scale deployments."
+  - question: "Can dbt replace Airflow for data pipeline orchestration?"
+    answer: "No, dbt (Data Build Tool) is designed for data transformation within a data warehouse or lakehouse, not as a full-fledged orchestrator. While dbt has its own scheduler, it only manages the 'T' in ETL/ELT. Orchestrators like Kestra are necessary to coordinate the 'E' (extraction), 'L' (loading), and downstream 'A' (activation) steps, integrating dbt into a complete data pipeline."
+  - question: "What workflow orchestration tools are similar to Airflow?"
+    answer: "Tools similar to Airflow in their goal of workflow orchestration include Prefect, Dagster, Argo Workflows, and Kestra. While they all manage dependencies and execution, they differ in their approach. Prefect and Dagster are Python-centric, with Dagster focusing on data assets. Argo is Kubernetes-native, and Kestra offers a declarative, language-agnostic, and event-driven model."
+  - question: "Is Apache Airflow still worth using in 2026?"
+    answer: "Apache Airflow remains a viable choice for Python-heavy data teams with existing investments in its ecosystem and a clear understanding of its operational model. However, with the Airflow 3.0 migration on the horizon and the rise of more modern, cloud-native, and polyglot orchestration platforms, many organizations are using this as an opportunity to re-evaluate their long-term strategy."
+  - question: "What is the best free and open-source alternative to Airflow?"
+    answer: "Kestra stands out as a strong open-source alternative to Airflow. It offers a fully functional community edition with declarative YAML workflows, polyglot task execution, and event-driven triggers. Other open-source options include Prefect and Dagster (both with cloud offerings), Argo Workflows (Kubernetes-native), and Apache NiFi (for dataflow automation)."
+author: "elliot"
+---
+Apache Airflow has been a cornerstone of data engineering for nearly a decade, enabling countless teams to build complex data pipelines. However, as data stacks evolve to include more diverse languages, real-time events, and cross-domain workflows spanning AI and infrastructure, many organizations are encountering its inherent limitations. Operational complexities, Python-centric constraints, and the overhead of managing Airflow at scale are prompting a search for more modern, flexible, and efficient orchestration solutions.
+
+This article explores the top alternatives to Airflow in 2026, offering a comparative analysis to help you navigate the evolving landscape. We'll examine each tool's strengths, ideal use cases, and how they address Airflow's common pain points, providing a clear framework to choose the best orchestrator for your modern data, AI, or infrastructure needs.
+
+## Why look for an alternative to Airflow?
+
+While Airflow is powerful, its architecture, born in a different era of data engineering, presents several challenges for modern teams. The [Airflow 2 End of Life](https://kestra.io/blogs/2026-04-06-airflow-2-end-of-life) and the subsequent migration to Airflow 3 have become a natural point for teams to re-evaluate whether it's the right long-term solution.
+
+Common pain points include:
+- **Operational Overhead and Complexity:** Managing Airflow's distributed components—scheduler, webserver, worker nodes, and metadata database—requires significant operational expertise. Debugging DAGs written in Python can be cumbersome, and dependency conflicts within the Python environment are a frequent source of friction.
+- **Python-centric Limitations:** Airflow's "DAGs as Python code" paradigm is a major hurdle for polyglot teams. Orchestrating non-Python workloads like SQL, shell scripts, or Java applications often requires wrapping them in Python operators, adding unnecessary layers of complexity and making workflows less accessible to non-Python developers.
+- **Scaling and Performance Challenges:** Airflow was designed primarily for scheduled batch jobs. While it can be adapted for event-driven or high-throughput scenarios, it's not its native strength. Scaling workers and tuning the scheduler for dynamic, real-time workloads can be a significant engineering challenge.
+- **Vendor Lock-in and Ecosystem Constraints:** Managed services like Amazon MWAA and Google Cloud Composer simplify deployment but can lead to vendor lock-in and inherit the same core architectural limitations. This can make it difficult to build a truly hybrid or multi-cloud orchestration strategy. For a deeper dive into these challenges, see our detailed [Kestra vs. Airflow comparison](https://kestra.io/vs/airflow).
+
+## How we evaluated these alternatives
+
+To provide a clear comparison, we evaluated each Airflow alternative based on a consistent set of criteria relevant to modern engineering teams. These include:
+- **Deployment Model:** Can it run on-prem, in the cloud, or in a hybrid environment? Is it Kubernetes-native?
+- **License:** Is it open-source, and what are the terms of its commercial offerings?
+- **Primary Use Case:** Is it designed for data engineering, infrastructure automation, AI/ML, or general-purpose workflows?
+- **Developer Experience:** Does it use a declarative (e.g., YAML) or code-first (e.g., Python) approach? How steep is the learning curve?
+- **Operational Overhead:** How complex is it to install, manage, and scale the platform?
+- **Ecosystem & Integrations:** How extensive is its library of plugins and connectors?
+
+## The Top 10 Airflow Alternatives
+
+### 1. Kestra: The Event-Driven Orchestration Control Plane
+
+Kestra is an open-source, event-driven orchestration platform that unifies data, AI, and infrastructure workflows under a single declarative control plane. It's designed to address Airflow's core limitations by separating the workflow definition (YAML) from the execution logic.
+
+- **Declarative YAML:** Workflows are defined in simple, human-readable YAML. This makes them easy to version control, review in pull requests, and manage with GitOps practices. Non-engineers can understand and even contribute to workflow logic.
+- **Polyglot & Language-Agnostic:** Kestra runs any code, anywhere. It has first-class support for Python, SQL, Bash, R, Node.js, and Java, as well as Docker containers, without requiring Python wrappers.
+- **Event-Driven by Default:** Kestra is built for modern, event-driven architectures. It can trigger workflows from webhooks, message queues (Kafka, SQS), file detections (S3, GCS), and more, with millisecond-level latency.
+- **Unified Orchestration:** Unlike tools focused solely on data, Kestra is a universal orchestrator. Teams at companies like [Apple and Crédit Agricole](https://kestra.io/use-cases/stories/apple-ml-team-orchestrates-large-scale-data-pipelines-with-kestra) use it to coordinate everything from infrastructure provisioning with Terraform to complex AI pipelines.
+- **Lower Operational Overhead:** Built on a robust JVM-based architecture, Kestra is a single binary that simplifies deployment and scaling compared to Airflow's complex distributed system.
+
+```yaml
+id: process-s3-file-on-arrival
+namespace: company.team
+
+tasks:
+  - id: python-transform
+    type: io.kestra.plugin.scripts.python.Script
+    docker:
+      image: python:3.11-slim
+    script: |
+      print("Processing file: {{ trigger.uri }}")
+      # Your transformation logic here
+
+triggers:
+  - id: watch-for-new-files
+    type: io.kestra.plugin.aws.s3.Trigger
+    bucket: my-landing-zone
+```
+
+**Best for:** Teams seeking a unified, language-agnostic, GitOps-friendly, and event-driven orchestrator to manage diverse workflows across [data](https://kestra.io/data), AI, and infrastructure with reduced operational complexity.
+
+### 2. Prefect: Pythonic Orchestration with a Focus on Developer Experience
+
+Prefect is a modern workflow orchestration platform that positions itself as a direct, more developer-friendly alternative to Airflow, while remaining within the Python ecosystem.
+
+- **Strengths:** Prefect offers an excellent developer experience for Python engineers, using simple decorators (`@flow`, `@task`) to turn Python functions into orchestrated workflows. It features a powerful UI for visualizing and managing dynamic, parameterized runs and a flexible hybrid execution model that separates the control plane (Prefect Cloud) from the execution layer (customer-managed workers).
+- **Trade-offs vs. Kestra:** It is fundamentally Python-only, which can be a limitation for polyglot teams. Workflows are defined as code, which can be harder to version and audit than declarative YAML. Its business model is cloud-first, with the open-source path being less prominent.
+
+**Best for:** Python-first data teams that prioritize developer experience and dynamic workflows, looking for a modern alternative to Airflow within the Python ecosystem.
+
+### 3. Dagster: Asset-Centric Data Orchestration
+
+Dagster is an orchestrator that shifts the focus from tasks to the data assets they produce, such as tables, files, or machine learning models. This asset-centric approach provides strong data lineage and observability.
+
+- **Strengths:** Dagster's asset graph is its key differentiator, making it excellent for tracking data lineage and understanding dependencies between data assets. It has strong support for software engineering best practices like typing and testing, and integrates natively with dbt.
+- **Trade-offs vs. Kestra:** Dagster is Python-only and has a steeper learning curve due to its unique asset paradigm. This model is highly effective for data-intensive workflows but can feel less natural for orchestrating non-data tasks like infrastructure automation or business processes.
+
+**Best for:** Analytics engineering teams and data platform teams that want strict data asset lineage, strong typing, and a software-engineering approach to data pipelines.
+
+### 4. Argo Workflows: Kubernetes-Native Workflow Engine
+
+Argo Workflows is an open-source, container-native workflow engine for orchestrating parallel jobs on Kubernetes. It is a project of the Cloud Native Computing Foundation (CNCF).
+
+- **Strengths:** As a truly Kubernetes-native tool, Argo defines workflows as Kubernetes Custom Resource Definitions (CRDs). This makes it a perfect fit for teams that live and breathe Kubernetes. Its declarative YAML philosophy is philosophically similar to Kestra's, and it excels at managing container-first workloads like ML training or large-scale batch processing.
+- **Trade-offs vs. Kestra:** Argo is tightly coupled to Kubernetes and has no standalone deployment path. Its plugin ecosystem for non-container tasks is less mature, and its UI can be less approachable for users who are not Kubernetes experts.
+
+**Best for:** Organizations with deep Kubernetes expertise and infrastructure that want orchestration to be an integral part of their K8s control plane.
+
+### 5. Temporal: Durable Execution for Microservices
+
+Temporal is a workflow-as-code platform designed for application developers. It focuses on providing durable, stateful execution for long-running processes embedded within application logic.
+
+- **Strengths:** Temporal's core strength is its durability model, which guarantees that long-running workflows (like a user signup process or a multi-day transaction) will complete even if servers restart. It offers SDKs in multiple languages (Go, Java, Python, TypeScript) and provides strong primitives for retries and compensations.
+- **Trade-offs vs. Kestra:** Temporal and Kestra solve different problems. Temporal is for workflows *inside* an application; Kestra is for orchestration *across* systems. Temporal is code-first and SDK-driven, making it less suited for the cross-system, declarative orchestration that Kestra provides.
+
+**Best for:** Application engineering teams building distributed, stateful backend systems where workflow logic is embedded directly in application code.
+
+### 6. Mage AI: Interactive Notebook-Centric Data Pipelines
+
+Mage is a modern, open-source data pipeline tool that integrates an interactive notebook-style development experience with a visual pipeline builder.
+
+- **Strengths:** Mage allows data scientists and engineers to build pipelines by writing and connecting blocks of code (Python, SQL, R) in an interactive notebook. This makes for a rapid development cycle. It also has strong built-in integrations for AI/ML tasks.
+- **Trade-offs vs. Kestra:** As a newer entrant, its feature set for complex, enterprise-wide orchestration and governance may be less mature than more established platforms. The notebook paradigm, while great for development, can sometimes be harder to productionize and version control than declarative YAML files.
+
+**Best for:** Data scientists and engineers who prefer a visual, notebook-centric environment for building and managing data pipelines, especially those with an AI/ML focus.
+
+### 7. Apache NiFi: Flow-Based Programming for Data Movement
+
+Apache NiFi is a powerful and mature tool for automating the movement of data between software systems. It provides a web-based UI for designing, controlling, and monitoring dataflows.
+
+- **Strengths:** NiFi excels at visual dataflow management. It's designed for real-time data ingestion, routing, and simple transformations, offering excellent data provenance and lineage tracking. Its flow-based programming model is intuitive for routing and mediating data streams.
+- **Trade-offs vs. Kestra:** NiFi is primarily a dataflow tool, not a general-purpose orchestrator. It is less suited for complex batch orchestration, conditional logic, or executing arbitrary code that isn't part of a data stream.
+
+**Best for:** Data engineers needing robust, visual tools for complex dataflow routing, mediation, and real-time data movement between systems.
+
+### 8. Windmill: Open-Source Developer Platform for Internal Tools
+
+Windmill is an open-source developer platform for quickly building internal tools, workflows, and scripts. It combines a low-code UI builder with the ability to run scripts in multiple languages.
+
+- **Strengths:** Windmill is highly versatile, allowing developers to write scripts in Python, TypeScript, Go, Bash, and SQL. It has a visual builder for creating internal UIs on top of these scripts and can be self-hosted, giving teams full control over their data and infrastructure.
+- **Trade-offs vs. Kestra:** Its scope as a broader "developer platform" means it may require more setup for pure orchestration workloads compared to a dedicated tool like Kestra. Its primary focus is on internal tools and ad-hoc scripts rather than enterprise-scale, mission-critical data and infrastructure pipelines.
+
+**Best for:** Development teams looking to quickly build internal tools, scripts, and automations, especially for backend tasks and APIs.
+
+### 9. Kedro: Production-Ready Machine Learning Pipelines
+
+Kedro is an open-source Python framework for creating reproducible, maintainable, and modular data science code. It provides a standardized project structure and a data catalog for managing data sources.
+
+- **Strengths:** Kedro is highly opinionated, which helps teams build robust and reproducible machine learning pipelines. Its project templating, configuration-based approach, and data catalog enforce best practices, making ML projects easier to scale and productionize.
+- **Trade-offs vs. Kestra:** It is designed specifically for ML pipelines and is less suitable for general-purpose data engineering, infrastructure automation, or business process orchestration.
+
+**Best for:** ML engineers and data scientists building modular, testable, and version-controlled machine learning pipelines that require strong reproducibility.
+
+### 10. Luigi: Simple Workflow Management for Python
+
+Luigi is an open-source Python package developed by Spotify for building complex pipelines of batch jobs. It focuses on dependency resolution and workflow management.
+
+- **Strengths:** Luigi is lightweight and easy to integrate into existing Python projects. It allows developers to define tasks and their dependencies programmatically in Python, making it a simple, code-centric solution for managing batch jobs.
+- **Trade-offs vs. Kestra:** It lacks many features of modern orchestrators, such as a rich UI, event-driven triggers, polyglot support, and distributed execution out-of-the-box. It is best suited for simpler batch processing and has been largely superseded by more comprehensive tools.
+
+**Best for:** Small teams or individual developers with Python-heavy batch jobs seeking a very lightweight, code-centric way to manage task dependencies.
+
+## Comparison Table: Airflow Alternatives at a Glance
+
+| Tool | License | Deployment Model | Primary Use Case | Declarative? | Event-Driven? | Language Support | Best for |
+|---|---|---|---|---|---|---|---|
+| **Kestra** | Open-Source (Apache 2.0), Enterprise | Cloud, On-Prem, Hybrid | Unified (Data, AI, Infra) | ✅ Yes (YAML) | ✅ Yes | Polyglot | Unified, event-driven, polyglot orchestration |
+| **Prefect** | Open-Source (Apache 2.0), Cloud | Cloud, On-Prem, Hybrid | Data & AI | ❌ No (Python Code) | ✅ Yes | Python | Python-first teams prioritizing developer experience |
+| **Dagster** | Open-Source (Apache 2.0), Cloud | Cloud, On-Prem, Hybrid | Data | ❌ No (Python Code) | ✅ Yes | Python | Analytics engineering teams needing asset lineage |
+| **Argo Workflows** | Open-Source (Apache 2.0) | Kubernetes-only | General Purpose (Container-first) | ✅ Yes (YAML) | ✅ Yes | Any (in containers) | Kubernetes-native CI/CD and batch jobs |
+| **Temporal** | Open-Source (MIT), Cloud | Cloud, On-Prem | Application Workflows | ❌ No (SDK in code) | ✅ Yes | Polyglot (SDKs) | Durable, stateful application logic |
+| **Mage AI** | Open-Source (Apache 2.0) | Self-hosted, Cloud | Data & AI | ❌ No (Notebooks) | ❌ No | Python, SQL, R | Interactive, notebook-centric pipeline development |
+| **Apache NiFi** | Open-Source (Apache 2.0) | On-Prem, Cloud | Dataflow Automation | ✅ Yes (Visual) | ✅ Yes | Java (processors) | Visual data routing and real-time ingestion |
+| **Windmill** | Open-Source (AGPLv3), Enterprise | Self-hosted, Cloud | Internal Tools & Scripts | ✅ Yes (Visual/Code) | ✅ Yes | Polyglot | Building internal tools and developer automation |
+| **Kedro** | Open-Source (Apache 2.0) | Self-hosted | Machine Learning | ❌ No (Python Code) | ❌ No | Python | Reproducible machine learning pipelines |
+| **Luigi** | Open-Source (Apache 2.0) | Self-hosted | Batch Jobs | ❌ No (Python Code) | ❌ No | Python | Lightweight, Python-based batch job dependencies |
+
+## How to choose the right Airflow alternative for your needs
+
+The best choice depends on your team's specific context, skills, and priorities.
+
+- **For Data Engineering Teams:** If your focus is on data asset lineage and you're heavily invested in dbt, **Dagster** is a strong contender. If you need to manage a mix of ETL/ELT, streaming, and data quality jobs across multiple tools and languages, **Kestra**'s unified platform and language-agnostic approach provide more flexibility. Explore more [data engineering resources](https://kestra.io/resources/data).
+- **For Infrastructure & DevOps Teams:** If your entire stack is Kubernetes-native, **Argo Workflows** is the most integrated solution. For teams managing a hybrid environment with a mix of IaC tools (Terraform, Ansible), cloud services, and legacy systems, **Kestra** provides a vendor-neutral control plane to orchestrate them all. See more on [infrastructure automation](https://kestra.io/infra-automation).
+- **For AI & ML Platform Teams:** If you need a standardized framework for building reproducible ML pipelines in Python, **Kedro** is an excellent choice. If you need to orchestrate the entire end-to-end AI lifecycle—from data ingestion and feature engineering to model training, deployment, and monitoring—**Kestra**'s ability to coordinate diverse tools and trigger workflows based on events makes it a more comprehensive solution for [AI automation](https://kestra.io/ai-automation).
+- **For Small Teams & Startups:** If your needs are simple and Python-centric, a lightweight tool like **Luigi** might suffice. However, for a solution that scales with you without adding operational complexity, **Kestra**'s open-source edition provides a powerful, production-ready platform that's easy to get started with.
+
+## Conclusion: Modernizing Your Orchestration Stack
+
+The orchestration landscape has evolved far beyond the batch-oriented, Python-centric world for which Airflow was originally designed. Today's challenges demand platforms that are declarative, language-agnostic, event-driven, and capable of unifying workflows across an entire organization.
+
+While tools like Prefect and Dagster offer excellent modern alternatives within the Python ecosystem, platforms like Kestra provide a more fundamental shift. By separating orchestration logic from business logic and embracing a declarative, YAML-based approach, Kestra empowers teams to build more reliable, scalable, and collaborative workflows across any language or system. As you move beyond Airflow, consider not just a replacement, but an upgrade to a true orchestration control plane.
+
+Ready to see how a modern, declarative orchestrator can simplify your data, AI, and infrastructure pipelines? [Get started with Kestra](https://kestra.io/get-started) today or [book a demo](https://kestra.io/demo) to see the platform in action.

--- a/src/contents/resources/apache-nifi-alternatives/index.md
+++ b/src/contents/resources/apache-nifi-alternatives/index.md
@@ -1,0 +1,148 @@
+---
+title: "8 Best Apache NiFi Alternatives (Open Source & Commercial)"
+description: "Explore the best Apache NiFi alternatives for data integration and ETL. Compare open-source tools and find your ideal solution today!"
+metaTitle: "8 Best Apache NiFi Alternatives (Open Source & Commercial)"
+metaDescription: "Looking for Apache NiFi alternatives? Compare top open-source tools like Kestra, Airflow, and Airbyte with commercial options for robust data integration and ETL workflows."
+tag: "data-orchestration"
+date: 2026-05-30
+slug: "apache-nifi-alternatives"
+faq:
+  - question: "Is Apache NiFi an ETL tool?"
+    answer: "Yes, Apache NiFi functions as a robust Extract, Transform, Load (ETL) tool, specifically designed for automating data flows. It excels at moving and processing data between various systems, offering a visual interface with hundreds of pre-built processors to facilitate complex data pipelines and real-time data ingestion."
+  - question: "Is Apache NiFi outdated?"
+    answer: "While Apache NiFi remains a powerful tool, recent developments suggest it faces modernization challenges. The NiFi Registry, its versioning system, was deprecated in February 2026 and is slated for removal in NiFi 3.0. This signals a shift towards Git-based flow registries, which some users may find more aligned with modern GitOps practices."
+  - question: "What is the best open-source ETL tool?"
+    answer: "The 'best' open-source ETL tool depends on specific needs. Apache NiFi is strong for dataflow automation, while Apache Airflow excels at programmatic workflow orchestration with Python DAGs. Newer tools like Airbyte focus on connector-based data integration. Kestra offers a declarative, language-agnostic approach, unifying ETL with broader data, AI, and infrastructure orchestration."
+  - question: "What is better than NiFi for modern data pipelines?"
+    answer: "For modern data pipelines, alternatives like Kestra, Airflow, and Airbyte often offer advantages over NiFi, depending on the use case. Kestra provides declarative, event-driven orchestration across data, AI, and infrastructure. Airflow excels with code-based Python DAGs for complex data workflows. Airbyte simplifies connector-based data ingestion. The choice depends on specific requirements for orchestration, language flexibility, and integration needs."
+  - question: "Is Apache NiFi worth using in 2026?"
+    answer: "Apache NiFi is still a powerful tool, especially for complex data flow automation and real-time data ingestion. Its flexibility with hundreds of processors remains a key strength. However, organizations should consider its operational overhead and the recent deprecation of NiFi Registry, which may impact future versioning and GitOps alignment. For specific use cases, it can still be a valuable part of a data stack."
+  - question: "How does Kestra compare to Apache NiFi for data integration?"
+    answer: "Kestra offers a declarative, YAML-based approach to data integration, contrasting with NiFi's visual flow-based design. While NiFi excels at real-time dataflow automation, Kestra provides a unified platform to orchestrate not just data integration, but also transformations, AI workflows, and infrastructure operations with a language-agnostic engine. Kestra emphasizes GitOps, event-driven execution, and lower operational complexity."
+author: "elliot"
+image: "/images/resources/apache-nifi-alternatives/cover.png"
+---
+
+Apache NiFi has long been a go-to for data engineers seeking to automate and manage data flows, excelling in real-time data ingestion and complex routing with its visual interface. However, recent shifts, such as the deprecation of its native NiFi Registry in February 2026, signal a move towards more Git-centric and declarative approaches in the data integration landscape. This change prompts many organizations to re-evaluate their orchestration strategies and consider modern alternatives.
+
+This article explores the top 8 alternatives to Apache NiFi, covering both open-source and commercial solutions. We'll examine their core strengths, trade-offs, and ideal use cases to help you navigate the evolving ecosystem. Whether you're seeking enhanced developer experience, broader multi-domain orchestration, or simplified operational overhead, this guide will help you find the ideal platform to build robust data pipelines in 2026 and beyond.
+
+## Why look for an alternative to Apache NiFi?
+
+Apache NiFi's strength lies in its visual, flow-based programming model and its extensive library of pre-built processors. It allows engineers to visually construct complex data flows, making it particularly effective for real-time data ingestion and routing. However, as data ecosystems evolve, some of NiFi's characteristics can become limitations.
+
+One of the most significant challenges is its operational complexity at scale. Managing state, scaling clusters, and ensuring high availability can require significant expertise and resources. Furthermore, while the visual interface is intuitive for some tasks, it can pose challenges for version control and GitOps practices. The traditional method of versioning flows using the NiFi Registry is a case in point. The Apache community voted to deprecate the NiFi Registry in February 2026, with plans to remove it in the upcoming NiFi 3.0. This move toward Git-based flow registries addresses a long-standing community request but also signals that the platform is adapting to modern development paradigms that were not part of its original design.
+
+For teams with diverse skill sets, NiFi's Java-centric ecosystem can be a hurdle. Modern data teams are often polyglot, using Python, SQL, and shell scripts interchangeably. Tools that require wrapping these scripts in platform-specific constructs can add friction. Finally, NiFi's resource consumption, particularly memory usage, can be substantial, requiring careful capacity planning. These factors lead many to explore alternatives that may offer a more declarative, code-native, or lightweight approach to building a [data pipeline](https://kestra.io/resources/data/data-pipeline).
+
+## How we evaluated these alternatives
+
+To provide a balanced comparison, we evaluated each Apache NiFi alternative based on a consistent set of criteria relevant to modern engineering teams. These criteria include:
+
+*   **Deployment Model:** Whether the tool runs on-premises, in the cloud, or in a hybrid model.
+*   **License:** If the tool is open-source, commercial, or follows a hybrid open-core model.
+*   **Primary Use Case:** The problem the tool is best suited to solve, from specific ETL tasks to general-purpose [data orchestration](https://kestra.io/resources/data/data-orchestration).
+*   **Ease of Use and Setup:** The learning curve and initial setup complexity, comparing visual interfaces to code-first or declarative approaches.
+*   **Scalability and Performance:** How well the tool handles growing data volumes and complex workloads.
+*   **Community and Support:** The strength of the open-source community or the quality of commercial support.
+*   **Cost-Effectiveness:** Total cost of ownership, including licensing, infrastructure, and operational overhead.
+*   **Integration Ecosystem:** The breadth and depth of available connectors, plugins, and integrations.
+
+## The Alternatives
+
+### 1. Kestra: Declarative Orchestration for Unified Workflows
+
+Kestra is an open-source orchestration platform that unifies data, AI, infrastructure, and business workflows under one declarative control plane. Unlike NiFi's visual-first approach, Kestra workflows are defined in simple YAML files, making them easy to version, review, and manage with Git.
+
+This declarative model separates the workflow definition from the execution logic, enabling a language-agnostic engine. Kestra can run tasks written in Python, SQL, Shell, Node.js, and more, without requiring platform-specific wrappers. Its event-driven architecture makes it highly suitable for real-time and reactive workflows. With an extensive plugin ecosystem and low operational overhead, Kestra is designed for modern data and platform engineering teams. For example, Leroy Merlin France leveraged Kestra to build a data mesh at scale, managing thousands of interdependent data pipelines declaratively.
+
+**Best for:** Kestra is best for engineering teams seeking a modern, declarative, and language-agnostic orchestrator that can unify diverse workflows across data, AI, and infrastructure.
+
+### 2. Airbyte: Open-Source Data Integration
+
+Airbyte is a leading open-source platform for data integration, focusing on the "Extract" and "Load" parts of the ELT process. Its primary strength is its vast library of over 300 pre-built connectors, which enable data replication from a wide array of sources to destinations like data warehouses and lakes.
+
+While NiFi is a general-purpose data flow tool, Airbyte is purpose-built for moving data. It offers a user-friendly UI for configuring connectors and managing syncs, but it can also be controlled via API. This makes it a powerful component within a larger data stack, often orchestrated by a tool like Kestra to handle post-ingestion transformations and business logic. You can learn more about how to [integrate Kestra and Airbyte](https://kestra.io/blogs/kestra-airbyte) to build robust pipelines.
+
+**Best for:** Airbyte is best for data teams needing extensive, customizable connectors for ELT, prioritizing rapid data ingestion over complex transformation logic.
+
+### 3. Apache Airflow: Workflow Orchestration
+
+Apache Airflow is the dominant open-source data orchestrator, particularly for batch-oriented workflows. Its core concept is defining workflows as Directed Acyclic Graphs (DAGs) in Python code. This "workflow-as-code" approach provides immense flexibility and is a natural fit for Python-heavy data teams.
+
+Compared to NiFi, Airflow excels at managing complex dependencies and scheduling batch jobs. It has a mature, battle-tested architecture and a massive ecosystem of operators for interacting with various systems. However, its reliance on Python can be a limitation for polyglot teams, and its operational complexity (requiring a scheduler, executor, web server, and metadata database) is significant. For a detailed breakdown, see our [Kestra vs. Airflow comparison](https://kestra.io/vs/airflow).
+
+**Best for:** Apache Airflow is best for Python-heavy data engineering teams with a strong preference for code-first workflow definitions and a need for a mature ecosystem of operators.
+
+### 4. StreamSets: Data Pipelines for the Enterprise
+
+StreamSets is a data integration platform designed for building smart data pipelines that can handle data drift—unexpected changes in data structure or semantics. It offers a visual pipeline designer similar to NiFi but places a strong emphasis on enterprise-grade governance, observability, and resilience. While primarily a commercial product, it includes open-source components like StreamSets Data Collector.
+
+Its ability to detect and handle data drift automatically makes it a strong choice for environments where data sources are unstable or poorly documented. It supports both batch and streaming data, making it a versatile tool for enterprise data integration in hybrid and multi-cloud settings.
+
+**Best for:** StreamSets is best for enterprises requiring a visual, enterprise-grade platform with strong data governance and drift detection for complex data integration across diverse environments.
+
+### 5. Talend: Powerful ETL Capabilities
+
+Talend is a comprehensive data integration and data management platform known for its powerful ETL capabilities. It provides a visual, Eclipse-based design environment (Talend Studio) where users can build complex data pipelines using a vast library of pre-built components and connectors.
+
+Talend offers both open-source (Talend Open Studio) and commercial versions, with the latter providing more advanced features for data quality, master data management, and enterprise-scale collaboration. It's a mature and robust solution, well-suited for traditional data warehousing, data migration, and complex, high-volume ETL processes.
+
+**Best for:** Talend is best for organizations needing a powerful, comprehensive data integration suite with strong ETL, data quality, and master data management features.
+
+### 6. Integrate.io: Comprehensive Data Integration Platform
+
+Integrate.io is a cloud-native, low-code data integration platform designed to be accessible to a wide range of users, not just data engineers. It offers a simple, visual interface for building ETL, ELT, and Reverse ETL pipelines, supported by a wide array of pre-built connectors.
+
+The platform's focus on ease of use and its fully managed nature make it an attractive option for small to medium-sized businesses or individual departments that need to set up data pipelines quickly without managing infrastructure. Its capabilities are particularly strong for integrating data from sales, marketing, and customer service applications.
+
+**Best for:** Integrate.io is best for business users and teams prioritizing ease of use, low-code development, and a managed service for comprehensive data integration.
+
+### 7. Fivetran: Automated Data Movement
+
+Fivetran is a cloud-native, fully automated data movement platform that simplifies the ELT process. It specializes in providing zero-maintenance connectors that automatically adapt to schema and API changes from the source. This "set it and forget it" approach makes it highly reliable and frees up engineering teams from the burden of building and maintaining data connectors.
+
+Unlike NiFi, which requires users to build and manage their data flows, Fivetran abstracts away the entire ingestion process. It is an excellent choice for teams that want to focus on data analysis and transformation rather than data ingestion.
+
+**Best for:** Fivetran is best for teams seeking fully automated, low-maintenance data ingestion from a wide array of sources, prioritizing reliability and ease of setup.
+
+### 8. SnapLogic Intelligent Integration Platform (IIP)
+
+SnapLogic is an enterprise Integration Platform as a Service (iPaaS) that handles application, data, and API integration. Its Intelligent Integration Platform uses AI-powered recommendations to help users build integrations faster. It features a visual, drag-and-drop interface for creating data pipelines, which it calls "Snaps."
+
+SnapLogic is designed for complex enterprise scenarios, connecting a wide variety of cloud and on-premises systems. It provides robust capabilities for API management and B2B integration, making it a broader platform than a pure data integration tool like NiFi.
+
+**Best for:** SnapLogic IIP is best for large enterprises requiring a comprehensive iPaaS solution with AI assistance for application, data, and API integration across hybrid environments.
+
+## Apache NiFi vs. Alternatives: A Feature Comparison
+
+Choosing the right tool requires a clear understanding of their fundamental differences. The table below summarizes the key characteristics of NiFi and its alternatives.
+
+| Tool | License | Deployment | Best for | Ease of Use | Scalability | Primary Persona |
+|---|---|---|---|---|---|---|
+| **Apache NiFi** | Open Source | On-Prem, Cloud | Visual dataflow automation | Moderate | High | Data Engineer |
+| **Kestra** | Open Source (OSS & EE) | On-Prem, Cloud, Hybrid | Unified declarative orchestration | High | Very High | Platform/Data Engineer |
+| **Airbyte** | Open Source (OSS & Cloud) | On-Prem, Cloud | Connector-based ELT | High | High | Analytics Engineer |
+| **Apache Airflow** | Open Source | On-Prem, Cloud | Python-based batch orchestration | Moderate | High | Data Engineer |
+| **StreamSets** | Commercial (OSS components) | On-Prem, Cloud, Hybrid | Enterprise data drift handling | Moderate | High | Enterprise Architect |
+| **Talend** | Commercial (OSS available) | On-Prem, Cloud | Comprehensive ETL & data management | Moderate | High | ETL Developer |
+| **Integrate.io** | Commercial | Cloud | Low-code data integration | Very High | Moderate | Business Analyst |
+| **Fivetran** | Commercial | Cloud | Automated data movement (ELT) | Very High | High | Data Analyst |
+| **SnapLogic** | Commercial | Cloud, Hybrid | Enterprise iPaaS | High | High | Integration Specialist |
+
+While NiFi's visual approach is powerful, alternatives like Kestra offer a declarative, YAML-based experience that aligns better with modern GitOps and CI/CD practices. Code-first tools like Airflow provide unparalleled flexibility for Python developers, whereas fully managed services like Fivetran and Integrate.io prioritize ease of use and low operational overhead. The choice often comes down to balancing control, flexibility, and the total cost of ownership, which includes both licensing fees and the operational burden of self-hosting. For more on this, see our breakdown of [Open-Source vs. Enterprise editions](https://kestra.io/docs/oss-vs-paid).
+
+## Choosing the Best Apache NiFi Alternative for Your Needs
+
+So, what is better than NiFi? The answer depends entirely on your specific use case, team skills, and organizational goals. There is no single best alternative, only the right fit for the job.
+
+If your primary need is real-time data routing with complex, dynamic rules, and your team is comfortable with its operational model, NiFi remains a strong contender. However, if you're facing challenges with versioning, scalability, or cross-domain orchestration, it's worth considering an alternative.
+
+*   **For data engineering teams** building complex, batch-oriented pipelines with Python, **Apache Airflow** is a natural choice. For teams focused on rapidly ingesting data from hundreds of sources, **Airbyte** is hard to beat. For those needing a unified platform to orchestrate ELT, dbt transformations, and data quality checks in a declarative, language-agnostic way, **Kestra** provides a modern solution.
+*   **For infrastructure and DevOps teams** tasked with automating more than just data flows, a broader orchestrator is needed. **Kestra** excels here by managing infrastructure-as-code tools like Terraform and Ansible alongside data tasks. Enterprise iPaaS solutions like **SnapLogic** or **StreamSets** also fit well when integration spans both on-prem and cloud applications.
+*   **For AI and ML platform teams**, the ability to orchestrate multi-step pipelines involving data preparation, model training, and deployment is key. **Kestra**'s language-agnostic engine is ideal for coordinating Python-based ML tasks with data ingestion and infrastructure provisioning.
+*   **For small teams or business users**, the simplicity of managed, low-code platforms like **Integrate.io** or the zero-maintenance approach of **Fivetran** can deliver value much faster than a self-hosted open-source tool.
+
+Ultimately, Apache NiFi is still worth using in 2026 for the specific dataflow automation use cases it was designed for. But the modern data landscape requires tools that are more flexible, developer-friendly, and capable of orchestrating workflows across the entire tech stack.
+
+The world of data integration is no longer isolated from infrastructure automation or AI. The most effective solutions provide a unified control plane to manage all these processes. By evaluating your needs against the alternatives presented here, you can select a platform that not only solves today's data flow challenges but also scales to meet the orchestration demands of the future. Explore Kestra's declarative approach to unify your [data](https://kestra.io/data), [AI](https://kestra.io/ai-automation), and [infrastructure](https://kestra.io/infra-automation) workflows by checking out our [getting started guide](https://kestra.io/get-started).

--- a/src/contents/resources/apache-nifi-alternatives/index.md
+++ b/src/contents/resources/apache-nifi-alternatives/index.md
@@ -3,7 +3,7 @@ title: "8 Best Apache NiFi Alternatives (Open Source & Commercial)"
 description: "Explore the best Apache NiFi alternatives for data integration and ETL. Compare open-source tools and find your ideal solution today!"
 metaTitle: "8 Best Apache NiFi Alternatives (Open Source & Commercial)"
 metaDescription: "Looking for Apache NiFi alternatives? Compare top open-source tools like Kestra, Airflow, and Airbyte with commercial options for robust data integration and ETL workflows."
-tag: "data-orchestration"
+tag: "data"
 date: 2026-05-30
 slug: "apache-nifi-alternatives"
 faq:

--- a/src/contents/resources/apache-nifi-alternatives/index.md
+++ b/src/contents/resources/apache-nifi-alternatives/index.md
@@ -20,7 +20,6 @@ faq:
   - question: "How does Kestra compare to Apache NiFi for data integration?"
     answer: "Kestra offers a declarative, YAML-based approach to data integration, contrasting with NiFi's visual flow-based design. While NiFi excels at real-time dataflow automation, Kestra provides a unified platform to orchestrate not just data integration, but also transformations, AI workflows, and infrastructure operations with a language-agnostic engine. Kestra emphasizes GitOps, event-driven execution, and lower operational complexity."
 author: "elliot"
-image: "/images/resources/apache-nifi-alternatives/cover.png"
 ---
 
 Apache NiFi has long been a go-to for data engineers seeking to automate and manage data flows, excelling in real-time data ingestion and complex routing with its visual interface. However, recent shifts, such as the deprecation of its native NiFi Registry in February 2026, signal a move towards more Git-centric and declarative approaches in the data integration landscape. This change prompts many organizations to re-evaluate their orchestration strategies and consider modern alternatives.

--- a/src/contents/resources/astronomer-alternatives/index.md
+++ b/src/contents/resources/astronomer-alternatives/index.md
@@ -1,0 +1,125 @@
+---
+title: "Top Astronomer Alternatives: Expert Insights for Data Orchestration"
+description: "Explore top Astronomer alternatives and competitors like Kestra, Apache Airflow, Prefect, and Dagster. Find the best solution for your data orchestration needs today."
+metaTitle: "Top Astronomer Alternatives & Competitors | Kestra"
+metaDescription: "Seeking Astronomer alternatives? Compare Kestra, Apache Airflow, Prefect, Dagster, and more. Get expert insights to choose the best data orchestration platform."
+tag: "data-orchestration"
+date: 2026-05-27
+slug: "astronomer-alternatives"
+faq:
+  - question: "Who is Astronomer's biggest competitor?"
+    answer: "Astronomer operates in the managed data orchestration space, building on Apache Airflow. Key competitors include other managed Airflow providers like Google Cloud Composer, as well as alternative orchestration platforms such as Kestra, Prefect, and Dagster, which offer different architectural approaches and feature sets."
+  - question: "Is Astronomer the same as Airflow?"
+    answer: "No, Astronomer is a commercial platform that provides a managed service and enterprise features built on top of the open-source Apache Airflow. While it leverages Airflow's core capabilities, Astronomer adds value through enhanced monitoring, scalability, security, and support, simplifying Airflow operations for large organizations."
+  - question: "Is there anything better than Airflow?"
+    answer: "Whether an alternative is 'better' than Airflow depends on specific needs. Tools like Kestra offer declarative YAML, polyglot task execution, and cross-domain orchestration. Dagster provides an asset-centric approach for data lineage, while Prefect focuses on a Python-native developer experience. Each offers distinct advantages over Airflow's traditional Python DAG model."
+  - question: "What companies use Astronomer?"
+    answer: "Astronomer serves a wide range of enterprises that rely on Apache Airflow for their data orchestration, particularly those needing robust managed services, enhanced support, and enterprise-grade features. While specific customer lists are often private, large organizations with complex data pipelines are typical users."
+  - question: "Can Kestra replace Astronomer?"
+    answer: "Kestra can serve as a compelling alternative to Astronomer, especially for organizations seeking a declarative, language-agnostic, and event-driven orchestration platform that can unify data, AI, and infrastructure workflows. It offers a self-hosted open-source option, enterprise edition, and managed cloud, providing flexibility beyond a managed Airflow solution."
+  - question: "How does Google Cloud Composer compare to Astronomer?"
+    answer: "Google Cloud Composer is Google's managed Apache Airflow service, similar to Astronomer's offering. Both simplify Airflow deployment and operation. The choice often comes down to cloud ecosystem preference (GCP vs. multi-cloud/hybrid) and specific enterprise features or support models offered by each vendor."
+author: "Kestra"
+image: "/images/blogs/astronomer-alternatives/cover.png"
+---
+
+Apache Airflow celebrated its 10-year anniversary this year, a testament to its enduring impact on data orchestration. For many organizations, managing Airflow at scale, especially with its Python-based DAGs and complex operational overhead, has led to the emergence of managed services like Astronomer. Astronomer, built on Airflow, aims to simplify these challenges by offering enterprise-grade features and support. However, as data stacks evolve and engineering teams demand more flexibility beyond Python-centric pipelines or vendor lock-in, the need for robust alternatives has grown.
+
+The leading alternatives to Astronomer in 2026 include Kestra, Apache Airflow (OSS), Prefect, Dagster, Google Cloud Composer, Databricks Workflows, and AWS Step Functions. Each offers unique strengths, catering to different architectural preferences, team compositions, and deployment strategies. This article will delve into why many data practitioners are exploring options beyond Astronomer, evaluate the top alternatives based on critical criteria, and provide expert insights to help you choose the best solution for your organization's evolving data orchestration needs.
+
+## Why look for an alternative to Astronomer?
+
+While Astronomer provides a valuable service by managing the complexities of Airflow, several factors drive teams to seek alternatives.
+
+- **Operational Complexity of Managed Airflow**: Astronomer simplifies Airflow deployment, but teams still operate within the Airflow paradigm. This means they inherit challenges like debugging complex Python DAGs, managing dependencies, and dealing with scheduler intricacies that a managed service can only partially abstract away.
+- **Vendor Lock-in and Cost Concerns**: Committing to a single managed service for a critical component like orchestration can lead to vendor lock-in. As data pipelines scale, the cost structure of a managed platform may become less economical compared to open-source solutions or platforms with more flexible licensing models.
+- **Python-centric Limitations**: Airflow's foundation in Python can be a constraint for polyglot engineering teams. Workflows that require R, Go, Java, or complex shell scripting often need cumbersome workarounds, limiting the platform's utility as a universal orchestrator.
+- **Narrower Scope for Cross-Domain Orchestration**: Astronomer is primarily designed for data pipeline orchestration. For organizations looking to unify data workflows with infrastructure automation, AI/ML pipelines, or business process automation, a more domain-agnostic platform is often required.
+- **Migration Considerations for Airflow 3.0**: The [migration from Airflow 2 to 3](//blogs/airflow-3-vs-airflow-2) is a significant undertaking. This natural inflection point encourages teams to evaluate whether to reinvest in the Airflow ecosystem or explore modern [enterprise Airflow alternatives](//blogs/enterprise-airflow-alternatives) that offer different architectural benefits.
+
+## How we evaluated these alternatives
+
+We evaluated each Astronomer alternative on its core architectural design, deployment flexibility (cloud-native, hybrid, on-prem), language agnosticism, native AI integrations, operational overhead, and overall community health. Our goal is to provide a comprehensive perspective that moves beyond traditional data-only comparisons to embrace the modern demands of unified orchestration.
+
+## The Top Astronomer Alternatives
+
+### 1. Kestra
+
+Kestra is the open-source orchestration platform that unifies data, AI, infrastructure, and business workflows under one declarative control plane. Instead of defining pipelines in Python code, Kestra uses a simple, declarative YAML interface. This makes workflows easier to write, review, and manage, especially for teams with diverse technical skills.
+
+Its key strengths lie in its language-agnostic and event-driven architecture. Kestra can natively execute tasks in Python, R, Go, SQL, Shell, and Docker containers without complex workarounds. With over 1,400 plugins, a strong GitOps integration, and native AI capabilities, it serves as a universal control plane. Kestra's flexible deployment options—including open-source, enterprise, and a managed cloud offering—allow it to run anywhere from Kubernetes to on-prem, air-gapped environments. This versatility is demonstrated by its adoption at companies like [Apple and JPMorgan Chase](//blogs/kestra-series-a) for mission-critical, large-scale orchestration. While Kestra is a newer entrant compared to Airflow, its modern architecture addresses many of the limitations inherent in older, code-based orchestrators. You can learn more about its philosophy in the [Why Kestra](/docs/why-kestra) documentation or explore ready-to-use workflows in our [Blueprints library](/blueprints).
+
+**Best for**: Organizations seeking a truly universal, declarative orchestrator that unifies diverse technical and business workflows, prioritizes GitOps, and needs robust, scalable execution across any environment.
+
+### 2. Apache Airflow (Open Source)
+
+Apache Airflow is the dominant open-source data orchestrator, known for its Python-based DAGs and extensive operator ecosystem. As the foundation for Astronomer, self-hosting Airflow offers complete control and avoids vendor lock-in. Its strengths are its maturity, a massive and active community, and an unparalleled library of operators that can connect to almost any tool in the data ecosystem. For a decade, it has been the go-to choice for data engineers who prefer a code-first approach to defining pipelines.
+
+The primary trade-off is the significant operational overhead required to run, scale, and maintain it in production. Unlike Kestra's declarative model, Airflow's Python DAGs can become complex to manage, version, and debug. Astronomer solves the operational burden but adds a commercial layer. For teams considering managed Airflow, understanding the open-source baseline is crucial.
+
+**Best for**: Python-heavy data teams with existing Airflow expertise who prefer a code-first approach and are willing to manage the operational burden of a self-hosted solution.
+
+### 3. Prefect
+
+Prefect is a Pythonic orchestrator focused on developer experience and dynamic workflows. It positions itself as a modern alternative to Airflow, offering features like native async support, a powerful UI for visualizing and managing dynamic runs, and a flexible hybrid execution model. This model allows a managed cloud control plane to orchestrate tasks on customer-managed workers, providing a balance of convenience and control.
+
+However, Prefect remains a Python-only tool, defining workflows in code rather than a declarative format like Kestra's YAML. Its business model is also cloud-first, which may not be suitable for all deployment scenarios. Is Prefect a good alternative to Astronomer? Yes, for teams that want to stay within the Python ecosystem but desire a more modern and developer-friendly experience than traditional Airflow.
+
+**Best for**: Python-centric data and ML teams looking for a modern, developer-friendly orchestration tool with dynamic flow capabilities, especially if they prefer a managed cloud control plane.
+
+### 4. Dagster
+
+Dagster is an asset-centric orchestrator that brings a software-engineering approach to data pipelines. Its core paradigm focuses on data assets (like tables or models) rather than tasks, providing excellent data lineage and observability out of the box. With strong typing, built-in testing capabilities, and native dbt integration, Dagster is highly appealing to analytics engineering teams.
+
+The trade-offs include a steeper learning curve due to its opinionated, asset-based model and its Python-only nature. This asset-centric approach, while powerful for data, is less intuitive for orchestrating non-data workflows like infrastructure provisioning or business processes. For teams committed to Airflow's task-based model, Dagster represents a significant mental shift.
+
+**Best for**: Analytics engineering teams and data platform teams heavily invested in dbt and software-engineering best practices for data, prioritizing data lineage and asset management.
+
+### 5. Google Cloud Composer
+
+Google Cloud Composer is Google's managed Apache Airflow service. As a direct competitor to Astronomer, it offers a fully managed environment that handles the installation, scaling, and maintenance of Airflow. Its primary advantage is its deep integration with the Google Cloud Platform, making it a seamless choice for teams already invested in services like BigQuery, GCS, and Dataproc.
+
+The main drawbacks are its lock-in to the GCP ecosystem and the fact that it inherits Airflow's core Python-centric architecture. While it reduces operational toil, it doesn't solve the fundamental challenges of DAG complexity or the need for polyglot orchestration. The choice between Composer and Astronomer often boils down to your cloud strategy and which vendor's enterprise features best fit your needs.
+
+**Best for**: Organizations deeply committed to the Google Cloud ecosystem that want a managed Airflow experience without the burden of self-management.
+
+### 6. Databricks Workflows
+
+Databricks Workflows provides native orchestration for jobs running within the Databricks Lakehouse platform. It is designed to seamlessly schedule and manage Databricks-native tasks like notebooks, SQL queries, and ML model training. For teams whose entire data lifecycle lives within Databricks, it's a convenient and tightly integrated solution that minimizes tool sprawl.
+
+Its limitation is that it is platform-bound. Databricks Workflows is not a general-purpose orchestrator and struggles to manage tasks that run outside the Databricks ecosystem. For complex pipelines that need to coordinate tools across different clouds or on-prem systems, a universal orchestrator like Kestra is a more suitable choice.
+
+**Best for**: Existing Databricks customers who want to orchestrate workloads primarily within the Databricks platform and minimize tool sprawl.
+
+### 7. AWS Step Functions
+
+AWS Step Functions is a serverless workflow service for orchestrating distributed applications and microservices within the AWS ecosystem. It uses a visual workflow builder and a JSON-based state machine definition to coordinate AWS services like Lambda, ECS, and SQS. Its strengths are its serverless nature, managed durability, and deep integration with the AWS stack.
+
+While powerful for application integration, Step Functions is less suited for traditional, data-heavy batch pipelines and is entirely locked into the AWS cloud. It lacks the polyglot code execution and cross-platform capabilities of a tool like Kestra, making it a specialized alternative rather than a universal one.
+
+**Best for**: AWS-native organizations building serverless applications or microservices that need to coordinate various AWS services with managed durability.
+
+## Comparison Table
+
+| Tool | License | Deployment | Best for | Python-only? | Declarative? | Cross-Domain? |
+|---|---|---|---|---|---|---|
+| Kestra | Apache 2.0 OSS / EE | Hybrid (Cloud, K8s, on-prem) | Universal orchestration (data, AI, infra, business) | No | Yes (YAML) | Yes |
+| Apache Airflow (OSS) | Apache 2.0 OSS | Self-hosted | Python-centric data pipelines | Yes | No (Python code) | Limited |
+| Prefect | Apache 2.0 OSS / Cloud | Hybrid (Cloud + workers) | Python-native dynamic data/AI workflows | Yes | No (Python code) | Limited |
+| Dagster | Apache 2.0 OSS / Cloud | Self-hosted / Cloud | Asset-centric data lineage & analytics engineering | Yes | No (Python code) | Limited |
+| Google Cloud Composer | Managed Service | GCP Cloud | Managed Airflow for GCP-centric teams | Yes | No (Python code) | Limited |
+| Databricks Workflows | Proprietary | Databricks Platform | Lakehouse-native ETL/ML jobs | No (Spark) | Yes (notebooks/jobs) | No |
+| AWS Step Functions | Proprietary | AWS Cloud | Serverless application/microservice orchestration | No (AWS services) | Yes (JSON) | No |
+
+
+## Finding the best solution for your data pipelines
+
+- **For data engineering teams**: If your team is primarily Python-centric and values a vast ecosystem, Apache Airflow remains a strong contender, either self-hosted or via a managed provider. For modern, asset-centric approaches, Dagster offers superior lineage. If you need polyglot, declarative capabilities beyond Python for [data orchestration](/resources/data/data-orchestration), Kestra stands out. Explore Kestra's capabilities for [data teams](/data).
+- **For infrastructure / DevOps teams**: Teams prioritizing GitOps and [infrastructure-as-code](/resources/infrastructure/what-is-infrastructure-as-code) principles will find Kestra's declarative YAML and cross-domain capabilities highly appealing. AWS Step Functions can be powerful for AWS-native infra automation. See how Kestra can serve as your [infrastructure automation control plane](/infra-automation).
+- **For AI / ML platform teams**: Kestra's AI-native agents and polyglot support for ML frameworks make it a strong choice for unifying diverse [MLOps workflows](/resources/ai/what-is-mlops). Databricks Workflows is excellent for ML pipelines strictly within the Lakehouse. Prefect also offers a compelling Python-native experience for ML. Discover Kestra's solutions for [AI automation](/ai-automation).
+- **For small teams getting started**: Open-source Airflow or Kestra's OSS edition provide powerful, free starting points. Prefect also offers a generous free tier for its managed service.
+
+## Conclusion
+
+Choosing the right orchestration platform is a strategic decision that impacts team productivity, operational costs, and future scalability. While Astronomer offers a robust managed Airflow experience, the market provides diverse alternatives tailored to specific needs—from Kestra's universal declarative approach to Dagster's asset-centric data focus. By carefully evaluating your team's technical stack, operational preferences, and long-term vision, you can select an orchestrator that truly empowers your engineering efforts.
+```

--- a/src/contents/resources/astronomer-alternatives/index.md
+++ b/src/contents/resources/astronomer-alternatives/index.md
@@ -3,7 +3,7 @@ title: "Top Astronomer Alternatives: Expert Insights for Data Orchestration"
 description: "Explore top Astronomer alternatives and competitors like Kestra, Apache Airflow, Prefect, and Dagster. Find the best solution for your data orchestration needs today."
 metaTitle: "Top Astronomer Alternatives & Competitors | Kestra"
 metaDescription: "Seeking Astronomer alternatives? Compare Kestra, Apache Airflow, Prefect, Dagster, and more. Get expert insights to choose the best data orchestration platform."
-tag: "data-orchestration"
+tag: "data"
 date: 2026-05-27
 slug: "astronomer-alternatives"
 faq:

--- a/src/contents/resources/astronomer-alternatives/index.md
+++ b/src/contents/resources/astronomer-alternatives/index.md
@@ -20,7 +20,6 @@ faq:
   - question: "How does Google Cloud Composer compare to Astronomer?"
     answer: "Google Cloud Composer is Google's managed Apache Airflow service, similar to Astronomer's offering. Both simplify Airflow deployment and operation. The choice often comes down to cloud ecosystem preference (GCP vs. multi-cloud/hybrid) and specific enterprise features or support models offered by each vendor."
 author: "Kestra"
-image: "/images/blogs/astronomer-alternatives/cover.png"
 ---
 
 Apache Airflow celebrated its 10-year anniversary this year, a testament to its enduring impact on data orchestration. For many organizations, managing Airflow at scale, especially with its Python-based DAGs and complex operational overhead, has led to the emergence of managed services like Astronomer. Astronomer, built on Airflow, aims to simplify these challenges by offering enterprise-grade features and support. However, as data stacks evolve and engineering teams demand more flexibility beyond Python-centric pipelines or vendor lock-in, the need for robust alternatives has grown.

--- a/src/contents/resources/aws-step-functions-alternatives/index.md
+++ b/src/contents/resources/aws-step-functions-alternatives/index.md
@@ -1,0 +1,140 @@
+---
+title: "AWS Step Functions Alternatives You Need to Know"
+description: "Explore top AWS Step Functions alternatives, including open-source options and managed solutions. Find the best fit for your workflow orchestration needs today!"
+metaTitle: "AWS Step Functions Alternatives | Kestra"
+metaDescription: "Seeking AWS Step Functions alternatives? Discover open-source, managed, and flexible solutions like Kestra, Temporal, and Airflow for your workflow orchestration needs."
+tag: "Infrastructure Automation"
+date: 2026-05-27
+slug: "aws-step-functions-alternatives"
+faq:
+  - question: "How do AWS Step Functions compare to n8n for workflow automation?"
+    answer: "AWS Step Functions are designed for coordinating workflows across AWS services, ideal for cloud-native engineers. n8n, conversely, is a visual, open-source automation tool focused on integrating SaaS applications and APIs. While both orchestrate multi-step processes, Step Functions is deeply integrated into the AWS ecosystem, whereas n8n offers broader connectivity to external business applications for non-AWS-centric automation."
+  - question: "What are the key differences between AWS Step Functions and MWAA?"
+    answer: "AWS Step Functions is a serverless orchestration service for coordinating AWS services into state machine-driven workflows. AWS MWAA (Managed Workflows for Apache Airflow) provides a managed environment for Apache Airflow, an open-source platform for programmatically authoring, scheduling, and monitoring data pipelines. Step Functions is AWS-native and state-machine-based, while MWAA offers the flexibility and ecosystem of Airflow as a managed service."
+  - question: "What are the main limitations of AWS Step Functions?"
+    answer: "The primary limitation of AWS Step Functions is its strong vendor lock-in to the AWS ecosystem, making multi-cloud or hybrid-cloud orchestration challenging. It can also introduce complexity for very long-running or highly dynamic workflows that require custom code outside of simple service integrations. Operational visibility for deeply nested state machines can sometimes be difficult without additional tooling."
+  - question: "Is using AWS Step Functions more cost-effective than AWS Lambda?"
+    answer: "In scenarios where Step Functions is orchestrating multiple Lambda functions, you pay for both. However, for complex workflows involving multiple steps, Step Functions can be more cost-effective than managing the state and error handling within individual Lambda functions or custom code. Step Functions charges per state transition, which can be cheaper than the compute costs and development effort of building equivalent logic with Lambda alone."
+  - question: "Why consider alternatives to AWS Step Functions for workflow orchestration?"
+    answer: "Organizations often seek alternatives to AWS Step Functions due to concerns about vendor lock-in, as it's tightly integrated with the AWS ecosystem. Other reasons include a need for multi-cloud or hybrid-cloud orchestration, a desire for open-source solutions to avoid proprietary dependencies, or a preference for declarative workflow definitions that are easier to version and manage as code. Cost optimization for specific use cases can also be a factor."
+author: "elliot"
+image: "/images/blogs/aws-step-functions-alternatives/cover.png"
+---
+
+AWS Step Functions has long served as a powerful serverless orchestration tool for many organizations deeply invested in the Amazon Web Services ecosystem. It excels at coordinating various AWS services into robust, state-machine-driven workflows, providing reliability and built-in error handling for cloud-native applications. However, as enterprises expand their operations across multiple clouds, integrate diverse technologies, or seek greater control over their orchestration layer, the limitations of a vendor-specific solution become increasingly apparent. Concerns about vendor lock-in, the complexity of managing highly dynamic workflows, and the desire for more flexible, open-source alternatives are driving many to explore beyond AWS's native offerings.
+
+This guide delves into the top AWS Step Functions alternatives in 2026, offering a comprehensive comparison of leading open-source, managed, and cloud-agnostic platforms. We will examine solutions like Kestra, Temporal, Apache Airflow, and others, evaluating them against criteria such as deployment flexibility, language support, cost-efficiency, and ecosystem integration. Whether you're a data engineering team, an infrastructure specialist, or an AI/ML platform builder, this article will equip you with the insights needed to choose the right orchestrator that aligns with your specific technical requirements and strategic vision, ensuring your workflows run seamlessly across any environment.
+
+## Why look for an alternative to AWS Step Functions?
+
+AWS Step Functions is a serverless workflow service that allows developers to coordinate multiple AWS services into visual, state machine-driven workflows. It's an excellent choice for orchestrating sequences of Lambda functions, ECS tasks, and other AWS resources. However, teams often start looking for alternatives when they encounter certain limitations:
+
+*   **Vendor Lock-In:** The most significant drawback is its tight coupling to the AWS ecosystem. Workflows built in Step Functions are not portable to other cloud providers or on-premise environments, making [multi-cloud orchestration](https://kestra.io/resources/infrastructure/multi-cloud-orchestration) difficult.
+*   **Complexity in Hybrid Environments:** Integrating with services outside of AWS can be cumbersome. While it supports HTTP tasks, the primary design focus is on AWS services, which can add friction when orchestrating tools across different clouds or on-premise data centers.
+*   **Limited Language and Tooling Flexibility:** While Step Functions can invoke code in any language via Lambda or container tasks, the orchestration logic itself is defined in Amazon States Language (ASL), a JSON-based structured language. This can be less flexible than general-purpose programming languages or declarative YAML for complex logic.
+*   **Cost Considerations:** For workflows with a very high volume of state transitions, the pay-per-transition pricing model can become expensive. Evaluating the cost-effectiveness against self-hosted or other managed solutions is a common driver for seeking alternatives.
+*   **Operational Visibility:** While Step Functions provides a visual representation of workflows, debugging complex, deeply nested state machines can be challenging. Teams may require more advanced observability and a unified view that spans beyond a single cloud provider.
+
+For a direct comparison, see our [Kestra vs. AWS Step Functions](https://kestra.io/vs/aws-step-functions) page.
+
+## How we evaluated these alternatives
+
+To provide a balanced comparison, we evaluated each AWS Step Functions alternative based on a core set of criteria relevant to modern engineering teams:
+
+*   **Deployment Flexibility:** Can the tool run anywhere—cloud, on-premise, hybrid, or even air-gapped environments?
+*   **Language and Tool Agnosticism:** Does it support running tasks in multiple languages (polyglot) and integrate with a wide range of tools, not just those from a single vendor?
+*   **Workflow Definition:** Are workflows defined declaratively (e.g., YAML) for easy version control and GitOps, or are they defined programmatically in code?
+*   **Scalability and Operational Overhead:** How does the platform scale, and what is the level of effort required to maintain it?
+*   **Cost-Efficiency:** What is the pricing model (open-source, usage-based, per-seat), and how does it compare for different use cases?
+*   **Community and Ecosystem:** How active is the community, and how extensive is the ecosystem of plugins and integrations?
+
+For more details on Kestra's architecture, you can review our [deployment architecture documentation](https://kestra.io/docs/architecture/deployment-architecture).
+
+## The Top 7 AWS Step Functions Alternatives
+
+### 1. Kestra: The Open-Source, Cloud-Agnostic Control Plane
+
+Kestra is an open-source orchestration platform that unifies data, AI, infrastructure, and business workflows under a single, declarative control plane. Workflows are defined in simple YAML, making them easy to write, review, and manage with GitOps practices.
+
+Its key strength lies in its vendor-agnostic and language-agnostic design. With a rich ecosystem of plugins, Kestra can orchestrate any tool, from dbt and Terraform to custom Python scripts and Docker containers, across any cloud or on-premise environment. Its event-driven architecture allows for building highly responsive and scalable systems. For instance, global enterprises like Crédit Agricole use Kestra to replace fragmented infrastructure scripts and cron jobs with a single, auditable orchestration layer. While Kestra offers a powerful UI with a visual editor, its core is YAML-first, which may represent a shift for teams accustomed to purely drag-and-drop interfaces.
+
+**Best for:** Teams seeking a truly vendor-neutral, scalable, and declarative orchestration platform to manage workflows across all technical domains.
+
+### 2. Temporal: Durable Execution for Microservices
+
+Temporal is a workflow-as-code platform designed for application developers, focusing on providing durable, reliable execution for long-running processes. It uses an SDK-driven, code-first approach, allowing developers to write complex workflow logic in languages like Go, Java, Python, and TypeScript.
+
+Temporal's main advantage is its powerful primitives for handling failures, retries, and compensations, making it ideal for stateful application workflows like order processing or user sign-ups. However, its focus on application-level orchestration makes it less natural for batch data pipelines or infrastructure automation tasks. The code-first model also means that workflow logic is embedded within application code, which can be less accessible to non-developer personas.
+
+**Best for:** Application engineering teams building distributed, stateful backend systems that require high durability and fault tolerance.
+
+### 3. Apache Airflow: The Pythonic Data Orchestrator
+
+Apache Airflow is the dominant open-source orchestrator in the data engineering space. Its "DAGs-as-code" paradigm, where workflows are defined in Python, has made it a standard for data teams. It boasts a massive community and an extensive catalog of operators and providers for integrating with various data sources and tools.
+
+Airflow's strength is its deep alignment with the Python data ecosystem. However, this is also its limitation. It is primarily a data-centric tool and can be operationally complex to set up and maintain at scale. The tight coupling to Python means that even non-Python tasks must be wrapped in Python code, which can add unnecessary overhead.
+
+**Best for:** Python-heavy data engineering teams with an existing investment in the Airflow ecosystem and a primary focus on [data orchestration](https://kestra.io/resources/data/data-orchestration).
+
+### 4. Apache NiFi: Flow-Based Data Integration
+
+Apache NiFi is an open-source tool for automating the movement of data between software systems. It provides a web-based, visual user interface for designing, controlling, and monitoring data flows. NiFi's core strength is its flow-based programming model, which excels at real-time data ingestion, routing, and transformation, with strong data provenance capabilities.
+
+While powerful for dataflow management, NiFi is less suited for general-purpose workflow orchestration that involves complex, multi-step logic, conditional branching, or integration with non-data systems like infrastructure tools. For teams accustomed to modern IaC practices, the developer experience can feel dated compared to declarative or code-first alternatives.
+
+**Best for:** Teams focused on real-time data ingestion, routing, and transformation with strong data provenance needs.
+
+### 5. n8n: Visual App Automation for Business Workflows
+
+n8n is an open-source workflow automation tool often described as a "self-hosted Zapier." It features a visual, node-based editor that makes it easy to connect hundreds of SaaS applications and APIs to automate business processes. It has gained popularity for its user-friendly interface and growing capabilities in AI automation.
+
+n8n excels at app-to-app integration and is a great choice for operations teams or citizen developers. However, it is not designed for high-throughput data pipelines or complex infrastructure orchestration. The visual-first authoring model can also become a challenge for governance and version control in complex, mission-critical engineering workflows.
+
+**Best for:** Operations teams and non-engineers automating SaaS-to-SaaS integrations and business processes.
+
+### 6. Google Cloud Workflows: GCP-Native Service Orchestration
+
+Google Cloud Workflows is the direct counterpart to AWS Step Functions within the Google Cloud ecosystem. It is a fully managed, serverless service for orchestrating and automating Google Cloud and HTTP-based API services. Workflows are defined in YAML, making them easy to read and version control.
+
+Like Step Functions, its primary strength is its deep integration with its native cloud ecosystem (GCP). It offers a pay-per-use pricing model and a serverless execution environment. The main limitation is, again, vendor lock-in. It is designed for orchestrating GCP services and is not a suitable choice for multi-cloud, hybrid, or on-premise scenarios.
+
+**Best for:** Organizations deeply committed to the Google Cloud Platform for their API and service orchestration needs.
+
+### 7. AWS MWAA: Managed Airflow for AWS
+
+For teams that like the Airflow paradigm but want to stay within the AWS ecosystem, Amazon Managed Workflows for Apache Airflow (MWAA) is a strong contender. It provides a fully managed Airflow environment, reducing the operational burden of hosting and scaling it yourself. It integrates with AWS security, monitoring, and identity services.
+
+MWAA offers the familiarity and extensive ecosystem of Airflow. However, it inherits Airflow's data-centric and Python-focused nature. It also represents a form of vendor lock-in, as it ties your orchestration platform to AWS, even though Airflow itself is open-source.
+
+**Best for:** Existing Airflow users who want a managed Airflow experience within the AWS ecosystem.
+
+## Comparison Table: AWS Step Functions Alternatives at a Glance
+
+| Tool | License | Deployment | Primary Use Case | Language Agnosticism | Vendor Lock-in | Pricing Model |
+|---|---|---|---|---|---|---|
+| **Kestra** | Apache 2.0 | Any Cloud, On-Prem, Hybrid | Universal Orchestration (Data, Infra, AI) | Yes (Polyglot) | None | Open-Source / Enterprise |
+| **Temporal** | MIT | Any Cloud, On-Prem | Application Workflows | Yes (SDK-based) | None | Open-Source / Cloud |
+| **Apache Airflow** | Apache 2.0 | Any Cloud, On-Prem | Data Orchestration | No (Python-centric) | None | Open-Source |
+| **Apache NiFi** | Apache 2.0 | Any Cloud, On-Prem | Dataflow Automation | No (JVM-based) | None | Open-Source |
+| **n8n** | Sustainable Use License | Any Cloud, On-Prem | SaaS/Business Automation | Yes (via integrations) | None | Open-Source / Cloud |
+| **Google Cloud Workflows** | Proprietary | GCP Only | GCP Service Orchestration | Yes (via HTTP) | High (GCP) | Usage-based |
+| **AWS MWAA** | Proprietary (Service) | AWS Only | Managed Data Orchestration | No (Python-centric) | High (AWS) | Usage-based |
+
+## How to Choose the Right Alternative for Your Workflows
+
+Selecting the right orchestrator depends on your team's primary needs and technical environment.
+
+*   **For data engineering teams:** If you need a flexible platform for complex ETL/ELT pipelines that span multiple tools and languages, **Kestra** offers a declarative, polyglot solution. If your team is heavily invested in Python and the data ecosystem, **Apache Airflow** (or **AWS MWAA**) is a standard choice. For data-intensive application logic, **Temporal** can be a good fit. Explore more on [declarative orchestration for data engineers](https://kestra.io/data).
+*   **For infrastructure & DevOps teams:** If your goal is to automate infrastructure provisioning, CI/CD pipelines, and GitOps workflows across any cloud, **Kestra** provides a vendor-neutral control plane. **Temporal** is suitable for orchestrating complex, stateful infrastructure logic within microservices. **Google Cloud Workflows** is an option if you are fully committed to GCP. Learn more about [infrastructure automation](https://kestra.io/infra-automation).
+*   **For AI/ML platform teams:** **Kestra** can orchestrate the entire ML lifecycle, from data ingestion and feature engineering to model training and deployment, integrating with any AI tool or provider. **Temporal** is effective for managing long-running, stateful ML inference workflows. Discover more on [AI pipeline automation](https://kestra.io/ai-automation).
+*   **For business automation & citizen integrators:** If you need to quickly connect SaaS apps and automate business processes with a visual interface, **n8n** is an excellent choice.
+*   **For teams committed to AWS:** If you are not looking to move away from AWS but need a more data-centric tool than Step Functions, **AWS MWAA** provides a managed Airflow experience within your existing ecosystem.
+
+## Conclusion: Beyond AWS Lock-in
+
+The orchestration market offers a rich set of powerful and flexible alternatives to AWS Step Functions. While Step Functions remains a solid choice for AWS-native serverless workflows, the move towards multi-cloud, hybrid, and open-source solutions has highlighted the need for more versatile platforms.
+
+The right choice depends on your specific requirements: Temporal for durable application code, Airflow for Python-based data pipelines, and n8n for business process automation. For teams seeking a single, unified control plane to orchestrate everything—from data pipelines and AI models to infrastructure and business processes—Kestra provides a declarative, language-agnostic, and truly cloud-agnostic solution. By breaking free from vendor lock-in, you can build more portable, scalable, and future-proof workflows.
+
+Explore Kestra's capabilities for your data, AI, and infrastructure workflows to see how a unified orchestration platform can streamline your operations. [Get started today](https://kestra.io/get-started) or [book a demo](https://kestra.io/demo) with our team.
+```

--- a/src/contents/resources/aws-step-functions-alternatives/index.md
+++ b/src/contents/resources/aws-step-functions-alternatives/index.md
@@ -18,7 +18,6 @@ faq:
   - question: "Why consider alternatives to AWS Step Functions for workflow orchestration?"
     answer: "Organizations often seek alternatives to AWS Step Functions due to concerns about vendor lock-in, as it's tightly integrated with the AWS ecosystem. Other reasons include a need for multi-cloud or hybrid-cloud orchestration, a desire for open-source solutions to avoid proprietary dependencies, or a preference for declarative workflow definitions that are easier to version and manage as code. Cost optimization for specific use cases can also be a factor."
 author: "elliot"
-image: "/images/blogs/aws-step-functions-alternatives/cover.png"
 ---
 
 AWS Step Functions has long served as a powerful serverless orchestration tool for many organizations deeply invested in the Amazon Web Services ecosystem. It excels at coordinating various AWS services into robust, state-machine-driven workflows, providing reliability and built-in error handling for cloud-native applications. However, as enterprises expand their operations across multiple clouds, integrate diverse technologies, or seek greater control over their orchestration layer, the limitations of a vendor-specific solution become increasingly apparent. Concerns about vendor lock-in, the complexity of managing highly dynamic workflows, and the desire for more flexible, open-source alternatives are driving many to explore beyond AWS's native offerings.

--- a/src/contents/resources/aws-step-functions-alternatives/index.md
+++ b/src/contents/resources/aws-step-functions-alternatives/index.md
@@ -3,7 +3,7 @@ title: "AWS Step Functions Alternatives You Need to Know"
 description: "Explore top AWS Step Functions alternatives, including open-source options and managed solutions. Find the best fit for your workflow orchestration needs today!"
 metaTitle: "AWS Step Functions Alternatives | Kestra"
 metaDescription: "Seeking AWS Step Functions alternatives? Discover open-source, managed, and flexible solutions like Kestra, Temporal, and Airflow for your workflow orchestration needs."
-tag: "Infrastructure Automation"
+tag: "infrastructure"
 date: 2026-05-27
 slug: "aws-step-functions-alternatives"
 faq:

--- a/src/contents/resources/azure-alternatives/index.md
+++ b/src/contents/resources/azure-alternatives/index.md
@@ -1,0 +1,285 @@
+---
+title: "Azure alternatives: Top Cloud Computing Platforms"
+description: "Explore the best Azure alternatives for cloud apps. Find competitive pricing, simpler interfaces, and robust solutions today!"
+metaTitle: "Azure Alternatives: Top Cloud Platforms & Pricing"
+metaDescription: "Explore the best Azure alternatives for cloud apps. Find competitive pricing, simpler interfaces, and robust solutions today!"
+tag: "infrastructure"
+date: 2026-05-28
+slug: "azure-alternatives"
+faq:
+  - question: "What is an alternative to Azure?"
+    answer: "An alternative to Azure is any cloud platform that provides similar services, such as hosting, scaling, and deploying applications. These platforms offer alternatives for various reasons, including different pricing models, simpler interfaces, or specialized services. Examples include AWS, Google Cloud, DigitalOcean, Scaleway, and Kestra, among others."
+  - question: "What is a competitor of Microsoft Azure?"
+    answer: "Microsoft Azure's main competitors are other hyperscale cloud providers like Amazon Web Services (AWS) and Google Cloud Platform (GCP). However, many other platforms compete in specific niches, offering specialized services, different pricing, or regional advantages, such as DigitalOcean for simplicity or Scaleway for European data sovereignty."
+  - question: "Who are the big 3 cloud providers?"
+    answer: "The three biggest cloud service providers globally are Amazon Web Services (AWS), Google Cloud Platform (GCP), and Microsoft Azure. These providers dominate the market, offering extensive portfolios of services ranging from compute and storage to advanced AI and machine learning capabilities."
+  - question: "What is Azure being replaced with?"
+    answer: "Azure itself is not being replaced, but some specific services may evolve or be rebranded. For instance, Azure Active Directory has been rebranded as Microsoft Entra ID. For organizations looking to move away from Azure, a variety of alternatives offer similar or enhanced capabilities, depending on their specific needs."
+  - question: "Can Kestra replace Azure?"
+    answer: "Kestra is not a direct replacement for Azure as an IaaS/PaaS cloud provider. Instead, Kestra acts as an orchestration control plane that can coordinate workflows across Azure, other clouds, on-premise infrastructure, and various tools. It can orchestrate Azure services, complementing or enhancing existing Azure deployments, or facilitate multi-cloud strategies."
+author: "virgile"
+image: "/images/resources/azure-alternatives/cover.png"
+hub: "infrastructure"
+alternatives_count: 6
+---
+
+The cloud computing landscape is constantly evolving, with organizations continually re-evaluating their infrastructure choices. While Microsoft Azure offers a robust suite of services, many factors—from cost optimization and vendor lock-in concerns to specific regional requirements or a desire for simpler developer experiences—drive the search for alternatives. The leading alternatives to Azure in 2026 range from fellow hyperscalers like AWS and GCP to specialized platforms like DigitalOcean and European providers like Scaleway, each suited to different workloads.
+
+This article explores the top cloud computing platforms and specialized services that stand as viable Azure alternatives. We'll delve into their strengths, trade-offs, and ideal use cases, helping you navigate the options and make an informed decision for your cloud strategy.
+
+## Why look for an alternative to Azure?
+
+Organizations explore Azure alternatives for several strategic and operational reasons. Understanding these drivers is the first step toward finding the right fit for your needs.
+
+*   **Cost Complexity and Unpredictable Billing:** Azure's extensive service catalog can lead to complex and sometimes unpredictable billing. Teams often seek alternatives with more transparent, fixed-price models to better manage budgets and avoid unexpected cost overruns.
+*   **Vendor Lock-in and Multi-Cloud Strategy:** Relying on a single cloud provider creates dependency. Adopting a [multi-cloud orchestration](https://kestra.io/resources/infrastructure/multi-cloud-orchestration) strategy mitigates this risk, improves resilience, and allows teams to leverage the best services from different providers. This is a common motivation for moving away from a single-vendor approach, whether it's Azure, AWS, or GCP.
+*   **Operational Overhead:** While powerful, Azure's platform can introduce significant operational complexity for certain workloads. Teams may look for simpler, more developer-centric platforms that reduce the management burden for deploying and scaling applications.
+*   **Data Sovereignty and Compliance:** For many European companies, data residency is a critical regulatory requirement. Alternatives with data centers located within the EU, such as Scaleway or OVHcloud, offer a straightforward solution to meet GDPR and other data sovereignty needs.
+
+## How we evaluated these alternatives
+
+To provide a balanced comparison, we evaluated each Azure alternative based on a consistent set of criteria relevant to modern engineering and business needs:
+
+*   **Deployment Model:** We considered the primary offering, whether it's Infrastructure-as-a-Service (IaaS), Platform-as-a-Service (PaaS), serverless, or a hybrid model.
+*   **Pricing Transparency:** We assessed how easy it is to understand and predict costs, favoring platforms with clear, straightforward pricing.
+*   **Primary Use Case Fit:** We identified the ideal scenarios for each platform, from general-purpose cloud computing to specialized DevOps or data-intensive workloads.
+*   **Ecosystem and Integration:** The breadth and depth of available integrations, plugins, and third-party tool support were key considerations.
+*   **Ease of Use:** We evaluated the developer experience, from the user interface and API design to the overall learning curve.
+*   **Community and Support:** The health of the user community and the availability of professional support options were also factored in.
+
+## 1. Kestra: The Universal Orchestration Control Plane
+
+Kestra is not a direct IaaS replacement for Azure but serves as a powerful alternative for managing and orchestrating workloads across any environment. As an open-source, declarative, and event-driven orchestration platform, Kestra provides a vendor-agnostic control plane that unifies disparate tools and clouds.
+
+Workflows in Kestra are defined as simple YAML files, making them easy to version, review, and manage with GitOps principles. Its language-agnostic architecture allows teams to run tasks written in Python, Bash, SQL, Node.js, and more, all within a single workflow. This makes it ideal for coordinating complex processes that span multiple systems, such as:
+*   Data pipelines involving [Azure Data Factory](https://kestra.io/vs/azure-data-factory) and other services.
+*   Infrastructure automation with tools like Terraform and Ansible.
+*   AI/ML model training and deployment pipelines.
+*   Business processes that require human-in-the-loop approvals.
+
+For instance, Crédit Agricole replaced fragmented infrastructure scripts with Kestra to create a unified automation layer. Similarly, Apple's ML teams use Kestra to orchestrate large-scale data pipelines. By separating workflow logic from the underlying execution environment, Kestra allows you to build resilient, portable, and observable systems that are not tied to a single cloud provider. You can securely manage credentials for Azure, AWS, and GCP using an [external secrets manager](https://kestra.io/docs/enterprise/governance/secrets-manager).
+
+**Best for:** Organizations seeking a vendor-agnostic control plane to unify diverse workloads across their hybrid or multi-cloud environment, reduce operational complexity, and implement GitOps for everything.
+
+## 2. Amazon Web Services (AWS): The Market Leader
+
+As the largest cloud provider by market share, Amazon Web Services (AWS) is the most common and comprehensive alternative to Azure. Its primary strength lies in the sheer breadth and maturity of its service portfolio, which is the most extensive in the industry.
+
+AWS offers robust solutions for nearly any use case, from computing (EC2) and storage (S3) to serverless (Lambda) and managed Kubernetes (EKS). Its global reach and massive ecosystem of partners and third-party integrations make it a default choice for many enterprises. However, this vastness can also be a drawback, leading to a steep learning curve and pricing models that are as complex, if not more so, than Azure's.
+
+**Best for:** Enterprises needing the widest range of services, deep integration capabilities, and proven scalability, especially those already invested in the AWS ecosystem.
+
+## 3. Google Cloud Platform (GCP): Innovation and Analytics Powerhouse
+
+Google Cloud Platform (GCP) has carved out a strong position as an Azure alternative, particularly for organizations focused on data analytics, machine learning, and modern application development. Its key differentiator is its excellence in data services, with products like BigQuery offering unparalleled performance for large-scale analytics.
+
+GCP is also highly regarded for its leadership in open-source technologies, especially Kubernetes, which originated at Google. Google Kubernetes Engine (GKE) is often considered the most mature managed Kubernetes offering. While its market share is smaller than AWS and Azure, GCP competes aggressively on price and often leads in innovation for data and AI workloads.
+
+**Best for:** Data-intensive organizations, AI/ML-focused teams, and those prioritizing open-source integration and modern development practices.
+
+## 4. DigitalOcean: Simplicity and Developer Experience
+
+For teams that find the complexity of hyperscalers like Azure overwhelming, DigitalOcean offers a refreshing alternative focused on simplicity and a superior developer experience. It provides a core set of IaaS and PaaS products, like Droplets (VMs) and the App Platform, with transparent, predictable pricing.
+
+DigitalOcean's straightforward interface and excellent documentation make it a favorite among developers, startups, and small to mid-sized businesses. While it lacks the extensive service catalog and enterprise-grade features of Azure, it excels at its core mission: making cloud infrastructure easy to deploy and manage.
+
+**Best for:** Developers, startups, and SMBs prioritizing ease of deployment, predictable costs, and straightforward infrastructure management.
+
+## 5. Scaleway & OVHcloud: European Alternatives for Data Sovereignty
+
+For companies operating in Europe, data sovereignty is a paramount concern. Scaleway (France) and OVHcloud (France) are leading European cloud providers that offer a compelling Azure alternative by guaranteeing that data remains within EU jurisdiction, ensuring GDPR compliance.
+
+Both providers offer a competitive range of services, including compute instances, object storage, managed databases, and Kubernetes, often at a lower price point than the hyperscalers. They also have a strong focus on sustainability and bare-metal offerings, which can be a significant advantage for performance-sensitive workloads. Their primary trade-off is a smaller global footprint and a less extensive ecosystem compared to Azure.
+
+**Best for:** European companies with strict data residency requirements, those seeking cost-effective infrastructure, and organizations prioritizing local providers.
+
+## 6. Harness: Cloud-Native DevOps and Software Delivery Platform
+
+Harness is an alternative that focuses on a different layer of the stack: the software delivery lifecycle. While not an IaaS provider, it replaces and enhances many of the capabilities found in Azure DevOps. Harness provides a comprehensive platform for Continuous Integration (CI), Continuous Delivery (CD), feature flags, and cloud cost management.
+
+It is designed for modern DevOps practices and excels in multi-cloud environments, allowing teams to build, test, and deploy applications consistently across Azure, AWS, GCP, and Kubernetes. It complements existing cloud infrastructure by providing a unified control plane for software delivery.
+
+**Best for:** DevOps and platform engineering teams looking to streamline software delivery, optimize cloud costs, and enhance security across multi-cloud environments.
+
+## Other Notable Cloud Platforms and Services
+
+The cloud market is diverse, with many other excellent alternatives catering to specific needs:
+
+*   **Vultr and Linode (now Akamai Cloud):** Like DigitalOcean, these providers focus on simple, affordable, and developer-friendly IaaS.
+*   **IBM Cloud and Oracle Cloud Infrastructure (OCI):** These enterprise-focused providers offer strong alternatives, particularly for organizations with existing investments in their respective ecosystems (e.g., IBM for hybrid cloud, OCI for Oracle database workloads).
+*   **PaaS Providers (Render, Fly.io, Railway, Northflank):** These modern platforms abstract away infrastructure management, allowing developers to focus solely on their code. They are excellent for rapid application deployment.
+*   **OpenShift (Red Hat):** A leading enterprise Kubernetes platform that can be deployed on any cloud or on-premise, providing a consistent application environment.
+
+## Comparison Table
+
+| Tool | License | Deployment Model | Primary Use Case | Key Differentiator | Starting Price/Model |
+|---|---|---|---|---|---|
+| **Kestra** | Open-Source (Apache 2.0) & Enterprise | Self-hosted, Cloud | Universal Orchestration | Vendor-agnostic, declarative YAML workflows | Open-source is free; Enterprise/Cloud custom pricing |
+| **AWS** | Proprietary | Public Cloud (IaaS, PaaS, etc.) | General-purpose Cloud | Broadest service portfolio | Free Tier, On-Demand, Savings Plans |
+| **GCP** | Proprietary | Public Cloud (IaaS, PaaS, etc.) | Data Analytics, AI/ML, Kubernetes | BigQuery, GKE, AI/ML services | Free Tier, Sustained/Committed Use Discounts |
+| **DigitalOcean** | Proprietary | Public Cloud (IaaS, PaaS) | Developer & SMB Infrastructure | Simplicity, predictable pricing | Starts at ~$4/mo for Droplets |
+| **Scaleway** | Proprietary | Public Cloud, Bare Metal | European Cloud Infrastructure | Data sovereignty, cost-effectiveness | Free Tier, Stardust/Pro tiers |
+| **Harness** | Proprietary | SaaS | CI/CD, DevOps Automation | Unified software delivery platform | Free Tier, Team/Enterprise plans |
+
+## Choosing the Right Azure Alternative for Your Needs
+
+Selecting the best alternative depends entirely on your team's priorities and use cases.
+
+*   **For Data Engineering Teams:** If your focus is on analytics and data processing, **GCP**'s BigQuery and data services are hard to beat. To orchestrate complex data pipelines across any cloud, including Azure, **Kestra** provides a unified, declarative solution.
+*   **For Infrastructure & DevOps Teams:** For the broadest set of infrastructure services, **AWS** remains the market leader. For teams focused on unifying automation and implementing GitOps across multiple tools and clouds, **Kestra** provides the necessary [infrastructure automation](https://kestra.io/resources/infrastructure) control plane. **Harness** is an excellent choice for standardizing the CI/CD lifecycle.
+*   **For AI / ML Platform Teams:** **GCP**'s Vertex AI and specialized hardware make it a top contender. For orchestrating the entire MLOps lifecycle from data ingestion to model deployment, explore our [AI orchestration resources](https://kestra.io/resources/ai).
+*   **For Small Teams & Startups:** **DigitalOcean** offers the best balance of simplicity, performance, and predictable pricing for getting applications off the ground quickly.
+*   **For European Organizations:** **Scaleway** and **OVHcloud** are the go-to choices for ensuring data sovereignty and GDPR compliance without sacrificing performance or cost-effectiveness.
+
+## Conclusion: Navigating the Cloud Computing Landscape
+
+The search for Azure alternatives reveals a vibrant and diverse cloud market. While hyperscalers like AWS and GCP remain the most direct competitors, a rich ecosystem of specialized IaaS, PaaS, and orchestration platforms offers compelling advantages in simplicity, cost, and functionality.
+
+As organizations increasingly adopt multi-cloud and hybrid strategies, the need for a flexible, vendor-agnostic control plane becomes critical. A universal orchestration platform like Kestra allows you to harness the best of each provider, defining your infrastructure and application workflows as code while avoiding vendor lock-in. By choosing the right combination of infrastructure and orchestration, you can build a resilient, cost-effective, and future-proof cloud strategy.
+
+## Structured data
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is an alternative to Azure?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "An alternative to Azure is any cloud platform that provides similar services, such as hosting, scaling, and deploying applications. These platforms offer alternatives for various reasons, including different pricing models, simpler interfaces, or specialized services. Examples include AWS, Google Cloud, DigitalOcean, Scaleway, and Kestra, among others."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is a competitor of Microsoft Azure?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Microsoft Azure's main competitors are other hyperscale cloud providers like Amazon Web Services (AWS) and Google Cloud Platform (GCP). However, many other platforms compete in specific niches, offering specialized services, different pricing, or regional advantages, such as DigitalOcean for simplicity or Scaleway for European data sovereignty."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Who are the big 3 cloud providers?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The three biggest cloud service providers globally are Amazon Web Services (AWS), Google Cloud Platform (GCP), and Microsoft Azure. These providers dominate the market, offering extensive portfolios of services ranging from compute and storage to advanced AI and machine learning capabilities."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is Azure being replaced with?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Azure itself is not being replaced, but some specific services may evolve or be rebranded. For instance, Azure Active Directory has been rebranded as Microsoft Entra ID. For organizations looking to move away from Azure, a variety of alternatives offer similar or enhanced capabilities, depending on their specific needs."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can Kestra replace Azure?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Kestra is not a direct replacement for Azure as an IaaS/PaaS cloud provider. Instead, Kestra acts as an orchestration control plane that can coordinate workflows across Azure, other clouds, on-premise infrastructure, and various tools. It can orchestrate Azure services, complementing or enhancing existing Azure deployments, or facilitate multi-cloud strategies."
+      }
+    }
+  ]
+}
+```
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Top Azure Alternatives",
+  "description": "A list of the top alternatives to Microsoft Azure for cloud computing and workflow orchestration.",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "item": {
+        "@type": "Service",
+        "name": "Kestra",
+        "description": "The Universal Orchestration Control Plane for unifying workloads across any cloud.",
+        "url": "https://kestra.io"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "item": {
+        "@type": "Service",
+        "name": "Amazon Web Services (AWS)",
+        "description": "The market-leading cloud provider with the broadest portfolio of services."
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "item": {
+        "@type": "Service",
+        "name": "Google Cloud Platform (GCP)",
+        "description": "A cloud provider specializing in data analytics, AI/ML, and Kubernetes."
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "item": {
+        "@type": "Service",
+        "name": "DigitalOcean",
+        "description": "A developer-focused cloud platform known for simplicity and transparent pricing."
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 5,
+      "item": {
+        "@type": "Service",
+        "name": "Scaleway & OVHcloud",
+        "description": "Leading European cloud providers focused on data sovereignty."
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 6,
+      "item": {
+        "@type": "Service",
+        "name": "Harness",
+        "description": "A cloud-native DevOps and software delivery platform."
+      }
+    }
+  ]
+}
+```
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://kestra.io"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Resources",
+      "item": "https://kestra.io/resources"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Infrastructure",
+      "item": "https://kestra.io/resources/infrastructure"
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "name": "Azure alternatives: Top Cloud Computing Platforms"
+    }
+  ]
+}
+```

--- a/src/contents/resources/azure-alternatives/index.md
+++ b/src/contents/resources/azure-alternatives/index.md
@@ -18,7 +18,6 @@ faq:
   - question: "Can Kestra replace Azure?"
     answer: "Kestra is not a direct replacement for Azure as an IaaS/PaaS cloud provider. Instead, Kestra acts as an orchestration control plane that can coordinate workflows across Azure, other clouds, on-premise infrastructure, and various tools. It can orchestrate Azure services, complementing or enhancing existing Azure deployments, or facilitate multi-cloud strategies."
 author: "virgile"
-image: "/images/resources/azure-alternatives/cover.png"
 hub: "infrastructure"
 alternatives_count: 6
 ---

--- a/src/contents/resources/camunda-alternatives/index.md
+++ b/src/contents/resources/camunda-alternatives/index.md
@@ -3,7 +3,7 @@ title: "Top Camunda Alternatives: Find Your Workflow Solution"
 description: "Explore the best Camunda alternatives for your business process management. Discover powerful, efficient, and user-friendly competitors today!"
 metaTitle: "Top Camunda Alternatives for Workflow Automation"
 metaDescription: "Seeking Camunda alternatives? Compare leading workflow automation platforms like Kestra, Temporal, and Appian for scalability, features, and cost-effectiveness."
-tag: "orchestration"
+tag: "data"
 date: 2026-05-30
 slug: "camunda-alternatives"
 faq:

--- a/src/contents/resources/camunda-alternatives/index.md
+++ b/src/contents/resources/camunda-alternatives/index.md
@@ -20,7 +20,6 @@ faq:
   - question: "Is BPM outdated?"
     answer: "Traditional, rigid BPM approaches are evolving. Modern trends favor simplicity, agility, and AI readiness, moving away from overly complex modeling. While the core principles of process management remain vital, the tools and methodologies are adapting to integrate more seamlessly with developer-centric and event-driven automation paradigms."
 author: "Virgile Fanucci"
-image: "/images/blogs/camunda-alternatives/cover.png"
 hub: "infrastructure"
 alternatives_count: 6
 ---

--- a/src/contents/resources/camunda-alternatives/index.md
+++ b/src/contents/resources/camunda-alternatives/index.md
@@ -3,7 +3,7 @@ title: "Top Camunda Alternatives: Find Your Workflow Solution"
 description: "Explore the best Camunda alternatives for your business process management. Discover powerful, efficient, and user-friendly competitors today!"
 metaTitle: "Top Camunda Alternatives for Workflow Automation"
 metaDescription: "Seeking Camunda alternatives? Compare leading workflow automation platforms like Kestra, Temporal, and Appian for scalability, features, and cost-effectiveness."
-tag: "data"
+tag: "infrastructure"
 date: 2026-05-30
 slug: "camunda-alternatives"
 faq:

--- a/src/contents/resources/camunda-alternatives/index.md
+++ b/src/contents/resources/camunda-alternatives/index.md
@@ -1,0 +1,137 @@
+---
+title: "Top Camunda Alternatives: Find Your Workflow Solution"
+description: "Explore the best Camunda alternatives for your business process management. Discover powerful, efficient, and user-friendly competitors today!"
+metaTitle: "Top Camunda Alternatives for Workflow Automation"
+metaDescription: "Seeking Camunda alternatives? Compare leading workflow automation platforms like Kestra, Temporal, and Appian for scalability, features, and cost-effectiveness."
+tag: "orchestration"
+date: 2026-05-30
+slug: "camunda-alternatives"
+faq:
+  - question: "What are the competitors of Camunda?"
+    answer: "Beyond traditional BPM tools, modern workflow automation platforms like Kestra, Temporal, Appian, Bizagi, ProcessMaker, and n8n offer diverse approaches to orchestrating business processes, data pipelines, and infrastructure. Each provides unique strengths in areas like low-code development, developer experience, or universal integration capabilities."
+  - question: "Is Camunda outdated?"
+    answer: "While Camunda remains a powerful tool for specific BPMN-driven use cases, its older version, Camunda 7 Community Edition, reached its official end-of-life in October 2025. This signals a shift towards newer, more flexible, and often cloud-native workflow automation platforms that better support modern development practices and broader orchestration needs."
+  - question: "What is the best workflow automation platform?"
+    answer: "The 'best' workflow automation platform depends heavily on your specific needs. For universal, declarative, and language-agnostic orchestration across data, AI, and infrastructure, Kestra is a strong contender. For application-centric durable workflows, Temporal excels. For low-code business process management, Appian and Bizagi are popular choices."
+  - question: "Is Camunda a unicorn?"
+    answer: "Camunda has been recognized for its growth and market presence, being included in Viva Technology's 'Top 100 next unicorns' list in both 2023 and 2024. This highlights its significant standing in the business process management and workflow automation market."
+  - question: "What is the best open-source Camunda alternative?"
+    answer: "For open-source Camunda alternatives, Kestra offers a declarative, YAML-based approach to universal orchestration, supporting polyglot tasks across various domains. ProcessMaker provides an open-source BPMN-compliant platform for visual process design. n8n is another open-source option, excelling in visual workflow automation for app and API integrations."
+  - question: "Is BPM outdated?"
+    answer: "Traditional, rigid BPM approaches are evolving. Modern trends favor simplicity, agility, and AI readiness, moving away from overly complex modeling. While the core principles of process management remain vital, the tools and methodologies are adapting to integrate more seamlessly with developer-centric and event-driven automation paradigms."
+author: "Virgile Fanucci"
+image: "/images/blogs/camunda-alternatives/cover.png"
+hub: "infrastructure"
+alternatives_count: 6
+---
+
+For years, Camunda has been a go-to for Business Process Management (BPM) and workflow automation, offering robust BPMN-driven solutions. However, the rapidly evolving landscape of enterprise IT, coupled with the end-of-life for Camunda 7 Community Edition in October 2025, is prompting many organizations to re-evaluate their orchestration strategies. Teams are seeking alternatives that offer greater agility, broader integration capabilities, and a more developer-friendly experience beyond traditional process modeling. This article explores the top alternatives to Camunda, evaluating them across critical factors to help you find a workflow automation platform that aligns with your modern engineering and business needs.
+
+## Understanding Camunda and the shift in workflow needs
+
+### What is Camunda and its traditional strengths?
+Camunda is a workflow automation platform historically centered around Business Process Model and Notation (BPMN) and Decision Model and Notation (DMN). Its core strength lies in modeling and executing complex, human-centric business processes with high visibility. For organizations with formal process management needs, Camunda provides a powerful engine for orchestrating human tasks, managing long-running processes, and ensuring compliance through clear, standardized visual models. This makes it a strong fit for use cases like loan processing, insurance claims, and customer onboarding where process diagrams are the source of truth.
+
+### Why consider alternatives to Camunda?
+While powerful in its niche, Camunda's BPMN-centric approach can introduce friction for modern engineering teams. The complexity of BPMN modeling is often an overhead for purely technical workflows like data pipelines or infrastructure automation. Self-hosting Camunda can involve significant operational overhead, and its developer experience may feel cumbersome for teams accustomed to code-first, declarative paradigms. As orchestration needs expand beyond business processes to include data, AI, and infrastructure, many organizations find they need a more universal and flexible platform.
+
+### Is Camunda outdated? The context of Camunda 7 Community Edition's end-of-life
+The term "outdated" is relative, but a significant event has forced many users to reconsider their reliance on older versions. According to Camunda's official announcements, the final release of Camunda 7 Community Edition (v7.24) was published on October 14, 2025. Since then, it no longer receives updates, security patches, or official support. While the Camunda 7 Enterprise Edition end-of-life has been extended to April 2030, this shift effectively sunsets the free, self-supported version many teams relied on. This change, along with the architectural differences in the newer, SaaS-first Camunda 8, makes it a natural point to evaluate the wider market for alternatives.
+
+## How we evaluated these Camunda alternatives
+To provide a clear comparison, we evaluated each alternative based on a set of criteria relevant to modern engineering and business teams:
+- **Deployment Model**: We considered the availability of cloud-native, on-prem, hybrid, and open-source options.
+- **Primary Use Case Fit**: We assessed each tool's suitability for business process automation (BPMN), data orchestration, infrastructure automation, AI/ML workflows, and microservices.
+- **Developer Experience**: We compared the primary authoring model, whether declarative (YAML), code-first (SDK), or visual low-code.
+- **Scalability & Performance**: We looked at the architecture's ability to handle high-throughput and complex, long-running workflows.
+- **Integration Ecosystem**: We evaluated the breadth and depth of available connectors, plugins, and APIs.
+- **Cost-Effectiveness & Licensing**: We considered pricing transparency and the total cost of ownership.
+
+## The top 6 Camunda alternatives
+
+### 1. Kestra: The declarative control plane for universal orchestration
+Kestra is an open-source, declarative orchestration platform that unifies data, AI, infrastructure, and business workflows under a single control plane. Workflows are defined as simple YAML files, making them easy to write, review, and manage with GitOps practices. Its language-agnostic architecture allows teams to run Python, Shell, SQL, and hundreds of other task types natively without being locked into a single programming language.
+
+Kestra's event-driven design makes it ideal for building responsive, real-time automations. For example, financial institutions like Crédit Agricole use Kestra to replace fragmented infrastructure scripts with a single, governed orchestration layer. This ability to coordinate diverse tools and teams makes Kestra a powerful alternative for organizations looking to consolidate their automation stack.
+
+**Best for**: Organizations seeking a single, declarative, and highly extensible platform to orchestrate diverse technical and business workflows, moving beyond domain-specific tools.
+
+### 2. Temporal: Durable workflow orchestration for developers
+Temporal is a workflow-as-code platform designed for application developers. It provides SDKs in languages like Go, Java, Python, and TypeScript, allowing engineers to write durable, long-running, and stateful application workflows directly in their code. Its core strength is its robust handling of retries, compensations, and long-running processes, ensuring that workflows complete reliably even in the face of failures.
+
+Is Temporal a good alternative to Camunda? Yes, for a specific audience. It excels in orchestrating complex microservices and application-level business logic.
+
+**Best for**: Application engineering teams building highly reliable, distributed, and stateful backend systems where workflow logic is deeply embedded in code.
+**Honest limitation**: Its code-first approach is less accessible to non-developers and is not natively designed for batch data processing or infrastructure operations, which often require a higher-level orchestration layer. You can learn more in our detailed [Kestra vs. Temporal comparison](/vs/temporal).
+
+### 3. Appian: Low-code enterprise automation platform
+Appian is a comprehensive low-code platform for building enterprise applications and automating business processes. It combines BPM, case management, RPA, and AI capabilities into a unified suite. Its primary interface is a visual, drag-and-drop designer, which empowers business users and citizen developers to create sophisticated applications with minimal coding.
+
+Appian is a strong contender for organizations looking to replace Camunda with a more holistic, low-code solution for digital transformation initiatives.
+
+**Best for**: Large enterprises needing a powerful, all-in-one low-code platform to accelerate digital transformation, especially for complex business applications with human-in-the-loop processes.
+**Honest limitation**: Appian is a proprietary platform with a higher total cost of ownership. The learning curve for its advanced features can be steep, and it places less emphasis on code-driven, developer-first orchestration patterns.
+
+### 4. Bizagi: User-friendly low-code BPM solution
+Bizagi focuses on intelligent process automation with a highly intuitive visual process modeling interface. It's designed to be accessible to business users, allowing them to design, automate, and execute workflows without extensive technical knowledge. As a cloud-first platform, it offers a managed environment for deploying and scaling business processes.
+
+Bizagi serves as a direct alternative for teams that find Camunda's developer-centric tools too complex for their business-led automation projects.
+
+**Best for**: Organizations prioritizing ease of use and rapid development for business process automation, particularly those with a strong focus on empowering business analysts and process owners.
+**Honest limitation**: Its primary focus on BPMN can be an overhead for purely technical or event-driven orchestration. It has less emphasis on polyglot code execution compared to platforms like Kestra.
+
+### 5. ProcessMaker: Flexible open-source BPMN workflow platform
+ProcessMaker is an open-source BPM platform that is fully BPMN 2.0 compliant. It offers a visual workflow designer and a robust engine for executing business processes. It strikes a balance between formal process modeling and modern integration capabilities, and its open-source nature allows for self-hosting and customization.
+
+For those seeking an open-source alternative that stays within the BPMN paradigm, ProcessMaker is a viable option.
+
+**Best for**: Teams seeking an open-source BPMN solution with visual design capabilities, especially those who prefer the flexibility and control of self-hosting.
+**Honest limitation**: It still carries the conceptual overhead of traditional BPMN. The operational complexity of self-hosted deployments and the scope of community support may be considerations for smaller teams.
+
+### 6. n8n: Visual workflow automation for apps and APIs
+n8n is an open-source platform for visual workflow automation, often described as a self-hostable Zapier. It excels at connecting hundreds of SaaS applications and APIs through a node-based visual editor. With growing capabilities in AI automation, it allows for rapid prototyping and deployment of integration-heavy workflows.
+
+While not a traditional BPM tool, n8n is an excellent Camunda alternative for use cases centered around app-to-app automation and event-driven tasks.
+
+**Best for**: Ops teams and developers looking for a flexible, visual tool for automating tasks across SaaS applications, prototyping integrations, and exploring AI agent workflows.
+**Honest limitation**: n8n is not designed for high-throughput data engineering or complex infrastructure orchestration. Its target persona and core strengths differ significantly from engineering-focused platforms. Explore the differences in our [n8n vs Kestra analysis](/vs/n8n).
+
+## Comparison table: Camunda alternatives at a glance
+| Tool | License | Deployment Model | Primary Focus | Developer Experience | Key Differentiator |
+|---|---|---|---|---|---|
+| **Kestra** | Open-Source (Apache 2.0) & Enterprise | Cloud, On-prem, Hybrid | Universal Orchestration | Declarative (YAML) | Language-agnostic, unified platform for data, AI, infra & business workflows. |
+| **Temporal** | Open-Source (MIT) & Cloud | Cloud, On-prem | Application Workflows | Code-first (SDKs) | Durable execution for stateful, long-running application logic. |
+| **Appian** | Proprietary | Cloud | Low-Code App Dev & BPM | Visual Low-Code | All-in-one platform for enterprise applications and process automation. |
+| **Bizagi** | Proprietary | Cloud | Business Process Automation | Visual Low-Code | User-friendly interface for business-led process design. |
+| **ProcessMaker** | Open-Source (AGPL) & Enterprise | Cloud, On-prem | BPMN Workflows | Visual Low-Code & API | Open-source, BPMN-compliant process automation. |
+| **n8n** | Open-Source (Sustainable Use License) & Cloud | Cloud, On-prem | App & API Integration | Visual Node-based | Extensive SaaS connectors and visual workflow building. |
+
+## Choosing the best workflow automation platform for your needs
+
+### For data engineering teams
+For data engineers, the primary needs are scalability, language-agnostic task execution, and robust observability for complex data pipelines.
+- **Recommendation**: **Kestra** is the top choice due to its declarative YAML interface, native support for SQL, Python, and other languages, and its ability to orchestrate tools like dbt and Airbyte seamlessly. **Temporal** can be a fit for specific data applications requiring extreme durability at the code level.
+- Explore more in our [Data Engineering Resources](/resources/data).
+
+### For infrastructure and platform teams
+These teams prioritize GitOps, Infrastructure as Code (IaC), and the ability to unify disparate automation scripts and tools into a cohesive system.
+- **Recommendation**: **Kestra** excels here with its declarative nature, Terraform provider, and ability to orchestrate tools like Ansible and Kubernetes. For teams exclusively in a Kubernetes environment, **Argo Workflows** is also a strong, K8s-native option.
+- See more patterns in our [Infrastructure Automation Resources](/resources/infrastructure).
+
+### For AI and ML platform teams
+AI and ML workflows require orchestrating a diverse set of tasks, from data ingestion and model training to RAG pipelines and agentic systems.
+- **Recommendation**: **Kestra** provides the flexibility to orchestrate multi-step AI workflows, including calling various AI providers and managing human-in-the-loop approvals. For teams with purely Python-centric ML pipelines, **Prefect** or **Dagster** are also strong alternatives.
+- Discover more at our [AI Orchestration Resources](/resources/ai).
+
+### For business-led process automation
+When the goal is to empower business analysts and process owners, low-code visual builders are essential.
+- **Recommendation**: **Appian**, **Bizagi**, and **ProcessMaker** are all strong choices, offering powerful visual designers tailored for business process modeling. **n8n** is excellent for simpler, integration-focused automations led by ops teams.
+
+### Re-evaluating traditional BPM in a modern context
+The shift away from monolithic, top-down BPM reflects a broader trend in software development. Modern orchestration favors agile, event-driven, and code-adjacent workflows that integrate with existing tools rather than replacing them. The best modern platforms act as a control plane that provides governance and visibility without imposing a rigid, one-size-fits-all methodology.
+
+## Conclusion
+Choosing an alternative to Camunda is about more than finding a replacement; it's an opportunity to adopt a workflow automation platform that aligns with modern engineering practices and future business needs. While traditional BPM tools have their place, platforms like Kestra offer a more universal, declarative, and developer-friendly approach. By unifying orchestration for data, AI, infrastructure, and business processes, Kestra provides a scalable foundation to automate your entire enterprise.
+
+Ready to see how a declarative control plane can simplify your complex workflows? [Book a demo with one of our experts](/demo) to explore Kestra's capabilities.
+```

--- a/src/contents/resources/data-warehouse-etl/index.md
+++ b/src/contents/resources/data-warehouse-etl/index.md
@@ -3,7 +3,7 @@ title: "Data warehouse ETL: explained and simplified"
 description: "Data warehouse ETL (Extract, Transform, Load) is crucial for data integration. Learn how this process streamlines your data for robust analytics and business intelligence."
 metaTitle: "Data Warehouse ETL Explained: Simplify Data for Analytics"
 metaDescription: "Learn how Data Warehouse ETL (Extract, Transform, Load) processes integrate and prepare your data for powerful analytics. Discover steps, tools, and best practices."
-tag: "Data Pipelines"
+tag: "data"
 date: 2026-05-27
 slug: "data-warehouse-etl"
 faq:

--- a/src/contents/resources/data-warehouse-etl/index.md
+++ b/src/contents/resources/data-warehouse-etl/index.md
@@ -1,0 +1,212 @@
+---
+title: "Data warehouse ETL: explained and simplified"
+description: "Data warehouse ETL (Extract, Transform, Load) is crucial for data integration. Learn how this process streamlines your data for robust analytics and business intelligence."
+metaTitle: "Data Warehouse ETL Explained: Simplify Data for Analytics"
+metaDescription: "Learn how Data Warehouse ETL (Extract, Transform, Load) processes integrate and prepare your data for powerful analytics. Discover steps, tools, and best practices."
+tag: "Data Pipelines"
+date: 2026-05-27
+slug: "data-warehouse-etl"
+faq:
+  - question: "What is ETL in data warehousing?"
+    answer: "ETL—meaning Extract, Transform, Load—is a data integration process that combines, cleans, and organizes data from multiple sources into a single, consistent dataset. It then loads that data into a data warehouse, data lake, or another target system, making it ready for analysis and reporting."
+  - question: "What are the 4 types of data warehouses?"
+    answer: "The primary types of data warehouses include: Enterprise Data Warehouses (EDW) for organization-wide data, Data Marts for specific business functions, Virtual Data Warehouses that integrate data virtually without a central repository, and Operational Data Stores (ODS) for near real-time operational reporting. Cloud-based data warehouses are a modern deployment model for any of these types."
+  - question: "Is ETL similar to SQL?"
+    answer: "ETL and SQL are distinct but complementary. ETL (Extract, Transform, Load) refers to the end-to-end data integration process, often managed by specialized tools. SQL (Structured Query Language) is a programming language used within the 'Transform' phase of ETL to manipulate and query data in relational databases, but it is not the entire ETL process itself."
+  - question: "What are the benefits of ETL for data warehouses?"
+    answer: "ETL processes offer numerous benefits for data warehouses, including improved data quality and consistency, enhanced data integration from disparate sources, better support for business intelligence and analytics, and historical data storage for trend analysis. It also provides a structured approach to data governance and compliance."
+  - question: "What are the common challenges in ETL implementation?"
+    answer: "Common ETL challenges include managing data quality and consistency across diverse sources, handling large volumes of data efficiently, ensuring data security and compliance, optimizing performance for complex transformations, and adapting to evolving data schemas. Orchestrating dependencies and error handling across multiple systems also presents significant hurdles."
+  - question: "How does ETL differ from ELT?"
+    answer: "ETL performs data transformations before loading data into the target system, often in a staging area. ELT, conversely, loads raw data directly into the target data warehouse (typically cloud-based) and then performs transformations using the warehouse's compute power. The choice depends on data volume, transformation complexity, and target system capabilities."
+  - question: "What are the top ETL tools?"
+    answer: "The top ETL tools vary based on use case and budget, but popular choices include cloud-native options like AWS Glue, Azure Data Factory, and Google Dataflow; traditional enterprise solutions like Informatica PowerCenter and IBM DataStage; and modern alternatives like Matillion, Talend, and Kestra (for orchestrating ETL workflows)."
+author: "Kestra"
+image: "/images/blogs/data-warehouse-etl/cover.png"
+---
+
+Data warehouses are the backbone of modern analytics, but their value is only as good as the data they contain. This is where ETL—Extract, Transform, Load—becomes indispensable. It’s the foundational process that cleans, consolidates, and prepares raw data from countless sources, making it ready for the critical business insights that drive decisions.
+
+Yet, "working with ETL" often feels like grappling with complex, brittle pipelines. This guide cuts through the theory to explain what ETL truly means in a data warehousing context, how its phases work, and why it's more crucial than ever. We'll explore its benefits, compare it with ELT, and discuss how modern orchestration platforms like Kestra simplify its automation and management.
+
+## Understanding Data Warehouse ETL
+
+At its core, ETL is a data integration process that moves data from source systems to a target repository, typically a data warehouse. It ensures that the data arriving in the warehouse is reliable, consistent, and structured for analysis.
+
+### Defining ETL: Extract, Transform, Load Explained
+
+ETL is a sequential three-phase process that forms the foundation of many [data pipelines](https://kestra.io/resources/data/data-pipeline). Each phase has a distinct purpose:
+
+1.  **Extract**: Data is retrieved from one or more source systems. These sources can be incredibly diverse, including relational databases (like PostgreSQL, MySQL), SaaS applications (like Salesforce), APIs, flat files (CSV, JSON), and streaming platforms.
+2.  **Transform**: Once extracted, the data is moved to a staging area where it undergoes transformation. This is the most critical phase, involving cleansing, validating, standardizing, and structuring the data to conform to the schema of the target data warehouse.
+3.  **Load**: The transformed data is loaded into the final target system, such as a data warehouse, data mart, or data lake. This makes the clean, structured data available for business intelligence (BI) tools, analytics, and reporting.
+
+The entire end-to-end process is often managed as an [ETL workflow](https://kestra.io/resources/data/etl-workflow), where each step is a dependency for the next.
+
+### The Role of ETL in Data Warehousing
+
+A data warehouse is designed to be a single source of truth for an organization's historical data. However, data in its raw form is often messy, inconsistent, and spread across dozens of disconnected systems. The role of ETL is to bridge this gap.
+
+ETL acts as the preparatory engine for the data warehouse. It enforces consistency by converting data from various formats into a unified structure. It improves data quality by filtering out errors and duplicates. Through this process of [data ingestion](https://kestra.io/resources/data/what-is-data-ingestion) and transformation, ETL ensures that the data warehouse contains high-quality, analytics-ready data. This entire process requires a robust [data orchestration](https://kestra.io/resources/data/data-orchestration) layer to manage dependencies, handle errors, and ensure reliability.
+
+## The ETL Process: Steps and Phases in Detail
+
+Each phase of the ETL process involves specific methods and strategies tailored to the data and the business requirements.
+
+### Extracting Data: Sources and Methods
+
+The extraction phase involves pulling data from its original sources. Common sources include:
+
+*   **Databases**: SQL and NoSQL databases like Oracle, SQL Server, MongoDB.
+*   **APIs**: Web services and SaaS platforms that expose data via REST or GraphQL APIs.
+*   **Files**: Structured and semi-structured files such as CSV, JSON, XML, and Parquet.
+*   **Streaming Sources**: Real-time data from platforms like Kafka or AWS Kinesis.
+
+Extraction methods vary based on the source and requirements:
+
+*   **Full Extraction**: The entire dataset is copied from the source. This is common for initial loads or for small datasets.
+*   **Incremental Extraction**: Only the data that has changed since the last extraction is pulled. This is more efficient for large datasets and is often implemented using timestamps or version numbers.
+*   **Change Data Capture (CDC)**: A more advanced method that tracks row-level changes (inserts, updates, deletes) in source databases and propagates them to the target. [Change Data Capture (CDC)](https://kestra.io/resources/data/change-data-capture) is highly efficient for keeping data warehouses in sync with operational systems.
+
+### Transforming Data: Cleaning, Conforming, and Aggregating
+
+The transformation stage is where the raw data is refined into a usable format. This often involves multiple [tasks](https://kestra.io/docs/workflow-components/tasks) and is where the majority of the business logic is applied. Key transformation activities include:
+
+*   **Cleansing**: Identifying and correcting errors, handling missing values, and removing duplicate records.
+*   **Conforming (Standardization)**: Ensuring data from different sources adheres to a consistent format. This includes standardizing date formats, units of measurement, and categorical values (e.g., converting "USA" and "United States" to a single standard).
+*   **Aggregating and Joining**: Summarizing data to a higher level (e.g., calculating daily sales from individual transactions) and joining datasets from different sources to create a richer, unified view.
+
+SQL is a primary tool used for transformations, especially when dealing with structured data. However, transformations can also involve complex logic written in Python or other programming languages to handle semi-structured data like [JSON](https://kestra.io/docs/how-to-guides/json).
+
+### Loading Data: Destinations and Strategies
+
+In the final phase, the transformed data is loaded into the target data warehouse. Popular cloud data warehouses include Snowflake, Google BigQuery, and Amazon Redshift. The loading strategy depends on the use case:
+
+*   **Full Refresh (or Overwrite)**: The existing data in the target table is completely replaced with the new data. This is simple but can be slow and disruptive for large tables.
+*   **Incremental Load (Append)**: New records are added to the target table without altering existing records. This is suitable for time-series data or logs.
+*   **Upsert (Update/Insert)**: New records are inserted, and existing records are updated based on a key. This is common for synchronizing dimension tables.
+
+A well-designed [data warehouse integration strategy](https://kestra.io/blogs/2024-03-06-guide-integration-ingestion) will often combine these methods.
+
+## Why ETL is Crucial for Data Warehouses
+
+ETL is more than just a data movement process; it’s a strategic component that directly impacts the value derived from a data warehouse.
+
+### Benefits of Efficient ETL for Data Integration
+
+An efficient ETL process provides a solid foundation for data analytics. Key benefits include:
+
+*   **Improved Data Quality**: By cleansing and validating data, ETL ensures that analytics are based on accurate and reliable information, which is a cornerstone of good [data quality](https://kestra.io/resources/data/data-quality).
+*   **Single Source of Truth**: ETL consolidates data from disparate systems into a single, consistent repository, eliminating data silos and providing a unified view of the business.
+*   **Historical Context**: Data warehouses are designed to store historical data. ETL processes methodically load this data over time, enabling trend analysis and historical reporting that is not possible with operational systems alone.
+
+### How ETL Supports Business Intelligence and Analytics
+
+The ultimate goal of a data warehouse is to support BI and analytics. ETL is the critical enabler of this goal. By transforming data into a structured, query-optimized format (like a star schema), ETL makes it easier and faster for BI tools like Tableau or Power BI to generate reports and dashboards. This structured approach also simplifies complex analytical queries, allowing data analysts and scientists to focus on uncovering insights rather than wrangling data. Effective [data observability](https://kestra.io/resources/data/data-observability) over ETL pipelines is key to trusting these downstream analytics.
+
+## ETL vs. ELT: Understanding the Differences
+
+A common point of confusion is the distinction between ETL and its modern counterpart, ELT (Extract, Load, Transform).
+
+### Key Distinctions Between ETL and ELT Methodologies
+
+The primary difference lies in the sequence of operations:
+
+*   **ETL (Extract, Transform, Load)**: Transformations happen *before* the data is loaded into the data warehouse, typically on a separate staging server or processing engine.
+*   **ELT (Extract, Load, Transform)**: Raw data is loaded directly into the target data warehouse first. Transformations are then performed *inside* the warehouse, leveraging its powerful compute capabilities.
+
+This seemingly small change has significant implications. ELT is well-suited for cloud data warehouses that can scale their compute resources on-demand, while ETL is often preferred when transformations are complex or require specialized processing outside the warehouse. You can find a detailed comparison in our guide on [ETL vs. ELT](https://kestra.io/resources/data/etl-vs-elt).
+
+### When to Choose ETL Over ELT
+
+While ELT has gained popularity with the rise of cloud data warehouses, ETL remains the better choice in several scenarios:
+
+*   **Data Privacy and Security**: If sensitive data (like PII) needs to be masked or anonymized, ETL allows you to perform these transformations *before* the data lands in the warehouse, reducing compliance risks.
+*   **Legacy Systems**: When dealing with older source systems that produce data in non-standard formats, a dedicated transformation engine in an ETL process can be more flexible than trying to handle it within the warehouse.
+*   **Complex Transformations**: For computationally intensive transformations that might strain the data warehouse's resources or are not well-suited for SQL, an external transformation step in ETL is more appropriate.
+
+The concepts of ETL and ELT are also foundational to understanding [Reverse ETL](https://kestra.io/resources/data/reverse-etl), which moves data out of the warehouse and back into operational systems.
+
+## ETL Automation and Modern Approaches
+
+Manually running ETL jobs is not scalable. Automation and modern orchestration are key to building reliable and efficient data warehouse pipelines.
+
+### Tools and Platforms for ETL Automation
+
+The landscape of [ETL tools](https://kestra.io/resources/data/etl-pipeline-tools) is vast and includes:
+
+*   **Cloud-Native Services**: AWS Glue, Azure Data Factory, and Google Dataflow offer managed ETL services within their respective cloud ecosystems.
+*   **iPaaS (Integration Platform as a Service)**: Tools like MuleSoft and Boomi provide visual interfaces for building integrations.
+*   **Orchestration Platforms**: Tools like Kestra are not ETL tools themselves but are used to orchestrate and manage the entire ETL workflow, coordinating various tools and scripts. With over a thousand available [plugins](https://kestra.io/plugins), orchestration platforms can connect to virtually any data source or destination.
+
+### Emerging Trends in Data Warehouse ETL
+
+The field of ETL is constantly evolving. Key trends include:
+
+*   **Real-time ETL**: Moving from batch processing to streaming data pipelines that update the data warehouse in near real-time.
+*   **AI/ML in ETL**: Using artificial intelligence to automate tasks like schema detection, data quality checks, and transformation logic generation.
+*   **Data Mesh**: A decentralized approach to data ownership and architecture where domain teams are responsible for their own ETL pipelines, promoting scalability and agility. You can learn more about this in our guide to [data mesh architecture](https://kestra.io/resources/data/data-mesh-architecture).
+
+These trends highlight a shift towards more dynamic, automated, and scalable [data engineering practices](https://kestra.io/blogs/2026-03-05-data-eng-trends-2026).
+
+### Kestra for Declarative ETL Orchestration
+
+Modern ETL workflows often involve multiple tools and languages. Kestra simplifies this complexity by providing a unified, declarative orchestration layer. Instead of writing brittle imperative scripts, you define your entire ETL pipeline as a simple YAML file.
+
+For example, an ETL workflow in Kestra might extract data using a Python script, transform it with SQL, and load it into Snowflake. Kestra manages the dependencies, retries, and error handling automatically.
+
+```yaml
+id: api-to-snowflake-etl
+namespace: company.team.production
+
+tasks:
+  - id: extract_data
+    type: io.kestra.plugin.scripts.python.Script
+    script: |
+      # Python code to extract data from an API
+      # ...
+      
+  - id: transform_data
+    type: io.kestra.plugin.jdbc.duckdb.Query
+    sql: |
+      -- SQL to clean and aggregate the extracted data
+      -- ...
+
+  - id: load_to_snowflake
+    type: io.kestra.plugin.jdbc.snowflake.Upload
+    from: "{{ outputs.transform_data.uri }}"
+    # ... more Snowflake configuration
+```
+
+This declarative approach makes ETL workflows more readable, versionable, and easier to manage at scale. It's one of the reasons [why Kestra](https://kestra.io/docs/why-kestra) is a powerful choice for modern [data engineers](https://kestra.io/use-cases/data-engineers) building complex pipelines.
+
+## Working with ETL in the Industry
+
+Implementing ETL in a real-world setting comes with its own set of challenges and best practices.
+
+### Common Challenges in ETL Implementation and How to Overcome Them
+
+Data teams often face several hurdles:
+
+*   **Data Quality Issues**: Inconsistent or missing data from sources can break pipelines. Implementing automated data validation steps and robust [error handling](https://kestra.io/docs/workflow-components/errors) is crucial.
+*   **Performance Bottlenecks**: Large data volumes can slow down extraction and transformation. Optimizing queries, processing data in parallel, and using incremental loads can mitigate this.
+*   **Schema Evolution**: Source data schemas can change unexpectedly, causing ETL jobs to fail. Using orchestration platforms with monitoring and alerting helps detect these issues quickly.
+
+Solving these [orchestration problems](https://kestra.io/blogs/2023-12-14-orchestration-problems-and-complexity) requires a combination of good design and the right tooling.
+
+### Best Practices for Successful ETL Projects
+
+To build resilient and maintainable ETL pipelines, follow these best practices:
+
+*   **Modularity**: Break down complex ETL processes into smaller, reusable subflows or tasks.
+*   **Version Control**: Store your ETL logic (e.g., Kestra YAML files, SQL scripts) in a Git repository to track changes and collaborate effectively. Kestra has built-in [Git integration](https://kestra.io/docs/version-control-cicd/git) for this purpose.
+*   **Monitoring and Alerting**: Implement comprehensive monitoring to track pipeline performance and set up alerts for failures.
+*   **Testing**: Just like software, ETL code should be tested. Validate data transformations and ensure data integrity at each step.
+
+Following these [flow best practices](https://kestra.io/docs/best-practices/flows) ensures that your data warehouse remains a reliable asset.
+
+### Real-World ETL Scenarios with Kestra
+
+The principles of ETL are applied across industries to solve complex data challenges. For instance, [Apple's ML team orchestrates large-scale ETL workloads](https://kestra.io/use-cases/stories/apple-ml-team-orchestrates-large-scale-data-pipelines-with-kestra) with Kestra, leveraging its declarative syntax and fault tolerance to manage pipelines that are critical for their products.
+
+Whether you're building a pipeline to move NoSQL data to an analytics warehouse or coordinating a multi-tool workflow with Airbyte and dbt, a robust orchestration layer is the key to success.

--- a/src/contents/resources/data-warehouse-etl/index.md
+++ b/src/contents/resources/data-warehouse-etl/index.md
@@ -22,7 +22,6 @@ faq:
   - question: "What are the top ETL tools?"
     answer: "The top ETL tools vary based on use case and budget, but popular choices include cloud-native options like AWS Glue, Azure Data Factory, and Google Dataflow; traditional enterprise solutions like Informatica PowerCenter and IBM DataStage; and modern alternatives like Matillion, Talend, and Kestra (for orchestrating ETL workflows)."
 author: "Kestra"
-image: "/images/blogs/data-warehouse-etl/cover.png"
 ---
 
 Data warehouses are the backbone of modern analytics, but their value is only as good as the data they contain. This is where ETL—Extract, Transform, Load—becomes indispensable. It’s the foundational process that cleans, consolidates, and prepares raw data from countless sources, making it ready for the critical business insights that drive decisions.

--- a/src/contents/resources/hpc-workflow/index.md
+++ b/src/contents/resources/hpc-workflow/index.md
@@ -3,7 +3,7 @@ title: "HPC Workflow: Guide to High-Performance Workflows"
 description: "Demystify HPC workflows. Explore tools, understanding, and automation strategies for high-performance computing tasks with Kestra's declarative orchestration."
 metaTitle: "HPC Workflow: Guide to High-Performance Workflows"
 metaDescription: "Demystify HPC workflows. Explore tools, understanding, and automation strategies for high-performance computing tasks. Learn how Kestra unifies and automates HPC, AI, and infrastructure."
-tag: "Infrastructure"
+tag: "infrastructure"
 date: 2026-05-27
 slug: "hpc-workflow"
 faq:

--- a/src/contents/resources/hpc-workflow/index.md
+++ b/src/contents/resources/hpc-workflow/index.md
@@ -1,0 +1,71 @@
+---
+title: "HPC Workflow: Guide to High-Performance Workflows"
+description: "Demystify HPC workflows. Explore tools, understanding, and automation strategies for high-performance computing tasks with Kestra's declarative orchestration."
+metaTitle: "HPC Workflow: Guide to High-Performance Workflows"
+metaDescription: "Demystify HPC workflows. Explore tools, understanding, and automation strategies for high-performance computing tasks. Learn how Kestra unifies and automates HPC, AI, and infrastructure."
+tag: "Infrastructure"
+date: 2026-05-27
+slug: "hpc-workflow"
+faq:
+  - question: "What are HPC workflows?"
+    answer: "HPC workflows define the individual components and steps involved in executing high-performance computing tasks, from initial setup to generating actionable research data. They are crucial for managing complex, resource-intensive computational processes in fields like scientific research and large-scale data analysis."
+  - question: "What does HPC stand for?"
+    answer: "HPC stands for High-Performance Computing. It refers to the use of supercomputers and computer clusters to solve advanced computation problems that are too large or complex for standard computers."
+  - question: "What are the three key components of HPC?"
+    answer: "HPC systems typically consist of three main components: compute (processors and processing units), storage (high-speed data storage systems), and networking (high-bandwidth, low-latency interconnections). These components work in concert to aggregate resources for massive computational challenges."
+  - question: "What are examples of HPC?"
+    answer: "Examples of HPC applications include weather forecasting and climate modeling, drug discovery and molecular dynamics simulations, financial modeling, seismic data processing for oil and gas exploration, and complex AI/ML model training."
+  - question: "What are the four types of workflows?"
+    answer: "While 'four types of workflows' can vary by context, in a general sense, workflows often categorize into sequential, parallel, conditional, and event-driven. In HPC, these patterns apply to how computational tasks are structured and executed across distributed resources."
+author: "..."
+---
+
+High-Performance Computing (HPC) powers breakthroughs across science, engineering, and artificial intelligence, tackling problems too vast for conventional systems. Yet, the true challenge often lies not just in the raw computational power, but in orchestrating the intricate sequences of tasks that make up an HPC workflow. From data preparation to simulation, analysis, and visualization, these workflows demand precision, scalability, and robust automation.
+
+This guide demystifies HPC workflows, exploring their fundamental components, the tools that manage them, and how modern platforms like Kestra are transforming their execution. We’ll delve into strategies for optimization, the growing role of AI, and practical approaches to automating and governing your most demanding computational tasks.
+
+## What are HPC workflows?
+
+High-Performance Computing (HPC) refers to the practice of aggregating computing power in a way that delivers much higher performance than one could get out of a typical desktop computer or workstation. In the context of HPC, a workflow is the sequence of computational and data-management steps required to accomplish a scientific or engineering goal. These aren't simple, linear processes; they often involve complex dependencies, massive datasets, and diverse computational tasks running in parallel or in response to specific events.
+
+The core of any HPC environment rests on three key components:
+1.  **Compute**: Clusters of powerful processors (CPUs and GPUs) that perform the calculations.
+2.  **Storage**: High-speed, parallel file systems designed to handle the massive input/output (I/O) demands of large-scale simulations.
+3.  **Networking**: Low-latency, high-bandwidth interconnects (like InfiniBand) that allow nodes within the cluster to communicate efficiently.
+
+Real-world examples of HPC workflows are vast and impactful. They include weather forecasting, which simulates atmospheric conditions; genomics, which analyzes massive DNA sequences; and drug discovery, which models molecular interactions. Increasingly, the training of large-scale AI models is also a primary use case for HPC infrastructure. Effective [workflow management](https://kestra.io/resources/infrastructure/workflow-management) is critical to coordinate these complex operations, bridging the gap between raw compute power and actionable results through robust [data orchestration](https://kestra.io/resources/data/data-orchestration) and [infrastructure automation](https://kestra.io/resources/infrastructure/automation).
+
+## Understanding and optimizing your HPC workflow
+
+Managing HPC workflows effectively requires specialized tools that can orchestrate tasks across distributed systems, manage data movement, and handle failures gracefully. For data-centric science, these tools are essential for productivity, enabling researchers to automate repetitive tasks and focus on analysis rather than manual job submission.
+
+A critical aspect of managing HPC workflows is performance diagnosis. A holistic view is necessary to identify bottlenecks that can occur at any stage:
+-   **Compute-bound tasks**: Is the CPU or GPU the limiting factor? Are the algorithms efficient?
+-   **I/O bottlenecks**: Is the workflow slowed by reading from or writing to the storage system?
+-   **Network latency**: Does communication between compute nodes create delays in tightly coupled parallel jobs?
+-   **Resource contention**: Are jobs waiting too long in the scheduler's queue?
+
+Optimizing an HPC workflow involves analyzing these factors and adjusting parameters, algorithms, or even the workflow structure itself. Modern orchestration platforms provide the visibility needed to track these metrics over time. By understanding the [performance benchmarks](https://kestra.io/docs/performance/benchmark) of your tasks and engaging in continuous [performance tuning](https://kestra.io/docs/performance/performance-tuning), you can significantly improve throughput and efficiency. This often involves right-sizing the infrastructure, ensuring that the allocated resources match the workload's actual needs, which is a key part of [sizing and scaling infrastructure](https://kestra.io/docs/performance/sizing-and-scaling-infrastructure).
+
+## AI-coupled and automated HPC workflows
+
+The line between traditional HPC and artificial intelligence is blurring. AI-coupled workflows, where machine learning models are integrated with physical simulations, are becoming a transformative force in scientific computing. For example, an ML model might act as a surrogate for a computationally expensive part of a simulation, or it could steer the simulation in real-time by analyzing intermediate results.
+
+This new paradigm introduces another layer of complexity that demands sophisticated automation. This is where modern orchestration tools with AI capabilities come into play:
+-   **AI Copilot**: Tools like [Kestra's AI Copilot](https://kestra.io/docs/ai-tools/ai-copilot) can translate natural language descriptions into executable, declarative workflow code. This accelerates development and makes HPC accessible to a broader range of domain experts.
+-   **Agentic Orchestration**: The concept of [agentic orchestration](https://kestra.io/resources/ai/agentic-orchestration) involves deploying autonomous [AI agents](https://kestra.io/docs/ai-tools/ai-agents) that can manage and adapt workflows dynamically. An agent could monitor a long-running simulation, detect anomalies, and automatically launch a new set of analytical tasks or adjust simulation parameters without human intervention.
+
+These AI-driven approaches are not just about convenience; they enable a more dynamic and intelligent form of scientific discovery, making it possible to explore vast parameter spaces and react to unforeseen results in real time. For more information, explore our [AI Orchestration Resources](https://kestra.io/resources/ai).
+
+## Enabling and managing HPC workflows with Kestra
+
+Kestra provides a unified control plane to manage the entire lifecycle of HPC workflows, from simple batch jobs to complex, AI-coupled pipelines. Its declarative and language-agnostic nature makes it an ideal HPC workflow manager.
+
+With Kestra, you define your entire workflow as a simple YAML file. This "workflow-as-code" approach ensures reproducibility, facilitates version control, and simplifies collaboration. Kestra’s engine can execute any tool, script, or container, allowing you to seamlessly integrate diverse components written in Python, R, C++, or any other language used in the HPC ecosystem.
+
+Key capabilities for HPC include:
+-   **Cloud Integration**: Kestra has a rich library of [plugins](https://kestra.io/plugins) for major cloud providers, including [AWS](https://kestra.io/plugins/plugin-aws), [Azure](https://kestra.io/plugins/plugin-azure), and [GCP](https://kestra.io/plugins/plugin-gcp). This allows you to orchestrate workflows that leverage cloud-based HPC resources, such as running [parallel Python workloads on AWS Batch](https://kestra.io/blueprints/aws-batch-terraform-git).
+-   **Container Orchestration**: With native support for [Kubernetes](https://kestra.io/orchestration/kubernetes) and Docker, Kestra can manage containerized tasks, ensuring a consistent and portable environment for your computational jobs.
+-   **Extensibility**: If a specific tool isn't already supported, you can easily build a custom plugin using our [developer guide](https://kestra.io/docs/plugin-developer-guide).
+
+Platforms like Kestra are used by organizations like Apple's ML team and JPMorgan Chase to orchestrate large-scale, mission-critical data and compute pipelines. By providing a single platform for [infrastructure automation](https://kestra.io/infra-automation), Kestra helps teams manage complexity and scale their HPC operations with confidence. Explore our [Infrastructure Automation Resources](https://kestra.io/resources/infrastructure) to learn more.

--- a/src/contents/resources/kubernetes-workflow-orchestration/index.md
+++ b/src/contents/resources/kubernetes-workflow-orchestration/index.md
@@ -1,0 +1,122 @@
+---
+title: "Kubernetes Workflow Orchestration Engine"
+description: "Orchestrate parallel jobs on Kubernetes with a powerful workflow engine. Discover how to enhance your Kubernetes workflow orchestration today!"
+metaTitle: "Kubernetes Workflow Orchestration with Kestra"
+metaDescription: "Explore Kubernetes workflow orchestration engines, compare tools like Argo, Airflow, and Prefect, and see how Kestra unifies data, AI, and infrastructure workflows on K8s."
+tag: "infrastructure"
+date: 2026-05-27
+slug: "kubernetes-workflow-orchestration"
+faq:
+  - question: "What is Kubernetes workflow orchestration?"
+    answer: "Kubernetes workflow orchestration involves managing the sequence and interaction of automated tasks across containers within a Kubernetes cluster. It enables building application services that span multiple containers, scheduling them across a cluster, scaling them, and managing their health over time."
+  - question: "What is the difference between workflow and orchestration?"
+    answer: "While workflow automation focuses on automating individual tasks, workflow orchestration manages the sequence, dependencies, and interactions of these automated tasks to achieve a cohesive, end-to-end process. Orchestration provides a higher-level control plane over multiple workflows."
+  - question: "What are the top Kubernetes orchestration tools for AI workflows?"
+    answer: "For AI workflows on Kubernetes, leading tools include KubeFlow, KubeRay (Ray on Kubernetes), Argo Workflows, and Flyte. Kestra also provides a robust, language-agnostic platform to orchestrate complex AI pipelines, including RAG and multi-agent systems, directly on Kubernetes."
+  - question: "How does Kubernetes orchestration work?"
+    answer: "Kubernetes orchestration works by using a control plane to manage worker nodes, where containerized applications run. It automates deployment, scaling, and management through declarative configurations (YAML) and custom resources, ensuring applications maintain their desired state and resource allocation."
+  - question: "Is ECS an orchestrator?"
+    answer: "Yes, Amazon ECS (Elastic Container Service) is a fully managed container orchestration service. It allows teams to build, manage, and run containerized workloads without the complexity of infrastructure management, freeing up development teams to innovate faster within the AWS ecosystem."
+  - question: "What is Argo Workflows used for?"
+    answer: "Argo Workflows is primarily used for orchestrating parallel jobs on Kubernetes. It's a container-native workflow engine ideal for CI/CD pipelines, machine learning workflows, and batch processing, leveraging Kubernetes Custom Resources for declarative workflow definitions."
+  - question: "How does Kestra enhance Kubernetes workflow orchestration?"
+    answer: "Kestra enhances Kubernetes workflow orchestration by offering a declarative, polyglot, and event-driven engine. It unifies data, AI, and infrastructure workflows, enabling users to define complex pipelines in YAML, execute tasks in any language, and manage them with GitOps best practices on Kubernetes."
+author: "elliot"
+---
+
+Managing complex, distributed applications on Kubernetes demands more than just containerization—it requires robust workflow orchestration. As modern data, AI, and infrastructure operations converge, the need for a unified control plane that can coordinate tasks across diverse systems and languages becomes critical. Traditional Kubernetes orchestration tools often excel in specific domains, but struggle to provide a holistic view and consistent operational model across the enterprise.
+
+This article explores the landscape of Kubernetes workflow orchestration, from foundational concepts to leading tools and their capabilities. We’ll dive into how these engines streamline operations, enhance reliability, and enable automation for parallel jobs on Kubernetes. By the end, you’ll understand the key differences between popular orchestrators and discover how Kestra extends their power to unify all your workflows.
+
+## Understanding Kubernetes Workflow Orchestration
+
+At its core, [Kubernetes workflow orchestration](https://kestra.io/resources/infrastructure/kubernetes) is the practice of managing complex, multi-step processes across containers in a Kubernetes cluster. While Kubernetes itself is a container orchestrator, it primarily manages the lifecycle of individual containers and pods. A workflow orchestration engine sits a layer above, coordinating the sequence, dependencies, and data flow between these containerized tasks to execute a complete business process.
+
+The benefits of this approach are significant:
+- **Scalability**: Dynamically allocate resources and scale jobs up or down based on demand.
+- **Reliability**: Kubernetes' self-healing capabilities ensure that failed tasks are automatically restarted, improving fault tolerance.
+- **Resource Efficiency**: Optimize resource utilization by scheduling tasks on available nodes, reducing idle compute costs.
+- **Automation**: Fully automate complex processes, from CI/CD pipelines to data processing and AI model training.
+- **Declarative Infrastructure**: Define both infrastructure and workflows as code, enabling GitOps practices and reproducible environments.
+
+A common point of confusion is the distinction between a workflow and orchestration. A **workflow** is a defined sequence of [tasks](https://kestra.io/docs/workflow-components/tasks) designed to achieve a specific outcome. **Orchestration**, on the other hand, is the higher-level coordination of multiple workflows and systems, managing their interactions, dependencies, and error handling to create a cohesive, end-to-end process. Kubernetes excels at orchestrating containers, while a workflow engine orchestrates the business logic running inside them.
+
+## Leading Tools for Kubernetes Workflow Orchestration
+
+The market for Kubernetes workflow orchestration is diverse, with tools tailored to different personas and use cases. Understanding their core philosophies is key to choosing the right one for your team.
+
+### Argo Workflows: The Kubernetes-Native Approach
+
+[Argo Workflows](https://kestra.io/vs/argo-workflows) is a popular open-source, container-native workflow engine. Its defining feature is its deep integration with Kubernetes; workflows are defined as Custom Resource Definitions (CRDs) and managed directly via `kubectl`. This makes it a natural choice for platform engineering teams already fluent in Kubernetes.
+
+Argo is primarily used for orchestrating parallel jobs on Kubernetes. It excels at CI/CD pipelines, machine learning workflows, and large-scale batch processing where each step can be encapsulated in a container. Its strengths lie in its lightweight design and efficient handling of container-based parallelism. However, its UI is more functional than user-friendly for non-Kubernetes experts, and its plugin ecosystem is less mature than that of other orchestrators.
+
+### Other Popular Orchestrators on Kubernetes
+
+While Argo is Kubernetes-native, many general-purpose orchestrators can be deployed effectively on Kubernetes:
+
+- **Apache Airflow**: The long-standing incumbent in data orchestration, [Airflow can be deployed on Kubernetes](https://kestra.io/vs/apache-airflow) using its Kubernetes Executor. This allows each Airflow task to run in its own pod, providing excellent isolation. However, Airflow's Python-first, DAG-as-code paradigm and significant operational overhead remain, even on Kubernetes.
+- **Prefect**: A modern, Pythonic alternative to Airflow, [Prefect also integrates well with Kubernetes](https://kestra.io/vs/prefect). It focuses on a superior developer experience for Python users and supports dynamic, parameterized workflows. Prefect is a strong choice for data teams that want a more flexible, code-centric model than Airflow without leaving the Python ecosystem.
+
+### Orchestrating AI Workflows on Kubernetes
+
+[AI and ML pipelines](https://kestra.io/resources/ai/ai-pipeline) have unique requirements, including GPU scheduling, data versioning, and model reproducibility. Several tools specialize in this domain on Kubernetes:
+- **KubeFlow**: A comprehensive ML platform for Kubernetes, offering components for the entire ML lifecycle.
+- **KubeRay**: Simplifies running Ray, a popular framework for distributed computing, on Kubernetes.
+- **Flyte**: An open-source, container-native workflow engine specifically designed for ML and data processing.
+
+The best AI orchestration tool depends on the specific need. While specialized tools are powerful, a universal orchestrator that can manage the entire [agentic orchestration](https://kestra.io/resources/ai/agentic-orchestration) lifecycle—from data ingestion to model training and deployment—is often more efficient. This is where platforms that support polyglot execution and integrate with various [AI agents](https://kestra.io/docs/ai-tools/ai-agents) and providers like [OpenAI](https://kestra.io/plugins/plugin-ai/provider/io.kestra.plugin.ai.provider.openai) can provide a significant advantage.
+
+## How Kestra Unifies Kubernetes Workflow Orchestration
+
+While tools like Argo focus on container-native execution and others like Airflow are data-centric, Kestra provides a unified control plane for all your workflows on Kubernetes. It combines the declarative nature of Kubernetes with a language-agnostic and event-driven engine.
+
+With Kestra, you can [orchestrate Kubernetes resources](https://kestra.io/orchestration/kubernetes) and workloads using simple, declarative YAML. This approach aligns perfectly with GitOps principles and makes workflows easy to version, review, and manage.
+
+Key features that set Kestra apart on Kubernetes include:
+- **Polyglot Execution**: Run tasks in any language—Python, Shell, SQL, Go, R—as first-class citizens. You are not forced to wrap every script in a Docker container or Python operator.
+- **Native Kubernetes Integration**: Use the [Kubernetes Task Runner](https://kestra.io/docs/how-to-guides/long-running-intensive-tasks) to execute tasks in isolated pods, inheriting the scalability and resilience of Kubernetes.
+- **Declarative and Low-Code**: Define all workflows in YAML. Kestra's UI provides a [visual flow editor](https://kestra.io/docs/no-code/no-code-flow-building) that simplifies development without abstracting away the power of code.
+- **Event-Driven Architecture**: Use [triggers](https://kestra.io/docs/workflow-components/triggers) to start workflows based on Kubernetes events, API calls, messages, or schedules, enabling reactive and real-time automation.
+
+Here is an example of a Kestra task that runs a command inside a dedicated Kubernetes pod:
+
+```yaml
+id: kubernetes-pod-task
+namespace: dev.team
+tasks:
+  - id: run-in-pod
+    type: io.kestra.plugin.kubernetes.core.PodCreate
+    namespace: kestra-tasks
+    spec:
+      containers:
+      - name: my-container
+        image: busybox:1.28
+        command:
+        - "/bin/sh"
+        - "-c"
+        - "echo 'Hello from a Kubernetes pod managed by Kestra!'"
+```
+
+This simple YAML definition demonstrates how Kestra abstracts Kubernetes complexity while providing direct access to its power, making it a versatile platform for platform engineers and data teams alike. You can [deploy Kestra on Kubernetes with Helm](https://kestra.io/docs/installation/kubernetes) in minutes.
+
+## Key Considerations for Implementing Kubernetes Orchestration
+
+### Scalability, Reliability, and Observability
+
+A successful Kubernetes orchestration strategy requires designing for scale and resilience from day one. This means building workflows that are fault-tolerant, with defined retry mechanisms and error handling. For high-throughput scenarios, it's essential to understand the [performance benchmarks](https://kestra.io/docs/performance/benchmark) of your chosen engine and how to [size and scale its infrastructure](https://kestra.io/docs/performance/sizing-and-scaling-infrastructure).
+
+Observability is also critical. Integrating with tools like Prometheus and OpenTelemetry for monitoring and tracing is standard practice. Kestra simplifies this with a built-in UI that provides a live execution graph, detailed logs, and performance metrics, complementing your existing [monitoring setup](https://kestra.io/docs/administrator-guide/monitoring).
+
+### Integrating with External Systems and Visual Builders
+
+Workflows rarely exist in isolation. A powerful orchestration engine must connect to a wide range of external systems, including databases, APIs, and cloud services. Kestra’s extensive library of over [1,400 plugins](https://kestra.io/plugins) enables seamless integration across your entire stack.
+
+While YAML is the source of truth, visual workflow builders can accelerate development and empower less technical users. These tools help automate tasks without requiring deep Kubernetes expertise. It's also important to distinguish between different cloud-native orchestrators. For example, Amazon ECS is a powerful container orchestrator, but it is proprietary and designed for the AWS ecosystem, unlike Kubernetes, which is open and multi-cloud.
+
+## Future-Proofing Your Kubernetes Orchestration
+
+The world of workflow automation is evolving rapidly, driven by the rise of AI and agentic systems. Your choice of a Kubernetes orchestration engine should not only solve today's problems but also provide a foundation for future innovation.
+
+A platform that is declarative, polyglot, and event-driven offers the most flexibility. By decoupling the orchestration logic (YAML) from the execution environment (Kubernetes), you can adapt to new technologies without rewriting your core business processes. Kestra is designed as the [orchestration control plane for the AI era](https://kestra.io/blogs/kestra-series-a), providing a single platform to manage everything from [data pipelines](https://kestra.io/data) and [AI workflows](https://kestra.io/ai-automation) to [infrastructure automation](https://kestra.io/infra-automation). This unified approach reduces complexity, improves governance, and empowers your teams to build reliable, scalable applications on Kubernetes.
+```

--- a/src/contents/resources/kubernetes-workflow/index.md
+++ b/src/contents/resources/kubernetes-workflow/index.md
@@ -1,0 +1,162 @@
+---
+title: "Kubernetes Workflow: Orchestration & Automation with Kestra"
+description: "Master Kubernetes workflow orchestration with our guide. Deploy and manage containerized applications efficiently using Kestra's declarative engine. Start optimizing your workflows today!"
+metaTitle: "Kubernetes Workflow: Orchestration & Automation"
+metaDescription: "Master Kubernetes workflow orchestration with our guide. Deploy and manage containerized applications efficiently. Start optimizing your workflows today!"
+tag: "infrastructure"
+date: 2026-05-27
+slug: "kubernetes-workflow"
+faq:
+  - question: "Is Kubernetes still relevant in 2026?"
+    answer: "Absolutely. In 2026, Kubernetes remains the standard for cloud-native technologies, with 98% adoption. Its relevance is particularly strong for Artificial Intelligence workloads, where its robust container orchestration capabilities provide a scalable and resilient foundation for complex AI pipelines and agentic systems."
+  - question: "What are the 8 stages of workflow?"
+    answer: "Workflows typically progress through eight stages: Creation (defining the process), Initiation (starting the workflow), Execution (performing tasks), Review (checking progress and quality), Approval (authorizing steps), Documentation (recording details), Completion (finalizing the process), and Archival (storing for future reference or audit)."
+  - question: "Why are people moving away from Kubernetes?"
+    answer: "Some organizations explore alternatives due to Kubernetes' inherent complexity, significant resource consumption, and high maintenance overhead. This shift reflects a maturing ecosystem where simpler, more specialized solutions may offer better results for specific use cases, rather than a general abandonment of Kubernetes' core value."
+  - question: "What is Argo CD and Argo Workflows on Kubernetes?"
+    answer: "Argo Workflows is an open-source, container-native workflow engine for orchestrating parallel jobs directly on Kubernetes. It uses custom resource definitions (CRDs) to define multi-step workflows, with each step running in a separate container. Argo CD, on the other hand, is a declarative GitOps continuous delivery tool for Kubernetes, automating application deployment from Git repositories."
+  - question: "What's replacing Kubernetes?"
+    answer: "While no single technology is fully 'replacing' Kubernetes, alternatives are emerging for specific use cases. These include other container orchestrators like Nomad or Docker Swarm, serverless platforms (e.g., AWS Lambda, Google Cloud Functions), and Platform-as-a-Service (PaaS) offerings. For some, traditional VM-based or bare-metal automation remains sufficient."
+  - question: "Can I learn Kubernetes in 2 days?"
+    answer: "Learning Kubernetes in two days is challenging due to its extensive ecosystem and concepts. While an intensive bootcamp can provide a foundational overview, true mastery requires hands-on practice and deeper engagement with its architecture, deployment patterns, and operational nuances over a longer period."
+author: "elliot"
+---
+
+Modern applications thrive on containers, and Kubernetes has become the de facto operating system for the cloud. Yet, managing the lifecycle of these applications—from deployment to scaling and ongoing operations—often involves a labyrinth of scripts, manual interventions, and disparate tools. This complexity can quickly erode the very benefits Kubernetes promises.
+
+This guide cuts through the noise to demystify Kubernetes workflows. We'll explore how structured orchestration can transform your containerized application management, enabling seamless automation, improving reliability, and freeing your teams to innovate faster. Discover how declarative workflow engines, especially Kestra, provide the control plane you need to master your Kubernetes environment.
+
+## Understanding Kubernetes Workflow Basics
+
+### What is a Kubernetes workflow and why it matters?
+
+A Kubernetes workflow is a sequence of automated tasks designed to build, deploy, manage, and monitor applications running on a Kubernetes cluster. Instead of relying on manual `kubectl` commands or fragmented shell scripts, a workflow codifies these operations into a repeatable, version-controlled process.
+
+This matters because modern applications are rarely monolithic. They are collections of microservices that need to be deployed, scaled, and updated independently but cohesively. A well-defined [Kubernetes workflow](https://kestra.io/resources/infrastructure/kubernetes) ensures that these complex operations are performed consistently and reliably. It provides a structured approach to managing application lifecycles, reducing human error, and enabling automation at scale. For distributed systems, robust workflows are not just a convenience; they are a necessity for maintaining uptime and operational sanity.
+
+### Key components of the Kubernetes workflow architecture
+
+Kubernetes provides the building blocks that workflows manipulate. Understanding these components is key to designing effective automation:
+
+*   **Pods:** The smallest deployable units of computing that you can create and manage in Kubernetes. A workflow might create, monitor, or delete pods.
+*   **Deployments:** A higher-level object that manages replica sets of pods, enabling rolling updates and rollbacks. Most application deployment workflows interact with Deployment objects.
+*   **Services:** An abstraction that defines a logical set of Pods and a policy by which to access them. Workflows use Services to manage network traffic to applications.
+*   **Ingress:** Manages external access to the services in a cluster, typically HTTP. Workflows might configure Ingress rules to expose a newly deployed application.
+*   **Custom Resource Definitions (CRDs):** Extensions of the Kubernetes API that allow you to define your own object kinds. Workflow engines often use CRDs to represent workflows themselves as native Kubernetes objects.
+*   **Controllers & Operators:** The control loops that watch the state of your cluster and make changes to match the desired state. An operator is an application-specific controller that extends the Kubernetes API to create, configure, and manage instances of complex stateful applications on behalf of a Kubernetes user. You can [orchestrate Kubernetes with Kestra](https://kestra.io/docs/orchestration/kubernetes) to manage these components effectively.
+
+## Orchestrating Parallel Jobs on Kubernetes
+
+### Argo Workflows: a container-native engine for Kubernetes
+
+When discussing Kubernetes workflows, [Argo Workflows](https://kestra.io/vs/argo-workflows) is often the first tool that comes to mind. It's an open-source, container-native workflow engine designed specifically for orchestrating parallel jobs on Kubernetes. Its key strength lies in its tight integration with the Kubernetes ecosystem.
+
+Workflows in Argo are defined as Kubernetes CRDs in YAML, making them first-class citizens of the cluster. Each step in a workflow runs as a separate container inside a pod. This model is exceptionally well-suited for CI/CD pipelines, machine learning tasks, and any process that can be broken down into discrete, containerized steps. For teams deeply invested in a Kubernetes-native approach, Argo provides a powerful and familiar paradigm for automation. Its focus on container-level parallelism makes it a strong contender among [enterprise Airflow alternatives](https://kestra.io/blogs/enterprise-airflow-alternatives) for platform engineering teams.
+
+### Beyond Argo: Kestra as a versatile workflow engine for Kubernetes
+
+While Argo excels at container-native orchestration, many enterprise workflows extend beyond the boundaries of a single Kubernetes cluster or involve tasks that aren't containerized. This is where Kestra offers a more versatile and comprehensive solution. Kestra is a declarative, language-agnostic orchestration platform that runs on Kubernetes but is not limited by it.
+
+With Kestra, you can define complex workflows in simple YAML that coordinate tasks across your entire stack. You can run a Python script, execute a SQL query, call a Terraform plan, and manage a Kubernetes deployment all within the same auditable workflow. This polyglot execution model means you're not forced to containerize every script or tool. Kestra provides a unified control plane for data pipelines, AI workflows, and infrastructure automation, making it a powerful complement or alternative to more specialized tools like Argo. You can easily [deploy Kestra on Kubernetes with Helm](https://kestra.io/docs/installation/kubernetes) to get started.
+
+## Deploying and Managing Applications with Kubernetes Workflows
+
+### Typical workflow for deploying containerized applications
+
+A modern application deployment pipeline on Kubernetes typically follows GitOps principles, where Git is the single source of truth for both application code and infrastructure configuration. The workflow usually involves:
+
+1.  **Continuous Integration (CI):** Developers push code to a Git repository, triggering an automated pipeline that builds a container image, runs tests, and pushes the image to a container registry.
+2.  **Continuous Deployment (CD):** A change to the deployment configuration in Git (e.g., updating an image tag in a manifest file) triggers the deployment process.
+3.  **Deployment Strategy:** The Kubernetes cluster applies the change using a strategy like a rolling update (gradually replacing old pods with new ones) or a blue/green deployment (running two versions simultaneously and switching traffic).
+
+Tools like the [Kestra Kubernetes Operator](https://kestra.io/docs/version-control-cicd/cicd/kubernetes-operator) can automate this entire process, ensuring that your cluster state always reflects what's defined in Git. This approach provides a clear audit trail and simplifies rollbacks.
+
+### Using Kestra to deploy and manage Kubernetes
+
+Kestra excels at orchestrating the entire application lifecycle on Kubernetes, from infrastructure provisioning to application deployment and day-2 operations. It acts as a central control plane that can coordinate all the necessary tools.
+
+For example, a Kestra workflow can:
+1.  **Provision Infrastructure:** Use the [Terraform plugin](https://kestra.io/orchestration/terraform) to create a GKE, EKS, or AKS cluster.
+2.  **Configure Nodes:** Run an [Ansible playbook](https://kestra.io/orchestration/ansible) to apply specific configurations to the cluster nodes.
+3.  **Deploy the Application:** Execute `kubectl apply` commands using the [native Kubernetes plugin](https://kestra.io/plugins/plugin-kubernetes/kubectl) to deploy your application manifests.
+4.  **Verify Deployment:** Run health checks and wait for the application to become ready before proceeding.
+5.  **Notify Teams:** Send a Slack notification upon successful deployment or failure.
+
+Here is a simple Kestra flow that deploys an Nginx application and verifies its rollout:
+
+```yaml
+id: deploy-app-to-kubernetes
+namespace: company.team.platform
+
+tasks:
+  - id: apply_manifest
+    type: io.kestra.plugin.kubernetes.kubectl.Apply
+    manifest: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: nginx-deployment
+      spec:
+        replicas: 3
+        selector:
+          matchLabels:
+            app: nginx
+        template:
+          metadata:
+            labels:
+              app: nginx
+          spec:
+            containers:
+            - name: nginx
+              image: nginx:1.25.3
+              ports:
+              - containerPort: 80
+
+  - id: check_rollout_status
+    type: io.kestra.plugin.kubernetes.kubectl.Get
+    resourceType: "deployment/nginx-deployment"
+    waitFor:
+      - type: "jsonpath"
+        expression: ".status.readyReplicas == 3"
+```
+
+This declarative approach simplifies complex [CI/CD processes](https://kestra.io/docs/version-control-cicd/cicd), making them visible, auditable, and easy to manage.
+
+### Is Kubernetes still relevant in 2026?
+
+Yes, Kubernetes is more relevant than ever in 2026. With cloud-native adoption reaching near-universal levels, Kubernetes has solidified its position as the standard for container orchestration. Its growth is particularly fueled by the explosion of AI and machine learning workloads, which require the scalable, resilient, and portable infrastructure that Kubernetes provides. While the ecosystem continues to evolve, Kubernetes remains the foundational platform for building and running complex, distributed applications at scale.
+
+## Advanced Kubernetes Workflow Management and Automation
+
+### Managing complex Kubernetes workflows with AI-powered orchestration
+
+As Kubernetes environments grow, managing their complexity becomes a significant challenge. AI-powered orchestration tools like Kestra are emerging to address this. Kestra's [AI Copilot](https://kestra.io/docs/ai-tools/ai-copilot) can generate workflow YAML from natural language prompts, drastically reducing the time it takes to create deployment and management pipelines.
+
+Furthermore, [Kestra's AI agents](https://kestra.io/docs/ai-tools/ai-agents) can be used to build self-healing and automated remediation systems. For instance, an agent can monitor cluster events, detect anomalies like repeated pod crashes, analyze the logs to diagnose the root cause, and execute a corrective action, such as rolling back a faulty deployment or scaling a service. This level of automation, demonstrated in blueprints like the [Kubernetes AI-powered incident monitor](https://kestra.io/blueprints/k8s-ai-incident-monitor), transforms operations from reactive to proactive.
+
+### What is Argo CD and Argo Workflows on Kubernetes?
+
+Argo Workflows and Argo CD are two distinct but complementary projects within the Argo ecosystem.
+
+*   **Argo Workflows** is a workflow execution engine. It's used to define and run multi-step processes where each step is a container. Its primary use case is orchestrating jobs, such as CI/CD pipelines, data processing, or ML training.
+*   **Argo CD** is a GitOps continuous delivery tool. It continuously monitors a Git repository and a running Kubernetes cluster, ensuring that the live state of the application matches the configuration defined in Git.
+
+They often work together: an Argo Workflow might build a container image and update a manifest in Git, and Argo CD would then detect that change and automatically deploy the new version to the cluster. Kestra can act as a higher-level orchestrator, triggering both [Argo CD syncs](https://kestra.io/orchestration/argocd) and Argo Workflows as part of a broader, end-to-end process.
+
+### What's replacing Kubernetes?
+
+No single technology is poised to "replace" Kubernetes wholesale. Instead, the ecosystem is diversifying with specialized alternatives for different needs.
+
+*   **Serverless/FaaS:** Platforms like AWS Lambda and Google Cloud Functions are excellent for event-driven, stateless functions where you don't want to manage underlying infrastructure.
+*   **PaaS:** Platforms like Heroku or AWS App Runner offer a higher level of abstraction, simplifying the developer experience for standard web applications.
+*   **Other Orchestrators:** Tools like HashiCorp Nomad offer a simpler approach to orchestration that can manage both containerized and non-containerized applications.
+
+These tools are not so much replacements as they are options on a spectrum. Kubernetes remains the dominant choice for complex, distributed systems that require maximum flexibility, portability, and control. The choice often comes down to the specific use case, comparing trade-offs between tools like [Kestra vs. Temporal](https://kestra.io/vs/temporal) for application logic or [Kestra vs. Windmill](https://kestra.io/vs/windmill) for developer scripts.
+
+## Kestra for Unified Kubernetes Orchestration
+
+Mastering Kubernetes workflows requires a control plane that is as flexible and powerful as Kubernetes itself. Kestra provides this unified layer, enabling you to orchestrate every aspect of your containerized environment with a declarative, language-agnostic, and event-driven approach.
+
+From provisioning clusters with Terraform to deploying applications with `kubectl` and managing complex data pipelines that feed your microservices, Kestra connects all the dots. Its rich plugin ecosystem, enterprise-grade governance features, and innovative AI capabilities provide a comprehensive solution for taming Kubernetes complexity. By treating all your workflows as code, Kestra brings the best practices of GitOps and infrastructure-as-code to your entire stack.
+
+Explore Kestra's [powerful features](https://kestra.io/features) and see how it can serve as the central nervous system for your [infrastructure automation](https://kestra.io/infra-automation). To learn more about our design philosophy, read about [why we built Kestra](https://kestra.io/docs/why-kestra) and browse our [infrastructure resources](https://kestra.io/resources/infrastructure).

--- a/src/contents/resources/windows-cluster/index.md
+++ b/src/contents/resources/windows-cluster/index.md
@@ -1,0 +1,162 @@
+---
+title: "Windows Cluster: Create & Manage Failover Clusters"
+description: "Learn to create and manage Windows clusters for high availability. Explore failover clustering, nodes, and best practices. Get started today!"
+metaTitle: "Windows Cluster: Create & Manage Failover Clusters"
+metaDescription: "Master Windows cluster creation and management for high availability. Discover failover clustering, nodes, and best practices with our comprehensive guide."
+tag: "infrastructure"
+date: 2026-05-27
+slug: "windows-cluster"
+faq:
+  - question: "What is a Windows cluster?"
+    answer: "A Windows failover cluster is a group of independent servers (nodes) that work together to increase the availability and scalability of clustered roles like applications and services. These nodes are interconnected by physical cables and specialized software, allowing for automatic failover in case of a node failure and ensuring continuous operation of critical workloads."
+  - question: "How to repair a Windows cluster?"
+    answer: "To repair a Windows cluster, you typically need to take the cluster's Name resource offline first. In Failover Cluster Manager, right-click the Cluster Name, select 'Take Offline,' then right-click again, point to 'More Actions,' and choose 'Repair Active Directory Object.' This option will only be available when the Name resource is offline, allowing the cluster's object in Active Directory to be repaired."
+  - question: "How do I stop Windows cluster service?"
+    answer: "To safely stop Windows cluster service, begin by setting any Cluster Shared Volume (CSV) disks to Maintenance Mode. Next, set the quorum disk to the Offline mode. Finally, use the 'Shutdown Cluster' option within the Failover Cluster Manager interface. This sequence ensures a controlled shutdown, minimizing disruption and data integrity risks."
+  - question: "What does a PC cluster do?"
+    answer: "A PC cluster, or computer cluster, is a form of distributed computing where multiple independent computers are networked together to function as a single, more powerful system. By pooling their processing resources, clusters can perform complex computational tasks, enhance overall processing power, and improve the reliability and scalability of applications beyond what a single machine could achieve."
+  - question: "What is cluster and how does it work?"
+    answer: "A cluster is a network of interconnected computers or servers that operate as a unified system. It works by distributing workloads across its multiple nodes, allowing them to collectively handle demanding tasks. This architecture boosts performance, scalability, and reliability by providing redundancy—if one node fails, others can take over, ensuring continuous service availability."
+  - question: "How often do you use Windows Failover Cluster in business?"
+    answer: "Windows Failover Clusters are frequently used in business environments to ensure high availability for critical services. They are commonly deployed for file servers, SQL Server databases, Hyper-V virtual machines, and other applications where downtime must be minimized. Their usage is widespread across industries requiring continuous operation and robust disaster recovery capabilities."
+author: "kestra"
+image: "/images/resources/windows-cluster/cover.png"
+---
+
+In today's IT landscape, ensuring high availability and scalability for critical applications is paramount. Windows Server Failover Clustering (WSFC) provides a robust solution for achieving this, allowing multiple servers to work together as a single, highly resilient system. Whether you're safeguarding databases, file servers, or virtual machines, understanding how to effectively create and manage a Windows cluster is essential for maintaining continuous operations and minimizing downtime.
+
+This comprehensive guide will demystify Windows clustering, covering everything from fundamental concepts and setup procedures to advanced management and maintenance best practices. We'll explore how these powerful configurations enhance your infrastructure's resilience and how a modern orchestration platform like Kestra can further automate and govern your Windows-based workflows.
+
+## What is a Windows cluster?
+
+A Windows cluster is a group of independent servers that are connected and managed as a single system. This architecture is central to building resilient and scalable infrastructure. While there are different types of clusters, the most common in the Windows ecosystem is the failover cluster, designed specifically for high availability.
+
+### Defining a failover cluster
+
+A Windows Server Failover Cluster (WSFC) is a group of servers that work together to maintain the availability of applications and services. If one server, or "node," in the cluster fails, another node automatically takes over its workload—a process known as failover. This ensures that users experience minimal disruption. The entire process is managed by the Cluster service, which coordinates communication and resource ownership between the nodes. This focus on [high availability](https://kestra.io/docs/administrator-guide/high-availability) is a cornerstone of modern [infrastructure automation](https://kestra.io/resources/infrastructure/automation).
+
+### Understanding cluster nodes and resources
+
+A cluster is composed of several key components:
+- **Nodes:** These are the individual physical or virtual servers that are members of the cluster. Each node runs its own instance of Windows Server and the Failover Clustering feature.
+- **Cluster Resources:** These are the units that the cluster manages, such as an IP address, a network name, a shared disk, or a specific service like SQL Server. The cluster can move these resources between nodes.
+- **Clustered Roles:** A collection of cluster resources configured to provide a specific service. For example, a highly available file server role would include a network name, an IP address, and one or more shared storage volumes.
+
+### What does a PC cluster do?
+
+On a broader level, a PC cluster links multiple computers on a network to function as a single, more powerful computing resource. This technique, known as cluster computing, is used for two primary goals:
+1.  **High Performance Computing (HPC):** Combining the processing power of many machines to solve complex computational problems faster than a single computer could.
+2.  **High Availability (HA):** Providing redundancy to ensure services remain online even if one or more machines fail. Windows Failover Clustering falls squarely into this category.
+
+## Key benefits and use cases for Windows clustering
+
+Implementing Windows clustering offers significant advantages for IT infrastructure, primarily centered around reliability and performance. These benefits make it a standard practice for hosting critical business applications.
+
+### Ensuring high availability for applications
+
+The primary benefit of a failover cluster is high availability. By eliminating single points of failure, WSFC ensures that applications like Microsoft SQL Server, Exchange Server, Hyper-V virtual machines, and critical file servers remain operational during hardware failures or planned maintenance. This is a crucial component of any robust [disaster recovery](https://kestra.io/resources/infrastructure/disaster-recovery) strategy, minimizing downtime and its associated costs.
+
+### Scalability for server workloads
+
+While failover clusters are mainly for availability, Windows Server also supports Network Load Balancing (NLB) clusters, which are designed for scalability. NLB distributes incoming network traffic across a group of servers, which is ideal for stateless applications like web servers. This allows you to scale out your application's capacity by simply adding more nodes to the cluster, improving performance under heavy load. This principle extends to broader strategies like [multi-cloud orchestration](https://kestra.io/resources/infrastructure/multi-cloud-orchestration), where workloads are distributed for resilience and performance.
+
+### How often do you use Windows Failover Cluster in business?
+
+In business environments, Windows Failover Clusters are a common and essential technology. They are widely deployed for:
+- **Databases:** Ensuring SQL Server instances are always available.
+- **Virtualization:** Hosting highly available Hyper-V virtual machines.
+- **File Services:** Creating continuously available file shares for users and applications.
+- **Messaging:** Providing a resilient backend for Microsoft Exchange.
+
+Any application that is critical to business operations and cannot tolerate significant downtime is a prime candidate for being hosted on a WSFC.
+
+## How to create a Windows failover cluster
+
+Setting up a Windows failover cluster requires careful planning and adherence to specific prerequisites. The process involves validating the hardware and software configuration before creating the cluster itself.
+
+### Prerequisites for cluster setup
+
+Before you begin, ensure your environment meets these requirements:
+- **Servers:** Two or more physical or virtual servers running the same version of Windows Server (Standard or Datacenter edition).
+- **Networking:** All nodes must be connected to the same Active Directory domain. You need multiple network adapters on each node: one for public client traffic and at least one for private cluster communication (heartbeat).
+- **Storage:** A shared storage solution accessible by all nodes, such as a Storage Area Network (SAN) using iSCSI, Fibre Channel, or a Storage Spaces Direct (S2D) configuration.
+- **Active Directory:** An Active Directory domain is required. The cluster creates a computer object (Cluster Name Object or CNO) in AD.
+- **Permissions:** You need an account with administrative rights on all nodes and permissions to create computer objects in the target AD Organizational Unit (OU).
+
+### Step-by-step guide to create a failover cluster
+
+1.  **Install the Failover Clustering Feature:** On each server that will be a node, use Server Manager or PowerShell to install the Failover Clustering feature.
+    ```powershell
+    Install-WindowsFeature -Name Failover-Clustering -IncludeManagementTools
+    ```
+2.  **Run Cluster Validation:** Before creating the cluster, run the validation wizard from the Failover Cluster Manager or PowerShell. This test checks your hardware and software configuration for compatibility.
+    ```powershell
+    Test-Cluster -Node "node1.domain.com", "node2.domain.com"
+    ```
+3.  **Create the Cluster:** If validation passes, proceed with the "Create Cluster" wizard in Failover Cluster Manager or use PowerShell. You will need to provide a unique name for the cluster and a static IP address.
+    ```powershell
+    New-Cluster -Name MyCluster -Node "node1.domain.com", "node2.domain.com" -StaticAddress 192.168.1.100
+    ```
+4.  **Configure Quorum:** The cluster will automatically select a quorum configuration based on your setup. Review and adjust if necessary.
+5.  **Configure Clustered Roles:** Once the cluster is created, you can add roles like File Server or SQL Server using the High Availability Wizard.
+
+### Setup for Windows Server Failover Clustering on VMware
+
+When deploying WSFC on a VMware vSphere environment, there are specific considerations. The virtual machines acting as nodes require access to shared storage, typically configured using Raw Device Mappings (RDMs) or vSphere Virtual Volumes (vVols). It's essential to follow VMware's guidelines for SCSI controller configuration (e.g., using a dedicated paravirtual SCSI controller for shared disks) and multi-writer flags to ensure proper disk sharing and prevent data corruption. Automating these setups can be streamlined when you [orchestrate VMware](https://kestra.io/orchestration/vmware) with a platform-agnostic tool.
+
+## Managing and maintaining your Windows cluster
+
+Once a cluster is operational, ongoing management is crucial for maintaining its health and reliability. This includes monitoring, performing maintenance tasks, and knowing how to troubleshoot common issues.
+
+### Monitoring cluster health and performance
+
+Use the Failover Cluster Manager to get a real-time overview of your cluster's status, including node health, resource states, and recent events. Windows Performance Monitor and System Center Operations Manager (SCOM) can provide more in-depth performance metrics. Regular monitoring helps you proactively identify issues before they cause an outage. For more comprehensive visibility, integrating cluster alerts into a centralized [monitoring platform](https://kestra.io/docs/administrator-guide/monitoring) is a best practice.
+
+### How do I stop Windows cluster service?
+
+To safely shut down the entire cluster, you should follow a specific procedure to avoid issues:
+1.  In Failover Cluster Manager, move any Cluster Shared Volumes (CSVs) into maintenance mode.
+2.  Take the quorum disk offline.
+3.  Right-click the cluster name in the navigation tree and select "More Actions" > "Shut Down Cluster."
+
+This ensures a graceful shutdown of all clustered services. To stop the service on a single node for maintenance, you can use the "Pause" or "Drain Roles" option on that node.
+
+### How to repair a Windows cluster?
+
+If the cluster's Active Directory object (the CNO) becomes corrupted, you may need to repair it. This is typically done when the cluster name resource fails to come online.
+1.  In Failover Cluster Manager, right-click the cluster name resource and select "Take Offline."
+2.  Once it's offline, right-click it again, navigate to "More Actions," and select "Repair Active Directory Object."
+
+This action attempts to fix permissions and settings for the cluster's object in AD. These repair tasks can often be automated using [PowerShell scripts](https://kestra.io/plugins/plugin-script-powershell/io.kestra.plugin.scripts.powershell.script) as part of a larger maintenance workflow.
+
+## Advanced Windows clustering concepts
+
+To effectively manage a Windows cluster, it's important to understand the underlying technologies that ensure its stability and consistency, such as shared storage, quorum models, and network configuration.
+
+### Shared storage and quorum models
+
+Shared storage is the backbone of a failover cluster, as it holds the data and configuration for the clustered roles. This storage must be accessible by all nodes simultaneously. The quorum is a mechanism that prevents "split-brain" scenarios where network partitions could lead to nodes trying to take ownership of the same resources independently. The cluster uses a voting system, often involving a witness disk or cloud witness, to determine which group of nodes constitutes the majority and is allowed to run. Understanding your [data storage components](https://kestra.io/docs/architecture/data-components) is as critical here as it is in distributed applications.
+
+### Network configuration for clusters
+
+A robust network configuration is vital. Best practice dictates using multiple, redundant networks:
+- **Public Network:** For client connections to the clustered roles.
+- **Private Network:** For internal cluster communication, such as heartbeats, state synchronization, and CSV traffic. This network should be isolated from client traffic.
+
+Configuring these networks correctly ensures that cluster communication doesn't interfere with client access and that the cluster remains stable even if one network path fails. These configurations are often managed as part of an [Infrastructure as Code (IaC)](https://kestra.io/resources/infrastructure/what-is-infrastructure-as-code) strategy.
+
+## Orchestrating Windows Clusters with Kestra
+
+While Windows Failover Cluster Manager provides excellent tools for manual administration, modern IT operations benefit from a higher level of automation and orchestration. Kestra is a platform-agnostic orchestrator that can manage and integrate your Windows clusters into broader, automated workflows.
+
+### Automating setup and provisioning tasks
+
+Kestra can automate the repetitive tasks involved in cluster management. Using its declarative YAML workflows, you can define sequences of [PowerShell](https://kestra.io/plugins/plugin-script-powershell/io.kestra.plugin.scripts.powershell.script) or [Ansible](https://kestra.io/orchestration/ansible) tasks to perform actions like adding or removing nodes, configuring storage, or applying patches across the cluster in a controlled, auditable manner.
+
+### Monitoring and event-driven responses
+
+Instead of just passive monitoring, Kestra enables event-driven automation. A Kestra workflow can be triggered by an alert from your monitoring system (e.g., a node-down event). This workflow could then automatically execute a diagnostic script, create a ticket in ServiceNow, and notify the on-call engineer via Slack—all without manual intervention.
+
+### Integrating Windows clusters into cross-platform workflows
+
+Kestra excels at connecting disparate systems. You can create end-to-end workflows that involve your Windows cluster alongside other infrastructure. For example, a workflow could provision a new VM on a [VMware](https://kestra.io/orchestration/vmware) cluster, configure it using Ansible, add it to a Windows failover cluster, and then deploy an application to it. This ability to coordinate across different platforms and tools from a single control plane is what defines modern orchestration. Organizations are increasingly using tools like Kestra to manage complex, hybrid infrastructure, from on-prem virtualized environments to cloud-native services.

--- a/src/contents/resources/windows-cluster/index.md
+++ b/src/contents/resources/windows-cluster/index.md
@@ -20,7 +20,6 @@ faq:
   - question: "How often do you use Windows Failover Cluster in business?"
     answer: "Windows Failover Clusters are frequently used in business environments to ensure high availability for critical services. They are commonly deployed for file servers, SQL Server databases, Hyper-V virtual machines, and other applications where downtime must be minimized. Their usage is widespread across industries requiring continuous operation and robust disaster recovery capabilities."
 author: "kestra"
-image: "/images/resources/windows-cluster/cover.png"
 ---
 
 In today's IT landscape, ensuring high availability and scalability for critical applications is paramount. Windows Server Failover Clustering (WSFC) provides a robust solution for achieving this, allowing multiple servers to work together as a single, highly resilient system. Whether you're safeguarding databases, file servers, or virtual machines, understanding how to effectively create and manage a Windows cluster is essential for maintaining continuous operations and minimizing downtime.


### PR DESCRIPTION
## Summary
- Publishes 11 new resource articles generated and reviewed in the [kestra-seo](https://github.com/vfanucci/kestra-seo) workflow during 2026-W22.
- All pages live under `src/contents/resources/<slug>/index.md` and carry the standard resources front-matter (`title`, `description`, `metaTitle`, `metaDescription`, `tag`, `date`, `slug`, `faq`, `author`).
- No collisions with existing slugs on `main` (verified before commit).

## Pages added

| Slug | Source PR (kestra-seo) |
|---|---|
| `airflow-alternatives` | [#81](https://github.com/vfanucci/kestra-seo/pull/81) |
| `apache-nifi-alternatives` | [#82](https://github.com/vfanucci/kestra-seo/pull/82) |
| `astronomer-alternatives` | [#83](https://github.com/vfanucci/kestra-seo/pull/83) |
| `aws-step-functions-alternatives` | [#84](https://github.com/vfanucci/kestra-seo/pull/84) |
| `azure-alternatives` | [#85](https://github.com/vfanucci/kestra-seo/pull/85) |
| `camunda-alternatives` | [#86](https://github.com/vfanucci/kestra-seo/pull/86) |
| `data-warehouse-etl` | [#87](https://github.com/vfanucci/kestra-seo/pull/87) |
| `hpc-workflow` | [#88](https://github.com/vfanucci/kestra-seo/pull/88) |
| `kubernetes-workflow-orchestration` | [#89](https://github.com/vfanucci/kestra-seo/pull/89) |
| `kubernetes-workflow` | [#90](https://github.com/vfanucci/kestra-seo/pull/90) |
| `windows-cluster` | [#91](https://github.com/vfanucci/kestra-seo/pull/91) |

## Notes
- Cover images for each slug are expected at `/images/resources/<slug>/cover.png` and are auto-generated as part of the SEO workflow.
- The `\`\`\`yaml` wrapper that Gemini sometimes places around the front-matter has been stripped where present; YAML code blocks inside the article body are preserved as-is.

## Test plan
- [ ] Astro build passes on the preview deploy.
- [ ] Each new page renders at `/resources/<slug>` with valid front-matter (title, description, FAQ).
- [ ] FAQ schema is picked up in rich results test for at least one page (e.g., `/resources/airflow-alternatives`).
- [ ] Internal links inside the articles resolve (no 404s to `/vs/...`, `/docs/...`, `/blogs/...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)