### PR TITLE
docs(resources): add MCP orchestration page

### DIFF
--- a/src/contents/resources/mcp-orchestration/index.md
+++ b/src/contents/resources/mcp-orchestration/index.md
@@ -1,0 +1,137 @@
+---
+title: "MCP orchestration: The future of AI integration"
+description: "The rise of AI agents and large language models (LLMs) demands a new approach to how software components communicate. This guide explores Model Context Protocol (MCP) orchestration, detailing its role in unifying diverse AI tools and enabling sophisticated, multi-agent workflows. Understand how MCP standardizes communication, enhances flexibility, and future-proofs your AI infrastructure."
+metaTitle: "MCP Orchestration: Unifying AI Agents & Tools"
+metaDescription: "Discover MCP orchestration's role in unifying AI agents and tools. Master agentic AI with our comprehensive guide. Start orchestrating today!"
+tag: "ai"
+date: 2026-05-27
+slug: "mcp-orchestration"
+faq:
+  - question: "Is MCP an orchestration framework?"
+    answer: "No, MCP is not an orchestration engine itself. It's a protocol layer designed to standardize communication between AI agents and the tools they use. Think of it as an interoperability backbone that allows diverse AI components to interact in a consistent, discoverable way, often *within* a broader orchestration framework like Kestra."
+  - question: "What does MCP stand for?"
+    answer: "MCP stands for Model Context Protocol. It's a specification designed to standardize how AI models (especially large language models) discover, understand, and interact with external tools and services. This protocol enables AI agents to utilize various functions, APIs, and data sources effectively within complex workflows."
+  - question: "What is the difference between orchestrator and MCP?"
+    answer: "An orchestrator, like Kestra, defines and manages the overall workflow logic, including task sequencing, branching, error handling, and resource allocation. MCP, on the other hand, is a protocol for tool communication. An orchestrator *uses* MCP to enable AI agents to interact with tools, while the orchestrator itself handles the high-level coordination and execution flow."
+  - question: "Is MCP like gRPC?"
+    answer: "While both gRPC and MCP facilitate communication between services, their design philosophies differ significantly. gRPC is a general-purpose, high-performance framework for microservices, requiring explicit interface definitions. MCP is AI-native, built for LLMs to dynamically discover and understand tools using natural language, often without requiring explicit adapters."
+  - question: "Is MCP just a JSON?"
+    answer: "No, MCP is not just JSON. While MCP messages and tool descriptions often leverage JSON for data serialization, MCP is a *protocol* that defines the structure and semantics for tool discovery, invocation, and response. JSON is a data format that MCP uses, but the protocol encompasses much more, including the mechanisms for agents to interact with tools."
+---
+
+The landscape of artificial intelligence is rapidly evolving, with AI agents and Large Language Models (LLMs) taking center stage. Yet, the true potential of these advanced systems is often hindered by fragmented communication and a lack of standardized interoperability between diverse tools. This is where Model Context Protocol (MCP) orchestration emerges as a critical enabler. MCP provides a unified language for AI agents to discover, understand, and interact with external capabilities, transforming disparate tools into a cohesive ecosystem. This guide delves into MCP orchestration, exploring its foundational principles, its unique advantages over traditional methods, and its pivotal role in building scalable, enterprise-grade AI applications. We'll also examine how Kestra, as a declarative orchestration platform, leverages MCP to unify and govern these sophisticated AI workflows.
+
+## What is MCP orchestration?
+
+Model Context Protocol (MCP) orchestration refers to the use of MCP to enable and manage the interactions between AI agents and a wide array of external tools and services. It solves a fundamental problem in the AI ecosystem: the lack of a common language for different systems to communicate. Without a standard like MCP, integrating a new tool with an AI agent requires custom glue code, making the system brittle and difficult to scale. MCP provides a standardized contract, an "API for AI," that allows any compliant tool to be discoverable and usable by any MCP-aware agent.
+
+### What does MCP stand for?
+
+MCP stands for **Model Context Protocol**. The name highlights its core function: providing AI models with the necessary *context* to interact with the outside world. This context includes information about what a tool does, what inputs it requires, and what outputs it produces, all in a format that a language model can understand and act upon.
+
+### How MCP standardizes communication for AI tools
+
+MCP standardizes communication through a clear, structured approach to tool interaction. It defines mechanisms for:
+- **Tool Description:** Tools describe their capabilities, parameters, and return values in a machine-readable format. An LLM can parse this description to understand how and when to use the tool.
+- **Tool Discovery:** Agents can query an MCP server to discover available tools, allowing them to dynamically adapt their capabilities without being reprogrammed.
+- **Tool Invocation:** MCP specifies a consistent method for agents to call tools and pass arguments, abstracting away the underlying implementation details of each tool.
+
+This standardization creates a plug-and-play environment where developers can add or swap tools without rewriting the agent's core logic.
+
+### Key components of MCP in orchestration
+
+An MCP-driven orchestration system typically involves several key components:
+- **MCP Server:** A central service that exposes a collection of tools. It acts as a registry and a gateway, handling requests from agents and routing them to the appropriate tools.
+- **MCP Clients:** These are the tools themselves, wrapped to comply with the MCP specification. A tool could be anything from a simple Python function to a complex API. Kestra's [`StreamableHttpMcpClient`](/plugins/plugin-ai/tool/io.kestra.plugin.ai.tool.streamablehttpmcpclient) is an example of a client that connects to an MCP server.
+- **Tool Definitions:** The metadata that describes each tool's function and interface. This is what enables agents to perform discovery and reasoning.
+- **Agentic Workflows:** The high-level processes, often managed by an orchestrator, where AI agents use MCP-enabled [tools](/plugins/plugin-ai/tool) to accomplish complex tasks.
+
+## MCP vs. traditional orchestration frameworks
+
+It's crucial to distinguish between MCP and traditional orchestration frameworks. They are not competitors; they are complementary technologies that operate at different levels of abstraction.
+
+### Is MCP an orchestration framework?
+
+No, MCP is not a complete orchestration framework. It is a communication protocol, a specialized layer focused on the interaction between AI agents and their tools. It doesn't manage workflow state, handle scheduling, provide observability, or orchestrate the branching logic of a complex process. It provides the interoperability backbone that a true orchestration platform leverages.
+
+### What is the difference between orchestrator and MCP?
+
+An orchestrator is the "brain" of the entire operation, while MCP is the "nervous system" connecting the brain to the tools it can use.
+- **Orchestrator (e.g., Kestra):** Manages the end-to-end workflow. It defines the sequence of tasks, handles conditional logic, manages retries and error handling, ensures scalability, and provides logging and monitoring.
+- **MCP:** Facilitates a specific part of that workflow—the moment an AI agent needs to use an external tool. The orchestrator invokes the agent, and the agent uses MCP to communicate with its tools.
+
+### MCP's unique approach to agentic AI management
+
+Traditional orchestration often relies on pre-defined, hardcoded integrations. A workflow task is explicitly configured to call a specific API with specific parameters. MCP enables a more dynamic and intelligent approach. An AI agent, as part of an orchestrated workflow, can be given a goal. The agent can then use MCP to discover the available tools, reason about which ones are best suited for the task, and invoke them dynamically. This allows for more flexible and adaptive automation, where the system can solve problems without every step being explicitly programmed.
+
+## The role of MCP in agentic AI and LLM integration
+
+MCP is a catalyst for building more powerful and sophisticated [agentic AI systems](/resources/ai/agentic-ai). It bridges the gap between the reasoning capabilities of LLMs and the practical execution capabilities of software tools.
+
+### How MCP enables powerful AI with LLMs
+
+LLMs excel at understanding natural language and planning sequences of actions. However, they are inherently limited by their training data and cannot interact with live systems. MCP acts as their hands and eyes, allowing them to:
+- **Access Real-Time Data:** Use tools to query databases, check stock prices, or get weather updates.
+- **Perform Actions:** Invoke APIs to send emails, create tickets in a project management system, or provision infrastructure.
+- **Utilize Specialized Functions:** Leverage tools for complex calculations, data analysis, or image generation.
+
+### Integrating MCP clients and tools
+
+Any function or service can be turned into an MCP tool by creating a client that exposes it according to the protocol's specifications. This creates a library of "skills" that can be made available to AI agents. A platform like Kestra can orchestrate workflows that dynamically provide different sets of tools to an agent based on the context of the task.
+
+### Chaining, handoffs, and multi-agent coordination with MCP
+
+MCP is not limited to single-agent, single-tool interactions. It is foundational for creating complex, [multi-agent systems](/resources/ai/multi-agent-system). An orchestrator can define a workflow where:
+- The output of one agent's tool use becomes the input for another agent.
+- Specialized agents (e.g., a "research agent" and a "writing agent") collaborate on a task, handing off control and context.
+- A supervisor agent coordinates multiple subordinate agents, breaking down a large goal into smaller, manageable sub-tasks.
+
+This level of coordination is critical for tackling complex problems and is a key focus of modern [AI agent development](/blogs/introducing-ai-agents).
+
+## Implementing MCP for enterprise-scale AI
+
+While the concept of MCP is powerful, implementing it in a production environment requires more than just the protocol itself.
+
+### The missing links: runtime execution and scalability
+
+MCP defines *how* to communicate, but it doesn't provide the infrastructure to *run* the tools, manage state, or handle failures. This is where an orchestration platform is essential. It provides the robust runtime engine needed for:
+- **Scalable Execution:** Running thousands of tool invocations in parallel.
+- **State Management:** Persisting the results of tool calls for use in later steps.
+- **Observability:** Logging every interaction for debugging and auditing.
+- **Reliability:** Implementing retries and error handling for fallible tools.
+
+### Exposing Python functions as MCP tools
+
+A common use case is exposing existing Python code as tools for an AI agent. With MCP, this doesn't require building a full-fledged microservice. You can wrap the function in an MCP client, define its purpose and parameters in the required format, and register it with an MCP server. This low-friction approach allows development teams to rapidly "skill up" their AI agents using existing code assets.
+
+### Is MCP just a JSON?
+
+No. While JSON is commonly used as the data serialization format for MCP messages and tool definitions, MCP is the protocol that defines the structure, semantics, and interaction patterns. JSON is the language spoken, but MCP is the grammar and conversational rules that make communication meaningful.
+
+### Is MCP like gRPC?
+
+MCP and gRPC both facilitate inter-service communication, but they are designed for different purposes. gRPC is a general-purpose, high-performance RPC framework optimized for efficiency between microservices, often requiring pre-compiled stubs. MCP is an AI-native protocol designed for discoverability and semantic understanding by LLMs. Its focus is on making tools intelligible to AI, not just callable by other code.
+
+## How Kestra approaches MCP orchestration
+
+Kestra serves as the comprehensive orchestration control plane that brings enterprise-grade reliability, governance, and scalability to MCP-enabled workflows. While MCP handles the tool-level communication, Kestra manages the entire lifecycle of the agentic process.
+
+With Kestra, you can define complex [AI workflows declaratively in YAML](/docs/workflow-components/flow). This approach allows you to version, audit, and manage your agentic systems as code. Kestra's extensive [plugin ecosystem](/plugins/plugin-ai) can expose virtually any system—from databases and APIs to infrastructure tools—as an MCP-compliant tool for your agents.
+
+Kestra's built-in features like the [AI Copilot](/docs/ai-tools/ai-copilot) and native [AI Agents](/docs/ai-tools/ai-agents) are designed to work seamlessly with protocols like MCP. As announced with [Kestra 1.0](/blogs/release-1-0), our platform provides the runtime execution, robust logging, monitoring, and governance layer that is essential for running these AI systems in production. You can find more details in our [documentation](/docs).
+
+## Benefits of an MCP-driven orchestration strategy
+
+Adopting MCP as part of a broader orchestration strategy offers significant advantages for organizations building on AI.
+
+### Streamlined AI integration and management
+
+By standardizing tool integration, MCP drastically reduces the amount of custom code needed to build and maintain AI applications. This accelerates development cycles and makes the entire system easier to manage and update.
+
+### Enhanced flexibility and extensibility
+
+An MCP-based architecture is inherently modular. You can add new tools, update existing ones, or even swap out the underlying LLMs with minimal impact on the overall workflow. This flexibility is crucial in the fast-changing field of AI.
+
+### Future-proofing your AI infrastructure with MCP
+
+MCP provides a vendor-neutral, open standard for AI tool communication. By building on this protocol, you avoid locking your applications into a single AI provider or platform. This ensures that your AI infrastructure can evolve and incorporate new models and technologies as they emerge. By combining this protocol with a powerful orchestration platform, you can build a robust and adaptable foundation for your organization's [AI automation initiatives](/ai-automation) and explore our comprehensive [AI resources](/resources/ai) to learn more.


### PR DESCRIPTION
## Summary
- Import du brouillon SEO `brief-mcp-orchestration` ([vfanucci/kestra-seo#118](https://github.com/vfanucci/kestra-seo/pull/118)) dans le template `resources`
- Nouvelle page : `/resources/mcp-orchestration`
- Slug, frontmatter (title, metaTitle, description, FAQ, tag, date) et contenu repris à l'identique du draft

## Test plan
- [ ] Vérifier le rendu de la page `/resources/mcp-orchestration` en preview
- [ ] Vérifier la FAQ et les liens internes

🤖 Generated with [Claude Code](https://claude.com/claude-code)