### PR TITLE
fix(github): fix GitHub star count showing 0 due to API rate limiting

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -197,6 +197,11 @@ export default defineConfig({
                 optional: true,
                 default: false,
             }),
+            GITHUB_TOKEN: envField.string({
+                context: "server",
+                access: "secret",
+                optional: true,
+            }),
             NO_RANDOM_ORDER: envField.boolean({
                 context: "client",
                 access: "public",

--- a/src/pages/api/github.ts
+++ b/src/pages/api/github.ts
@@ -1,5 +1,5 @@
 import { $fetchCached, $fetchCachedRaw } from "~/utils/fetch"
-import { DISABLE_GITHUB } from "astro:env/server"
+import { DISABLE_GITHUB, GITHUB_TOKEN } from "astro:env/server"
 
 const defaultValues = {
     stargazers: 0,
@@ -16,11 +16,15 @@ export async function getValues() {
     if (DISABLE_GITHUB) {
         return defaultValues
     }
+    const authHeaders: Record<string, string> = GITHUB_TOKEN
+        ? { "User-Agent": "request", Authorization: `Bearer ${GITHUB_TOKEN}` }
+        : { "User-Agent": "request" }
+
     let contribCountRes: any
     try {
         contribCountRes = await $fetchCachedRaw(
             "https://api.github.com/repos/kestra-io/kestra/contributors?anon=true&per_page=1",
-            { headers: { "User-Agent": "request" } },
+            { headers: authHeaders },
         )
     } catch (error) {
         console.error("Error fetching contributors count:", error)
@@ -28,15 +32,12 @@ export async function getValues() {
     }
 
     if (!contribCountRes.ok) {
-        if (contribCountRes.status === 404) {
-            return defaultValues
-        }
-        // Handle other errors
         console.error(
             "Error fetching contributors count:",
             contribCountRes.status,
             contribCountRes.statusText,
         )
+        return defaultValues
     }
 
     const contribStr =
@@ -53,7 +54,7 @@ export async function getValues() {
     }
 
     return await $fetchCached("https://api.github.com/repos/kestra-io/kestra", {
-        headers: { "User-Agent": "request" },
+        headers: authHeaders,
     }).then((value) => {
         return {
             stargazers: value.stargazers_count,


### PR DESCRIPTION
## Summary

- GitHub API calls were unauthenticated, capped at 60 req/hr per server IP — easily exhausted in production
- On non-404 errors the handler logged but continued, potentially serving stale/zero data
- Added optional `GITHUB_TOKEN` support via Astro's `env` schema to authenticate requests (raises limit to 5000/hr)
- Fixed the error fallthrough: non-404 errors now return `defaultValues` immediately

## Deployment step required

Add `GITHUB_TOKEN` as a secret env var in **Cloudflare Pages** → `kestra-io` project → Settings → Environment variables.
Use the value of the existing `GH_READ_ORG_TOKEN` org secret.

## Test plan

- [ ] Add `GITHUB_TOKEN` to Cloudflare Pages env vars
- [ ] Redeploy and confirm star count renders correctly on kestra.io homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)