### PR TITLE
seo(redirects): real 301 for /sitemap_index.xml, /preview-access, /cloud-early-access (fix #4824)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -215,8 +215,6 @@ export default defineConfig({
             "https://app.drata.com/trust/0a8e867d-7c4c-4fc5-bdc7-217f9c839604",
         "/docs/migration-guide/v0.24.0/retries-maxAttempts":
             "/docs/migration-guide/v0.24.0/retries-maxattempts",
-        "/preview-access": "/get-started",
-        "/cloud-early-access": "/cloud",
     },
     vite: {
         plugins: [

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -213,7 +213,6 @@ export default defineConfig({
         "/slack": "https://api.kestra.io/v1/communities/slack/redirect",
         "/trust":
             "https://app.drata.com/trust/0a8e867d-7c4c-4fc5-bdc7-217f9c839604",
-        "/sitemap_index.xml": "/sitemap/index.xml",
         "/docs/migration-guide/v0.24.0/retries-maxAttempts":
             "/docs/migration-guide/v0.24.0/retries-maxattempts",
         "/preview-access": "/get-started",

--- a/src/pages/cloud-early-access.ts
+++ b/src/pages/cloud-early-access.ts
@@ -1,0 +1,10 @@
+import type { APIRoute } from "astro"
+
+export const GET: APIRoute = () => {
+    return new Response(null, {
+        status: 301,
+        headers: {
+            Location: "/cloud",
+        },
+    })
+}

--- a/src/pages/preview-access.ts
+++ b/src/pages/preview-access.ts
@@ -1,0 +1,10 @@
+import type { APIRoute } from "astro"
+
+export const GET: APIRoute = () => {
+    return new Response(null, {
+        status: 301,
+        headers: {
+            Location: "/get-started",
+        },
+    })
+}

--- a/src/pages/sitemap_index.xml.ts
+++ b/src/pages/sitemap_index.xml.ts
@@ -1,0 +1,10 @@
+import type { APIRoute } from "astro"
+
+export const GET: APIRoute = () => {
+    return new Response(null, {
+        status: 301,
+        headers: {
+            Location: "/sitemap/index.xml",
+        },
+    })
+}


### PR DESCRIPTION
## Problem

Three internal redirects declared in `astro.config.mjs` were not behaving as HTTP 301s in production:

| URL | Current behavior | Expected |
|---|---|---|
| `/sitemap_index.xml` | 200, same XML body & etag as `/sitemap/index.xml` (introduced by #4824) | 301 → `/sitemap/index.xml` |
| `/preview-access` | 200, full HTML of `/get-started` | 301 → `/get-started` |
| `/cloud-early-access` | 200, full HTML of `/cloud` | 301 → `/cloud` |

Each pair = duplicate-content for Google.

Evidence for `/sitemap_index.xml`:
```
$ curl -sI https://kestra.io/sitemap_index.xml | grep -E "HTTP|etag"
HTTP/2 200
etag: "bfb4d4cdbb09f3e33b27906a6bea0ce7"

$ curl -sI https://kestra.io/sitemap/index.xml | grep -E "HTTP|etag"
HTTP/2 200
etag: "bfb4d4cdbb09f3e33b27906a6bea0ce7"
```

## Root cause

Astro's `redirects` field emits a real HTTP 301 **only for external destinations** (e.g. `/slack → https://api.kestra.io/...` correctly returns 301). For **internal** path destinations, Astro performs a server-side rewrite: the URL stays unchanged and the response body is the destination route's output. That's why all three URLs were responding 200 with the destination's content.

## Fix

Replace each internal rewrite with an explicit `APIRoute` that returns a real `301` + `Location` header:

- `src/pages/sitemap_index.xml.ts` → `/sitemap/index.xml`
- `src/pages/preview-access.ts` → `/get-started`
- `src/pages/cloud-early-access.ts` → `/cloud`

And remove the three entries from the `redirects` block in `astro.config.mjs`.

## Notes

- The remaining `docs/migration-guide/.../retries-maxAttempts → retries-maxattempts` entry is left as-is. It's a case-only alias that isn't externally linked and isn't an SEO duplicate-content concern, but happy to fix in a follow-up if desired.
- `/slack` and `/trust` are external destinations — unchanged, they already produce real 301s.

## Test plan
- [ ] `curl -I https://kestra.io/sitemap_index.xml` → `HTTP/2 301`, `location: /sitemap/index.xml`
- [ ] `curl -I https://kestra.io/preview-access` → `HTTP/2 301`, `location: /get-started`
- [ ] `curl -I https://kestra.io/cloud-early-access` → `HTTP/2 301`, `location: /cloud`
- [ ] `curl -sL` from each old URL still lands on the right destination in one hop
- [ ] `https://kestra.io/sitemap/index.xml`, `/get-started`, `/cloud` are unchanged (200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)