### PR TITLE
seo(redirects): disable prerender so 301 routes actually emit HTTP 301

### DIFF
--- a/src/pages/cloud-early-access.ts
+++ b/src/pages/cloud-early-access.ts
@@ -1,5 +1,9 @@
 import type { APIRoute } from "astro"
 
+// SSR at runtime — when prerendered, Astro converts 301 responses into a
+// meta-refresh HTML page (200), defeating the redirect.
+export const prerender = false
+
 export const GET: APIRoute = () => {
     return new Response(null, {
         status: 301,

--- a/src/pages/preview-access.ts
+++ b/src/pages/preview-access.ts
@@ -1,5 +1,9 @@
 import type { APIRoute } from "astro"
 
+// SSR at runtime — when prerendered, Astro converts 301 responses into a
+// meta-refresh HTML page (200), defeating the redirect.
+export const prerender = false
+
 export const GET: APIRoute = () => {
     return new Response(null, {
         status: 301,

--- a/src/pages/sitemap_index.xml.ts
+++ b/src/pages/sitemap_index.xml.ts
@@ -1,5 +1,9 @@
 import type { APIRoute } from "astro"
 
+// SSR at runtime — when prerendered, Astro converts 301 responses into a
+// meta-refresh HTML page (200), defeating the redirect.
+export const prerender = false
+
 export const GET: APIRoute = () => {
     return new Response(null, {
         status: 301,


### PR DESCRIPTION
## Problem

Follow-up to #4881. After deploy, all three URLs were **still 200** with a meta-refresh HTML page instead of a real HTTP 301:

\`\`\`
$ curl -sI https://kestra.io/preview-access | head -2
HTTP/2 200

$ curl -s https://kestra.io/preview-access
<!doctype html><title>Redirecting to: /get-started</title>
<meta http-equiv="refresh" content="0;url=/get-started">
<meta name="robots" content="noindex">
<link rel="canonical" href="https://kestra.io/get-started">
<body>...</body>
\`\`\`

Same behaviour observed on \`/sitemap_index.xml\` and \`/cloud-early-access\`.

## Root cause

The three APIRoutes from #4881 were **prerendered at build time** (Astro's default for routes without an explicit \`prerender = false\`). During prerender, Astro intercepts \`Response(null, { status: 301 })\` and converts it into a static meta-refresh HTML file written to \`dist/\`. Cloudflare then serves that file as a 200.

Visible in the existing codebase: \`src/pages/robots.txt.ts\` uses \`export const prerender = false\` for the same reason — it needs a real runtime response.

## Fix

Add \`export const prerender = false\` to each of the three redirect routes so the response is produced by the Cloudflare Worker at runtime — where the 301 status is honored.

## Test plan
- [ ] \`curl -I https://kestra.io/sitemap_index.xml\` → \`HTTP/2 301\` + \`location: /sitemap/index.xml\`
- [ ] \`curl -I https://kestra.io/preview-access\` → \`HTTP/2 301\` + \`location: /get-started\`
- [ ] \`curl -I https://kestra.io/cloud-early-access\` → \`HTTP/2 301\` + \`location: /cloud\`
- [ ] \`curl -sL\` for each → lands on the destination in one hop
- [ ] Destinations themselves (\`/sitemap/index.xml\`, \`/get-started\`, \`/cloud\`) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)