### PR TITLE
build(ci): use GH_READ_ORG_TOKEN for welcome workflow

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: plbstl/first-contribution@v4
         env:
-          GH_PAT_READ_ORG: ${{ secrets.GITHUB_READ_ORG_TOKEN }}
+          GH_PAT_READ_ORG: ${{ secrets.GH_READ_ORG_TOKEN }}
         with:
           skip-internal-contributors: true
           pr-opened-msg: |


### PR DESCRIPTION
## Summary
- Fix token name: replace `secrets.GITHUB_READ_ORG_TOKEN` with `secrets.GH_READ_ORG_TOKEN` for `GH_PAT_READ_ORG` in the welcome workflow

Supersedes #4874.