### PR TITLE
chore(deps): ignore develop pre-release bumps of @kestra-io/kestra-sdk in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -100,3 +100,8 @@ updates:
             "prettier",
             "prettier-*",
           ]
+
+    ignore:
+      # Ignore develop pre-release versions of kestra-sdk (managed internally, not via Dependabot)
+      - dependency-name: "@kestra-io/kestra-sdk"
+        versions: ["*-develop*"]


### PR DESCRIPTION
## Summary

- Adds an ignore rule for `@kestra-io/kestra-sdk` versions matching `*-develop*` so Dependabot stops opening PRs for internal develop pre-releases (e.g. `2.0.0-develop.17797027.1f59eb1f.3afa0199`)