### PR TITLE
chore(deps): remove invalid kestra-sdk dependabot ignore rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -101,7 +101,3 @@ updates:
             "prettier-*",
           ]
 
-    ignore:
-      # Ignore develop pre-release versions of kestra-sdk (managed internally, not via Dependabot)
-      - dependency-name: "@kestra-io/kestra-sdk"
-        versions: ["*-develop*"]


### PR DESCRIPTION
The `*-develop*` glob is not valid npm semver — GitHub flagged it as an invalid version requirement. Removing the rule entirely.