### PR TITLE
seo(resources): publish W22 batch — 12 new alternatives pages

### DIFF
--- a/src/contents/resources/amazon-mwaa-alternatives/index.md
+++ b/src/contents/resources/amazon-mwaa-alternatives/index.md
@@ -20,7 +20,6 @@ faq:
   - question: "Does Airbnb still use Airflow?"
     answer: "Yes, Airbnb, the creator of Apache Airflow, continues to use it extensively for orchestrating its data pipelines. However, like many large organizations, they also employ other specialized tools alongside Airflow for various aspects of their data and infrastructure management."
 author: "elliot"
-image: "/images/resources/top-amazon-mwaa-alternatives/cover.png"
 hub: "data"
 alternatives_count: 7
 ---

--- a/src/contents/resources/amazon-mwaa-alternatives/index.md
+++ b/src/contents/resources/amazon-mwaa-alternatives/index.md
@@ -1,0 +1,293 @@
+---
+title: "Top Amazon MWAA alternatives for data pipelines"
+description: "Amazon MWAA offers managed Airflow, but its costs and AWS lock-in drive many teams to seek alternatives. Explore leading options like Kestra, Prefect, and Dagster to find a solution that better fits your needs for data orchestration, cost efficiency, and deployment flexibility."
+metaTitle: "Top Amazon MWAA Alternatives for Data Pipelines"
+metaDescription: "Discover the best Amazon MWAA alternatives for data orchestration. Compare features, costs, and benefits to find your ideal solution today!"
+tag: "data"
+date: 2026-05-27
+slug: "amazon-mwaa-alternatives"
+faq:
+  - question: "Is MWAA expensive?"
+    answer: "MWAA's pricing can accumulate quickly, especially with numerous DAGs and high resource usage. The base hourly cost (around $0.50/hour) combines with charges for metadata storage, logging, and network traffic, making cost optimization a common challenge for users."
+  - question: "What is the difference between MWAA and Astro?"
+    answer: "Astro provides a multi-cloud managed Airflow experience, deployable across AWS, Azure, and GCP. MWAA is a fully AWS-native service, limiting deployments to the AWS ecosystem. Organizations with multi-cloud strategies often prefer Astro for its broader deployment flexibility."
+  - question: "What is the difference between Airflow and MWAA?"
+    answer: "Apache Airflow is the open-source workflow orchestration framework. MWAA is Amazon's managed service offering of Apache Airflow, handling infrastructure, scaling, and patching. While MWAA simplifies operations, it introduces AWS vendor lock-in and still inherits Airflow's Python-centric DAG-as-code model."
+  - question: "Is Kestra better than Airflow?"
+    answer: "Kestra offers a declarative, YAML-based approach to workflow definition, which can simplify versioning and rollbacks compared to Airflow's Python DAGs. It also provides native polyglot execution and is designed as a universal control plane for data, AI, and infrastructure workflows, offering broader applicability than Airflow's data-centric focus."
+  - question: "What is the AWS equivalent of Airflow?"
+    answer: "Amazon Managed Workflows for Apache Airflow (MWAA) is the direct AWS equivalent, offering a fully managed service for Apache Airflow environments. Other AWS services like AWS Step Functions or AWS Glue can also orchestrate workflows but serve different architectural patterns and use cases."
+  - question: "Does Airbnb still use Airflow?"
+    answer: "Yes, Airbnb, the creator of Apache Airflow, continues to use it extensively for orchestrating its data pipelines. However, like many large organizations, they also employ other specialized tools alongside Airflow for various aspects of their data and infrastructure management."
+author: "elliot"
+image: "/images/resources/top-amazon-mwaa-alternatives/cover.png"
+hub: "data"
+alternatives_count: 7
+---
+
+Amazon Managed Workflows for Apache Airflow (MWAA) offers data teams a managed service for Apache Airflow, abstracting away some of the operational burden. However, as organizations scale their data pipelines, many encounter challenges such as escalating costs, vendor lock-in to the AWS ecosystem, and the inherent complexities of Airflow's Python-centric DAG-as-code model. These factors often prompt a search for more flexible, cost-effective, or broader orchestration alternatives. The leading alternatives to Amazon MWAA in 2026 include Kestra, self-hosted Apache Airflow, Astronomer Astro, Prefect, Dagster, Argo Workflows, and Apache NiFi—each suited to different workloads such as multi-cloud data orchestration, infrastructure automation, or asset-centric data lineage. This article will compare these options to help you identify the ideal solution for your specific data and operational needs.
+
+## Why look for an alternative to Amazon MWAA?
+
+While MWAA simplifies running Airflow on AWS, several factors drive teams to explore other options. Understanding these limitations is key to finding the right alternative.
+
+**Cost at Scale:** MWAA's pricing model, which combines an hourly rate with charges for metadata storage, logging, and networking, can lead to unpredictable and escalating costs. For teams managing hundreds of DAGs or running high-frequency jobs, these costs accumulate quickly, making it a significant operational expense.
+
+**AWS Vendor Lock-In:** As an AWS-native service, MWAA tightly couples your orchestration to a single cloud provider. This poses a challenge for organizations adopting multi-cloud or hybrid-cloud strategies, as it complicates deploying and managing workflows across different environments.
+
+**Inherited Complexity of Airflow:** MWAA is a managed service for Apache Airflow, meaning it inherits Airflow's core architecture and limitations. Workflows are defined as Python DAGs, which can be difficult to version, review, and roll back compared to declarative formats. Debugging complex DAGs remains a significant operational burden, and the model is less intuitive for non-Python engineers. An [enterprise Airflow alternative](https://kestra.io/blogs/enterprise-airflow-alternatives) often addresses these operational hurdles directly.
+
+**Limited Language Agnosticism:** Airflow's operator model wraps most tasks in Python, even when the underlying job is written in another language like SQL or Bash. This adds a layer of abstraction and complexity that is unnecessary in more flexible, polyglot orchestrators.
+
+## How we evaluated these alternatives
+
+We assessed each Amazon MWAA alternative based on a set of criteria critical for modern engineering teams. The evaluation focused on:
+
+- **Deployment Model:** Whether the tool is a managed service, self-hosted, or offers a hybrid approach.
+- **License:** The licensing model, distinguishing between open-source and commercial offerings.
+- **Primary Use Case Fit:** The tool's ideal domain, whether it's data-centric, infrastructure-focused, AI/ML-driven, or a universal automation platform.
+- **Cost Model:** How the service is priced, such as per-run, per-instance, or usage-based.
+- **Language Agnosticism & Flexibility:** The ability to natively orchestrate tasks written in various programming languages.
+- **Community & Ecosystem:** The health and size of the community and the availability of pre-built integrations.
+
+## The Top 7 Amazon MWAA Alternatives
+
+### 1. Kestra: The Declarative, Polyglot Orchestration Control Plane
+
+Kestra is an open-source orchestration platform that uses a declarative YAML interface to define and manage workflows. This approach separates the orchestration logic from the business logic, making workflows easier to version, audit, and manage through GitOps practices.
+
+Unlike Airflow's Python-centric model, Kestra is language-agnostic by design, with native support for Python, Bash, SQL, R, and containerized tasks via Docker. It functions as a universal control plane, capable of unifying [data pipelines](https://kestra.io/data), [infrastructure automation](https://kestra.io/infra-automation), and [AI workflows](https://kestra.io/ai-automation) on a single platform. Its event-driven architecture and real-time capabilities make it a strong fit for modern, responsive data systems. For a deeper look into its philosophy, see [Why Kestra](https://kestra.io/docs/why-kestra).
+
+**Best for:** Teams seeking a universal, auditable, and scalable orchestration platform that unifies workflows across domains and tech stacks.
+
+### 2. Apache Airflow (Self-Hosted)
+
+For teams wanting full control over their environment, self-hosting the open-source Apache Airflow is a direct alternative to MWAA. This option provides maximum flexibility and avoids vendor-specific costs, but it shifts the entire operational burden—including infrastructure provisioning, scaling, patching, and security—onto your team.
+
+The primary benefit is access to Airflow's massive operator ecosystem and a large community of users. It remains a solid choice for data-heavy organizations with deep Python and infrastructure expertise. Self-hosting Airflow means you are running the same open-source framework that MWAA manages, making it the most direct "equivalent" outside of a managed service.
+
+**Best for:** Python-heavy data teams with existing Airflow expertise and the dedicated resources required for self-management.
+
+### 3. Astronomer Astro
+
+Astro, from Astronomer, is a fully managed Airflow platform that offers a multi-cloud experience. Unlike MWAA, which is confined to AWS, Astro can be deployed on AWS, Azure, and Google Cloud Platform. This makes it a compelling option for organizations that need to avoid single-vendor lock-in or operate in a multi-cloud environment.
+
+Astro provides an enterprise-grade layer on top of open-source Airflow, including enhanced observability, CI/CD integrations, and dedicated support. While it still operates on the DAG-as-code paradigm, it abstracts away the underlying infrastructure management more comprehensively than MWAA.
+
+**Best for:** Organizations committed to Airflow but seeking a managed service with multi-cloud flexibility and enterprise support.
+
+### 4. Prefect
+
+Prefect is a modern data orchestrator that focuses on a Pythonic developer experience. It uses decorators and a native async framework to define dynamic, code-native workflows. This approach appeals to Python developers who find Airflow's DAG structure rigid and verbose.
+
+Prefect's hybrid execution model allows a managed cloud control plane to orchestrate tasks running on your own infrastructure, offering a balance of convenience and security. Its strength lies in handling complex, dynamic pipelines where parameters and runtime conditions can change the workflow's structure.
+
+**Best for:** Python-only teams prioritizing developer experience, dynamic workflows, and a modern alternative to traditional Airflow.
+
+### 5. Dagster
+
+Dagster takes an asset-centric approach to orchestration. Instead of focusing on tasks, it models workflows as a graph of data assets (e.g., tables, files, models). This provides strong data lineage, observability, and testability out of the box, aligning well with software engineering best practices.
+
+With its native dbt integration and focus on the modern data stack, Dagster is particularly well-suited for analytics engineering teams. The learning curve can be steeper due to its unique paradigm, but for teams prioritizing data quality and lineage, it offers powerful capabilities not found in traditional orchestrators.
+
+**Best for:** Analytics engineering teams focused on data assets, lineage, and applying software engineering rigor to data pipelines.
+
+### 6. Argo Workflows
+
+Argo Workflows is a Kubernetes-native workflow engine. Workflows are defined as Kubernetes Custom Resource Definitions (CRDs) in YAML, making it a natural fit for teams already invested in the Kubernetes ecosystem. Its container-first model excels at orchestrating batch jobs, CI/CD tasks, and machine learning pipelines.
+
+Because it's deeply integrated with Kubernetes, Argo provides excellent parallelism and scalability. However, this tight coupling also means it's not a suitable choice for organizations that are not running on Kubernetes.
+
+**Best for:** Teams with deep Kubernetes expertise and workloads that are inherently container-based.
+
+### 7. Apache NiFi
+
+Apache NiFi is a visual, flow-based programming tool designed for data routing and transformation. It provides a drag-and-drop interface for building dataflows, which is excellent for real-time data ingestion, mediation, and provenance tracking.
+
+NiFi's strength lies in its ability to handle high-volume, streaming data from disparate sources. However, it is less suited for orchestrating complex, code-heavy batch jobs or general-purpose workflows. Its visual paradigm can become difficult to manage for complex logic that is more easily expressed in code or declarative YAML.
+
+**Best for:** Dataflow routing, mediation, and real-time data ingestion use cases with strong visual requirements.
+
+## Comparison Table
+
+| Tool | License | Deployment | Best for | Cost Model | Key Differentiator |
+|---|---|---|---|---|---|
+| **Kestra** | Open-Source (Apache 2.0) & Enterprise | Self-hosted, Cloud | Universal orchestration across data, infra, AI | Per-instance (Enterprise) | Declarative YAML, Language-agnostic |
+| **Apache Airflow** | Open-Source (Apache 2.0) | Self-hosted | Python-centric data pipelines | Free (Infrastructure cost) | Massive operator ecosystem |
+| **Astronomer Astro** | Commercial | Managed Cloud | Enterprise Airflow with multi-cloud support | Usage-based | Multi-cloud managed Airflow |
+| **Prefect** | Open-Source (Apache 2.0) & Commercial | Self-hosted, Hybrid, Cloud | Dynamic, Python-native workflows | Usage-based (Cloud) | Pythonic developer experience |
+| **Dagster** | Open-Source (Apache 2.0) & Commercial | Self-hosted, Cloud | Asset-centric data lineage & quality | Usage-based (Cloud) | Data asset-centric model |
+| **Argo Workflows** | Open-Source (Apache 2.0) | Self-hosted (Kubernetes) | Kubernetes-native batch jobs & ML | Free (Infrastructure cost) | Kubernetes-native CRD approach |
+| **Apache NiFi** | Open-Source (Apache 2.0) | Self-hosted | Visual dataflow routing and ingestion | Free (Infrastructure cost) | Visual, flow-based interface |
+
+## How to choose the right Amazon MWAA alternative
+
+The best alternative depends entirely on your team's needs, skills, and strategic goals.
+
+- **For data engineering teams** focused on reliability and lineage, **Dagster** offers a powerful asset-based model. For teams needing to integrate multiple tools and languages, **Kestra** provides a flexible, declarative control plane.
+- **For infrastructure and DevOps teams**, **Argo Workflows** is the clear choice for Kubernetes-native automation. **Kestra** is a strong contender when orchestration needs to coordinate IaC tools like Terraform with other systems across the enterprise.
+- **For AI and ML platform teams**, the container-native approach of **Argo Workflows** is well-suited for training jobs. **Kestra** offers a broader solution for orchestrating the entire end-to-end ML lifecycle, from data ingestion to model deployment and agentic workflows.
+- **For small teams or startups**, self-hosting open-source tools like **Prefect** or **Kestra** can offer a powerful, cost-effective start without the vendor lock-in of a managed service.
+
+## Conclusion
+
+Moving away from Amazon MWAA opens up a diverse landscape of powerful orchestration tools. While managed Airflow provides a convenient entry point, its limitations in cost, flexibility, and operational scope lead many to seek alternatives. The right choice depends on your primary workload: Python-native teams may prefer Prefect, analytics engineers might lean towards Dagster's asset model, and Kubernetes-native shops will find Argo Workflows a natural fit.
+
+However, for organizations looking to break down silos and establish a single, auditable control plane across all technical domains, Kestra offers a compelling solution. By embracing a declarative, language-agnostic approach, it provides the flexibility to orchestrate any workflow, anywhere. To see how this works in practice, explore our library of [workflow blueprints](https://kestra.io/blueprints).
+
+## Structured data
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is MWAA expensive?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "MWAA's pricing can accumulate quickly, especially with numerous DAGs and high resource usage. The base hourly cost (around $0.50/hour) combines with charges for metadata storage, logging, and network traffic, making cost optimization a common challenge for users."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the difference between MWAA and Astro?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Astro provides a multi-cloud managed Airflow experience, deployable across AWS, Azure, and GCP. MWAA is a fully AWS-native service, limiting deployments to the AWS ecosystem. Organizations with multi-cloud strategies often prefer Astro for its broader deployment flexibility."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the difference between Airflow and MWAA?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Apache Airflow is the open-source workflow orchestration framework. MWAA is Amazon's managed service offering of Apache Airflow, handling infrastructure, scaling, and patching. While MWAA simplifies operations, it introduces AWS vendor lock-in and still inherits Airflow's Python-centric DAG-as-code model."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Kestra better than Airflow?",
+      "acceptedAnswer": {
+        "@type":": "Answer",
+        "text": "Kestra offers a declarative, YAML-based approach to workflow definition, which can simplify versioning and rollbacks compared to Airflow's Python DAGs. It also provides native polyglot execution and is designed as a universal control plane for data, AI, and infrastructure workflows, offering broader applicability than Airflow's data-centric focus."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the AWS equivalent of Airflow?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Amazon Managed Workflows for Apache Airflow (MWAA) is the direct AWS equivalent, offering a fully managed service for Apache Airflow environments. Other AWS services like AWS Step Functions or AWS Glue can also orchestrate workflows but serve different architectural patterns and use cases."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Airbnb still use Airflow?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, Airbnb, the creator of Apache Airflow, continues to use it extensively for orchestrating its data pipelines. However, like many large organizations, they also employ other specialized tools alongside Airflow for various aspects of their data and infrastructure management."
+      }
+    }
+  ]
+}
+```
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Top Amazon MWAA Alternatives",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Kestra",
+        "url": "https://kestra.io"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Apache Airflow (Self-Hosted)"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Astronomer Astro"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Prefect"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 5,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Dagster"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 6,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Argo Workflows"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 7,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Apache NiFi"
+      }
+    }
+  ]
+}
+```
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://kestra.io/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Resources",
+      "item": "https://kestra.io/resources"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Data Engineering Resources",
+      "item": "https://kestra.io/resources/data"
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "name": "Top Amazon MWAA alternatives for data pipelines",
+      "item": "https://kestra.io/resources/data/top-amazon-mwaa-alternatives"
+    }
+  ]
+}
+```

--- a/src/contents/resources/cloud-composer-alternatives/index.md
+++ b/src/contents/resources/cloud-composer-alternatives/index.md
@@ -20,7 +20,6 @@ faq:
   - question: "What is the best free alternative to Cloud Composer?"
     answer: "For teams prioritizing cost-effectiveness and control, self-hosted Apache Airflow or Kestra's open-source edition are strong free alternatives. Self-hosting Airflow requires significant operational expertise, while Kestra offers a modern, declarative approach that can reduce operational complexity while remaining open-source."
 author: "Virgile Fanucci"
-image: "/images/blogs/cloud-composer-alternatives/cover.png"
 ---
 Google Cloud Composer has long been a go-to solution for data teams seeking a managed Apache Airflow experience, offering deep integration within the GCP ecosystem. However, as data stacks evolve and operational demands shift, many organizations are re-evaluating their orchestration choices. Factors like escalating costs, the desire for multi-cloud flexibility, or the inherent complexities of Python-heavy DAGs can prompt a search for alternatives that offer greater control, broader language support, or a more streamlined operational model.
 

--- a/src/contents/resources/cloud-composer-alternatives/index.md
+++ b/src/contents/resources/cloud-composer-alternatives/index.md
@@ -1,0 +1,135 @@
+---
+title: "Cloud Composer Alternatives for Data Orchestration"
+description: "Explore top Cloud Composer alternatives for robust data orchestration, including managed and self-hosted options. Find the best fit for your workflow needs!"
+metaTitle: "Cloud Composer Alternatives | Data Orchestration"
+metaDescription: "Seeking Cloud Composer alternatives? Discover managed, self-hosted, and cloud-native options for data orchestration. Compare features, costs, and scalability to find your ideal workflow solution."
+tag: "data"
+date: 2026-05-30
+slug: "cloud-composer-alternatives"
+faq:
+  - question: "Are Cloud Composer and Airflow the same?"
+    answer: "Cloud Composer is Google Cloud's fully managed service for Apache Airflow. While it leverages the open-source Airflow project, it provides a managed infrastructure, automatic scaling, and deep integration with other Google Cloud services, abstracting away much of the operational overhead of self-hosting Airflow."
+  - question: "Why look for Cloud Composer alternatives?"
+    answer: "Organizations often seek Cloud Composer alternatives due to factors like vendor lock-in, desire for multi-cloud or hybrid environments, high operational costs, or the need for a more flexible, language-agnostic orchestration paradigm beyond Python-centric DAGs. Some teams also prefer a more hands-on approach to infrastructure management."
+  - question: "What is the difference between Cloud Scheduler and Cloud Composer?"
+    answer: "Cloud Scheduler is a lightweight, fully managed cron job service designed for triggering simple, time-based events or HTTP requests. Cloud Composer, based on Apache Airflow, is a powerful and complex platform for orchestrating intricate, multi-step data workflows with dependencies, retries, and a rich ecosystem of operators."
+  - question: "What is the difference between Cloud Composer and Dataflow?"
+    answer: "Cloud Composer is an orchestration tool that schedules and manages workflows, including data pipelines. Google Cloud Dataflow is a fully managed service for executing Apache Beam pipelines, primarily focused on large-scale data processing (batch and streaming). Composer orchestrates; Dataflow processes."
+  - question: "Can Kestra replace Cloud Composer?"
+    answer: "Yes, Kestra can serve as a powerful alternative to Cloud Composer. Kestra offers a declarative, language-agnostic approach to orchestration using YAML, enabling polyglot workflows across data, AI, and infrastructure. It provides similar scheduling and dependency management capabilities, often with lower operational overhead and greater deployment flexibility across any cloud or on-premises environment."
+  - question: "What is the best free alternative to Cloud Composer?"
+    answer: "For teams prioritizing cost-effectiveness and control, self-hosted Apache Airflow or Kestra's open-source edition are strong free alternatives. Self-hosting Airflow requires significant operational expertise, while Kestra offers a modern, declarative approach that can reduce operational complexity while remaining open-source."
+author: "Virgile Fanucci"
+image: "/images/blogs/cloud-composer-alternatives/cover.png"
+---
+Google Cloud Composer has long been a go-to solution for data teams seeking a managed Apache Airflow experience, offering deep integration within the GCP ecosystem. However, as data stacks evolve and operational demands shift, many organizations are re-evaluating their orchestration choices. Factors like escalating costs, the desire for multi-cloud flexibility, or the inherent complexities of Python-heavy DAGs can prompt a search for alternatives that offer greater control, broader language support, or a more streamlined operational model.
+
+The leading alternatives to Cloud Composer in 2026 include Kestra, Google Cloud Workflows, Managed Apache Airflow services like Astronomer Astro, self-hosted Apache Airflow, Argo Workflows, and Databricks Workflows—each suited to different workloads such as real-time data processing, infrastructure automation, or asset-centric data pipelines. This article dives into these top alternatives, exploring their strengths, trade-offs, and ideal use cases to help you make an informed decision for your data orchestration needs.
+
+## Why Look for an Alternative to Google Cloud Composer?
+
+While Cloud Composer simplifies Airflow deployment on GCP, several factors drive teams to explore other options:
+
+*   **Cost Escalation:** The underlying GKE cluster and managed services can become expensive, especially for environments with fluctuating workloads or many development instances.
+*   **Vendor Lock-in:** Deep integration with GCP services makes it challenging to adopt a multi-cloud or hybrid strategy without significant re-engineering.
+*   **Python-Centric Limitations:** Like Airflow, Composer is fundamentally built around Python DAGs. This can be a bottleneck for polyglot teams or for workflows that orchestrate non-Python tasks like infrastructure automation or SQL-heavy pipelines.
+*   **Operational Complexity:** Despite being a managed service, debugging, managing dependencies, and optimizing the underlying Airflow environment can still be complex and time-consuming.
+*   **Multi-Cloud Strategy:** For organizations operating across AWS, Azure, and GCP, a cloud-agnostic [data orchestration](https://kestra.io/resources/data/data-orchestration) tool provides a unified control plane, reducing tool sprawl and operational overhead. An [Airflow vs Kestra](https://kestra.io/vs/airflow) comparison often highlights these differences in portability.
+
+## How We Evaluated These Alternatives
+
+We assessed each alternative based on a core set of criteria relevant to data and platform engineering teams:
+
+*   **Deployment Model:** Is it fully managed, self-hosted, or hybrid?
+*   **License:** Is it open-source or proprietary?
+*   **Primary Use Case:** Is it optimized for data engineering, infrastructure automation, API choreography, or all of the above?
+*   **Developer Experience:** How easy is it to define, test, and debug workflows?
+*   **Scalability & Cost-Effectiveness:** How does it scale with workload complexity and what is the total cost of ownership?
+
+## The Alternatives
+
+### 1. Kestra: The Open-Source Orchestration Control Plane
+
+Kestra is a modern, declarative orchestration platform that unifies data, AI, and infrastructure workflows under a single control plane. Workflows are defined as simple YAML files, making them easy to write, review, and manage with GitOps principles.
+
+Unlike Python-centric tools, Kestra is language-agnostic, natively running Python, R, Go, SQL, Docker containers, and more. Its event-driven architecture excels at real-time use cases, and its low operational overhead makes it a cost-effective choice for teams of all sizes. You can explore a wide range of pre-built workflows in our [Blueprints library](https://kestra.io/blueprints).
+
+**Best for:** Teams seeking a flexible, polyglot, multi-domain orchestrator with strong GitOps principles and event-driven capabilities, deployable anywhere from a single laptop to a multi-cloud Kubernetes cluster. [Kestra's design philosophy](https://kestra.io/docs/why-kestra) centers on separating orchestration logic from business logic.
+
+### 2. Google Cloud Workflows: Serverless API Orchestration
+
+Google Cloud Workflows is a fully managed, serverless orchestration service designed for chaining together Google Cloud services and HTTP-based APIs. It uses a JSON or YAML-based syntax to define stateful workflows, scales to zero, and has a generous free tier, making it highly cost-effective for simple, event-driven tasks.
+
+However, it lacks the complex dependency management, rich data-centric integrations, and observability features of a full-fledged data orchestrator like Airflow or Kestra.
+
+**Best for:** GCP-committed teams needing lightweight, serverless orchestration for API calls and simple service chaining, where complex data dependencies are minimal. See a detailed comparison in our [Kestra vs. Google Workflows](https://kestra.io/vs/google-workflows) analysis.
+
+### 3. Google Cloud Scheduler & Pub/Sub: Lightweight Task Triggers
+
+For the simplest scheduling needs, combining Cloud Scheduler with Pub/Sub offers a basic but effective solution. Cloud Scheduler acts as a fully managed cron service, triggering a Pub/Sub topic on a defined schedule. Downstream services, like Cloud Functions, can then subscribe to this topic to execute tasks.
+
+This pattern is extremely cost-effective for isolated, time-based jobs but offers no built-in dependency management, error handling, or workflow visibility. It's a trigger mechanism, not an orchestration engine.
+
+**Best for:** GCP users needing simple, cost-effective scheduling for isolated tasks or basic event-driven patterns, without the full complexity of a workflow engine.
+
+### 4. Astronomer Astro: Enterprise-Grade Managed Airflow
+
+Astronomer Astro is a fully managed, cloud-native Apache Airflow platform. It addresses many of the operational pain points of both self-hosted Airflow and standard managed services by providing enhanced observability, faster deployments, and robust enterprise-grade security and support.
+
+Astro runs on Kubernetes and can be deployed on any major cloud provider, offering more flexibility than the GCP-locked Cloud Composer. It remains, however, an Airflow-centric solution. For teams exploring orchestration beyond Python DAGs, see our [Kestra vs. Astronomer](https://kestra.io/vs/astronomer) comparison.
+
+**Best for:** Organizations deeply committed to the Apache Airflow ecosystem but desiring a best-in-class managed service with enterprise features, support, and multi-cloud capabilities. If you are considering an upgrade from older versions, check if it's better to upgrade or migrate in our [Airflow 3 vs Airflow 2 analysis](https://kestra.io/blogs/airflow-3-vs-airflow-2).
+
+### 5. Self-Hosted Apache Airflow: Full Control and Customization
+
+Running your own Apache Airflow instance gives you complete control over the infrastructure, configuration, and security. This is the most flexible option, allowing you to customize your environment precisely to your needs and avoid managed service costs.
+
+The trade-off is significant operational overhead. Your team is responsible for managing the webserver, scheduler, workers, metadata database, and all associated networking and security, which can be a full-time job for a platform team.
+
+**Best for:** Python-centric data teams that require absolute control over their orchestration environment, are willing to manage the operational complexity of an [ETL workflow](https://kestra.io/resources/data/etl-workflow), and have deep in-house Airflow expertise.
+
+### 6. Argo Workflows: Kubernetes-Native Automation
+
+Argo Workflows is an open-source, container-native workflow engine for orchestrating jobs on Kubernetes. Workflows are defined as Kubernetes CRDs in YAML, making it a natural fit for teams already invested in the Kubernetes ecosystem. It excels at running massively parallel, containerized tasks, making it a popular choice for ML training, data processing, and CI/CD pipelines.
+
+While powerful, its tight coupling to Kubernetes means it's not a fit for non-containerized workloads or teams without strong K8s expertise.
+
+**Best for:** Teams with a strong Kubernetes footprint and expertise, needing to orchestrate containerized workloads, CI/CD, or ML training pipelines directly within their K8s clusters. Discover how it compares to a broader orchestrator in our [Kestra vs. Argo Workflows](https://kestra.io/vs/argo-workflows) page.
+
+### 7. Databricks Workflows: Lakehouse-Native Data & AI Orchestration
+
+For teams heavily invested in the Databricks ecosystem, Databricks Workflows provides a native solution for orchestrating jobs within the Lakehouse Platform. It offers deep integration with Databricks notebooks, Delta Live Tables, Unity Catalog, and MLflow, creating a seamless experience for end-to-end data and AI pipelines that run entirely on Databricks.
+
+Its primary limitation is its platform-centric nature. Orchestrating tasks outside of Databricks can be cumbersome, making it less suitable as a universal orchestrator.
+
+**Best for:** Organizations heavily invested in the Databricks ecosystem, looking for seamless orchestration of ETL, analytics, and ML workloads that primarily reside within Databricks. For a comparison, see [Kestra vs. Databricks Workflows](https://kestra.io/vs/databricks-workflows).
+
+## Comparison Table
+
+| Tool | License | Deployment | Best For | Key Differentiators |
+|---|---|---|---|---|
+| **Kestra** | Open-Source (Apache 2.0) | Self-Hosted, Cloud | Multi-cloud, polyglot, event-driven workflows | Declarative YAML, language-agnostic, unifies data/AI/infra |
+| **Google Cloud Workflows** | Proprietary | Managed (GCP) | Serverless API orchestration in GCP | Scales to zero, lightweight, cost-effective for simple jobs |
+| **GCP Scheduler/PubSub** | Proprietary | Managed (GCP) | Basic cron-like task triggering in GCP | Extremely low cost, simple, event-based triggering |
+| **Astronomer Astro** | Proprietary | Managed | Enterprise-grade managed Airflow | Multi-cloud, enhanced observability, strong support |
+| **Self-Hosted Airflow** | Open-Source (Apache 2.0) | Self-Hosted | Full control over a Python-centric stack | Maximum flexibility, large community, high operational cost |
+| **Argo Workflows** | Open-Source (Apache 2.0) | Self-Hosted (K8s) | Kubernetes-native, containerized tasks | YAML-based (CRDs), built for K8s ecosystem |
+| **Databricks Workflows** | Proprietary | Managed (Databricks) | Orchestration within the Databricks Lakehouse | Deep integration with Databricks, notebook-centric |
+
+## How to Choose the Right Cloud Composer Alternative
+
+The best choice depends on your team's skills, existing stack, and strategic goals.
+
+*   **For GCP-centric teams with simple needs:** Google Cloud Workflows or the Scheduler/PubSub combo are cost-effective choices for lightweight tasks.
+*   **For committed Airflow users:** Astronomer Astro provides a superior managed experience, while self-hosting offers ultimate control for teams with the necessary operational capacity.
+*   **For Kubernetes-native environments:** Argo Workflows is the most natural fit for orchestrating container-based jobs.
+*   **For Databricks-heavy organizations:** Databricks Workflows offers the most seamless integration for Lakehouse-native pipelines.
+*   **For multi-cloud, polyglot, and event-driven needs:** Kestra provides a universal, declarative control plane that bridges [data](https://kestra.io/data), [infrastructure](https://kestra.io/infra-automation), and [AI](https://kestra.io/ai-automation) workflows, offering flexibility and lower operational complexity.
+
+It's also important to distinguish between orchestration and processing. Cloud Composer is often compared to Google Cloud Dataflow, but they serve different purposes. Composer orchestrates the workflow (the *when* and *how*), while Dataflow is a data processing engine that executes the work itself (the *what*). A robust data platform often uses both.
+
+## Conclusion
+
+Moving away from Google Cloud Composer opens up a diverse landscape of powerful orchestration tools. The decision hinges on whether you need a lightweight serverless solution, an enterprise-grade managed Airflow platform, or a flexible, multi-domain control plane. By evaluating your specific requirements around cost, control, ecosystem, and language support, you can select an alternative that not only solves today's challenges but also scales with your future needs.
+
+If a modern, declarative, and language-agnostic approach aligns with your goals, [get started with Kestra's open-source edition](https://kestra.io/get-started) to see how it can simplify your orchestration across your entire stack.

--- a/src/contents/resources/dagster-alternatives/index.md
+++ b/src/contents/resources/dagster-alternatives/index.md
@@ -1,0 +1,118 @@
+---
+title: "Top Dagster Alternatives for Data Orchestration"
+description: "Explore the best Dagster alternatives for data pipeline orchestration. Compare features and find the right tool for your modern data stack."
+metaTitle: "Top Dagster Alternatives for Data Orchestration"
+metaDescription: "Discover leading Dagster alternatives like Kestra, Airflow, and Prefect. Compare features, pricing, and use cases to find the best data orchestrator for your team."
+tag: "data"
+date: 2026-05-27
+slug: "dagster-alternatives"
+faq:
+  - question: "Why should I consider alternatives to Dagster?"
+    answer: "While Dagster excels with its asset-centric data model and Python-native approach, teams often seek alternatives due to its Python-only constraint, a steeper learning curve, and less natural fit for non-data-centric workflows like infrastructure automation or general business processes."
+  - question: "Is Dagster still a relevant data orchestrator in 2026?"
+    answer: "Yes, Dagster remains a highly relevant tool, particularly for analytics engineering teams focused on strong data lineage and software engineering practices for data. However, its asset-centric paradigm may not be the optimal fit for all teams or use cases, especially those requiring polyglot or cross-domain orchestration."
+  - question: "How does Kestra compare to Dagster for data orchestration?"
+    answer: "Kestra offers a declarative, YAML-based approach that supports polyglot task execution (Python, SQL, Shell, etc.), making it more versatile for diverse teams. Unlike Dagster's Python-only focus, Kestra unifies data, AI, and infrastructure workflows under a single control plane, offering greater flexibility and lower operational overhead."
+  - question: "What are the main differences between Dagster, Airflow, and Prefect?"
+    answer: "Dagster is asset-centric and Python-based, emphasizing data lineage. Airflow is also Python-based with a vast operator ecosystem, known for its maturity but also operational complexity. Prefect offers a Pythonic, developer-friendly experience with dynamic workflows and a hybrid execution model, also primarily Python-focused."
+  - question: "What is the best free and open-source alternative to Dagster?"
+    answer: "Kestra is a strong open-source alternative to Dagster, offering a declarative, event-driven, and polyglot orchestration platform with a generous Apache 2.0 license. Apache Airflow is another popular open-source choice, though it comes with higher operational complexity and is Python-centric."
+author: "Virgile Fanucci"
+hub: data
+---
+
+Dagster has emerged as a powerful orchestrator for data teams embracing software engineering principles. Its unique asset-centric view provides strong lineage and observability, making it a favorite among analytics engineers. Yet, as data stacks grow more complex and teams become more polyglot, many organizations find themselves exploring alternatives that offer broader language support, simplified operational models, or extended capabilities beyond purely data-focused workflows. The increasing demand for a unified control plane across data, AI, and infrastructure further drives this search.
+
+The leading alternatives to Dagster in 2026 include Kestra, Apache Airflow, Prefect, Mage, and more lightweight options like Luigi and Metaflow. Each offers a distinct approach to [data orchestration](https://kestra.io/resources/data/data-orchestration), from polyglot declarative workflows to Python-native pipeline management, catering to different team structures and scalability needs. This guide evaluates these top alternatives, focusing on their core strengths, potential trade-offs, and ideal use cases to help you identify the best fit for your modern data stack.
+
+## Why Look for an Alternative to Dagster?
+
+While Dagster offers significant advantages for certain data teams, several factors often lead users to seek alternatives. A deeper look at the [Dagster vs. Kestra comparison](/vs/dagster) reveals common motivations for exploring other tools:
+
+*   **Python-Only Constraint:** Dagster's deep integration with Python, while powerful for Python-centric teams, limits flexibility for organizations with polyglot environments or those needing to orchestrate tasks in other languages like SQL, Go, or Java natively.
+*   **Steeper Learning Curve:** The asset-centric paradigm, though beneficial for data lineage, introduces a new conceptual model that can require a significant ramp-up period for teams accustomed to more traditional job-based orchestration.
+*   **Limited Scope Beyond Data:** While Dagster is expanding, its primary focus remains data orchestration. Teams seeking a unified platform to manage infrastructure automation, AI pipelines, or broader business processes might find it less suitable as a universal control plane.
+*   **Operational Overhead:** Deploying and managing Dagster at scale, especially in complex environments, can still incur significant operational burden, prompting a search for more lightweight or managed solutions.
+
+## How We Evaluated These Alternatives
+
+We evaluated each alternative on several key criteria: deployment model (self-hosted, hybrid, cloud), license (open-source vs. commercial), primary use case fit, and community health. We also considered developer experience, language flexibility, and the operational overhead associated with each platform to provide a holistic view for diverse team needs.
+
+## The Leading Dagster Alternatives for Workflow Orchestration
+
+### 1. Kestra: Unifying Workflows Across Domains
+
+Kestra stands out as an open-source, declarative orchestration platform designed to unify data, AI, infrastructure, and business workflows under a single control plane. Workflows are defined in YAML, enabling GitOps practices for all automation. Its JVM-based engine supports polyglot task execution, allowing teams to run Python, SQL, Shell, Go, R, and more as first-class citizens. Kestra's event-driven architecture and extensive plugin ecosystem simplify complex integrations and reduce operational overhead. This versatility is demonstrated in use cases like [Apple's ML team orchestrating large-scale data pipelines](/use-cases/stories/apple-ml-team-orchestrates-large-scale-data-pipelines-with-kestra).
+
+*   **Best for:** Organizations seeking a versatile, language-agnostic orchestrator for cross-domain automation with a strong emphasis on declarative configuration and GitOps.
+
+### 2. Apache Airflow: The Established Data Orchestrator
+
+Apache Airflow is the most widely adopted open-source data orchestrator, known for its extensive ecosystem of operators and providers. Its Python-based DAGs offer robust dependency management and scheduling capabilities. While mature and battle-tested, Airflow often presents a significant operational overhead due to its complex architecture. The recent [end of life for Airflow 2](/blogs/2026-04-06-airflow-2-end-of-life) has also prompted many teams to evaluate modern alternatives.
+
+*   **Best for:** Python-heavy data engineering teams with existing investment in the Airflow ecosystem and a preference for code-first workflow definition.
+
+### 3. Prefect: Modern Pythonic Pipelines
+
+Prefect offers a modern, Pythonic approach to workflow orchestration, focusing on developer experience and dynamic workflows. Its hybrid execution model, combining Prefect Cloud with customer-managed workers, provides flexibility. Prefect excels at handling dynamic, data-aware pipelines with strong features for retries, caching, and logging. However, like Airflow, it is primarily Python-centric, which is a key point in the [Prefect vs. Kestra comparison](/vs/prefect).
+
+*   **Best for:** Python-only teams seeking a modern, flexible, and developer-friendly alternative to Airflow without leaving the Python ecosystem.
+
+### 4. Mage: The Intuitive Data Pipeline Tool
+
+Mage positions itself as an intuitive, notebook-centric data pipeline tool with a strong focus on data quality and observability. It offers a visual UI for building and monitoring data pipelines, making it accessible to a broader audience. Built with a modern Python stack, Mage emphasizes an iterative development experience. As a newer entrant, its community and plugin ecosystem are still growing compared to more established platforms, but it's a noteworthy option among [ETL pipeline tools](/resources/data/etl-pipeline-tools).
+
+*   **Best for:** Data teams prioritizing visual development, a notebook-like experience, and built-in data quality features, especially those with a Python-centric stack.
+
+### 5. Lightweight Orchestrators: Luigi and Metaflow
+
+For teams seeking less comprehensive, more embedded solutions, lightweight orchestrators like Luigi and Metaflow offer focused capabilities. **Luigi**, developed by Spotify, is a Python module for building complex pipelines of batch jobs, focusing on dependency resolution. **Metaflow**, from Netflix, is a framework for data science and machine learning, emphasizing reproducibility and versioning. These tools are often used to orchestrate specific components, such as various [dataframe operations](/blogs/dataframes), within a larger ecosystem.
+
+*   **Best for:** Small-scale, Python-only batch jobs (Luigi) or specialized ML research pipelines (Metaflow) where a full orchestration platform might be overkill.
+
+## Comparison Table
+
+| Tool | License | Deployment | Best for | Starting Price/Model | Language Support | Asset-Centric? |
+|---|---|---|---|---|---|---|
+| Kestra | Apache 2.0 OSS / EE | Self-hosted, Hybrid, Cloud | Unified data, AI, infra, business workflows | Free (OSS), Subscription (EE/Cloud) | Polyglot (YAML-defined) | No (Flow-centric) |
+| Apache Airflow | Apache 2.0 OSS | Self-hosted, Managed Cloud | Python-heavy batch data pipelines | Free (OSS), Subscription (Managed) | Python | No (DAG-centric) |
+| Prefect | Apache 2.0 OSS / Commercial | Self-hosted, Hybrid Cloud | Python-native data & AI workflows | Free (OSS), Subscription (Cloud) | Python | No (Flow-centric) |
+| Mage | Apache 2.0 OSS | Self-hosted, Hybrid | Visual, notebook-centric data pipelines | Free (OSS) | Python | Yes (Block-centric) |
+| Luigi | Apache 2.0 OSS | Self-hosted | Simple Python batch job pipelines | Free (OSS) | Python | No (Task-centric) |
+| Metaflow | Apache 2.0 OSS | Self-hosted, Cloud | ML/Data science workflows | Free (OSS) | Python, R | Yes (Flow-centric) |
+
+## How to Choose the Right Dagster Alternative
+
+Selecting the right Dagster alternative depends heavily on your team's specific needs and existing ecosystem.
+
+*   **For Data Engineering Teams**: If you prioritize polyglot support, declarative workflows, and unifying your diverse data stack, Kestra offers a compelling solution. For Python-native teams, Prefect provides a modern, developer-friendly experience.
+    *   Explore [declarative orchestration for modern data engineers](/data).
+*   **For Infrastructure & DevOps Teams**: When the goal is to orchestrate workflows across infrastructure, data, and AI with GitOps principles, Kestra's declarative YAML-first approach is highly advantageous.
+    *   Discover [Kestra for infrastructure automation](/infra-automation).
+*   **For AI & ML Platform Teams**: For orchestrating complex AI pipelines, especially those needing reproducibility, versioning, and human-in-the-loop approvals, Kestra's AI-native agentic capabilities and polyglot support are a strong fit.
+    *   Learn about [Kestra for AI orchestration](/ai-automation).
+*   **For Small Teams Getting Started**: Kestra's ease of deployment with Docker Compose and its intuitive UI make it a great option for quick starts. Luigi offers a very lightweight, code-embedded solution for simple Python batch jobs.
+    *   [Get started with Kestra](/get-started) in minutes.
+
+## Frequently Asked Questions
+
+**Why should I consider alternatives to Dagster?**
+While Dagster excels with its asset-centric data model and Python-native approach, teams often seek alternatives due to its Python-only constraint, a steeper learning curve, and less natural fit for non-data-centric workflows like infrastructure automation or general business processes.
+
+**Is Dagster still a relevant data orchestrator in 2026?**
+Yes, Dagster remains a highly relevant tool, particularly for analytics engineering teams focused on strong data lineage and software engineering practices for data. However, its asset-centric paradigm may not be the optimal fit for all teams or use cases, especially those requiring polyglot or cross-domain orchestration.
+
+**How does Kestra compare to Dagster for data orchestration?**
+Kestra offers a declarative, YAML-based approach that supports polyglot task execution (Python, SQL, Shell, etc.), making it more versatile for diverse teams. Unlike Dagster's Python-only focus, Kestra unifies data, AI, and infrastructure workflows under a single control plane, offering greater flexibility and lower operational overhead.
+
+**What are the main differences between Dagster, Airflow, and Prefect?**
+Dagster is asset-centric and Python-based, emphasizing data lineage. Airflow is also Python-based with a vast operator ecosystem, known for its maturity but also operational complexity. Prefect offers a Pythonic, developer-friendly experience with dynamic workflows and a hybrid execution model, also primarily Python-focused.
+
+**What is the best free and open-source alternative to Dagster?**
+Kestra is a strong open-source alternative to Dagster, offering a declarative, event-driven, and polyglot orchestration platform with a generous Apache 2.0 license. Apache Airflow is another popular open-source choice, though it comes with higher operational complexity and is Python-centric.
+
+## Conclusion
+
+Choosing the right data orchestrator is a critical decision that impacts team productivity, operational efficiency, and scalability. While Dagster offers a powerful, asset-centric model for Python-heavy data teams, the market provides a rich array of [alternatives](/vs). From Kestra's unified, polyglot, and declarative approach to Airflow's vast ecosystem or Prefect's modern Pythonic experience, the ideal tool aligns with your specific technical stack, team composition, and long-term automation strategy. Evaluating these options against your core requirements will ensure you select a platform that not only solves today's challenges but also scales with your evolving needs.
+
+Ready to simplify your data, AI, and infrastructure workflows with a single, declarative platform? [Book a demo](/demo) to see Kestra in action.

--- a/src/contents/resources/databricks-workflows-alternatives/index.md
+++ b/src/contents/resources/databricks-workflows-alternatives/index.md
@@ -1,0 +1,290 @@
+---
+title: "Databricks Workflows Alternatives: Unify Your Data Orchestration"
+description: "Discover top Databricks Workflows alternatives for modern orchestration. Compare options like Kestra, Airflow, and Prefect to unify your data processes and reduce lock-in."
+metaTitle: "Databricks Workflows Alternatives: Kestra, Airflow, Prefect"
+metaDescription: "Explore leading Databricks Workflows alternatives. Compare Kestra, Apache Airflow, Prefect, and more for universal orchestration, cost efficiency, and reduced vendor lock-in."
+tag: "data"
+date: 2026-05-27
+slug: "databricks-workflows-alternatives"
+faq:
+  - question: "Is Databricks Workflows still worth using in 2026?"
+    answer: "Databricks Workflows remains a strong choice for workloads that are entirely contained within the Databricks Lakehouse platform. Its native integration with Databricks services offers a streamlined experience for existing users. However, if your orchestration needs extend beyond the Databricks ecosystem, or if you're seeking to reduce vendor lock-in and optimize costs, exploring alternatives becomes essential to avoid fragmented automation."
+  - question: "What are the main limitations of Databricks Workflows?"
+    answer: "Key limitations include platform lock-in, as it's primarily designed for Databricks-native workloads, making cross-cloud or hybrid orchestration challenging. It may also present cost considerations for larger scale or diverse workloads. Furthermore, its focus on data and AI workflows means it's less suited for broader infrastructure or business process orchestration, which might necessitate additional tools."
+  - question: "Can Kestra replace Databricks Workflows for data orchestration?"
+    answer: "Yes, Kestra can replace or complement Databricks Workflows, especially for teams seeking a universal orchestration control plane. Kestra excels at coordinating heterogeneous workloads across various platforms, including Databricks, other clouds, and on-premises systems. It allows you to run Databricks jobs as tasks within a broader, declarative YAML-defined workflow, offering greater flexibility, polyglot execution, and reduced vendor lock-in."
+  - question: "What is the best open-source alternative to Databricks Workflows?"
+    answer: "For open-source alternatives, Apache Airflow is a long-standing option, especially for Python-centric data teams. However, Kestra provides a more modern, declarative, and language-agnostic approach that extends beyond just data workflows to cover AI, infrastructure, and business processes. Kestra's open-source core offers high extensibility and deploy-anywhere flexibility without the operational overhead often associated with Airflow at scale."
+  - question: "How does Databricks Workflows compare to Apache Airflow?"
+    answer: "Databricks Workflows is tightly integrated with the Databricks Lakehouse, ideal for jobs running exclusively on that platform. Apache Airflow, in contrast, is a more generalized, Python-centric data orchestrator with a vast ecosystem. While Airflow offers flexibility, it comes with higher operational complexity. Kestra combines the best of both: the declarative simplicity and extensibility of a modern orchestrator, with the ability to integrate seamlessly with Databricks and other tools."
+  - question: "Which orchestration tool is best for combining Databricks with other cloud services?"
+    answer: "For orchestrating Databricks alongside a diverse set of other cloud services and on-premises systems, Kestra stands out. Its vendor-agnostic and declarative YAML approach allows seamless coordination of tasks across AWS, GCP, Azure, and your Databricks environment. This unified control plane reduces complexity and provides end-to-end visibility, making it ideal for multi-cloud or hybrid data strategies that include Databricks."
+author: "elliot"
+image: "/images/blogs/databricks-workflows-alternatives/cover.png"
+---
+
+Databricks Workflows offers powerful, native orchestration for jobs within the Databricks Lakehouse Platform. It provides a streamlined experience for data and AI workloads, tightly integrated with the Databricks ecosystem. Yet, as organizations scale and diversify their technology stacks, the very strength of platform-native tools—deep integration—can become a limitation. Teams increasingly face challenges related to vendor lock-in, escalating costs, or the need to orchestrate workflows that span beyond a single cloud platform or domain.
+
+In 2026, the landscape of data orchestration demands more flexibility and broader reach. The leading alternatives to Databricks Workflows address these challenges by offering greater architectural freedom, polyglot execution, and the ability to unify data, AI, and infrastructure processes under a single, declarative control plane. This guide will explore the top alternatives, including Kestra, Apache Airflow, Prefect, Matillion, and Pixeltable, evaluating them against critical criteria such as deployment model, integration ecosystems, and cost efficiency. By understanding the strengths and trade-offs of each, you can choose the best orchestrator to unify your data strategy.
+
+## Why look for an alternative to Databricks Workflows?
+
+While Databricks Workflows excels at managing jobs within its own environment, several factors drive teams to seek out alternatives for their [data orchestration](https://kestra.io/resources/data/data-orchestration) needs.
+
+*   **Platform Lock-in and Vendor Dependence**: The tight coupling with the Databricks ecosystem, while convenient for native tasks, can create silos. Orchestrating processes that involve other cloud services (AWS, GCP, Azure), on-premises systems, or third-party SaaS applications becomes complex and often requires brittle, custom-coded solutions. A dedicated orchestrator provides a neutral control plane that avoids vendor lock-in.
+*   **Cost Considerations**: Databricks operates on a consumption-based pricing model. For organizations running a high volume of diverse or long-running jobs, these costs can become significant and hard to predict. Alternatives with more transparent pricing or efficient open-source models can offer better cost control.
+*   **Narrower Scope for Universal Orchestration**: Databricks Workflows is purpose-built for data and AI pipelines. It is less suited for broader use cases like infrastructure automation (Terraform, Ansible), ITSM workflows (ServiceNow), or general business process automation. This limitation often forces companies to maintain multiple orchestration tools, leading to a fragmented and complex automation landscape.
+*   **Complexity for Heterogeneous Stacks**: Modern data platforms are rarely monolithic. When your stack includes tools like Fivetran for ingestion, dbt for transformation, and various databases or APIs, coordinating them from within Databricks Workflows can add layers of complexity and reduce visibility. A universal orchestrator simplifies this by providing a single point of control and observability. For many [data engineers](https://kestra.io/data), a more flexible solution is a key requirement.
+
+## How we evaluated these alternatives
+
+To provide a clear comparison, we evaluated each alternative based on a consistent set of criteria relevant to teams looking beyond Databricks Workflows. Our assessment considers deployment flexibility, licensing models, primary use cases, and the breadth of integration capabilities. We also looked at language support, cost efficiency, and the strength of community and enterprise support. This framework helps highlight how each tool addresses different pain points, from reducing operational overhead to enabling a truly universal orchestration strategy. You can explore the differences between [open-source and enterprise offerings](https://kestra.io/docs/oss-vs-paid) to see which model best fits your organization's needs.
+
+## 1. Kestra: The Universal Orchestration Control Plane
+
+Kestra is an open-source, declarative orchestration platform designed to unify data, AI, infrastructure, and business workflows under a single control plane. Instead of defining pipelines in a specific programming language, Kestra uses a simple, declarative YAML interface. This makes workflows easy to create, review, and manage, following GitOps best practices.
+
+Its language-agnostic architecture allows you to run tasks in Python, SQL, Bash, Go, Java, or as Docker containers, providing maximum flexibility for polyglot teams. Kestra is event-driven by default, making it ideal for modern, real-time data stacks. With over a thousand [plugins](https://kestra.io/plugins), it integrates seamlessly with your existing tools, including Databricks.
+
+Leading enterprises like Apple, JPMorgan Chase, and Toyota use Kestra to manage large-scale data and AI pipelines, demonstrating its scalability and reliability in mission-critical environments.
+
+**Best for**: Organizations seeking a flexible, vendor-agnostic, and scalable orchestrator that unifies diverse workloads across clouds and on-premises environments.
+
+## 2. Apache Airflow: The Open-Source Standard for Data
+
+Apache Airflow has long been the dominant open-source data orchestrator. Its primary strength lies in its massive ecosystem of pre-built operators and a large, active community. For many data engineering teams, Airflow is a familiar and battle-tested tool.
+
+However, its reliance on Python-defined DAGs (Directed Acyclic Graphs) can introduce operational complexity. Workflows defined as code are harder to review and version than declarative YAML, and the operational burden of managing Airflow's components (scheduler, executor, metadata database) at scale is significant. While powerful for data-centric pipelines, it is less suited for orchestrating across other domains like infrastructure or business applications. The recent migration from Airflow 2.x to 3.0 has prompted many teams to re-evaluate whether it remains the right long-term choice.
+
+**Best for**: Python-heavy data engineering teams with existing Airflow investment who do not require extensive cross-domain orchestration.
+
+## 3. Prefect: Pythonic Workflows for Data & AI
+
+Prefect is a modern data orchestrator that focuses on providing an excellent developer experience, particularly for Python users. It uses Python decorators to define workflows, which feels natural for developers accustomed to writing Python code. Its UI is well-regarded for visualizing and managing dynamic, parameterized runs, and its hybrid execution model allows for a managed control plane in the cloud while workers run on your infrastructure.
+
+The main trade-off is its Python-only authoring model, which may not suit polyglot teams. Like Airflow, it is a code-first, not a declarative, tool. Its business model is also cloud-first, which means the open-source path is less prominent compared to its managed offering.
+
+**Best for**: Python-only data teams seeking a modern, developer-friendly orchestrator with strong capabilities for dynamic workflows.
+
+## 4. Matillion: Visual ELT for Cloud Data
+
+Matillion is a cloud-native ELT (Extract, Load, Transform) platform that offers a visual, low-code interface for building data pipelines. Its key strength is its deep integration with major cloud data warehouses like Snowflake, BigQuery, and Redshift. This makes it an attractive option for data teams who want to build and manage data ingestion and transformation jobs without writing extensive code.
+
+As a proprietary, specialized ELT tool, Matillion is less of a general-purpose orchestrator. It is not designed for orchestrating infrastructure, AI agentic workflows, or complex business processes that fall outside the scope of data movement and transformation.
+
+**Best for**: Data teams that prefer a managed, visual ELT solution with deep integrations into cloud data warehouses.
+
+## 5. Prophecy: Data Transformation & Orchestration for the Lakehouse
+
+Prophecy positions itself as a low-code data engineering platform that combines a visual interface with code generation. It aims to bridge the gap between visual ETL tools and code-based solutions by allowing users to build pipelines visually while generating high-quality Spark and dbt code behind the scenes. It integrates deeply with Databricks and other cloud data platforms.
+
+Its focus remains squarely on data transformation and ETL/ELT workloads. While it provides orchestration for these data-specific tasks, it is not a universal orchestrator for managing workflows across an entire organization's tech stack. As a proprietary tool, it may also introduce vendor lock-in and higher costs.
+
+**Best for**: Data teams looking for a visual and code-centric ETL/ELT solution that integrates deeply with Databricks and other cloud data platforms.
+
+## 6. Pixeltable: Open-Source, Local-First AI Data Framework
+
+Pixeltable is a newer, open-source framework designed specifically for AI data workloads. It offers a local-first development experience, allowing developers to work with multimodal data (images, videos, documents) and vector embeddings on their own machines before scaling. Its Python-native API is familiar to AI developers and data scientists.
+
+As a specialized tool, its focus is narrower than a general-purpose orchestrator. It excels at the "T" (transformation) in ETL for AI applications but is not designed for broad workflow orchestration across different systems. Its ecosystem and community are also smaller compared to more established players.
+
+**Best for**: AI developers and smaller teams prioritizing open-source, local development, and multimodal data processing for AI applications.
+
+## Comparison Table
+
+| Tool | License | Deployment | Primary Use Case | Language Support | Cross-Domain Orchestration | Starting Price |
+|---|---|---|---|---|---|---|
+| **Kestra** | Open-Source (Apache 2.0) & Enterprise | Cloud, Self-hosted, Hybrid | Universal Orchestration | Polyglot (YAML, Python, SQL, etc.) | Yes | Free (Open-Source) |
+| **Apache Airflow** | Open-Source (Apache 2.0) | Self-hosted, Managed | Data Orchestration | Python | Limited | Free (Open-Source) |
+| **Prefect** | Open-Source (Apache 2.0) & Commercial | Cloud, Self-hosted, Hybrid | Data & AI Orchestration | Python | Limited | Free (Open-Source) |
+| **Matillion** | Proprietary | Cloud | ELT / Data Integration | Visual, SQL | No | Contact for pricing |
+| **Prophecy** | Proprietary | Cloud | Data Transformation | Visual, Spark, dbt | No | Contact for pricing |
+| **Pixeltable** | Open-Source (Apache 2.0) | Self-hosted | AI Data Processing | Python | No | Free (Open-Source) |
+
+## How to choose the right alternative
+
+Selecting the right orchestrator depends on your team's specific needs, existing stack, and long-term goals.
+
+### For Data Engineering teams
+
+If your primary focus is on robust, scalable, and maintainable ETL/ELT pipelines, you need a tool that handles complex dependencies and integrates with a wide range of data sources and destinations.
+*   **Recommendation**: **Kestra** for its polyglot support and declarative YAML, which simplifies complex data pipelines. **Airflow** is a solid choice for teams deeply invested in the Python ecosystem.
+*   **Learn more**: Explore [Data Engineering Resources](https://kestra.io/resources/data) and see how you can [schedule data workflows](https://kestra.io/resources/data/schedule-data-workflows) effectively.
+
+### For AI / ML Platform teams
+
+AI and ML workflows require orchestration that can handle heterogeneous tasks, from data preprocessing and model training to evaluation and deployment. Reproducibility and integration with MLOps tools are key.
+*   **Recommendation**: **Kestra** for its ability to orchestrate multi-provider AI agents and complex RAG pipelines. **Prefect** is a strong option for teams building dynamic, Python-native ML systems.
+*   **Learn more**: Discover [Kestra for AI Orchestration](https://kestra.io/ai-automation) and browse our [AI Orchestration Resources](https://kestra.io/resources/ai).
+
+### For teams seeking universal orchestration
+
+If your goal is to break down silos and create a single source of truth for all automated processes—across data, infrastructure, and business applications—a vendor-agnostic, universal control plane is essential.
+*   **Recommendation**: **Kestra** is designed for this exact purpose, providing a unified platform to [orchestrate your entire stack](https://kestra.io/orchestration).
+*   **Learn more**: See how Kestra stacks up against [other alternatives](https://kestra.io/vs).
+
+### For small teams and startups
+
+For smaller teams, ease of use, a low barrier to entry, and strong community support are critical. An open-source solution that can scale with the business is often the best choice.
+*   **Recommendation**: **Kestra**'s open-source edition is easy to get started with using Docker Compose and offers a powerful feature set that can grow with your needs.
+*   **Learn more**: [Get started with Kestra for free](https://kestra.io/get-started).
+
+## Conclusion
+
+While Databricks Workflows is an effective tool for jobs contained within the Lakehouse, the modern data landscape often requires more. The shift is toward universal orchestration platforms that can manage diverse workloads across any cloud, system, or language. Solutions like Kestra offer a path away from vendor lock-in and toward a more flexible, scalable, and future-proof automation strategy. By choosing a declarative and extensible orchestrator, you empower your teams to build reliable workflows that unify your entire technology stack.
+
+Explore how Kestra can unify your data, AI, and infrastructure workflows. [Book a demo today](/demo) or [get started for free](/get-started).
+
+## Structured data
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is Databricks Workflows still worth using in 2026?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Databricks Workflows remains a strong choice for workloads that are entirely contained within the Databricks Lakehouse platform. Its native integration with Databricks services offers a streamlined experience for existing users. However, if your orchestration needs extend beyond the Databricks ecosystem, or if you're seeking to reduce vendor lock-in and optimize costs, exploring alternatives becomes essential to avoid fragmented automation."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What are the main limitations of Databricks Workflows?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Key limitations include platform lock-in, as it's primarily designed for Databricks-native workloads, making cross-cloud or hybrid orchestration challenging. It may also present cost considerations for larger scale or diverse workloads. Furthermore, its focus on data and AI workflows means it's less suited for broader infrastructure or business process orchestration, which might necessitate additional tools."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can Kestra replace Databricks Workflows for data orchestration?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, Kestra can replace or complement Databricks Workflows, especially for teams seeking a universal orchestration control plane. Kestra excels at coordinating heterogeneous workloads across various platforms, including Databricks, other clouds, and on-premises systems. It allows you to run Databricks jobs as tasks within a broader, declarative YAML-defined workflow, offering greater flexibility, polyglot execution, and reduced vendor lock-in."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the best open-source alternative to Databricks Workflows?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "For open-source alternatives, Apache Airflow is a long-standing option, especially for Python-centric data teams. However, Kestra provides a more modern, declarative, and language-agnostic approach that extends beyond just data workflows to cover AI, infrastructure, and business processes. Kestra's open-source core offers high extensibility and deploy-anywhere flexibility without the operational overhead often associated with Airflow at scale."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does Databricks Workflows compare to Apache Airflow?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Databricks Workflows is tightly integrated with the Databricks Lakehouse, ideal for jobs running exclusively on that platform. Apache Airflow, in contrast, is a more generalized, Python-centric data orchestrator with a vast ecosystem. While Airflow offers flexibility, it comes with higher operational complexity. Kestra combines the best of both: the declarative simplicity and extensibility of a modern orchestrator, with the ability to integrate seamlessly with Databricks and other tools."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which orchestration tool is best for combining Databricks with other cloud services?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "For orchestrating Databricks alongside a diverse set of other cloud services and on-premises systems, Kestra stands out. Its vendor-agnostic and declarative YAML approach allows seamless coordination of tasks across AWS, GCP, Azure, and your Databricks environment. This unified control plane reduces complexity and provides end-to-end visibility, making it ideal for multi-cloud or hybrid data strategies that include Databricks."
+      }
+    }
+  ]
+}
+```
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Top Databricks Workflows Alternatives",
+  "description": "A curated list of the best alternatives to Databricks Workflows for data, AI, and infrastructure orchestration.",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Kestra",
+        "url": "https://kestra.io"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Apache Airflow",
+        "url": "https://airflow.apache.org/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Prefect",
+        "url": "https://www.prefect.io/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Matillion",
+        "url": "https://www.matillion.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 5,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Prophecy",
+        "url": "https://www.prophecy.io/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 6,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Pixeltable",
+        "url": "https://pixeltable.com/"
+      }
+    }
+  ]
+}
+```
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://kestra.io"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Resources",
+      "item": "https://kestra.io/resources"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Data",
+      "item": "https://kestra.io/resources/data"
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "name": "Databricks Workflows Alternatives: Unify Your Data Orchestration"
+    }
+  ]
+}
+```

--- a/src/contents/resources/databricks-workflows-alternatives/index.md
+++ b/src/contents/resources/databricks-workflows-alternatives/index.md
@@ -20,7 +20,6 @@ faq:
   - question: "Which orchestration tool is best for combining Databricks with other cloud services?"
     answer: "For orchestrating Databricks alongside a diverse set of other cloud services and on-premises systems, Kestra stands out. Its vendor-agnostic and declarative YAML approach allows seamless coordination of tasks across AWS, GCP, Azure, and your Databricks environment. This unified control plane reduces complexity and provides end-to-end visibility, making it ideal for multi-cloud or hybrid data strategies that include Databricks."
 author: "elliot"
-image: "/images/blogs/databricks-workflows-alternatives/cover.png"
 ---
 
 Databricks Workflows offers powerful, native orchestration for jobs within the Databricks Lakehouse Platform. It provides a streamlined experience for data and AI workloads, tightly integrated with the Databricks ecosystem. Yet, as organizations scale and diversify their technology stacks, the very strength of platform-native tools—deep integration—can become a limitation. Teams increasingly face challenges related to vendor lock-in, escalating costs, or the need to orchestrate workflows that span beyond a single cloud platform or domain.

--- a/src/contents/resources/google-workflows-alternatives/index.md
+++ b/src/contents/resources/google-workflows-alternatives/index.md
@@ -1,0 +1,181 @@
+---
+title: "Google Workflows Alternatives: Choose Your Orchestration"
+description: "Explore top Google Workflows alternatives for reliable application, process, and data pipeline automation. Find the best fit for your needs today!"
+metaTitle: "Google Workflows Alternatives for Cloud Orchestration"
+metaDescription: "Find top Google Workflows alternatives for reliable application, process, and data pipeline automation. Compare Kestra, Airflow, n8n, and more."
+tag: "infrastructure"
+date: 2026-05-27
+slug: "google-workflows-alternatives"
+faq:
+  - question: "Why look for alternatives to Google Workflows?"
+    answer: "Users often seek alternatives to Google Workflows to reduce cloud vendor lock-in, address limitations in specific use cases like complex data pipelines, or to gain more control over execution environments beyond Google Cloud's native offerings."
+  - question: "What is the best open-source alternative to Google Workflows?"
+    answer: "Kestra stands out as a leading open-source alternative, offering declarative YAML-based workflows that can orchestrate tasks across any cloud, on-premise, or hybrid environment. It supports a wide array of programming languages and integrates with diverse tools."
+  - question: "Can Kestra replace Google Workflows for GCP orchestration?"
+    answer: "Yes, Kestra can orchestrate GCP services through its extensive plugin ecosystem (e.g., BigQuery, GCS, Cloud Functions) while providing the flexibility to integrate non-GCP tools and manage workflows declaratively across multiple clouds, effectively replacing Google Workflows for broader use cases."
+author: "Virgile Fanucci"
+---
+
+Google Workflows offers a serverless approach to orchestrating GCP services, but many teams seek alternatives for broader cloud strategies, cost control, or specific feature sets. This guide explores leading options for application, process, and data pipeline automation, helping you choose an orchestrator that aligns with your operational needs and technical stack.
+
+## Why look for an alternative to Google Workflows?
+
+Google Workflows' strengths lie in its serverless, GCP-native integration, ideal for simple service choreography within Google Cloud. However, users often seek alternatives due to vendor lock-in, limited extensibility beyond GCP services, and a more code-centric approach that can hinder broader team collaboration or hybrid/multi-cloud deployments.
+
+## How we evaluated these alternatives
+
+We evaluated alternatives based on deployment flexibility (cloud-native vs. hybrid), language agnosticism, integration capabilities, and the ability to extend orchestration beyond a single cloud provider, focusing on solutions that offer a balance of control and ease of use.
+
+## The Top 5 Google Workflows Alternatives
+
+### 1. Kestra
+
+**Best for:** Unified, polyglot orchestration across any cloud, on-premise, or hybrid environment.
+
+Kestra provides an open-source, declarative orchestration platform where workflows are defined in simple YAML. This language-agnostic approach allows teams to run code in any language and integrate any tool, offering a single control plane to orchestrate your entire stack, including native GCP services via its extensive plugin library. Kestra is built to manage complex dependencies and scale from simple automations to enterprise-wide process orchestration.
+
+### 2. Apache Airflow / Google Cloud Composer
+
+**Best for:** Python-centric data pipelines and established data engineering teams.
+
+Apache Airflow, often used as the managed Google Cloud Composer service, excels in orchestrating complex data pipelines defined as Python DAGs. It has a massive community and a vast library of operators. While powerful for data-heavy tasks, its Python-only nature can be restrictive for polyglot teams or cross-domain automation beyond analytics.
+
+### 3. n8n
+
+**Best for:** Visual, low-code automation of SaaS applications and APIs.
+
+n8n is an open-source visual workflow automation tool, popular for its self-hosting option and large library of pre-built integrations for SaaS APIs. It offers a user-friendly, node-based interface for building automations rapidly, though it's less suited for the complex, code-heavy data or infrastructure orchestration required by engineering teams.
+
+### 4. AWS Step Functions
+
+**Best for:** Orchestrating serverless applications and microservices within the AWS ecosystem.
+
+As the AWS counterpart to Google Workflows, Step Functions provide a serverless workflow service for coordinating AWS services. It's a strong choice for event-driven, stateful workflows that live entirely within AWS, but like Google Workflows, it deepens vendor lock-in and is not designed for multi-cloud strategies.
+
+### 5. Temporal
+
+**Best for:** Building highly durable and scalable application-level workflows in code.
+
+Temporal is a durable execution platform for developers, enabling the creation of long-running, fault-tolerant workflows defined directly in application code (Go, Java, Python, TypeScript). It's ideal for complex microservice coordination and business logic but follows a code-first, SDK-driven model rather than a declarative one.
+
+## Comparison Table
+
+| Tool                       | License         | Deployment         | Best for                         | Starting price |
+| -------------------------- | --------------- | ------------------ | -------------------------------- | -------------- |
+| **Kestra**                 | Apache 2.0 OSS  | Hybrid/Any         | Universal, polyglot orchestration | Free (OSS)     |
+| **Apache Airflow / Composer** | Apache 2.0 OSS  | Cloud (Managed)    | Python data pipelines            | GCP pricing    |
+| **n8n**                    | Fair-code OSS   | Self-hosted/Cloud  | Visual SaaS automation           | Free (OSS)     |
+| **AWS Step Functions**     | Proprietary     | AWS Cloud          | AWS-native serverless apps       | AWS pricing    |
+| **Temporal**               | MIT OSS         | Self-hosted/Cloud  | Durable microservices            | Free (OSS)     |
+
+## How to choose the right alternative
+
+For **multi-cloud flexibility** and declarative workflows, [Kestra is the ideal choice](/vs/google-workflows). **Data engineering teams** with deep Python expertise might prefer [Airflow/Composer](/vs/airflow). **SaaS-heavy automation** points to [n8n](/vs/n8n). For **AWS-native serverless** workloads, [Step Functions](/vs/aws-step-functions) excel. Meanwhile, **application developers** needing durable execution should consider [Temporal](/vs/temporal). Each tool addresses a different center of gravity, from data to infrastructure to application logic.
+
+## Structured data
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Why look for alternatives to Google Workflows?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Users often seek alternatives to Google Workflows to reduce cloud vendor lock-in, address limitations in specific use cases like complex data pipelines, or to gain more control over execution environments beyond Google Cloud's native offerings."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the best open-source alternative to Google Workflows?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Kestra stands out as a leading open-source alternative, offering declarative YAML-based workflows that can orchestrate tasks across any cloud, on-premise, or hybrid environment. It supports a wide array of programming languages and integrates with diverse tools."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can Kestra replace Google Workflows for GCP orchestration?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, Kestra can orchestrate GCP services through its extensive plugin ecosystem (e.g., BigQuery, GCS, Cloud Functions) while providing the flexibility to integrate non-GCP tools and manage workflows declaratively across multiple clouds, effectively replacing Google Workflows for broader use cases."
+      }
+    }
+  ]
+}
+```
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Top 5 Google Workflows Alternatives",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Kestra",
+      "url": "https://kestra.io/vs/google-workflows"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Apache Airflow / Google Cloud Composer",
+      "url": "https://kestra.io/vs/airflow"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "n8n",
+      "url": "https://kestra.io/vs/n8n"
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "name": "AWS Step Functions",
+      "url": "https://kestra.io/vs/aws-step-functions"
+    },
+    {
+      "@type": "ListItem",
+      "position": 5,
+      "name": "Temporal",
+      "url": "https://kestra.io/vs/temporal"
+    }
+  ]
+}
+```
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://kestra.io/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Resources",
+      "item": "https://kestra.io/resources"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Infrastructure",
+      "item": "https://kestra.io/resources/infrastructure"
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "name": "Google Workflows Alternatives: Choose Your Orchestration",
+      "item": "https://kestra.io/resources/infrastructure/google-workflows-alternatives"
+    }
+  ]
+}
+```

--- a/src/contents/resources/make-alternatives/index.md
+++ b/src/contents/resources/make-alternatives/index.md
@@ -1,0 +1,298 @@
+---
+title: "8 Make Alternatives That Actually Work in 2026"
+description: "Discover the 8 best Make alternatives for automation, AI workflows, and efficient task management. Find your perfect Make alternative today!"
+metaTitle: "8 Make Alternatives for Automation & AI Workflows (2026)"
+metaDescription: "Looking for Make.com or Makefile alternatives? Explore 8 top tools including Kestra, n8n, and Zapier for robust automation, AI, and developer workflows in 2026."
+tag: "infrastructure"
+date: 2026-05-27
+slug: "make-alternatives"
+faq:
+  - question: "What does 'generate alternatives' mean?"
+    answer: "In the context of 'Make,' generating alternatives refers to identifying and evaluating other tools or platforms that can perform similar automation, workflow orchestration, or task management functions, often addressing specific limitations or offering different capabilities."
+  - question: "How do Make alternatives handle different scripting needs?"
+    answer: "Modern Make alternatives offer diverse scripting capabilities. Some provide visual builders for no-code/low-code scripting (e.g., Zapier, Make.com), while others support polyglot code execution (e.g., Kestra, Pipedream) for Python, JavaScript, Shell, and more, allowing developers to use their preferred language."
+  - question: "Can Kestra replace Make.com?"
+    answer: "Kestra can replace Make.com for many use cases, especially when workflows require code-level control, multi-language support, event-driven architecture, and integration across data, AI, and infrastructure. While Make.com excels at no-code SaaS integrations, Kestra provides a more powerful, declarative, and scalable platform for complex technical automations."
+  - question: "What is the best free alternative to Make.com?"
+    answer: "Two strong free alternatives stand out. Kestra is open-source (Apache 2.0) and offers a declarative, polyglot orchestration platform for unifying data, AI, and infrastructure workflows in YAML. n8n is fair-code with a large community of pre-built nodes, making it a closer drop-in for Make's visual experience. Choose Kestra for code-level control and technical workflows; choose n8n for a visual, self-hosted SaaS automation experience."
+  - question: "Is Make.com still worth using in 2026?"
+    answer: "Yes, Make.com remains a relevant choice in 2026 for business automation and no-code SaaS app integrations. Its visual builder and large connector library are ideal for marketing, sales, and SMB workflows. It is less suited for orchestrating data, AI, and infrastructure, where a declarative orchestrator like Kestra provides the necessary code-level control and scalability."
+author: "elliot"
+---
+
+Make, whether the low-code automation platform Make.com or the traditional developer tool Makefile, has long served as a backbone for automating tasks. However, as organizations scale and workflows become more complex, many teams encounter limitations that necessitate exploring alternatives. Whether it's the need for deeper code integration, broader ecosystem support, enhanced AI capabilities, or more flexible deployment options, the market for automation tools has evolved significantly.
+
+The leading alternatives to Make in 2026 include Kestra, Zapier, n8n, Lindy.ai, Activepieces, Pipedream, Microsoft Power Automate, and Composio—each suited to different workloads such as SaaS integration, AI automation, infrastructure as code, and data pipeline orchestration. This guide will help you navigate these options, providing a clear comparison and criteria to choose the best fit for your specific needs.
+
+## Understanding Make and the Need for Alternatives
+
+The name "Make" refers to two distinct tools serving different audiences, which often causes confusion. Understanding this distinction is key to finding the right alternative.
+
+### What exactly is Make.com?
+
+Make.com (formerly Integromat) is a low-code/no-code visual automation platform. It allows users to connect various SaaS applications (like Slack, Google Sheets, HubSpot) and automate workflows without writing code. Its core strength lies in its intuitive drag-and-drop interface, making it accessible to business users in marketing, sales, and operations for automating repetitive tasks and creating simple application integrations.
+
+### What is traditional Makefile?
+
+Makefile is a developer-centric build automation tool. It uses a file named `Makefile` to define a set of tasks and their dependencies, primarily for compiling and building software projects. Developers use it to automate repetitive command-line tasks, manage complex build processes, and ensure that only necessary parts of a project are recompiled after changes. It's a powerful, text-based tool deeply embedded in the C/C++ and Unix development ecosystems.
+
+### Why seek alternatives to Make?
+
+Teams look for alternatives to both versions of Make for several reasons:
+
+*   **Make.com Limitations**: Users often hit a wall with its pricing model which can become expensive at scale, potential vendor lock-in, and limitations in handling complex logic, error handling, and version control. It is not designed for orchestrating complex data pipelines or managing [infrastructure as code (IaC)](/resources/infrastructure/what-is-infrastructure-as-code).
+*   **Makefile Limitations**: While powerful, Makefile syntax can be cryptic and error-prone. It's not well-suited for modern, cloud-native workflows, lacks native support for containerization, and is less portable across different operating systems compared to modern task runners. This can lead to [unnecessary complexity in orchestration](/resources/infrastructure/orchestration-problems-complexity).
+
+## How We Evaluated These Alternatives
+
+We evaluated each alternative on a core set of criteria relevant to modern automation and development needs. This includes the deployment model (SaaS, self-hosted, hybrid), license type (open-source vs. proprietary), and primary use case (business automation, developer tools, AI, data, infrastructure). We also considered pricing transparency, extensibility through integrations and plugins, and the availability of enterprise-grade governance features like audit logs and role-based access control.
+
+## The Top 8 Make Alternatives for Automation and AI Workflows
+
+### 1. Kestra: Declarative Orchestration for Any Workflow
+
+Kestra is an open-source, event-driven orchestration platform that uses a declarative YAML interface to define and manage workflows. It's designed to be language-agnostic, allowing you to run tasks written in Python, Shell, SQL, Node.js, and more within a single workflow. This makes it a powerful control plane that can unify data pipelines, infrastructure automation, AI/ML model execution, and business processes. With native features for [agentic orchestration](/resources/ai/agentic-orchestration) and an AI Copilot to generate YAML, Kestra bridges the gap between simple automation and complex, code-driven orchestration.
+
+While Kestra's YAML-first approach provides immense power and auditability, it does require a basic understanding of code and configuration files, making it less suitable for non-technical users seeking a purely drag-and-drop experience.
+
+**Best for**: Platform engineers, data engineers, and AI/ML teams needing a powerful, code-centric, scalable, and auditable orchestration platform to manage workflows across diverse domains. If you need to manage your entire [infrastructure from one control plane](/infra-automation), Kestra is a strong choice. For a deeper dive, you can explore the core principles behind the platform in "[Why Kestra](/docs/why-kestra)".
+
+### 2. Zapier: The Market Leader for Business Teams
+
+Zapier is the most well-known name in no-code automation. It boasts an extensive library of over 5,000 app integrations, allowing users to create "Zaps" (automated workflows) with just a few clicks. Its user-friendly interface and vast connector ecosystem make it incredibly easy to get started.
+
+The main trade-offs are cost, which can escalate quickly with volume and complexity, and limited capabilities for custom logic or error handling.
+
+**Best for**: Marketing, sales, and operations teams needing simple, reliable, and ready-made automations between common SaaS applications without any developer involvement.
+
+### 3. n8n: The Open-Source Powerhouse
+
+n8n is a visual workflow automation tool that stands out for its open-source, self-hostable model. It provides a node-based visual editor that is more powerful than many competitors, allowing for branching logic, merging, and custom JavaScript snippets. This flexibility makes it a favorite among more technical users who want the convenience of a visual builder with the control of code. The community is active, and new integrations are added frequently.
+
+While powerful, managing a self-hosted n8n instance requires some technical overhead. The fair-code license also has some restrictions for commercial use.
+
+**Best for**: Technical users and small to medium businesses wanting a self-hosted, customizable visual automation tool with strong API integration capabilities. See a detailed comparison in our [n8n vs Kestra analysis](/vs/n8n).
+
+### 4. Lindy.ai: Best for Affordable AI Automations
+
+Lindy.ai positions itself as an AI-powered assistant designed to handle repetitive tasks. It focuses on agentic workflows where "Lindies" (AI agents) can manage your calendar, draft emails, and perform other administrative tasks. Its strength lies in its natural language interface and its focus on making AI automation accessible and affordable.
+
+Lindy is more of an AI assistant than a general-purpose workflow orchestrator, so it's not suitable for data pipelines or infrastructure management.
+
+**Best for**: Individuals and small teams looking for cost-effective AI assistants and agentic automation to handle personal and business administrative tasks.
+
+### 5. Activepieces: A Strong Contender for Workflow Automation
+
+Activepieces is another open-source alternative to Zapier and Make.com. It offers a clean visual builder and can be self-hosted, giving users full control over their data and infrastructure. It's designed with developers in mind, offering a better experience for creating custom pieces (integrations) and managing deployments.
+
+Its integration library is smaller than Zapier's or Make.com's, but it's growing rapidly thanks to its open-source community.
+
+**Best for**: Developers and technical teams seeking a self-hosted, open-source alternative to Zapier with more control and a focus on developer experience.
+
+### 6. Pipedream: For Developers Building Integrations
+
+Pipedream is a code-first, serverless integration platform built for developers. Workflows are defined in Node.js, Python, Go, or Bash, providing maximum flexibility. It offers thousands of pre-built integrations and triggers, but the core value is the ability to write custom code for any step. Its event-driven architecture is highly scalable and performant.
+
+Pipedream is not a low-code tool; it requires programming knowledge and is less accessible to non-technical users.
+
+**Best for**: Developers building custom integrations and event-driven workflows that require deep code control and serverless execution. For more on the differences, check out [Kestra vs. Pipedream](/vs/pipedream).
+
+### 7. Microsoft Power Automate: For Enterprise Solutions
+
+Microsoft Power Automate (formerly Microsoft Flow) is an enterprise-grade automation platform that integrates deeply with the Microsoft ecosystem, including Office 365, Dynamics 365, and Azure. It offers both no-code/low-code visual builders and Robotic Process Automation (RPA) capabilities for automating legacy desktop applications. Its governance and security features make it a strong choice for large organizations.
+
+Its power is most realized within the Microsoft ecosystem; it can be clunky and expensive for connecting to non-Microsoft services.
+
+**Best for**: Enterprises heavily invested in the Microsoft ecosystem needing to automate business processes and RPA tasks with strong governance.
+
+### 8. Composio: Ideal for Building AI Automation
+
+Composio is a developer-focused platform designed for building AI agents and automations. It provides a set of tools and a unified API to connect various apps, enabling developers to build complex, multi-tool AI workflows. Its strength is in simplifying the integration layer for AI applications, allowing developers to focus on the agent's logic rather than the boilerplate of connecting to third-party APIs.
+
+This is a specialized tool for AI developers, not a general-purpose automation platform for business users.
+
+**Best for**: Developers and AI teams building complex AI automations and agentic systems that require robust and varied tool integration.
+
+## Comparing Key Features: n8n vs. Make.com
+
+### Which is better, n8n or Make.com?
+
+The choice between n8n and Make.com depends on your priorities. Make.com is easier for non-technical users to get started with due to its polished UI and straightforward visual builder. n8n's node-based editor offers more power and flexibility for complex logic, which technical users appreciate. Make.com has a larger number of pre-built app integrations, while n8n's open-source nature allows for greater customization.
+
+### Scalability and Enterprise-Grade Automation
+
+Make.com offers enterprise plans with features like SSO and higher task limits, but complex, high-volume workflows can become prohibitively expensive. n8n's self-hosted model provides more control over scalability, as you can provision resources as needed. However, this also means the operational burden of scaling, logging, and maintenance falls on your team.
+
+### Cost-Effectiveness and Open-Source Benefits
+
+Make.com operates on a tiered subscription model based on the number of operations. n8n is free to self-host, with costs limited to your infrastructure. This provides significant cost savings and avoids vendor lock-in. The open-source community also contributes to a growing library of nodes and provides a valuable support channel.
+
+## Modern Alternatives to Traditional Makefile
+
+### What is the modern alternative to Makefile?
+
+The modern alternative to Makefile is often not a single tool but a combination of approaches. For build systems, tools like CMake, Bazel, or language-specific builders (e.g., Cargo for Rust, Gradle for Java) have become standard. For general-purpose task automation, developers are moving towards more declarative, YAML-based tools that are easier to read and maintain, and integrate better with CI/CD and [GitOps practices](/resources/infrastructure/gitops).
+
+### Taskfile: An Efficient Task Automation Tool
+
+Taskfile is a popular Makefile alternative that uses a simple YAML file (`Taskfile.yml`) to define tasks. Its syntax is more intuitive than Makefile's, it's a single binary with no dependencies, and it works consistently across Windows, macOS, and Linux.
+
+**Best for**: Developers seeking a simpler, more portable alternative to Makefile for project-specific task automation.
+
+### Which is better, CMake or Makefile?
+
+This is a common point of confusion. CMake is not a direct replacement for Makefile; it's a build system generator. You write a `CMakeLists.txt` file, and CMake uses it to generate a native build environment for your platform (like a Makefile on Linux or a Visual Studio project on Windows). Makefile is the tool that then executes the build.
+
+**Best for**: CMake is better for large, complex, cross-platform C/C++ projects that need to be built in various environments. Makefile is sufficient for simpler projects or for direct task automation where a build generator is overkill.
+
+## Choosing the Best Make Alternative for Your Needs
+
+### Factors to Consider When Selecting an Alternative
+
+*   **User Persona**: Is the tool for business users (Zapier, Make.com) or developers (Kestra, Pipedream)?
+*   **Workflow Complexity**: Do you need simple linear workflows or complex, conditional, parallel execution with robust error handling?
+*   **Deployment Model**: Do you prefer a managed SaaS solution or the control of a self-hosted or hybrid deployment?
+*   **Ecosystem**: Does the tool integrate with the specific applications, databases, and infrastructure you use?
+*   **Governance**: Do you require features like audit logs, RBAC, and version control?
+*   **Budget**: Are you looking for a free, open-source solution or a commercial product with enterprise support?
+
+### Solutions for Scalable Data Integration and AI Workflows
+
+For teams focused on [data orchestration](/resources/data/data-orchestration) and AI, general-purpose automation tools often fall short. Platforms like Kestra are specifically designed for these use cases, offering features like native integration with data tools (dbt, Airbyte), support for large data payloads, and the ability to orchestrate complex multi-stage AI pipelines. Kestra allows you to manage everything from [data engineering workflows](/data) to the deployment of [AI and agentic systems](/ai-automation) from a single, unified platform.
+
+## Comparison Table
+
+| Tool | License | Deployment | Best for | Starting price |
+|---|---|---|---|---|
+| **Kestra** | Apache 2.0 | Self-hosted, Hybrid, Cloud | Technical orchestration (Data, AI, Infra) | Free (Open-Source) |
+| **Zapier** | Proprietary | SaaS | No-code SaaS business automation | Free Tier |
+| **n8n** | Fair-code | Self-hosted, Cloud | Visual workflow automation for technical users | Free (Self-hosted) |
+| **Lindy.ai** | Proprietary | SaaS | AI assistants and agentic tasks | Usage-based |
+| **Activepieces** | MIT | Self-hosted, Cloud | Open-source Zapier alternative for developers | Free (Self-hosted) |
+| **Pipedream** | Proprietary | SaaS | Code-first, serverless developer integrations | Free Tier |
+| **Power Automate** | Proprietary | SaaS | Enterprise automation in Microsoft ecosystems | Per User/Flow |
+| **Composio** | Proprietary | SaaS | Building AI agents and automations | Free Tier |
+
+## Conclusion
+
+The landscape of automation tools is more diverse than ever. While Make.com excels at connecting SaaS applications for business users and Makefile remains a staple for build automation, their limitations have given rise to a new generation of powerful alternatives.
+
+Choosing the right tool requires a clear understanding of your use case. For simple app-to-app connections, Zapier and Make.com are excellent. For developer-centric task running, Taskfile is a great modern choice. But for complex, mission-critical workflows that span data, AI, and infrastructure, a true orchestration platform like Kestra provides the scalability, control, and observability needed to succeed. By aligning the tool's core strengths with your team's needs, you can move beyond simple automation to build robust, reliable, and scalable systems.
+
+Explore [Kestra's documentation](/docs) to see how declarative orchestration can unify your data, AI, and infrastructure workflows.
+
+## Structured data
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Top 8 Alternatives to Make",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Kestra",
+        "url": "https://kestra.io/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Zapier",
+        "url": "https://zapier.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "n8n",
+        "url": "https://n8n.io/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Lindy.ai",
+        "url": "https://www.lindy.ai/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 5,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Activepieces",
+        "url": "https://www.activepieces.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 6,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Pipedream",
+        "url": "https://pipedream.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 7,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Microsoft Power Automate",
+        "url": "https://powerautomate.microsoft.com/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 8,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Composio",
+        "url": "https://composio.dev/"
+      }
+    }
+  ]
+}
+```
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://kestra.io/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Resources",
+      "item": "https://kestra.io/resources"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Infrastructure",
+      "item": "https://kestra.io/resources/infrastructure"
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "name": "8 Make Alternatives That Actually Work in 2026",
+      "item": "https://kestra.io/resources/infrastructure/make-alternatives"
+    }
+  ]
+}
+```

--- a/src/contents/resources/microsoft-fabric-alternatives/index.md
+++ b/src/contents/resources/microsoft-fabric-alternatives/index.md
@@ -1,0 +1,311 @@
+---
+title: "Microsoft Fabric Alternatives: Top Competitors & More"
+description: "Explore the top Microsoft Fabric alternatives and competitors for your data platform needs. Compare features and find the best solution for your business."
+metaTitle: "Microsoft Fabric Alternatives: Top Competitors & More"
+metaDescription: "Discover leading Microsoft Fabric alternatives for data platforms. Compare features, pricing, and deployment to find the best solution for your business needs."
+tag: "data"
+date: 2026-05-27
+slug: "microsoft-fabric-alternatives"
+faq:
+  - question: "What are the core capabilities of Microsoft Fabric and its closest alternatives?"
+    answer: "Microsoft Fabric unifies data integration, engineering, warehousing, analytics, and business intelligence within the Microsoft ecosystem, leveraging OneLake for storage. Alternatives like Databricks offer a unified lakehouse for large-scale data and ML, while Snowflake provides a cloud data platform with a SQL-first approach. Kestra offers a declarative, polyglot orchestration layer that integrates with all these tools and extends beyond data."
+  - question: "Is Fabric replacing ADF?"
+    answer: "Fabric Data Factory is not merely ADF rebranded. It represents a SaaS-native evolution, moving beyond the PaaS model of Azure Data Factory. It is deeply integrated with OneLake, Lakehouse, Warehouse, and the broader Fabric analytics fabric, offering a more unified experience within the Microsoft ecosystem. Existing ADF users will find migration paths and similar functionalities within Fabric's Data Factory component."
+  - question: "Is Microsoft Fabric better than Databricks?"
+    answer: "The 'better' choice depends on specific priorities. If rapid deployment, tight integration with Microsoft tools, and streamlined governance are paramount, Microsoft Fabric is a strong contender. However, if use cases demand large-scale data processing, advanced ML pipelines, or architectural flexibility across different clouds and languages, Databricks often presents a stronger, more specialized solution."
+  - question: "Does Google have something like Microsoft Fabric?"
+    answer: "While Google Cloud Platform offers a rich suite of data and analytics services, it takes a modular approach rather than a single unified platform like Microsoft Fabric. Key components include BigQuery (serverless data warehouse), Dataflow (stream/batch processing), Dataproc (managed Spark/Hadoop), and Vertex AI (ML platform), and Looker (BI). These services can be combined to achieve similar functionalities but require more integration effort."
+  - question: "Does Microsoft have an ETL tool?"
+    answer: "Yes, Microsoft offers several ETL tools. Historically, SQL Server Integration Services (SSIS) was a prominent on-premise solution. In the cloud, Azure Data Factory (ADF) has been its primary managed ETL/ELT service. With the introduction of Microsoft Fabric, the Data Factory component within Fabric now serves as the modern, SaaS-native ETL/ELT capability, deeply integrated into the broader analytics platform."
+  - question: "How does Kestra fit into the Microsoft Fabric alternative landscape?"
+    answer: "Kestra acts as an open-source, declarative orchestration control plane that can sit above or alongside Microsoft Fabric and its alternatives. It unifies workflows across data, AI, and infrastructure, allowing teams to orchestrate tasks in any language, on any cloud. This provides flexibility and vendor neutrality, preventing lock-in while integrating existing tools like Databricks, Snowflake, or even specific Fabric components."
+author: "elliot"
+---
+
+Microsoft Fabric emerged in 2023 as Microsoft's ambitious play to unify data, analytics, and AI under a single SaaS umbrella. While promising a streamlined experience, many organizations quickly encounter familiar challenges: vendor lock-in, complex pricing, and limitations for specific, highly customized workloads. As discussions on platforms like Reddit highlight, the desire for greater control and flexibility often drives the search for alternatives.
+
+This article delves into the top Microsoft Fabric alternatives in 2026. The leading alternatives to Microsoft Fabric include Kestra for universal orchestration, Databricks for its Lakehouse architecture, Snowflake for its cloud data platform, and modular offerings from AWS and Google Cloud. We'll compare each to help you navigate the landscape and choose the right data platform for your evolving needs.
+
+## Understanding Microsoft Fabric and its purpose
+
+Microsoft Fabric is a unified analytics platform that bundles multiple services into a single, cohesive SaaS offering. Its core components include Data Factory for data integration, Synapse for data engineering and warehousing, Real-Time Analytics for streaming data, and Power BI for business intelligence. At its foundation is OneLake, a unified data lake for the entire organization.
+
+The primary value proposition of Fabric is simplification. By integrating these tools, Microsoft aims to reduce the complexity and management overhead of building an end-to-end data platform. For organizations already invested in the Microsoft ecosystem, it offers a seemingly straightforward path to modern analytics. However, this all-in-one approach is also its main point of friction, leading many to explore alternatives that offer more flexibility and control over their [data orchestration](/resources/data/data-orchestration).
+
+## Key reasons to consider Microsoft Fabric alternatives
+
+While Fabric's integrated approach is appealing, several factors drive teams to look for other solutions.
+
+### Hidden costs and complexity: Addressing common concerns
+
+Fabric's consumption-based pricing model, tied to "Capacities," can be difficult to predict and manage. What appears simple on the surface can lead to unexpected costs as usage scales. Despite being a managed service, there's still a significant learning curve, especially for teams not already steeped in the Azure ecosystem. Integrating with tools and processes outside of Microsoft's walled garden can also introduce friction and operational overhead.
+
+### Specific functionalities or integrations: When Fabric falls short
+
+No single platform can be the best at everything. Fabric's components are good, but may not match the depth of best-of-breed specialized tools. Teams with highly specific machine learning workflows, a need for polyglot development environments, or complex hybrid and multi-cloud strategies may find Fabric's capabilities restrictive. The lack of fine-grained control over underlying infrastructure can also be a blocker for advanced infrastructure automation tasks.
+
+### Vendor lock-in and ecosystem dependency
+
+The biggest trade-off with Fabric is its deep integration into the Microsoft ecosystem. While this simplifies things initially, it also creates significant vendor lock-in. The deeper an organization integrates with Fabric and OneLake, the more difficult and costly it becomes to migrate or adopt other technologies. This reliance on a single vendor's roadmap and pricing strategy is a strategic risk many organizations are unwilling to take, preferring a more open and flexible stack of [ETL pipeline tools](/resources/data/etl-pipeline-tools).
+
+## How we evaluated these alternatives
+
+To provide a balanced view, we evaluated each alternative on several key criteria. We considered architectural flexibility, deployment models (cloud-native, hybrid, self-hosted), and license type (open-source vs. proprietary). We also assessed their primary use case fit (data, AI, infra), pricing transparency, support for polyglot environments, and the breadth of their integration ecosystem. The goal is to highlight the best tool for different organizational needs, from enterprise-wide platforms to specialized engineering workflows.
+
+## The top Microsoft Fabric alternatives
+
+### 1. Kestra: The Declarative Orchestration Control Plane
+
+Kestra is an open-source, declarative, and event-driven orchestration platform. It is designed to unify data, AI, infrastructure, and business workflows under a single control plane, defined as code in simple YAML files.
+
+Instead of being a monolithic data platform, Kestra acts as a vendor-neutral layer that connects and coordinates all the tools you already use. With over 1400 plugins and the ability to run any code in any language (Python, SQL, Bash, Go, etc.), it provides ultimate flexibility. This approach allows you to orchestrate tasks across Fabric components, Databricks jobs, Snowflake queries, and infrastructure tools like Terraform or Ansible, all from one place. Its strong GitOps support and built-in CI/CD capabilities make it a natural fit for modern platform engineering practices.
+
+**Best for:** Organizations seeking a unified, flexible, and open-source orchestration layer to coordinate complex workflows across heterogeneous stacks, avoiding vendor lock-in.
+
+For example, financial services giant Crédit Agricole replaced fragmented infrastructure scripts and cron jobs with Kestra, creating a single, governed orchestration layer for secure infrastructure across disparate teams and tools.
+
+### 2. Databricks: Unified Analytics Platform for Lakehouse
+
+Databricks is the company behind Apache Spark and pioneers of the "Lakehouse" architecture, which combines the best of data lakes and data warehouses. It offers a powerful, unified platform for large-scale data engineering, machine learning, and data science.
+
+Its key strengths lie in Delta Lake for reliable data transactions, Unity Catalog for governance, and deep integration with MLflow for machine learning lifecycle management. Compared to Fabric, Databricks is more code-centric, appealing to teams with strong Python, Scala, and SQL skills. While it provides a comprehensive platform, orchestrating workflows that span outside of Databricks can still require additional tooling.
+
+**Best for:** Data-intensive organizations focused on building advanced analytics, machine learning pipelines, and a unified data lakehouse, especially those with strong Spark/Python expertise.
+
+So, is Microsoft Fabric better than Databricks? If your priorities are rapid deployment, tight integration with Microsoft tools, and streamlined governance, Fabric is a strong choice. If your use cases demand large-scale data processing, advanced ML pipelines, or architectural flexibility, Databricks is often the more powerful contender.
+
+### 3. Snowflake: Cloud Data Platform for SQL-first Analytics
+
+Snowflake is a leading cloud data platform known for its unique architecture that separates storage and compute, enabling massive scalability and concurrency. It has become a standard for SQL-first analytics, secure data sharing through its Data Cloud, and governed data access.
+
+While Snowflake is expanding its capabilities with Snowpark for Python and Java, Iceberg Tables, and container services, its core strength remains as a high-performance data warehouse. Compared to Fabric's all-in-one approach, Snowflake focuses on being the central data repository and query engine, integrating with a vast ecosystem of third-party tools for ingestion, transformation, and BI.
+
+**Best for:** Businesses prioritizing a scalable, high-performance cloud data warehouse for SQL-centric analytics, secure data sharing, and a robust ecosystem of data partners.
+
+### 4. AWS Data & Analytics Services: Modular, Cloud-Native Ecosystem
+
+Instead of a single unified platform, Amazon Web Services (AWS) offers a comprehensive suite of specialized, interoperable services. This modular approach includes Amazon S3 for object storage, AWS Glue for serverless ETL, Amazon Redshift for data warehousing, Amazon Athena for interactive queries, Amazon EMR for big data processing, and Amazon SageMaker for machine learning.
+
+The primary strength of the AWS ecosystem is its flexibility and granular control. Teams can pick and choose the best service for each part of their data pipeline and pay only for what they use. However, this flexibility comes at the cost of increased integration complexity. Architecting, deploying, and managing a cohesive data platform from these building blocks requires significant engineering effort compared to Fabric's out-of-the-box experience.
+
+**Best for:** Organizations deeply invested in AWS, seeking granular control, extreme flexibility, and the ability to customize every component of their data platform, accepting the integration overhead.
+
+### 5. Google Cloud Platform Data Tools: Scalable and Specialized Services
+
+Similar to AWS, Google Cloud Platform (GCP) provides a modular set of powerful data and analytics tools rather than a single Fabric-like product. Its flagship services include BigQuery, a highly scalable serverless data warehouse; Dataflow, a managed service for Apache Beam-based stream and batch processing; Dataproc for managed Spark and Hadoop; Vertex AI for a unified ML platform; and Looker for business intelligence.
+
+GCP's strengths lie in its serverless architecture, powerful real-time analytics capabilities, and strong, open-source-friendly ML offerings. Does Google have something like Microsoft Fabric? No, it offers a collection of best-in-class components that require integration. This gives teams the freedom to build a custom stack but demands more architectural work than Fabric's unified approach.
+
+**Best for:** Enterprises committed to Google Cloud, prioritizing serverless analytics, powerful ML capabilities, and a flexible, open-source-friendly data ecosystem.
+
+### 6. Peliqan: All-in-One Data Platform for Growing Teams
+
+Peliqan represents a category of data platforms that, like Fabric, aim for an all-in-one experience but often target a different market segment. It provides data ingestion, transformation, and visualization capabilities in a single tool, designed for simplicity and faster time-to-value.
+
+For small to medium-sized teams, this can be an attractive proposition, removing the need to stitch together multiple tools. The trade-off is typically in scale, customization, and the depth of features compared to enterprise-grade platforms like Fabric or specialized services from major cloud providers.
+
+**Best for:** Small to medium-sized businesses or teams needing a straightforward, all-in-one data platform for common ingestion and analytics tasks without heavy engineering investment.
+
+### 7. Oracle Cloud Infrastructure (OCI) Data Services: Enterprise-Grade Solutions
+
+For large enterprises, particularly those with existing investments in Oracle technologies, Oracle Cloud Infrastructure (OCI) offers a comprehensive suite of data services. This includes the Autonomous Data Warehouse, OCI Data Integration, Data Catalog, and various AI and machine learning services.
+
+OCI's strengths are its deep integration with Oracle's on-premise and cloud databases, robust security features, and strong enterprise support. While it provides a full-featured data platform, it is most compelling for organizations already in the Oracle ecosystem. It can be more complex and costly to integrate with non-Oracle tools compared to more open platforms.
+
+**Best for:** Large enterprises with significant existing investments in Oracle technologies, seeking a robust, secure, and integrated data platform within the OCI ecosystem.
+
+## Comparison Table: Microsoft Fabric Alternatives at a Glance
+
+| Tool | License | Deployment | Best for | Starting price | Polyglot Support | Cross-domain Orchestration |
+|---|---|---|---|---|---|---|
+| Kestra | Open-Source (Apache 2.0) | Hybrid (K8s, Docker, On-Prem) | Universal workflow orchestration across data, AI, infra | Free (OSS) / Contact Sales (EE) | High | High |
+| Databricks | Proprietary | Cloud | Unified Lakehouse, large-scale data & ML | Consumption-based | High (Python, Scala, SQL) | Medium (Data/ML focus) |
+| Snowflake | Proprietary | Cloud | Cloud Data Warehousing & SQL Analytics | Consumption-based | Medium (SQL, Python, Java, Scala) | Low (Data focus) |
+| AWS Data & Analytics | Proprietary | Cloud | Modular, highly customizable cloud data stack | Pay-as-you-go | High (via various services) | Medium (requires integration) |
+| GCP Data Tools | Proprietary | Cloud | Serverless analytics & ML on Google Cloud | Consumption-based | High (via various services) | Medium (requires integration) |
+| Peliqan | Proprietary | Cloud | All-in-one data platform for growing teams | Tiered pricing | Medium | Low |
+| Oracle Cloud Infra | Proprietary | Cloud | Enterprise data management in Oracle ecosystem | Consumption-based | Medium (SQL, PL/SQL, Python) | Low (Oracle ecosystem focus) |
+
+## Choosing the right Microsoft Fabric alternative for your needs
+
+### Factors to consider when evaluating data platforms
+
+Selecting the right platform depends entirely on your specific context. Key factors to evaluate include:
+*   **Existing Ecosystem:** Are you heavily invested in Microsoft Azure, AWS, GCP, or a hybrid/on-premise environment?
+*   **Team Skill Set:** Is your team stronger in SQL, Python, or a mix of languages?
+*   **Budget:** Do you prefer predictable costs or a consumption-based model?
+*   **Scale and Performance:** What are your data volume, velocity, and query performance requirements?
+*   **Governance and Compliance:** What are your security, access control, and regulatory needs?
+*   **Flexibility:** Do you need a multi-cloud or hybrid strategy? How important is it to avoid vendor lock-in?
+
+### Future-proofing your data strategy
+
+The data landscape evolves rapidly. To future-proof your strategy, prioritize flexibility, open standards, and the ability to integrate new tools without being locked into a single vendor's ecosystem. This is where an orchestration control plane like Kestra provides significant value. By decoupling your workflow logic from your data platform, you can adapt your stack as new technologies emerge, ensuring your data strategy remains agile and resilient. Whether you need to manage [data workflows](/resources/data), [AI pipelines](/resources/ai), or [infrastructure automation](/resources/infrastructure), a universal orchestrator provides the foundation for a scalable and adaptable future.
+
+Ready to see how a declarative, vendor-neutral orchestration layer can unify your entire data stack? [Get started with Kestra today](/get-started).
+
+## Structured data
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What are the core capabilities of Microsoft Fabric and its closest alternatives?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Microsoft Fabric unifies data integration, engineering, warehousing, analytics, and business intelligence within the Microsoft ecosystem, leveraging OneLake for storage. Alternatives like Databricks offer a unified lakehouse for large-scale data and ML, while Snowflake provides a cloud data platform with a SQL-first approach. Kestra offers a declarative, polyglot orchestration layer that integrates with all these tools and extends beyond data."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Fabric replacing ADF?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Fabric Data Factory is not merely ADF rebranded. It represents a SaaS-native evolution, moving beyond the PaaS model of Azure Data Factory. It is deeply integrated with OneLake, Lakehouse, Warehouse, and the broader Fabric analytics fabric, offering a more unified experience within the Microsoft ecosystem. Existing ADF users will find migration paths and similar functionalities within Fabric's Data Factory component."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Microsoft Fabric better than Databricks?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The 'better' choice depends on specific priorities. If rapid deployment, tight integration with Microsoft tools, and streamlined governance are paramount, Microsoft Fabric is a strong contender. However, if use cases demand large-scale data processing, advanced ML pipelines, or architectural flexibility across different clouds and languages, Databricks often presents a stronger, more specialized solution."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Google have something like Microsoft Fabric?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "While Google Cloud Platform offers a rich suite of data and analytics services, it takes a modular approach rather than a single unified platform like Microsoft Fabric. Key components include BigQuery (serverless data warehouse), Dataflow (stream/batch processing), Dataproc (managed Spark/Hadoop), and Vertex AI (ML platform), and Looker (BI). These services can be combined to achieve similar functionalities but require more integration effort."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Microsoft have an ETL tool?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, Microsoft offers several ETL tools. Historically, SQL Server Integration Services (SSIS) was a prominent on-premise solution. In the cloud, Azure Data Factory (ADF) has been its primary managed ETL/ELT service. With the introduction of Microsoft Fabric, the Data Factory component within Fabric now serves as the modern, SaaS-native ETL/ELT capability, deeply integrated into the broader analytics platform."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does Kestra fit into the Microsoft Fabric alternative landscape?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Kestra acts as an open-source, declarative orchestration control plane that can sit above or alongside Microsoft Fabric and its alternatives. It unifies workflows across data, AI, and infrastructure, allowing teams to orchestrate tasks in any language, on any cloud. This provides flexibility and vendor neutrality, preventing lock-in while integrating existing tools like Databricks, Snowflake, or even specific Fabric components."
+      }
+    }
+  ]
+}
+```
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Top Microsoft Fabric Alternatives",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "item": {
+        "@type": "Thing",
+        "name": "Kestra",
+        "description": "The Declarative Orchestration Control Plane"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "item": {
+        "@type": "Thing",
+        "name": "Databricks",
+        "description": "Unified Analytics Platform for Lakehouse"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "item": {
+        "@type": "Thing",
+        "name": "Snowflake",
+        "description": "Cloud Data Platform for SQL-first Analytics"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "item": {
+        "@type": "Thing",
+        "name": "AWS Data & Analytics Services",
+        "description": "Modular, Cloud-Native Ecosystem"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 5,
+      "item": {
+        "@type": "Thing",
+        "name": "Google Cloud Platform Data Tools",
+        "description": "Scalable and Specialized Services"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 6,
+      "item": {
+        "@type": "Thing",
+        "name": "Peliqan",
+        "description": "All-in-One Data Platform for Growing Teams"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 7,
+      "item": {
+        "@type": "Thing",
+        "name": "Oracle Cloud Infrastructure (OCI) Data Services",
+        "description": "Enterprise-Grade Solutions"
+      }
+    }
+  ]
+}
+```
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://kestra.io/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Resources",
+      "item": "https://kestra.io/resources"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Data",
+      "item": "https://kestra.io/resources/data"
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "name": "Microsoft Fabric Alternatives: Top Competitors & More",
+      "item": "https://kestra.io/resources/data/microsoft-fabric-alternatives"
+    }
+  ]
+}
+```
+```

--- a/src/contents/resources/n8n-alternatives/index.md
+++ b/src/contents/resources/n8n-alternatives/index.md
@@ -1,0 +1,177 @@
+---
+title: "Top 10 n8n Alternatives for Workflow Automation"
+description: "Discover the best n8n alternatives for developers and AI workflow automation. Compare options for open-source, free, and enterprise needs. Find your perfect fit!"
+metaTitle: "Top 10 n8n Alternatives for Workflow Automation"
+metaDescription: "Explore the best n8n alternatives for developers and AI workflow automation. Compare open-source, free, and enterprise tools to find your ideal workflow solution."
+tag: "infrastructure"
+date: 2026-05-27
+slug: "n8n-alternatives"
+faq:
+  - question: "Which is better than n8n for developers?"
+    answer: "For developers seeking greater control, polyglot execution, and declarative workflows, Kestra stands out as a strong alternative to n8n. It allows defining complex automation logic in YAML, supports various programming languages, and offers robust features for data, AI, and infrastructure orchestration, making it suitable for engineering-led platforms rather than just SaaS automation."
+  - question: "What is replacing n8n for AI workflows?"
+    answer: "Several platforms are emerging as strong replacements for n8n in AI workflow automation, including specialized tools like Gumloop, Lindy AI, and Vellum AI. These platforms offer enhanced capabilities for building and orchestrating AI agents and large language model applications, providing more specialized features for the rapidly evolving AI landscape than n8n's broader automation focus."
+  - question: "Is there a free and open-source alternative to n8n?"
+    answer: "Yes, Kestra offers a fully open-source (Apache 2.0) core edition that is free to use and self-hostable, providing a powerful, declarative workflow orchestration engine. Other free alternatives include Node-RED, which offers a visual programming environment, and Beehive, an open-source event and agent system, both of which can be self-hosted for custom automation needs."
+  - question: "Does Google have something similar to n8n?"
+    answer: "Google offers several services that provide workflow automation capabilities, though not a direct n8n equivalent. Google Cloud Workflows is a managed service for orchestrating HTTP-based services and Google Cloud products. Google Workspace Studio also includes an AI agent builder, allowing for automation within the Google ecosystem, similar to how n8n integrates various applications."
+  - question: "What are the key differences between n8n and Kestra?"
+    answer: "n8n excels at visual, low-code SaaS automation, connecting various applications with pre-built nodes. Kestra, on the other hand, is a declarative, code-first orchestration platform designed for engineers. It uses YAML for workflow definitions, supports polyglot tasks (Python, SQL, Bash), and unifies data, AI, and infrastructure automation, offering greater control, scalability, and auditability for complex engineering workloads."
+  - question: "Is n8n still worth using in 2026?"
+    answer: "n8n remains a valuable tool for visual, low-code automation, especially for connecting SaaS applications and prototyping. However, for engineering teams requiring declarative workflows, polyglot execution, and robust governance across data, AI, and infrastructure, more specialized alternatives like Kestra may offer better long-term scalability and operational benefits."
+  - question: "How does n8n compare to Zapier and Make?"
+    answer: "n8n, Zapier, and Make all offer workflow automation, but differ in approach. Zapier is a fully managed SaaS, known for ease of use and extensive integrations, ideal for no-code users. Make (formerly Integromat) is more powerful with complex logic, suited for business users with some technical skills. n8n offers self-hosting and more developer-centric flexibility, bridging the gap between no-code and code-heavy solutions, often appealing to teams who want more control over their data and infrastructure."
+author: "elliot"
+---
+
+The landscape of workflow automation is constantly evolving, with new tools emerging to meet the demands of modern data, AI, and infrastructure teams. n8n has carved out a significant niche as an open-source, self-hostable option for connecting APIs and automating tasks. Yet, as organizations scale and workflows become more complex, many developers and platform engineers find themselves seeking alternatives that offer greater control, advanced capabilities, or a different operational model.
+
+The leading alternatives to n8n in 2026 include Kestra, Zapier, Make, Microsoft Power Automate, Gumloop, Lindy AI, ZenML, Vellum AI, Relay.app, and Node-RED — each suited to different workloads such as SaaS integration, AI agent orchestration, or robust infrastructure automation. This guide explores these top alternatives, helping you evaluate their strengths and choose the best fit for your project's unique requirements.
+
+## Why look for an alternative to n8n?
+
+While n8n is a powerful tool for visual workflow automation, teams often start looking for alternatives as their needs mature. Common reasons include:
+
+*   **Operational Complexity for Technical Users**: For engineering teams, a visual-first interface can become a limitation. Code-first, declarative approaches offer better version control, testing, and integration into existing GitOps practices.
+*   **Scaling and Performance**: High-throughput data pipelines or complex, long-running processes can push the limits of n8n's architecture. Teams may need a solution designed for more demanding engineering workloads.
+*   **Limited Polyglot Support**: n8n's node-based system is excellent for API integrations but can be cumbersome for running custom scripts in various languages like Python, SQL, or R as first-class citizens.
+*   **Evolving AI and LLM Needs**: The rise of agentic AI requires more than simple API calls. Specialized platforms offer better tools for building, managing, and orchestrating complex AI agents and LLM chains.
+*   **Unified Orchestration**: Teams often manage separate tools for data pipelines, infrastructure automation, and business workflows. A single, unified control plane can reduce complexity and improve observability. Effective [workflow management](https://kestra.io/resources/infrastructure/workflow-management) requires a holistic view that n8n's app-centric focus may not provide.
+
+## How we evaluated these alternatives
+
+To provide a balanced comparison, we evaluated each n8n alternative based on a core set of criteria relevant to modern engineering and automation teams:
+
+*   **Deployment Model**: Whether the tool is SaaS, self-hosted, open-source, or a hybrid.
+*   **Primary Use Case**: The problem the tool is best at solving, such as SaaS integration, data engineering, AI agent building, or infrastructure automation.
+*   **Developer Experience**: How the tool caters to developers, from its authoring interface (UI vs. code) to its integration with engineering workflows like CI/CD and Git.
+*   **Scalability**: The tool's ability to handle a growing number of complex, high-volume workflows.
+*   **Community and Ecosystem**: The health of its open-source community and the breadth of its integration library.
+*   **Pricing Transparency**: The clarity and predictability of its pricing model.
+
+## 1. Kestra: Declarative Orchestration for the AI Era
+
+Kestra is an open-source, event-driven orchestration platform that uses a declarative YAML interface to define and manage workflows. Unlike n8n's visual, node-based approach, Kestra is designed for engineers who need to orchestrate complex processes across data, AI, infrastructure, and business domains from a single control plane.
+
+Its language-agnostic architecture allows you to run tasks in Python, SQL, R, Bash, or any Docker container as first-class citizens. This makes it ideal for polyglot teams and complex pipelines that mix data transformation, infrastructure provisioning, and AI model interactions.
+
+Workflows are managed as code, enabling GitOps best practices like version control, code reviews, and automated testing. This declarative model provides a strong foundation for auditable, repeatable, and scalable automation. For instance, financial institutions like Crédit Agricole use Kestra to replace fragmented infrastructure scripts and cron jobs with a single, governed orchestration layer.
+
+While Kestra's YAML-first approach has a steeper learning curve for non-technical users compared to n8n's visual builder, it provides unparalleled control and flexibility for engineering teams. Is Kestra a good alternative to n8n? Yes, especially for teams that have outgrown visual builders and need a robust, code-centric platform for mission-critical automation.
+
+**Best for**: Platform engineers and data teams seeking a code-first, declarative, polyglot orchestration platform that unifies [data](https://kestra.io/data), [AI](https://kestra.io/ai-automation), and [infrastructure](https://kestra.io/infra-automation) workflows with robust governance and scalability. For a direct comparison, see our [Kestra vs. n8n](https://kestra.io/vs/n8n) page.
+
+## 2. Zapier: The No-Code Integration Standard
+
+Zapier is arguably the most well-known name in the no-code automation space. It's a fully managed SaaS platform that excels at connecting thousands of web applications with a simple, trigger-action model. Its primary strength lies in its vast library of pre-built integrations, making it incredibly easy to automate simple tasks between apps like Slack, Google Sheets, and Salesforce without writing a single line of code.
+
+For teams whose primary need is to link SaaS tools for marketing, sales, or administrative tasks, Zapier is often the path of least resistance. However, it lacks the complex logic, error handling, and developer-centric features of n8n or Kestra. Its pricing model, based on the number of tasks, can also become expensive at scale.
+
+**Best for**: Non-technical users and small businesses needing quick, no-code integrations between a wide array of SaaS applications.
+
+## 3. Make (formerly Integromat): Visual Automation with Advanced Logic
+
+Make occupies a middle ground between the simplicity of Zapier and the developer focus of tools like n8n. It offers a powerful visual canvas that allows for more complex logic, including branching, looping, and advanced data manipulation, which can be challenging in Zapier.
+
+Make's visual representation of data flow makes it intuitive to build and debug multi-step scenarios. It supports a wide range of applications and offers more flexibility in its free and entry-level tiers than many competitors. While it's more powerful than Zapier, it's still primarily a visual, low-code tool and may not satisfy engineering teams looking for a true code-based, declarative workflow solution.
+
+**Best for**: Business users and technical automators who need a visual, flexible platform to build complex integrations and process automation.
+
+## 4. Microsoft Power Automate: Enterprise-Grade Automation
+
+Part of the Microsoft Power Platform, Power Automate is an enterprise-focused automation tool that deeply integrates with the Microsoft ecosystem, including Office 365, Dynamics 365, and Azure. It offers both cloud-based flows (similar to Zapier) and desktop-based Robotic Process Automation (RPA) for automating legacy applications.
+
+Its strengths are its robust security, governance, and administration features, making it a strong choice for large organizations already invested in Microsoft's cloud. However, it can be complex and expensive, and its integrations outside the Microsoft world are less extensive than those of other platforms.
+
+**Best for**: Enterprises deeply embedded in the Microsoft ecosystem (Azure, 365, Dynamics) that require comprehensive business process automation and RPA.
+
+## 5. Gumloop: Building AI Agents with Ease
+
+Gumloop is a developer-centric platform specifically designed for building, deploying, and managing AI agents. Unlike n8n's general-purpose automation, Gumloop provides a specialized toolset for creating complex LLM-powered workflows. It offers a visual builder combined with a code-first approach, allowing developers to define agent behaviors, connect to various LLMs, and manage long-running tasks.
+
+It's an excellent choice for teams focused on creating sophisticated AI applications, such as customer service bots, research agents, or internal tools that leverage generative AI. Its narrow focus on AI means it's not a direct replacement for all of n8n's use cases, but for AI-specific tasks, it's a powerful contender.
+
+**Best for**: Developers and AI engineers focused on rapidly building, deploying, and managing AI agents and LLM-powered applications.
+
+## 6. Lindy AI: Intelligent Automation for Modern Teams
+
+Lindy AI takes a different approach by positioning itself as an "AI employee" that can handle complex, multi-step tasks. It focuses on understanding natural language prompts to automate workflows across various business tools. For example, you could ask Lindy to screen your emails, draft responses, and schedule meetings based on the content.
+
+It's designed to be a high-level assistant that can learn and adapt to your processes. This makes it a powerful alternative for teams looking to offload cognitive work rather than just simple, repetitive API calls. It's less of a traditional workflow builder and more of an intelligent agent platform.
+
+**Best for**: Teams looking to delegate complex, multi-step tasks to an AI assistant that can integrate across various business tools using natural language.
+
+## 7. ZenML: For ML-Powered Workflows
+
+ZenML is not a general automation tool but a dedicated MLOps (Machine Learning Operations) platform. It's an open-source framework for creating reproducible machine learning pipelines. For teams using n8n to trigger ML models or manage simple ML tasks, ZenML offers a far more robust and specialized solution.
+
+It focuses on the entire ML lifecycle, including data validation, model training, experiment tracking, and deployment. If your workflows are centered around building and productionizing machine learning models, ZenML is a superior alternative that provides the necessary MLOps guardrails.
+
+**Best for**: ML engineers and data scientists needing robust orchestration and MLOps capabilities for their machine learning pipelines.
+
+## 8. Vellum AI: Specialized in AI Applications
+
+Vellum AI is another specialized platform focused on the development lifecycle of LLM applications. It provides tools for prompt engineering, versioning, testing, and evaluating different language models to find the best one for a specific task. It helps teams move from a prototype to a production-ready AI application with confidence.
+
+While n8n can call an LLM API, Vellum provides the surrounding infrastructure to do so reliably and effectively. It's an n8n alternative for the specific use case of building and fine-tuning AI-powered features, not for general business process automation.
+
+**Best for**: Teams specializing in LLM application development, offering a comprehensive platform for prompt engineering, model deployment, and evaluation.
+
+## 9. Relay.app: Event-Driven Intelligent Automation
+
+Relay.app is an intelligent automation platform that combines event-driven workflows with human-in-the-loop collaboration. It's particularly strong in use cases like incident response, customer onboarding, and security operations, where automated processes need to be supplemented with human judgment and approvals.
+
+It uses an AI-powered engine to orchestrate tasks and can trigger playbooks based on events from tools like PagerDuty, Datadog, or Stripe. Its focus on collaborative, intelligent automation makes it a compelling alternative for operations and support teams.
+
+**Best for**: Operations and security teams requiring event-driven, intelligent automation with human oversight for incident response and business processes.
+
+## 10. Node-RED: A Free Option for Technical Users
+
+Node-RED is a flow-based programming tool originally developed by IBM for wiring together hardware devices, APIs, and online services as part of the Internet of Things (IoT). It's open-source, runs on Node.js, and provides a browser-based editor for creating flows visually.
+
+For developers and technical users, Node-RED is a highly flexible and extensible tool that can be self-hosted anywhere. It has a strong community and a large library of nodes. While its UI and focus are more technical than n8n's, it's an excellent free alternative for those comfortable with JavaScript and looking for a lightweight, event-driven automation tool.
+
+**Best for**: Technical users and developers who prefer a visual, flow-based programming tool for IoT, home automation, and lightweight API integrations, especially for self-hosting.
+
+## Comparison Table: n8n Alternatives at a Glance
+
+| Tool | License | Deployment | Primary Use Case | Developer Focus | AI Capabilities | Starting Price |
+|---|---|---|---|---|---|---|
+| **Kestra** | Open-Source (Apache 2.0) & Enterprise | Self-Hosted, Cloud | Unified Orchestration (Data, AI, Infra) | High (YAML, Polyglot) | High (Agents, LLMs) | Free (Open-Source) |
+| **Zapier** | Proprietary | SaaS | SaaS Integration | Low (No-Code) | Low | Free Tier / Paid Plans |
+| **Make** | Proprietary | SaaS | Complex SaaS Automation | Low-Medium (Visual) | Medium | Free Tier / Paid Plans |
+| **Microsoft Power Automate** | Proprietary | SaaS | Enterprise & RPA | Low (Low-Code) | Medium | Per User/Flow Plans |
+| **Gumloop** | Proprietary | SaaS | AI Agent Building | High (API-first) | High (Specialized) | Contact for pricing |
+| **Lindy AI** | Proprietary | SaaS | AI Assistant | Low | High (Natural Language) | Per User Plans |
+| **ZenML** | Open-Source (Apache 2.0) | Self-Hosted, Cloud | MLOps | High (Python SDK) | High (ML Pipelines) | Free (Open-Source) |
+| **Vellum AI** | Proprietary | SaaS | LLM App Development | High (API-first) | High (Specialized) | Free Tier / Paid Plans |
+| **Relay.app** | Proprietary | SaaS | Event-Driven Ops | Medium | High | Free Tier / Paid Plans |
+| **Node-RED** | Open-Source (Apache 2.0) | Self-Hosted | IoT & API Integration | High (JS-based) | Low | Free |
+
+## Choosing the Best n8n Alternative for Your Project
+
+Selecting the right tool depends entirely on your team's needs, technical skills, and primary use cases. Here’s a framework to guide your decision:
+
+*   **For Low-Code/No-Code Users**: If your goal is to connect SaaS applications without writing code, **Zapier** is the simplest entry point, while **Make** offers more power for complex visual workflows.
+*   **For Enterprise Business Processes**: If you're in a large organization, especially one using Microsoft products, **Microsoft Power Automate** provides the enterprise-grade governance and RPA capabilities you need.
+*   **For AI and LLM Specialization**: If your primary focus is building AI agents and LLM-powered applications, specialized tools like **Gumloop**, **Lindy AI**, or **Vellum AI** will provide a much richer feature set than general-purpose automators.
+*   **For Engineering and Platform Teams**: If you need a robust, scalable, and auditable platform for orchestrating mission-critical workflows, **Kestra** is the clear choice. Its declarative, polyglot, and unified approach provides the control and flexibility that engineering teams require, setting it apart from visual builders and positioning it as a true [IT automation platform](https://kestra.io/resources/infrastructure/it-automation-platform). While it can be compared to data-centric tools like [Airflow](https://kestra.io/vs/airflow) or [Dagster](https://kestra.io/vs/dagster), its scope extends far beyond data to cover any engineering workflow.
+
+## Future Trends in Workflow Automation and AI
+
+The field of workflow automation is rapidly converging with advancements in AI. The future is not just about connecting APIs but about orchestrating intelligent, autonomous agents that can reason, plan, and execute complex tasks.
+
+Key trends include:
+
+*   **Agentic Orchestration**: Tools are moving beyond simple trigger-action logic to support [agentic workflows](https://kestra.io/resources/ai/agentic-orchestration), where AI agents can operate autonomously to achieve a goal.
+*   **Declarative and Unified Platforms**: As automation becomes more critical, the need for declarative, auditable, and unified platforms that can manage data, AI, and infrastructure workflows from a single control plane is growing. This is the vision behind [Kestra's Series A funding](https://kestra.io/blogs/kestra-series-a).
+*   **Human-in-the-Loop**: Complex automation will increasingly require human oversight and approval, making platforms with built-in collaboration and approval gates essential.
+
+## Conclusion: Embracing the Right Automation Tool
+
+n8n has democratized workflow automation with its open-source, self-hostable model. However, the expanding landscape of automation and AI means that one size no longer fits all. Whether you need the no-code simplicity of Zapier, the AI-native power of Gumloop, or the engineering-grade control of Kestra, there is a rich ecosystem of [alternatives to choose from](https://kestra.io/vs).
+
+The best tool for your project is the one that aligns with your team's skills, operational model, and long-term goals. For teams looking to build a scalable, future-proof automation platform grounded in software engineering best practices, a declarative orchestrator like Kestra provides the foundation for success.
+
+Ready to see how a declarative, code-first approach can transform your workflows? [Get started with Kestra today](https://kestra.io/get-started).
+```

--- a/src/contents/resources/pipedream-alternatives/index.md
+++ b/src/contents/resources/pipedream-alternatives/index.md
@@ -20,7 +20,6 @@ faq:
   - question: "What is the best free alternative to Pipedream?"
     answer: "The 'best' free alternative depends on your specific needs. For open-source, self-hosted workflow automation, n8n and Activepieces are strong contenders, offering visual builders and extensive integrations. Kestra's open-source edition provides a powerful, declarative, and language-agnostic orchestration engine for developers. These platforms allow for significant customization and deployment flexibility without initial licensing costs, though they may require more operational overhead than managed services."
 author: "Kestra Team"
-image: "/images/blogs/pipedream-alternatives/cover.png"
 ---
 
 Pipedream has carved a niche for developers seeking flexible, code-driven automation. Yet, as projects scale or requirements diversify, many teams find themselves evaluating alternatives that offer greater control, broader integration capabilities, or a different operational paradigm. Whether it's the need for a more robust open-source solution, advanced AI agent orchestration, or simplified management, the market for workflow automation is rich with options. This article explores the top Pipedream alternatives for 2026, offering a comprehensive guide to help you choose the right tool for your specific workflow automation needs.

--- a/src/contents/resources/pipedream-alternatives/index.md
+++ b/src/contents/resources/pipedream-alternatives/index.md
@@ -1,0 +1,135 @@
+---
+title: "Top Pipedream alternatives for workflow automation"
+description: "Explore the best Pipedream alternatives for developers in 2026. Discover powerful tools to enhance your workflow automation needs today!"
+metaTitle: "Top Pipedream Alternatives for Developers (2026)"
+metaDescription: "Looking for Pipedream alternatives in 2026? Discover leading workflow automation tools like Kestra, n8n, and Temporal for developers, AI agents, and more."
+tag: "infrastructure"
+date: 2026-05-27
+slug: "pipedream-alternatives"
+faq:
+  - question: "How does Pipedream compare to Zapier?"
+    answer: "Pipedream offers a code-first, developer-centric approach, supporting multiple languages like Node.js and Python for custom workflows. Zapier, conversely, is a no-code platform designed for business users to automate tasks across a vast ecosystem of SaaS applications without writing any code. While both automate workflows, Pipedream provides deeper technical control, whereas Zapier prioritizes ease of use and broader app connectivity for non-developers."
+  - question: "Is there anything better than Zapier?"
+    answer: "Whether an alternative is 'better' than Zapier depends on your specific needs. For developers seeking code-driven, highly customizable, and scalable automation across diverse technical stacks (data, AI, infrastructure), tools like Kestra, n8n, or Temporal offer superior control and flexibility. For business users or citizen developers, platforms like Make.com provide more advanced logic and visual building, often seen as a more powerful alternative to Zapier's simpler automations."
+  - question: "What is a Pipedream integration?"
+    answer: "A Pipedream integration refers to a connection between Pipedream and an external service or API. Pipedream provides a serverless platform that allows developers to connect APIs, databases, and other services using pre-built components or custom code in Node.js, Python, Go, or Bash. These integrations enable Pipedream workflows to interact with various systems, fetching data, triggering actions, or processing events across a wide range of applications."
+  - question: "What is a Pipedream string?"
+    answer: "String.com (by Pipedream) is a developer-centric AI agent builder that translates natural-language prompts into working code. It focuses on empowering developers to create AI agents by writing code, offering a flexible environment for building sophisticated AI-driven automations. This platform is distinct from Pipedream's core workflow automation service, emphasizing AI agent development through a code-first approach."
+  - question: "Is Pipedream worth it?"
+    answer: "Pipedream is worth it for developers who prioritize a code-first approach to automation and require deep customization with languages like Node.js, Python, Go, or Bash. It offers significant flexibility for technical users building custom integrations and AI agents. However, for teams needing broader cross-domain orchestration, enterprise-grade governance, or a more visual/low-code experience for non-developers, alternatives might offer a more suitable value proposition."
+  - question: "What is the best free alternative to Pipedream?"
+    answer: "The 'best' free alternative depends on your specific needs. For open-source, self-hosted workflow automation, n8n and Activepieces are strong contenders, offering visual builders and extensive integrations. Kestra's open-source edition provides a powerful, declarative, and language-agnostic orchestration engine for developers. These platforms allow for significant customization and deployment flexibility without initial licensing costs, though they may require more operational overhead than managed services."
+author: "Kestra Team"
+image: "/images/blogs/pipedream-alternatives/cover.png"
+---
+
+Pipedream has carved a niche for developers seeking flexible, code-driven automation. Yet, as projects scale or requirements diversify, many teams find themselves evaluating alternatives that offer greater control, broader integration capabilities, or a different operational paradigm. Whether it's the need for a more robust open-source solution, advanced AI agent orchestration, or simplified management, the market for workflow automation is rich with options. This article explores the top Pipedream alternatives for 2026, offering a comprehensive guide to help you choose the right tool for your specific workflow automation needs.
+
+## Understanding Pipedream and the Need for Alternatives
+
+### What is Pipedream and its core functionalities?
+Pipedream is a serverless integration platform designed for developers to build and run workflows that connect APIs, AI, and databases. Its core strength lies in its code-first approach, allowing users to write custom logic in Node.js, Python, Go, or Bash directly within their workflows. It offers a library of pre-built integrations and managed authentication to accelerate development. Recently, Pipedream has also expanded into AI with String.com, a developer-centric AI agent builder.
+
+### Why developers seek Pipedream alternatives for their projects
+While Pipedream is a powerful tool for API integrations, developers often look for alternatives for several key reasons:
+- **Operational Complexity at Scale:** As the number of workflows grows, managing code-based automations can become complex. Teams often seek more declarative, infrastructure-as-code paradigms to improve versioning, testing, and observability.
+- **Cross-Domain Orchestration:** Pipedream excels at connecting apps but is less suited for orchestrating complex data pipelines, infrastructure automation, or business processes that require a unified control plane.
+- **Deployment Flexibility:** The serverless model may not fit all enterprise needs, particularly for organizations requiring self-hosted, air-gapped, or hybrid cloud deployments for security and compliance.
+- **Open-Source and Governance:** Many teams prefer fully open-source solutions for maximum control and transparency, or require enterprise-grade governance features like RBAC, audit logs, and multi-tenancy that may be more mature in other platforms.
+
+## Key Considerations When Evaluating Pipedream Alternatives
+When choosing an alternative, consider these factors:
+- **Developer Experience & Flexibility:** Does the tool favor a code-first or visual approach? What programming languages does it support? How customizable is the platform for complex logic?
+- **Scalability & Performance:** Can it handle high-throughput workloads and distributed execution? How does it manage resources and ensure reliability?
+- **Deployment & Licensing:** Is it cloud-managed, self-hosted, or hybrid? Is it open-source or proprietary, and what does the pricing model look like?
+- **Integration Ecosystem:** How extensive is the library of pre-built connectors? How easy is it to build and maintain custom integrations?
+- **Observability & Governance:** What capabilities are available for monitoring, logging, and auditing workflows? Does it support enterprise security features like RBAC and SSO?
+
+## Top 6 Pipedream Alternatives for Workflow Automation in 2026
+
+### 1. Kestra: The Declarative Control Plane for Universal Orchestration
+Kestra is an open-source, declarative, and event-driven orchestration platform. It unifies data, AI, infrastructure, and business workflows under a single control plane defined by simple YAML files. Its language-agnostic engine supports polyglot task execution (Python, R, Go, SQL, shell, Java, Docker), and it offers an Enterprise Edition for advanced governance and a managed Kestra Cloud for a zero-ops experience.
+
+Kestra's strength is its GitOps-native approach, which simplifies versioning, collaboration, and rollbacks. The vast plugin ecosystem enables orchestration across virtually any system. With a native AI Copilot and auditable AI agents, it provides advanced capabilities for intelligent automation, all with robust observability and enterprise-grade governance. While it offers a visual editor, Kestra's core is YAML-based, which can present a learning curve for users accustomed to purely no-code interfaces.
+
+**Best for:** Platform engineers, data engineers, and AI teams seeking a unified, scalable, and highly customizable orchestration platform with strong governance and hybrid deployment options.
+
+### 2. n8n: Visual Workflow Automation for Self-Hosting
+n8n is an open-source visual workflow automation tool that allows users to connect APIs, automate tasks, and integrate data across hundreds of applications. Often positioned as a self-hosted alternative to Zapier, it provides more control through custom code blocks (Node.js).
+
+The intuitive visual builder makes n8n accessible for technical users who prefer a drag-and-drop interface. Its extensive library of SaaS integrations, combined with the flexibility to self-host, offers significant control over data privacy and costs. While powerful for app integrations, n8n can become cumbersome for large-scale data processing or complex infrastructure automation. Its design is less focused on execution reliability at enterprise scale compared to dedicated orchestration platforms.
+
+**Best for:** Developers and technical users who want to self-host a visual automation tool for SaaS integrations and basic AI workflows, with good customization via code.
+
+### 3. Temporal: Durable Execution for Application Workflows
+Temporal is an open-source, code-first platform for building and operating long-running, fault-tolerant application workflows. It provides SDKs in multiple languages (Go, Java, Python, TypeScript) to define durable workflows that automatically handle retries, failures, and state persistence.
+
+Temporal excels at ensuring the reliability of complex, stateful application logic, making it ideal for microservices orchestration, payment processing, or user onboarding flows. Its primary focus is on application-level workflows, making it less of a general-purpose orchestrator for data, infrastructure, or business processes. The paradigm requires a deeper engineering investment compared to declarative or visual tools.
+
+**Best for:** Application engineers building highly reliable, long-running, and stateful microservices or business logic workflows embedded within their code.
+
+### 4. Zapier: No-Code Automation for Business Users
+Zapier is a cloud-based, no-code automation platform designed to connect thousands of SaaS applications. Its primary value proposition is simplicity and speed for non-technical users.
+
+Zapier's strength is its ease of use and massive app directory, allowing anyone to set up simple "if this, then that" automations in minutes. However, its no-code nature limits customization and control, and the per-task pricing model can become expensive at scale. It is not designed for code-heavy logic, complex data transformations, or enterprise-grade orchestration.
+
+**Best for:** Business users, marketers, and small teams needing quick, simple automations between SaaS applications without writing any code.
+
+### 5. Make.com (formerly Integromat): Visual Workflow Builder with Advanced Logic
+Make.com is a cloud-based, visual workflow automation platform that offers more advanced logic capabilities than Zapier. It allows users to build complex, multi-step scenarios with branching, filtering, and error handling.
+
+Its highly visual interface makes it easy to design and debug intricate automations. Make.com is particularly strong at connecting APIs and manipulating data within a flow. As a proprietary cloud tool, it is not ideal for teams that prefer a code-first, self-hosted, or infrastructure-as-code approach to workflow management.
+
+**Best for:** Power users and small to medium businesses needing sophisticated visual automations with conditional logic and data manipulation, often bridging SaaS apps and APIs.
+
+### 6. Composio: The Integration Platform for AI Agents
+According to its public site, Composio is an integration toolkit that provides AI agents with a unified API to connect to and act on over 250 SaaS tools. It handles authentication, function calling, and observability for AI agent integrations.
+
+Composio's strength is its laser focus on empowering AI agents to interact with the SaaS ecosystem. However, this narrow scope means it is not a general-purpose orchestration platform. It lacks first-class primitives for data pipelines, infrastructure automation, or event-driven workflows. Its ecosystem is also newer compared to more established workflow automation tools.
+
+**Best for:** Developers and teams building AI agents that require robust, out-of-the-box integrations with various SaaS tools and APIs.
+
+## Comparison Table: Pipedream Alternatives at a Glance
+
+| Tool | License | Deployment | Best for | Key Differentiator |
+|---|---|---|---|---|
+| Kestra | Apache 2.0 OSS / EE / Cloud | Self-hosted (Docker, K8s, VM), Managed Cloud | Universal, declarative orchestration for data, AI, infra, business | Language-agnostic, GitOps, event-driven, full observability |
+| n8n | Fair-Code (Open-Core) | Self-hosted, Cloud | Visual workflow automation for SaaS integrations | Visual builder, custom code, strong community, self-hostable |
+| Temporal | MIT | Self-hosted, Cloud | Durable execution for application workflows | Stateful, fault-tolerant, multi-language SDKs for app dev |
+| Zapier | Proprietary | Cloud | Simple no-code SaaS app automation | Ease of use, vast app directory, quick setup |
+| Make.com | Proprietary | Cloud | Advanced visual automation with complex logic | Highly visual, powerful logic, API integration |
+| Composio | Proprietary (free tier + paid) | Cloud (managed) | AI agent integrations | Unified API for AI agents to act on 250+ SaaS tools |
+
+## Choosing the Right Pipedream Alternative for Your Needs
+
+### For AI/ML Platform Teams
+Teams building AI platforms need tools that can orchestrate complex, multi-stage pipelines and integrate with a variety of AI providers and tools.
+- **Kestra** is ideal for building declarative, auditable, and scalable [agentic orchestration](/resources/ai/agentic-orchestration) workflows that combine data processing, model training, and AI agent actions.
+- **Composio** offers a focused solution for connecting AI agents to SaaS applications.
+- **Temporal** can provide durable execution for long-running ML services and inference endpoints.
+
+### For Data Engineering Teams
+Data engineers require robust, scalable, and observable platforms for building and managing data pipelines.
+- **Kestra** offers a language-agnostic environment perfect for orchestrating diverse data tools like dbt, Spark, and Airbyte, all managed via a GitOps workflow.
+- **n8n** can be a good fit for simpler data movement and ETL tasks, especially when a visual interface is preferred.
+
+### For Infrastructure & DevOps Teams
+These teams prioritize infrastructure-as-code, GitOps, and the ability to automate across hybrid and multi-cloud environments.
+- **Kestra** provides a powerful control plane to [orchestrate infrastructure automation](/infra-automation) tools like Terraform and Ansible, enabling governed, event-driven operations.
+- **Temporal** is a solid choice for building complex application logic that manages infrastructure state.
+
+### For Small Teams & Startups
+Startups and small teams need tools that are easy to start with, cost-effective, and can scale with their needs.
+- **n8n** and **Kestra's open-source edition** offer powerful, self-hosted options with no initial cost.
+- **Zapier** and **Make.com** provide quick, no-code/low-code solutions for automating business processes without requiring deep technical expertise.
+
+## Is Pipedream Worth It?
+Pipedream holds its own as a developer-centric tool for teams that want a code-first approach to connecting APIs and building custom integrations. Its flexibility with multiple scripting languages and its dedicated AI agent builder make it a strong contender for specific use cases. However, when workflows need to scale across an organization, require enterprise-grade governance, or must span domains beyond app integration, alternatives often provide a better fit. The choice depends on whether you need a tool for isolated integrations or a true orchestration control plane for your entire stack.
+
+## Modernizing Your Workflow Automation
+The landscape of workflow automation offers a diverse range of tools, each with its own philosophy and ideal use case. Moving beyond Pipedream often means choosing a platform that better aligns with your team's specific needs, whether that's the no-code simplicity of Zapier, the application-level durability of Temporal, or the visual, self-hosted power of n8n.
+
+For teams looking for a single, unified platform to orchestrate everything from simple scripts to complex, cross-domain workflows, Kestra stands out. Its declarative, language-agnostic, and event-driven architecture provides a scalable and observable control plane for modern engineering teams.
+
+Ready to see how a declarative approach can simplify your automation? [Get started with Kestra today](/get-started).
+```

--- a/src/contents/resources/prefect-alternatives/index.md
+++ b/src/contents/resources/prefect-alternatives/index.md
@@ -1,0 +1,342 @@
+---
+title: "Prefect Alternatives: Orchestration Platforms for Data & AI Workflows"
+description: "Looking for Prefect alternatives? Explore leading platforms like Kestra, Airflow, and Dagster. Find the ideal orchestration solution for your data and AI workflows, considering flexibility, deployment, and language support."
+metaTitle: "Prefect Alternatives: Top Orchestration Platforms"
+metaDescription: "Explore the best Prefect alternatives for workflow orchestration. Discover platforms like Airflow, Dagster, and Kestra. Find your ideal solution for data, ML, and general automation today!"
+tag: "data"
+date: 2026-05-27
+slug: "prefect-alternatives"
+faq:
+  - question: "Why should I consider alternatives to Prefect?"
+    answer: "While Prefect excels in Python-native dynamic workflows, teams often seek alternatives due to its Python-centric nature, potential operational overhead at scale, or a desire for more declarative, language-agnostic, or self-hosted deployment options that integrate across broader IT and AI stacks."
+  - question: "Is Kestra a good alternative to Prefect for data pipelines?"
+    answer: "Yes, Kestra offers a strong alternative to Prefect, especially for teams needing polyglot task execution and declarative YAML workflows. It unifies data, AI, and infrastructure orchestration, providing flexibility beyond Python-only environments with robust event-driven capabilities and lower operational overhead."
+  - question: "How does Apache Airflow compare to Prefect as an alternative?"
+    answer: "Apache Airflow, a mature Python-based orchestrator, offers a vast operator ecosystem. Compared to Prefect, Airflow has a longer history and extensive community, but can involve higher operational complexity. It's suitable for Python-heavy teams, though many now seek modern alternatives."
+  - question: "What are the key advantages of Dagster over Prefect?"
+    answer: "Dagster's asset-centric design provides superior data lineage and observability, appealing to analytics engineering teams. While both are Python-first, Dagster's explicit asset model and strong typing offer a different paradigm for managing data pipelines, particularly with dbt integration."
+  - question: "Are there self-hosted Prefect alternatives?"
+    answer: "Yes, many Prefect alternatives offer robust self-hosting capabilities. Kestra, Apache Airflow, Dagster, and Windmill are prominent examples, providing flexibility for on-premise, hybrid, or air-gapped environments, addressing common needs for data sovereignty and infrastructure control."
+  - question: "Which Prefect alternative is best for ML-focused workflows?"
+    answer: "For ML-focused workflows, alternatives like ZenML and Metaflow offer specialized features for model training, versioning, and deployment. Kestra also supports AI workflows with native agentic capabilities and integrations with various ML tools, providing a versatile platform for MLOps."
+  - question: "What are the main factors when choosing a Prefect alternative?"
+    answer: "Key factors include deployment model (self-hosted vs. managed), language support (Python-only vs. polyglot), architectural philosophy (code-first vs. declarative), scalability needs, integration ecosystem, and cost considerations. Aligning these with your team's specific requirements is crucial."
+author: "elliot"
+---
+
+Prefect has established itself as a robust, Python-native workflow orchestrator, particularly popular for its focus on developer experience and dynamic workflows. However, as data and AI pipelines grow in complexity and span diverse technology stacks, many engineering teams find themselves evaluating alternatives. The increasing demand for language-agnostic solutions, declarative configuration, and greater control over self-hosted environments—especially with broader trends like the Airflow 3.0 migration prompting re-evaluation of orchestration layers—highlights a shifting landscape.
+
+While Prefect excels in its niche, its Python-first approach and cloud-managed control plane model can present trade-offs for organizations seeking a more universal orchestration platform. This article explores leading Prefect alternatives in 2026, including Kestra, Apache Airflow, Dagster, ZenML, Metaflow, Windmill, Apache NiFi, and Mage. Each platform offers distinct advantages for various workloads, from traditional data engineering and modern ML pipelines to general-purpose IT automation. We'll delve into their core functionalities, comparative strengths, and ideal use cases to help you navigate the options and find the orchestration solution that best aligns with your team's technical requirements and strategic goals.
+
+## Why look for an alternative to Prefect?
+
+Teams evaluate Prefect alternatives for several key reasons, often stemming from its core design philosophy and how that aligns with their evolving needs.
+
+*   **Python-centricity**: Prefect is deeply integrated with the Python ecosystem. While this is a strength for Python-heavy teams, it becomes a limitation when workflows must incorporate tasks in other languages like R, Julia, SQL, or shell scripts. A polyglot environment often requires a more language-agnostic orchestrator.
+*   **Operational Complexity at Scale**: While Prefect's hybrid model aims to simplify deployment, managing workers, infrastructure, and ensuring observability across a large number of flows can introduce significant operational overhead. Teams may look for solutions with a simpler, more scalable architecture out of the box.
+*   **Code-first vs. Declarative Workflows**: Prefect uses a code-first approach where workflows are defined in Python. Many organizations, especially those with platform engineering teams, prefer a declarative model (e.g., YAML) for [workflow management](https://kestra.io/resources/infrastructure/workflow-management). Declarative configurations are easier to version, audit, and manage with GitOps practices.
+*   **Cloud-first Business Model**: Prefect's commercial offering is centered around Prefect Cloud. Teams needing robust self-hosted, hybrid, or air-gapped deployments for data sovereignty or security reasons might find this model less flexible than alternatives designed with self-hosting as a first-class citizen.
+*   **Ecosystem and Domain Gaps**: While Prefect has a growing collection of integrations, it may lack the depth of a more mature ecosystem like Airflow's or the specialized focus of MLOps tools for specific use cases. As the market re-evaluates orchestration tools, particularly with events like the [Airflow 2 End of Life](https://kestra.io/blogs/2026-04-06-airflow-2-end-of-life) prompting a broader review, teams are looking for platforms that can unify more of their stack.
+
+## How we evaluated these alternatives
+
+To provide a balanced comparison, we evaluated each Prefect alternative based on a consistent set of criteria relevant to modern engineering teams:
+
+*   **Deployment Model**: We assessed whether the platform is primarily cloud-managed, self-hosted, or offers a flexible hybrid model.
+*   **Workflow Definition**: We looked at the core authoring experience—is it code-first (Python), declarative (YAML), visual, or a combination?
+*   **Language Support**: We considered whether the tool is Python-only or language-agnostic (polyglot), allowing tasks in various programming languages.
+*   **Primary Use Case Fit**: We identified the ideal domain for each tool, whether it's data engineering, ML/AI, infrastructure automation, or general-purpose workflows.
+*   **Scalability and Performance**: We evaluated the underlying architecture's ability to handle a high volume of workflows and complex dependencies.
+*   **Community and Documentation**: We considered the health of the open-source community, the quality of documentation, and the availability of support.
+*   **Pricing Model**: We noted whether the tool is open-source, has a commercial enterprise version, or follows a usage-based pricing model.
+
+## The Top Prefect Alternatives
+
+### 1. Kestra: The Declarative, Event-Driven Orchestration Control Plane
+
+Kestra is an open-source, language-agnostic orchestration platform that defines all workflows as declarative YAML. This approach decouples the orchestration logic from the business logic, allowing teams to run any code, anywhere. Its event-driven architecture makes it exceptionally well-suited for real-time and complex, interdependent workflows.
+
+Unlike Python-centric tools, Kestra's JVM-based engine can execute tasks written in Python, R, SQL, Shell, and more, all as first-class citizens. This makes it a universal control plane that can unify [data orchestration](https://kestra.io/data), AI pipelines, and infrastructure automation. For instance, Apple's ML team uses Kestra to orchestrate large-scale data pipelines, demonstrating its capability to handle complex, high-volume workloads in demanding environments. Kestra's architecture ensures low operational overhead and high scalability, with a simple deployment model that works equally well on a laptop or a large Kubernetes cluster.
+
+**Best for**: Teams seeking a universal, declarative, and polyglot orchestration platform with strong event-driven capabilities and low operational burden. Explore Kestra's [blueprints](https://kestra.io/blueprints) to see it in action.
+
+### 2. Apache Airflow: The Established Data Orchestrator
+
+As one of the most mature and widely adopted data orchestrators, Apache Airflow is a common consideration for teams managing Python-based data pipelines. Its primary strength lies in its massive operator ecosystem and a large, active community that has contributed integrations for nearly every tool in the data stack.
+
+However, Airflow's power comes with significant operational complexity. Managing its components (scheduler, executor, webserver, metadata database) requires dedicated infrastructure expertise. Workflows are defined as Python DAGs, which, like Prefect, can be a limitation for non-Python teams and can make versioning and rollbacks more complex than declarative approaches. While a solid choice, many teams view it as a legacy option and seek more modern [enterprise Airflow alternatives](https://kestra.io/blogs/enterprise-airflow-alternatives).
+
+**Best for**: Python-heavy data engineering teams with existing Airflow investment or those prioritizing a vast, mature operator ecosystem and familiar Python authoring.
+
+### 3. Dagster: The Asset-Centric Data Platform
+
+Dagster offers a unique, asset-centric approach to orchestration. Instead of focusing on tasks, Dagster models workflows as a graph of data assets, providing exceptional data lineage, observability, and testability. This software-engineering mindset appeals to analytics engineering teams who prioritize data quality and governance.
+
+Dagster's native dbt integration is a major draw for teams using dbt for data transformation. Like Prefect, it is Python-first, which can be a limitation for polyglot environments. Its asset-based paradigm, while powerful, introduces a steeper learning curve compared to traditional task-based orchestrators and is less naturally suited for non-data workflows like infrastructure provisioning or business process automation. The choice between dbt and alternatives like [SQLMesh](https://kestra.io/blogs/2024-02-28-dbt-or-sqlmesh) also plays a role in how teams adopt Dagster.
+
+**Best for**: Analytics engineering teams prioritizing data quality, lineage, and a software-engineering approach to data assets, especially those using dbt.
+
+### 4. ZenML: The ML-Focused MLOps Framework
+
+ZenML is not a general-purpose orchestrator but a specialized MLOps framework designed to create reproducible machine learning pipelines. It provides a standardized, portable way to structure ML workflows, from data ingestion and model training to deployment and monitoring.
+
+Its core strength is its deep focus on the ML lifecycle, with built-in abstractions for experiment tracking, model versioning, and environment management. This makes it a powerful tool for ML teams looking to enforce best practices. The trade-off is its specialization; it's not designed for the broader data and infrastructure tasks that a tool like Prefect or Kestra would handle. For more on this domain, see our guide to [MLOps](https://kestra.io/resources/ai/what-is-mlops).
+
+**Best for**: ML engineering teams needing a dedicated MLOps platform with deep integrations for the ML lifecycle.
+
+### 5. Metaflow: Scaling Data Science Workflows
+
+Originating at Netflix, Metaflow is designed to help data scientists and ML engineers build and manage real-life data science projects. It focuses on productivity and scalability, allowing users to write their workflow logic in Python or R and then scale it out to cloud computing resources like AWS Batch with minimal code changes.
+
+Metaflow is highly opinionated and prioritizes the iterative, experimental nature of data science over the rigid, scheduled execution of traditional ETL. It provides strong versioning capabilities for code and data, which is critical for reproducibility. However, it is less of a general-purpose orchestrator and more of a framework for data-intensive applications.
+
+**Best for**: Data scientists and ML engineers working with large-scale data, who need to manage complex, iterative data science projects.
+
+### 6. Windmill: Low-Code & Code-Based Workflow Engine
+
+Windmill positions itself as an alternative for building a wide range of internal tools and automations, from simple scripts to complex, multi-step workflows. Its key differentiator is the combination of a low-code, visual flow editor with the ability to drop into code (Python, TypeScript, Go, Bash) for any step.
+
+This hybrid approach makes it accessible to a broader range of users than a purely code-based tool like Prefect. It also offers a robust self-hosted open-source version. While it can handle complex logic, its primary focus is on internal tools and automations rather than high-throughput, production-grade data pipelines, making it a different kind of alternative.
+
+**Best for**: Teams building internal tools, automations, and light-to-medium complexity workflows that benefit from both visual and code-based authoring.
+
+### 7. Apache NiFi: Data Flow Automation
+
+Apache NiFi is a powerful tool for automating the movement of data between disparate systems. It provides a web-based UI for designing, controlling, and monitoring data flows. Its visual, flow-based programming model excels at data routing, transformation, and mediation in real-time.
+
+NiFi's strengths are in data ingestion and its ability to provide detailed data provenance (lineage). However, its paradigm is very different from job-based orchestrators like Prefect. It is less suited for orchestrating complex, multi-step batch jobs or workflows that involve significant custom code execution. For teams focused purely on data routing and transformation, it's a strong contender.
+
+**Best for**: Organizations with heavy requirements for real-time data ingestion, transformation, and routing, especially for streaming data.
+
+### 8. Mage: The Modern Data Pipeline Builder
+
+Mage is a newer open-source platform that aims to provide a better developer experience for building and running data pipelines. It integrates an interactive notebook-style editor, allowing data engineers to write and test Python, SQL, and R code in a single tool.
+
+Mage emphasizes a hybrid approach, combining the interactivity of notebooks with the rigor of engineering best practices. It's particularly well-suited for building ELT pipelines. As a more recent entrant, its ecosystem and community are smaller than those of established players like Airflow or Prefect.
+
+**Best for**: Data teams looking for a modern, notebook-centric platform to build, run, and manage ELT pipelines with a focus on developer productivity.
+
+## Comparison Table: Prefect Alternatives at a Glance
+
+| Tool | License | Deployment | Workflow Definition | Primary Language | Best for | Starting Price |
+|---|---|---|---|---|---|---|
+| **Kestra** | Apache 2.0 | Self-hosted, Cloud | Declarative (YAML) | Language-Agnostic | Universal orchestration (data, AI, infra) | Open Source |
+| **Apache Airflow** | Apache 2.0 | Self-hosted, Managed | Code-first (Python) | Python | Python-heavy data pipelines | Open Source |
+| **Dagster** | Apache 2.0 | Self-hosted, Cloud | Code-first (Python) | Python | Asset-centric data platforms (dbt) | Open Source |
+| **ZenML** | Apache 2.0 | Self-hosted, Cloud | Code-first (Python) | Python | MLOps and reproducible ML pipelines | Open Source |
+| **Metaflow** | Apache 2.0 | Self-hosted (on cloud) | Code-first (Python/R) | Python, R | Scaling data science projects | Open Source |
+| **Windmill** | AGPLv3 | Self-hosted, Cloud | Visual & Code | Python, TS, Go | Internal tools and automations | Open Source |
+| **Apache NiFi** | Apache 2.0 | Self-hosted | Visual Flow-based | Java (config) | Real-time data routing and ingestion | Open Source |
+| **Mage** | Apache 2.0 | Self-hosted, Cloud | Code-first (Python) | Python | Notebook-centric ELT pipelines | Open Source |
+
+## How to choose the right Prefect alternative
+
+Selecting the right orchestrator depends heavily on your team's composition, existing stack, and primary use cases.
+
+#### For Data Engineering Teams
+Your focus is on reliability, scalability, and integration with the data stack (dbt, Snowflake, etc.).
+*   **Kestra**: Choose for polyglot environments where pipelines involve more than just Python, and you want declarative, event-driven workflows.
+*   **Dagster**: Ideal if your team prioritizes data lineage, testability, and uses an asset-centric approach, especially with dbt.
+*   **Apache Airflow**: A safe bet for Python-only teams with a need for a massive library of existing operators who are comfortable with the operational overhead.
+
+#### For Infrastructure & DevOps Teams
+You need GitOps compatibility, Infrastructure as Code (IaC) integration, and cross-system automation.
+*   **Kestra**: The strongest choice here, acting as a universal control plane for [infrastructure automation](https://kestra.io/infra-automation) with its declarative YAML and language-agnostic design.
+*   **Windmill**: A good option for building self-service internal tools and automating operational runbooks.
+
+#### For AI & ML Platform Teams
+Your priorities are reproducibility, integration with ML tools, and managing complex, heterogeneous training pipelines.
+*   **Kestra**: A versatile choice for orchestrating the end-to-end ML lifecycle, including data prep, model training, and agentic workflows for [AI automation](https://kestra.io/ai-automation).
+*   **ZenML**: The best option if you need a dedicated MLOps framework to enforce reproducibility and best practices across your ML projects.
+*   **Metaflow**: Suited for data science teams at scale who need to easily transition from local development to cloud-based computation.
+
+#### For Small Teams & Startups
+You need a tool that is easy to set up, cost-effective, and allows for rapid iteration.
+*   **Kestra**: The open-source edition is easy to get started with Docker and scales with you without a steep learning curve.
+*   **Windmill**: The combination of low-code and code makes it accessible for teams with varying skill sets to build automations quickly.
+
+## Conclusion: Orchestration Beyond Python-First
+
+While Prefect offers a powerful, modern experience for Python-based workflows, the orchestration landscape is broad and diverse. The right alternative depends on your specific needs: Airflow's mature ecosystem, Dagster's asset-centric governance, or ZenML's MLOps focus each serve a distinct purpose.
+
+However, for teams looking to break free from language constraints and unify their automation efforts, a platform like Kestra offers a compelling path forward. By embracing a declarative, language-agnostic, and event-driven approach, Kestra acts as a universal control plane for your entire technology stack. It empowers data, platform, and AI teams to build reliable, scalable, and observable workflows without being locked into a single programming paradigm.
+
+Ready to see how a declarative approach can simplify your orchestration? [Get started with Kestra](https://kestra.io/get-started) or [book a demo](https://kestra.io/demo) to explore its capabilities.
+
+## Structured data
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Why should I consider alternatives to Prefect?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "While Prefect excels in Python-native dynamic workflows, teams often seek alternatives due to its Python-centric nature, potential operational overhead at scale, or a desire for more declarative, language-agnostic, or self-hosted deployment options that integrate across broader IT and AI stacks."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Kestra a good alternative to Prefect for data pipelines?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, Kestra offers a strong alternative to Prefect, especially for teams needing polyglot task execution and declarative YAML workflows. It unifies data, AI, and infrastructure orchestration, providing flexibility beyond Python-only environments with robust event-driven capabilities and lower operational overhead."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does Apache Airflow compare to Prefect as an alternative?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Apache Airflow, a mature Python-based orchestrator, offers a vast operator ecosystem. Compared to Prefect, Airflow has a longer history and extensive community, but can involve higher operational complexity. It's suitable for Python-heavy teams, though many now seek modern alternatives."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What are the key advantages of Dagster over Prefect?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Dagster's asset-centric design provides superior data lineage and observability, appealing to analytics engineering teams. While both are Python-first, Dagster's explicit asset model and strong typing offer a different paradigm for managing data pipelines, particularly with dbt integration."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are there self-hosted Prefect alternatives?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, many Prefect alternatives offer robust self-hosting capabilities. Kestra, Apache Airflow, Dagster, and Windmill are prominent examples, providing flexibility for on-premise, hybrid, or air-gapped environments, addressing common needs for data sovereignty and infrastructure control."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which Prefect alternative is best for ML-focused workflows?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "For ML-focused workflows, alternatives like ZenML and Metaflow offer specialized features for model training, versioning, and deployment. Kestra also supports AI workflows with native agentic capabilities and integrations with various ML tools, providing a versatile platform for MLOps."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What are the main factors when choosing a Prefect alternative?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Key factors include deployment model (self-hosted vs. managed), language support (Python-only vs. polyglot), architectural philosophy (code-first vs. declarative), scalability needs, integration ecosystem, and cost considerations. Aligning these with your team's specific requirements is crucial."
+      }
+    }
+  ]
+}
+```
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Top Prefect Alternatives",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Kestra",
+        "url": "https://kestra.io/vs/prefect"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Apache Airflow",
+        "url": "https://kestra.io/vs/airflow"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Dagster",
+        "url": "https://kestra.io/vs/dagster"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "ZenML"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 5,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Metaflow"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 6,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Windmill",
+        "url": "https://kestra.io/vs/windmill"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 7,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Apache NiFi",
+        "url": "https://kestra.io/vs/apache-nifi"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 8,
+      "item": {
+        "@type": "SoftwareApplication",
+        "name": "Mage"
+      }
+    }
+  ]
+}
+```
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://kestra.io/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Resources",
+      "item": "https://kestra.io/resources"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Data Engineering Resources",
+      "item": "https://kestra.io/resources/data"
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "name": "Prefect Alternatives: Orchestration Platforms for Data & AI Workflows",
+      "item": "https://kestra.io/resources/data/prefect-alternatives"
+    }
+  ]
+}
+```
+```

--- a/src/contents/resources/simplyask-alternatives/index.md
+++ b/src/contents/resources/simplyask-alternatives/index.md
@@ -18,7 +18,6 @@ faq:
   - question: "Can Kestra replace SimplyAsk for AI business efficiency?"
     answer: "Kestra can serve as a powerful alternative to SimplyAsk, particularly for engineering-led teams that require deep control over AI business efficiency workflows. While SimplyAsk focuses on a no-code platform with conversational AI, Kestra offers a declarative, YAML-defined approach to orchestrate complex AI agents, RAG pipelines, and data processes, integrating with existing systems for auditable and scalable automation."
 author: "elliot"
-image: "/images/blogs/simplyask-alternatives/cover.png"
 ---
 
 SimplyAsk has carved a niche with its no-code AI business efficiency platform, helping teams streamline processes with conversational AI agents. Yet, as organizations scale their automation initiatives, the need often arises for solutions offering deeper technical control, broader integration across diverse tech stacks, or specialized expertise beyond simply business efficiency. Whether driven by architectural constraints, the desire for a more code-centric approach, or the need to orchestrate complex data and infrastructure alongside AI, exploring alternatives is a strategic step.

--- a/src/contents/resources/simplyask-alternatives/index.md
+++ b/src/contents/resources/simplyask-alternatives/index.md
@@ -1,0 +1,118 @@
+---
+title: "SimplyAsk alternatives: Top Competitors & Options"
+description: "Explore SimplyAsk alternatives and competitors to find the best solution for your needs. Compare features, pricing, and reviews today!"
+metaTitle: "SimplyAsk Alternatives: Top Competitors & Options"
+metaDescription: "Seeking SimplyAsk alternatives? Compare top competitors like Kestra, Capital Numbers, and n8n. Find the best solution for AI, data, and business automation."
+tag: "ai"
+date: 2026-05-27
+slug: "simplyask-alternatives"
+faq:
+  - question: "What are the top 5 automation tools?"
+    answer: "The top automation tools vary by use case, but for universal orchestration across data, AI, and infrastructure, Kestra is a leading choice. Other prominent tools include n8n for visual app automation, Airflow for data pipelines, Ansible for infrastructure, and Prefect for Python-centric workflows. The best tool depends on your specific technical requirements, team skillset, and desired level of declarative control."
+  - question: "Who are the competitors of SimplyAsk AI?"
+    answer: "SimplyAsk AI competes with a range of AI business efficiency platforms and consulting firms. Key alternatives include Capital Numbers, Trigma, TechWize, and Designli in the consulting space, and platforms like Kestra for universal AI orchestration, and n8n for visual AI automation. These alternatives offer diverse approaches to leveraging AI for business processes."
+  - question: "Which automation tool is in demand in 2026?"
+    answer: "In 2026, automation tools that offer declarative, event-driven, and language-agnostic orchestration are highly in demand, especially for unifying AI, data, and infrastructure workflows. Kestra, with its YAML-defined, polyglot execution engine, is designed to meet these modern demands for scalability, auditability, and cross-domain integration."
+  - question: "Which automation tool is best?"
+    answer: "There is no single 'best' automation tool, as the ideal choice depends on your organization's specific needs. For robust, engineering-led orchestration across diverse technical stacks including data, AI, and infrastructure, Kestra stands out. For visual, no-code business process automation, tools like n8n or specialized RPA platforms might be more suitable. Evaluate based on your team's expertise, required scalability, and integration needs."
+  - question: "Can Kestra replace SimplyAsk for AI business efficiency?"
+    answer: "Kestra can serve as a powerful alternative to SimplyAsk, particularly for engineering-led teams that require deep control over AI business efficiency workflows. While SimplyAsk focuses on a no-code platform with conversational AI, Kestra offers a declarative, YAML-defined approach to orchestrate complex AI agents, RAG pipelines, and data processes, integrating with existing systems for auditable and scalable automation."
+author: "elliot"
+image: "/images/blogs/simplyask-alternatives/cover.png"
+---
+
+SimplyAsk has carved a niche with its no-code AI business efficiency platform, helping teams streamline processes with conversational AI agents. Yet, as organizations scale their automation initiatives, the need often arises for solutions offering deeper technical control, broader integration across diverse tech stacks, or specialized expertise beyond simply business efficiency. Whether driven by architectural constraints, the desire for a more code-centric approach, or the need to orchestrate complex data and infrastructure alongside AI, exploring alternatives is a strategic step.
+
+This article dives into the top SimplyAsk alternatives and competitors in 2026, including Kestra, Capital Numbers, and n8n. We'll evaluate each option based on key criteria to help AI/ML platform engineers, data engineering managers, and business leaders identify the best fit for their unique automation challenges.
+
+## Why look for an alternative to SimplyAsk?
+
+While SimplyAsk provides an accessible entry point to AI-driven automation, scaling or technical teams often encounter needs that push beyond its core focus. The primary reasons users seek alternatives stem from a desire for more robust, flexible, and integrated solutions.
+
+- **Need for Declarative, Code-First Control:** SimplyAsk's no-code and conversational AI interface is excellent for business users but can be a limitation for engineering teams. These teams often require a declarative, code-first approach (like YAML or Python) for version control, automated testing, and GitOps workflows.
+- **Complex Integration Requirements:** As automation matures, it must connect with a wider array of systems. This includes deep integration with complex [data orchestration](/resources/data/data-orchestration) pipelines, infrastructure-as-code tools, and legacy enterprise applications that may not be supported out-of-the-box.
+- **Universal Orchestration Needs:** Many organizations are moving towards a single control plane for all automated processes. They need a platform that can handle not just business logic and [agentic AI](/resources/ai/agentic-ai), but also [infrastructure automation](/resources/infrastructure/automation) and high-throughput data processing in a unified, auditable way.
+- **Deeper Observability and Operational Control:** Technical teams require granular control over performance, error handling, retries, and observability. A business-focused platform may not provide the detailed logging, metrics, and operational dashboards needed to manage mission-critical workflows at scale.
+
+## How we evaluated these SimplyAsk alternatives
+
+To provide a clear comparison, we evaluated each alternative based on a set of criteria designed to highlight the different approaches to automation and AI integration. We assessed each solution on its automation scope, technical approach (from no-code to declarative), deployment flexibility, integration ecosystem, scalability, and specific AI capabilities. This framework helps clarify which tool is best suited for different team structures and technical requirements, as detailed in our guide on [choosing an orchestrator](/docs/why-kestra).
+
+## 1. Kestra: The Universal Orchestration Control Plane
+
+Kestra is the open-source orchestration platform that unifies data, AI, infrastructure, and business workflows under one declarative control plane. It provides a powerful, engineering-centric alternative to SimplyAsk for organizations that need to build scalable, auditable, and mission-critical automations.
+
+Where SimplyAsk offers a no-code interface for business efficiency, Kestra provides a declarative YAML approach. This allows engineering teams to treat workflows as code, enabling robust versioning, CI/CD, and collaboration through Git. With its language-agnostic engine, Kestra can run scripts in Python, Go, Node.js, or Shell, orchestrate SQL queries, and manage Docker containers, all within the same workflow. This makes it ideal for unifying disparate tools and teams.
+
+Kestra's architecture is event-driven by default and features over 1,400 plugins, native AI agents, and a built-in Copilot for generating YAML from natural language. Its scalability is proven, with over 2 billion workflows executed in 2025 across more than 30,000 organizations.
+
+- **Best for:** Engineering teams (Data, Platform, ML/AI) seeking a single, auditable, and scalable platform to orchestrate mission-critical [workflows](/docs/workflow-components/flow) across all domains, including [AI Automation](/ai-automation) and [agentic workflows](/docs/ai-tools/ai-agents).
+- **Limitation:** Kestra's power comes from its declarative, code-centric nature. It requires technical expertise in YAML and engineering best practices, making it less suitable for non-technical users who prefer a purely visual, drag-and-drop interface.
+
+## 2. Capital Numbers: Agile Consulting & Development
+
+Capital Numbers is a global IT consulting and software development firm. It represents a service-based alternative to SimplyAsk's product-led approach. Instead of providing a platform, Capital Numbers offers custom solutions, including bespoke AI/ML development and integration services.
+
+This is an excellent option for organizations that have a specific, complex AI challenge but lack the in-house development resources to solve it. Rather than adapting business processes to an existing platform, Capital Numbers builds the platform or integration to fit the process.
+
+- **Best for:** Businesses needing custom software development, AI/ML model building, or specialized consulting services for complex digital transformation projects and [AI initiatives](/resources/ai).
+- **Limitation:** As a consulting firm, it is not a self-service platform. The model relies on external expertise, project-based engagements, and associated costs, rather than an in-house tooling strategy.
+
+## 3. n8n: Visual Workflow Automation for Apps and AI
+
+n8n is an open-source visual workflow automation tool, often positioned as a self-hosted alternative to Zapier. It provides a strong alternative for teams who appreciate SimplyAsk's efficiency focus but require broader integration with web services and SaaS APIs.
+
+With its visual, node-based editor, n8n excels at connecting different applications and automating business processes in a low-code environment. It has a vast library of pre-built integrations and is increasingly adding AI capabilities, including AI agents. For teams that want to automate tasks between tools like Slack, Google Sheets, and their CRM, n8n is a flexible and powerful choice.
+
+- **Best for:** Ops teams, marketers, and developers looking for a flexible, visual tool to automate tasks across SaaS applications, integrate APIs, and prototype AI workflows.
+- **Limitation:** While excellent for API-driven and business process automation, n8n is less suited for high-throughput data pipelines or complex infrastructure orchestration compared to engineering-focused platforms. See a detailed [Kestra vs. n8n comparison](/vs/n8n) for more. You can also orchestrate n8n workflows with Kestra's dedicated [n8n plugin](/plugins/plugin-n8n).
+
+## 4. Trigma: Digital Transformation Partner
+
+Trigma is a digital transformation agency that offers a full suite of services, from web and mobile development to AI/ML solutions and cloud consulting. As an alternative to SimplyAsk, Trigma acts as an end-to-end partner for businesses looking to implement AI and automation strategies from the ground up.
+
+This approach is ideal for organizations that require not just a tool, but a holistic strategy for digital transformation. Trigma can help define the problem, design the solution, and build the custom software required, contrasting with SimplyAsk's product-centric offering.
+
+- **Best for:** Companies seeking a strategic partner for comprehensive digital transformation projects, including custom AI development, cloud migration, and enterprise application solutions across various [use cases](/use-cases).
+- **Limitation:** Trigma offers a service-based model. It is not a software product that can be adopted and managed internally, but rather a partnership for custom project delivery.
+
+## 5. TechWize: IT Consulting & Solutions Provider
+
+TechWize is an IT consulting firm specializing in cloud solutions, digital transformation, and enterprise application services. It serves as an alternative to SimplyAsk for organizations that need expert guidance and hands-on implementation of AI and automation within their existing enterprise systems.
+
+TechWize provides project-based advisory and implementation services, helping businesses integrate new technologies into complex, often legacy, IT landscapes. This is valuable for large enterprises that need to ensure new automation initiatives are compliant, secure, and well-integrated.
+
+- **Best for:** Enterprises requiring specialized IT consulting for cloud adoption, custom software projects, and integrating AI and automation into their existing stack, often choosing from the [best IT automation platforms](/resources/infrastructure/it-automation-platform).
+- **Limitation:** This is a project-based engagement model, not a direct software platform. Success depends on the consulting partnership rather than on the features of a self-managed tool.
+
+## 6. Metalogix Software (now Quest Software): Data Migration & Content Management
+
+Metalogix, now part of Quest Software, is known for its tools for data migration, content management, and information archiving, particularly within the Microsoft ecosystem (SharePoint, M365). While not a direct competitor in AI process automation, it can be considered an alternative in the broader context of improving business efficiency through better data governance.
+
+Where SimplyAsk automates processes, Metalogix organizes the underlying data and content. For businesses whose primary inefficiency stems from disorganized or inaccessible data, a tool like Metalogix can be a foundational step before process automation is even possible.
+
+- **Best for:** Organizations with large volumes of unstructured data and content, especially within Microsoft ecosystems, that need robust tools for migration, archiving, and management as part of their [data pipeline strategy](/resources/data/data-pipeline).
+- **Limitation:** It is not an AI-centric or workflow automation platform. Its focus is on data and content infrastructure, not the orchestration of business logic or processes.
+
+## Comparison Table: SimplyAsk Alternatives at a Glance
+
+| Tool | License | Deployment | Primary User | AI Focus | Automation Scope |
+|---|---|---|---|---|---|
+| Kestra | Apache 2.0 OSS / EE | Cloud, Hybrid, On-prem | Engineers (Data, Platform, ML/AI) | High (Native Agents, Copilot) | Universal (Data, AI, Infra, Business) |
+| Capital Numbers | Service-based | N/A (Consulting) | Businesses needing custom dev | High (Custom AI/ML) | Custom Software, AI/ML |
+| n8n | OSS / Cloud | Cloud, Self-hosted | Ops, Automation Builders, Devs | Medium (Integrations, Agents) | App Automation, SaaS Integration |
+| Trigma | Service-based | N/A (Consulting) | Businesses seeking digital transformation | High (Custom AI/ML) | Digital Transformation, AI/ML |
+| TechWize | Service-based | N/A (Consulting) | Enterprises needing IT consulting | Medium (Integration of AI) | Cloud, Digital Transformation |
+| Metalogix (Quest) | Proprietary | On-prem, Cloud | IT Admins, Data Managers | Low | Data Migration, Content Management |
+
+## How to choose the right SimplyAsk alternative
+
+Selecting the right alternative depends entirely on your team's goals, skills, and the nature of the problems you're solving.
+
+- **For AI/ML platform teams:** Prioritize platforms with robust AI agent capabilities, deep integration with ML pipelines, and version control for AI-generated workflows. A platform like Kestra offers declarative control over [AI agents and RAG pipelines](/ai-automation).
+- **For data engineering teams:** Look for tools that seamlessly integrate with existing data stacks, offer scalable [data pipeline orchestration](/data), and provide strong observability. Kestra excels at unifying data workflows across various databases and tools.
+- **For infrastructure/DevOps teams:** Consider platforms that support Infrastructure as Code (IaC) principles, GitOps, and can orchestrate operations across cloud and on-prem environments. Kestra provides a unified control plane for [infrastructure automation](/infra-automation).
+- **For business/ops teams:** If a visual, no-code approach for app-to-app automation is paramount, tools like n8n can be highly effective. For bespoke solutions requiring external expertise, consulting firms like Capital Numbers or Trigma are suitable.
+- **For small teams getting started:** Prioritize ease of use, community support, and transparent pricing. Kestra's powerful open-source core provides a free, scalable starting point for any automation project.
+
+Ultimately, the choice is between a productized, no-code platform, a custom-built solution from a consulting partner, or a universal orchestration platform that provides deep control. For a broader look at how different tools stack up, explore our [Kestra vs. Alternatives](/vs) comparisons.

--- a/src/contents/resources/snowflake-tasks-alternatives/index.md
+++ b/src/contents/resources/snowflake-tasks-alternatives/index.md
@@ -1,0 +1,217 @@
+---
+title: "Snowflake Tasks Alternatives & Competitors"
+description: "Explore the top Snowflake Tasks alternatives and learn how they compare. Discover the best solution for your data workflows today!"
+metaTitle: "Snowflake Tasks Alternatives: Kestra, Airflow & More"
+metaDescription: "Looking for Snowflake Tasks alternatives? Compare Kestra, Airflow, Databricks Workflows, and more for robust, cross-platform data pipeline orchestration. Find your ideal solution."
+tag: "data"
+date: 2026-05-28
+slug: "snowflake-tasks-alternatives"
+faq:
+  - question: "Is Snowflake Tasks being discontinued?"
+    answer: "No, Snowflake Tasks are an actively maintained feature of the Snowflake platform. However, they are designed for orchestrating workloads *within* Snowflake. For complex, cross-platform, or polyglot workflows, external orchestrators often provide more flexibility and advanced capabilities, leading many users to seek alternatives for broader use cases."
+  - question: "What is the best free alternative to Snowflake Tasks?"
+    answer: "For teams seeking a free alternative, Kestra's open-source edition offers a powerful, declarative, and polyglot orchestration engine that can manage Snowflake workloads alongside other systems. Apache Airflow is another popular open-source choice, particularly for Python-centric data pipelines, though it often comes with higher operational overhead."
+  - question: "Can Kestra replace Snowflake Tasks?"
+    answer: "Yes, Kestra can fully replace and extend the capabilities of Snowflake Tasks. While Snowflake Tasks are limited to SQL-based logic within Snowflake, Kestra orchestrates jobs across any system, language, or cloud. This allows for unified control of data ingestion, transformations (including Snowflake), machine learning pipelines, and infrastructure automation from a single platform."
+  - question: "How does Kestra compare to Airflow for Snowflake orchestration?"
+    answer: "Both Kestra and Airflow can orchestrate Snowflake workloads. Kestra offers declarative YAML-based workflows and native support for multiple languages and event-driven patterns, making it highly flexible for diverse tech stacks. Airflow, primarily Python-based, excels in Python-heavy data environments with its vast operator ecosystem. Kestra generally offers lower operational complexity for multi-cloud or hybrid environments."
+  - question: "When should I use Snowflake Tasks versus an external orchestrator?"
+    answer: "Use Snowflake Tasks when your orchestration needs are entirely contained within Snowflake and involve only SQL-based logic. Opt for an external orchestrator like Kestra, Airflow, or Prefect when you need to coordinate workflows across multiple systems (e.g., data lakes, cloud services, APIs), use different programming languages, or require advanced features like dynamic task generation, complex event handling, or human-in-the-loop approvals."
+  - question: "What are the limitations of Snowflake Tasks?"
+    answer: "Snowflake Tasks are primarily SQL-centric and confined to the Snowflake ecosystem, limiting their ability to orchestrate external systems, execute non-SQL code (like Python or R), or handle complex event-driven logic. They also incur Snowflake compute costs for orchestration, which can be inefficient for simple scheduling compared to dedicated orchestrators."
+  - question: "How do managed Airflow services compare to Snowflake Tasks?"
+    answer: "Managed Airflow services like Google Cloud Composer or Astronomer provide a more robust and scalable orchestration layer than native Snowflake Tasks, offering a full Python ecosystem and enterprise-grade features. However, they remain Python-centric and may still incur significant operational overhead, unlike truly serverless or declarative alternatives that simplify cross-platform orchestration."
+author: "elliot"
+image: "/images/resources/snowflake-tasks-alternatives/cover.png"
+---
+
+Snowflake has become a cornerstone for modern data warehousing, offering impressive scalability and performance for analytical workloads. A key feature for automating processes within this ecosystem is Snowflake Tasks, enabling users to schedule and execute SQL statements or stored procedures directly within the data platform. However, as data architectures evolve and become increasingly complex, many organizations find themselves pushing the boundaries of what native Snowflake Tasks can effectively orchestrate. From managing dependencies across diverse systems to integrating polyglot code and intricate event-driven logic, the need for a more comprehensive orchestration solution often arises.
+
+This article explores the landscape of Snowflake Tasks alternatives, moving beyond the platform’s native capabilities to provide a unified control plane for your entire data stack. We'll delve into dedicated workflow orchestrators that offer greater flexibility, advanced features, and a broader scope, ensuring your data pipelines are not just efficient within Snowflake, but seamlessly integrated across your entire enterprise. The leading alternatives to Snowflake Tasks in 2026 include Kestra, Apache Airflow, Databricks Workflows, Google Cloud Composer, AWS Step Functions, and Prefect — each suited to different workloads such as cross-platform data pipelines, polyglot environments, and complex event-driven workflows. We'll evaluate each option based on critical criteria, helping you make an informed decision to streamline your data operations.
+
+## Understanding Snowflake Tasks: Benefits and Limitations
+
+### What are Snowflake Tasks?
+Snowflake Tasks are a feature within the Snowflake data cloud that allows users to execute a single SQL statement or call a stored procedure on a scheduled basis. They are part of a directed acyclic graph (DAG) of tasks, enabling the creation of chained operations where one task's completion triggers another. This native functionality simplifies basic automation for data loading, transformations, and data quality checks directly within the Snowflake environment.
+
+### When to use Snowflake Tasks?
+Snowflake Tasks are ideal for simple, SQL-centric workflows that are entirely contained within the Snowflake ecosystem. This includes:
+- Scheduling periodic data loading from internal stages.
+- Running simple data transformation queries (e.g., `MERGE`, `UPDATE`).
+- Orchestrating stored procedures that perform data quality checks or administrative tasks.
+- Building straightforward dependency chains where all steps are SQL-based.
+
+### Common challenges with Snowflake Tasks
+While convenient, Snowflake Tasks come with several limitations that often prompt users to seek alternatives:
+- **SQL-centricity:** They are limited to SQL or stored procedures, making it difficult to integrate Python, R, Java, or other programming languages.
+- **Limited cross-platform orchestration:** Tasks cannot natively orchestrate workloads outside Snowflake, requiring external tools for end-to-end pipeline management that span data lakes, external APIs, or other cloud services.
+- **Lack of advanced control flow:** While they support basic DAGs, complex branching, dynamic task generation, or advanced error handling can be challenging to implement.
+- **Cost implications:** Task executions consume Snowflake compute credits, which can be inefficient for pure orchestration logic compared to dedicated orchestrators.
+- **Vendor lock-in:** Relying solely on Snowflake Tasks increases dependence on the Snowflake ecosystem, potentially hindering flexibility for multi-cloud strategies.
+- **Observability beyond Snowflake:** Monitoring and logging are confined to Snowflake's interface, lacking a unified view across a broader data stack.
+
+## Why look for an alternative to Snowflake Tasks?
+The decision to seek an alternative to Snowflake Tasks usually stems from a need to overcome their inherent limitations and achieve more robust, flexible, and cost-effective orchestration.
+- **Beyond SQL:** Modern data pipelines frequently require polyglot capabilities, integrating Python for machine learning, R for statistical analysis, or custom scripts for specialized tasks. Snowflake Tasks cannot natively execute these.
+- **Cross-system coordination:** Data pipelines rarely live in a single platform. Orchestrating ingestion from cloud storage, transformations in dbt, model training in Databricks, and [reverse ETL](/resources/data/reverse-etl) to SaaS applications demands a tool that can span multiple technologies.
+- **Operational efficiency & cost:** While convenient, the compute costs associated with running orchestration logic directly within Snowflake can add up. Dedicated orchestrators often offer more cost-efficient execution models, especially for complex or frequent workflows.
+- **Developer experience & governance:** External orchestrators often provide richer developer tooling, GitOps integration, and more advanced governance features like RBAC, audit logs, and version control for workflows as code.
+- **Event-driven architectures:** The shift towards real-time data processing and event-driven patterns is poorly supported by the scheduled nature of Snowflake Tasks. External orchestrators excel at reacting to events from various sources.
+
+## How we evaluated these alternatives
+We evaluated each alternative based on its ability to address the limitations of Snowflake Tasks and provide superior workflow orchestration capabilities. Key criteria included:
+- **Deployment Model & License:** Open-source vs. proprietary, cloud-managed vs. self-hosted.
+- **Primary Use Case Fit:** How well it handles data, AI, infrastructure, and cross-domain workflows.
+- **Language Support:** SQL, Python, R, Java, Bash, Docker, etc.
+- **Cross-Platform Capability:** Ability to orchestrate tasks across Snowflake, other data warehouses, cloud services, APIs, and on-prem systems.
+- **Advanced Orchestration Features:** Support for dynamic DAGs, complex error handling, retries, conditional logic, and event-driven triggers.
+- **Cost Implications:** Transparency and efficiency of the pricing model.
+- **Developer Experience:** Ease of use, tooling, GitOps integration.
+- **Community Health & Ecosystem:** Plugin ecosystem, active development, support.
+
+## Top Alternatives to Snowflake Tasks for Workflow Orchestration
+
+### 1. Kestra: The Universal Orchestration Control Plane
+[Kestra](/) is an open-source, [declarative orchestration platform](/features/declarative-data-orchestration) designed to unify data, AI, infrastructure, and business workflows under a single control plane. Workflows are defined in YAML, enabling GitOps practices and making them easily reviewable and version-controlled. Kestra's JVM-based engine is language-agnostic, allowing it to execute tasks written in Python, R, Julia, SQL, Bash, or within Docker containers, making it a powerful solution for heterogeneous environments.
+
+**Key Differentiators:**
+- **Declarative YAML:** Workflows are code, enabling GitOps, easy versioning, and collaboration.
+- **Polyglot Execution:** First-class support for any language or Docker container, breaking free from SQL-only limitations.
+- **Event-Driven by Default:** Native support for real-time triggers from various sources (Kafka, S3, webhooks) alongside scheduled jobs.
+- **Cross-Platform & Hybrid:** Orchestrates across clouds, on-prem, and air-gapped environments, seamlessly integrating with [Snowflake](/orchestration/snowflake) and other tools.
+- **Unified Control Plane:** Coordinates [data pipelines](/resources/data/data-pipeline), ML workflows, infrastructure automation (Terraform, Ansible), and human approvals from one platform.
+- **AI-Native:** Includes [Copilot for YAML generation and AI agents](/blogs/release-1-0) for autonomous orchestration with full auditability.
+
+**Best for:** Organizations seeking a unified, language-agnostic orchestration control plane across data, AI, and infrastructure, especially those with heterogeneous tech stacks, a need for fine-grained control, auditability, and modern GitOps practices. Kestra is ideal for breaking free from vendor lock-in and building future-proof automation.
+
+### 2. Apache Airflow: The Python-Centric Data Orchestrator
+Apache Airflow is a widely adopted open-source platform for programmatically authoring, scheduling, and monitoring workflows. It defines workflows as Directed Acyclic Graphs (DAGs) using Python code, leveraging a vast ecosystem of operators for various data sources and services. Airflow is a mature and battle-tested choice, particularly within Python-heavy data engineering teams.
+
+**Key Differentiators:**
+- **Python-Native:** Workflows are defined in Python, offering flexibility for data engineers comfortable with the language.
+- **Extensive Ecosystem:** A massive collection of operators and providers for integrating with a wide range of data tools and cloud services.
+- **Mature & Battle-Tested:** Proven at scale in numerous organizations, with a large and active community.
+
+**Limitations:**
+- **Python-only:** Can be cumbersome for non-Python tasks, often requiring Python wrappers for shell scripts or other languages.
+- **Operational Overhead:** Self-hosting Airflow can be complex, requiring significant effort to manage schedulers, workers, and metadata databases.
+- **DAG-as-Code Complexity:** Python DAGs can be harder to review, version, and roll back than declarative configurations.
+
+**Best for:** Python-centric data engineering teams with existing investment in the Airflow ecosystem, needing robust batch orchestration and leveraging its extensive operator catalog. Check out a detailed [comparison between Kestra and Airflow](/vs/airflow).
+
+### 3. Databricks Workflows: Lakehouse-Native Orchestration
+Databricks Workflows provides native job orchestration directly within the Databricks Lakehouse Platform. It's designed to schedule, manage, and monitor data, AI, and ETL jobs that run on Databricks clusters. This makes it a natural fit for organizations deeply committed to the Databricks ecosystem and its unified approach to data and machine learning.
+
+**Key Differentiators:**
+- **Lakehouse-Native:** Deep integration with Databricks, Unity Catalog, and other Lakehouse features.
+- **Unified Platform:** Orchestrates ETL, analytics, and ML workflows within a single Databricks environment.
+- **Simplified Experience:** Streamlined for existing Databricks users, reducing tool sprawl within the platform.
+
+**Limitations:**
+- **Platform-Bound:** Limited in orchestrating workloads that span significantly outside the Databricks platform.
+- **Vendor Lock-in:** Tightly coupled to Databricks' pricing and operational model.
+- **Less Universal:** Not designed as a universal orchestrator for heterogeneous stacks that include non-Databricks components.
+
+**Best for:** Teams heavily invested in the Databricks Lakehouse for data and AI, seeking native orchestration within that platform to minimize external tooling. See how [Kestra and Databricks work together](/blogs/2024-03-07-databricks-partnership).
+
+### 4. Google Cloud Composer: Managed Airflow for GCP
+Google Cloud Composer is a fully managed workflow orchestration service built on Apache Airflow, running on Google Cloud Platform. It provides a cloud-native environment for authoring, scheduling, and monitoring data pipelines using Airflow's familiar Python DAGs and operators. As a managed service, it significantly reduces the operational burden of self-hosting Airflow.
+
+**Key Differentiators:**
+- **Managed Airflow:** Google handles the underlying infrastructure, upgrades, and scaling of Airflow.
+- **GCP Integration:** Seamless integration with Google Cloud services like BigQuery, Dataflow, and Cloud Storage.
+- **Python Ecosystem:** Benefits from Airflow's vast Python operator ecosystem.
+
+**Limitations:**
+- **GCP-Centric:** Primarily optimized for Google Cloud, making cross-cloud or hybrid orchestration more complex.
+- **Python-only:** Inherits Airflow's limitations regarding polyglot task execution.
+- **Cost:** Can be more expensive than self-hosted Airflow or other alternatives, with costs tied to GCP resources.
+
+**Best for:** GCP-committed data teams already using Airflow who want a fully managed service to reduce operational overhead. Compare [Kestra vs. Google Cloud Composer](/vs/cloud-composer).
+
+### 5. AWS Step Functions: Serverless Workflows in AWS
+AWS Step Functions is a serverless workflow service that allows developers to define complex workflows as state machines using JSON. It orchestrates distributed applications and microservices, making it easy to build workflows that integrate with various AWS services. Step Functions manages state, retries, and error handling automatically, abstracting away much of the underlying complexity.
+
+**Key Differentiators:**
+- **Serverless & Managed:** No servers to provision or manage, with automatic scaling and high availability.
+- **AWS-Native:** Deep integration with over 200 AWS services.
+- **Visual Workflow Design:** Workflows can be designed and visualized using a graphical console.
+
+**Limitations:**
+- **AWS Lock-in:** Exclusively operates within the AWS ecosystem, making multi-cloud or hybrid orchestration challenging.
+- **JSON-Based:** While powerful, defining complex logic in JSON can be less intuitive for some users compared to code or declarative YAML.
+- **Cost for Long-Running Workflows:** Pricing is based on state transitions, which can become costly for very long-running or highly granular workflows.
+
+**Best for:** Serverless architectures and workflows that are entirely contained within the AWS ecosystem, coordinating various [AWS services](/orchestration/aws) and microservices.
+
+### 6. Prefect: Pythonic Workflow Automation for Data & AI
+Prefect is an open-source workflow management system that focuses on developer experience and building robust data pipelines. It emphasizes Python-native workflows, allowing engineers to define flows using familiar Python syntax and decorators. Prefect offers a flexible hybrid execution model, combining a managed cloud control plane with customer-managed workers.
+
+**Key Differentiators:**
+- **Pythonic Design:** Excellent Python developer experience with native async support and decorators for defining workflows.
+- **Dynamic Workflows:** Strong capabilities for building dynamic flows where parameters and data drive runtime structure.
+- **Hybrid Execution:** Combines the benefits of a managed cloud service (Prefect Cloud) with the flexibility of self-managed agents.
+
+**Limitations:**
+- **Python-Only:** Similar to Airflow, it is primarily focused on Python, which can be a limitation for polyglot teams.
+- **Cloud-First Model:** While open-source, the most robust features often lean towards its managed cloud offering.
+- **Newer Ecosystem:** While growing rapidly, its plugin ecosystem is smaller than more established platforms like Airflow or Kestra.
+
+**Best for:** Python-only data and ML teams that prioritize developer experience, dynamic flows, and a modern alternative to Airflow without leaving the [Python ecosystem](/use-cases/python-workflows).
+
+## Broader Snowflake Competitors and their Offerings
+While the above tools offer direct alternatives for *orchestrating* tasks that Snowflake Tasks handle, a broader view might involve considering alternative data platforms that also offer their own task management or orchestration capabilities. These platforms often compete with Snowflake itself, providing different approaches to data warehousing, analytics, and integrated workflow management.
+
+### Microsoft Fabric OneLake
+Microsoft Fabric is an end-to-end analytics platform that unifies data, analytics, and AI. OneLake, a core component, offers a single, logical data lake for all Fabric workloads. While it has its own orchestration capabilities within Data Factory (part of Fabric), it's primarily a platform alternative to Snowflake, designed for a Microsoft-centric ecosystem.
+
+### ClickHouse: A Different Perspective on Data Warehousing
+ClickHouse is an open-source, column-oriented database management system for online analytical processing (OLAP). It's renowned for its high performance and scalability for analytical queries. While ClickHouse doesn't have a native "Tasks" feature like Snowflake, external orchestrators can easily integrate to manage data loading and transformations. It represents an architectural alternative for specific analytical workloads.
+
+### Google BigQuery: Serverless Data Warehousing and Tasks
+Google BigQuery is a fully managed, serverless data warehouse that enables scalable analysis over petabytes of data. BigQuery offers its own scheduling capabilities (scheduled queries) which are analogous to Snowflake Tasks, allowing for SQL-based automation within its ecosystem. It's a direct competitor to Snowflake for data warehousing, with integrated orchestration.
+
+### Amazon Redshift: Scalable Data Warehousing and Alternatives
+Amazon Redshift is a fully managed, petabyte-scale cloud data warehouse service. Redshift also provides capabilities for scheduling SQL queries and stored procedures, offering a similar native automation experience to Snowflake Tasks within the AWS ecosystem. It's a long-standing competitor to Snowflake, particularly for AWS-native organizations.
+
+## Comparison Table
+
+| Tool | License | Deployment | Best for | Language Support | Cross-Platform Capability |
+|---|---|---|---|---|---|
+| **Kestra** | Apache 2.0 | Hybrid (Cloud, On-prem, K8s) | Universal Orchestration (Data, AI, Infra) | Any Language, Docker | High |
+| **Snowflake Tasks** | Proprietary | Snowflake Cloud | Snowflake-native SQL orchestration | SQL only | None |
+| **Apache Airflow** | Apache 2.0 | Self-hosted, Managed | Python-centric data pipelines | Python | Medium |
+| **Databricks Workflows** | Proprietary | Databricks Cloud | Lakehouse-native data & AI jobs | Python, SQL, R, Scala | Low |
+| **Google Cloud Composer**| Proprietary | GCP Managed | Managed Airflow on GCP | Python | Low (GCP-centric) |
+| **AWS Step Functions** | Proprietary | AWS Serverless | AWS-native serverless workflows | Any (via Lambda) | Low (AWS-centric) |
+| **Prefect** | Apache 2.0 | Hybrid (Cloud, Self-hosted) | Python-native dynamic workflows | Python | Medium |
+
+## How to Choose the Right Snowflake Tasks Alternative
+
+Selecting the right alternative depends on your team's skills, your existing tech stack, and your future architectural goals.
+
+### For Data Engineering Teams
+If your primary need is to build robust, multi-step [ETL/ELT pipelines](/resources/data/etl-vs-elt) that span multiple systems, a dedicated orchestrator is essential.
+- **Kestra** is ideal for teams with diverse language needs (SQL, Python, etc.) who value declarative configuration, GitOps, and a single platform for all data workflows. Explore how Kestra can improve your [data engineering](/data).
+- **Apache Airflow** (or managed versions like Cloud Composer) is a strong choice for Python-heavy teams that can manage its operational complexity.
+
+### For Infrastructure & Platform Teams
+If your goal is to provide a standardized, self-service automation platform for the entire organization, a universal orchestrator is the best fit.
+- **Kestra** excels here by providing a single control plane to orchestrate infrastructure (Terraform, Ansible), data jobs, and business processes, reducing tool sprawl and enforcing governance. See how Kestra enables [infrastructure automation](/infra-automation).
+
+### For AI & ML Teams
+When orchestrating complex machine learning pipelines that involve data preprocessing, model training, and deployment, you need a tool that can handle diverse computational requirements.
+- **Kestra** can coordinate the entire ML lifecycle, from data ingestion to model serving, integrating with tools across any cloud.
+- **Databricks Workflows** is a good fit if your entire ML process is contained within the Databricks ecosystem. Learn more about [AI automation with Kestra](/ai-automation).
+
+### For Teams Staying within a Single Cloud
+If your architecture is heavily invested in a single cloud provider and you don't anticipate multi-cloud needs, the native solutions can be effective.
+- **AWS Step Functions** is powerful for orchestrating AWS services.
+- **Google Cloud Composer** offers a managed Airflow experience for GCP users.
+
+## Conclusion
+While Snowflake Tasks offer a convenient entry point for automation within the Snowflake ecosystem, their limitations quickly become apparent in modern, heterogeneous data environments. The shift from in-database schedulers to universal orchestration platforms is a response to the need for greater flexibility, polyglot support, and cross-platform control.
+
+Tools like Kestra, Airflow, and Prefect provide the power to build, manage, and monitor complex workflows that span your entire tech stack, treating Snowflake as a critical component rather than a siloed island. By adopting a dedicated orchestrator, you gain a future-proof control plane that can evolve with your data architecture, ensuring scalability, governance, and operational efficiency.
+
+Ready to see how a universal orchestrator can streamline your Snowflake workflows and beyond? [Get started with Kestra's open-source edition](/docs/quickstart) today or [explore our blueprints](/blueprints) for inspiration.

--- a/src/contents/resources/snowflake-tasks-alternatives/index.md
+++ b/src/contents/resources/snowflake-tasks-alternatives/index.md
@@ -22,7 +22,6 @@ faq:
   - question: "How do managed Airflow services compare to Snowflake Tasks?"
     answer: "Managed Airflow services like Google Cloud Composer or Astronomer provide a more robust and scalable orchestration layer than native Snowflake Tasks, offering a full Python ecosystem and enterprise-grade features. However, they remain Python-centric and may still incur significant operational overhead, unlike truly serverless or declarative alternatives that simplify cross-platform orchestration."
 author: "elliot"
-image: "/images/resources/snowflake-tasks-alternatives/cover.png"
 ---
 
 Snowflake has become a cornerstone for modern data warehousing, offering impressive scalability and performance for analytical workloads. A key feature for automating processes within this ecosystem is Snowflake Tasks, enabling users to schedule and execute SQL statements or stored procedures directly within the data platform. However, as data architectures evolve and become increasingly complex, many organizations find themselves pushing the boundaries of what native Snowflake Tasks can effectively orchestrate. From managing dependencies across diverse systems to integrating polyglot code and intricate event-driven logic, the need for a more comprehensive orchestration solution often arises.


### PR DESCRIPTION
## Summary
- 12 new pages under `src/contents/resources/` migrated from open PRs in [vfanucci/kestra-seo](https://github.com/vfanucci/kestra-seo/pulls)
- Duplicates skipped — pages that already exist (`morpheus-`, `stonebranch-`, `rundeck-`, `ibm-workload-automation-`, `hp-orchestration-`, `chef-`, `broadcom-dollar-universe-`, `pagerduty-alternatives`) were not re-imported
- Tags normalized to the content collection enum (`infrastructure`/`data`/`ai`/`whitepapers`); slugs aligned with folder names

## Pages added
| Slug | Tag | Source PR |
|---|---|---|
| `amazon-mwaa-alternatives` | data | [kestra-seo#92](https://github.com/vfanucci/kestra-seo/pull/92) |
| `cloud-composer-alternatives` | data | [kestra-seo#93](https://github.com/vfanucci/kestra-seo/pull/93) |
| `dagster-alternatives` | data | [kestra-seo#94](https://github.com/vfanucci/kestra-seo/pull/94) |
| `databricks-workflows-alternatives` | data | [kestra-seo#95](https://github.com/vfanucci/kestra-seo/pull/95) |
| `google-workflows-alternatives` | infrastructure | [kestra-seo#96](https://github.com/vfanucci/kestra-seo/pull/96) |
| `make-alternatives` | infrastructure | [kestra-seo#97](https://github.com/vfanucci/kestra-seo/pull/97) |
| `microsoft-fabric-alternatives` | data | [kestra-seo#98](https://github.com/vfanucci/kestra-seo/pull/98) |
| `n8n-alternatives` | infrastructure | [kestra-seo#99](https://github.com/vfanucci/kestra-seo/pull/99) |
| `pipedream-alternatives` | infrastructure | [kestra-seo#100](https://github.com/vfanucci/kestra-seo/pull/100) |
| `prefect-alternatives` | data | [kestra-seo#101](https://github.com/vfanucci/kestra-seo/pull/101) |
| `simplyask-alternatives` | ai | [kestra-seo#102](https://github.com/vfanucci/kestra-seo/pull/102) |
| `snowflake-tasks-alternatives` | data | [kestra-seo#103](https://github.com/vfanucci/kestra-seo/pull/103) |

## Test plan
- [ ] Astro build passes (content collection schema validation)
- [ ] Each page renders at `/resources/<slug>`
- [ ] FAQ accordion renders for each page
- [ ] Cover images at `/images/resources/<slug>/cover.png` (auto-generated separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)