### PR TITLE
docs(resources): add legacy orchestration migration page

### DIFF
--- a/src/contents/resources/legacy-orchestration-migration/index.md
+++ b/src/contents/resources/legacy-orchestration-migration/index.md
@@ -1,0 +1,193 @@
+```yaml
+---
+title: "Legacy Orchestration Migration: A Complete Guide"
+description: "Learn about legacy orchestration migration strategies, best practices, and tools to modernize your data workflows. Start your migration today!"
+metaTitle: "Legacy Orchestration Migration Guide | Kestra"
+metaDescription: "Modernize your data, AI, and infrastructure workflows. This guide covers strategies, best practices, and tools for legacy orchestration migration to Kestra."
+tag: "workflow management"
+date: 2026-05-27
+slug: "legacy-orchestration-migration"
+faq:
+  - question: "What is legacy orchestration migration?"
+    answer: "Legacy orchestration migration involves moving outdated workflow management systems to modern platforms. This process aims to enhance agility, reduce operational costs, and improve reliability by adopting more flexible, scalable, and maintainable solutions, often leveraging cloud-native or declarative technologies."
+  - question: "Why is migrating legacy orchestrators important for modern enterprises?"
+    answer: "Migrating legacy orchestrators is crucial for enterprises to overcome limitations like vendor lock-in, high maintenance costs, and difficulty integrating with modern tools. It enables faster development cycles, better observability, improved scalability, and the ability to orchestrate across diverse domains like data, AI, and infrastructure, which is essential for digital transformation."
+  - question: "What are the biggest challenges in migrating from legacy orchestration?"
+    answer: "Key challenges include the complexity of existing workflows, ensuring data integrity and security during the transition, minimizing downtime for critical operations, and managing the cultural shift within engineering teams. Identifying dependencies, validating new systems, and avoiding vendor lock-in with new tools are also significant hurdles."
+  - question: "How does Kestra support phased migration approaches?"
+    answer: "Kestra supports phased migration by allowing teams to incrementally move workflows. You can start by wrapping existing legacy jobs (e.g., Airflow DAGs, shell scripts) within Kestra workflows, gaining observability and control. New workflows can then be built natively in Kestra, gradually reducing reliance on the legacy system without a full, disruptive cutover."
+  - question: "Can Kestra integrate with existing legacy systems during migration?"
+    answer: "Yes, Kestra is designed for seamless integration with existing legacy systems. Its extensive plugin ecosystem allows it to trigger and monitor jobs running on platforms like Airflow, Jenkins, or even mainframes via SSH or custom scripts. This capability enables a hybrid orchestration model, facilitating a smooth transition without immediate full replacement."
+  - question: "What kind of legacy orchestrators can Kestra replace?"
+    answer: "Kestra can replace a wide range of legacy orchestrators and job schedulers, including traditional workload automation tools like Control-M, Autosys, and IBM Workload Automation, as well as older data orchestrators like Apache Airflow 1.x or custom cron-based systems. Its declarative and polyglot nature makes it adaptable to diverse environments."
+  - question: "How does Kestra ensure data integrity during migration?"
+    answer: "Kestra ensures data integrity through robust error handling, built-in retries, and comprehensive logging. Workflows can include validation steps, data quality checks, and transactional operations. Its declarative nature ensures that every change is version-controlled and auditable, providing a clear history of modifications and execution outcomes."
+  - question: "What are the benefits of using a declarative platform like Kestra for migration?"
+    answer: "A declarative platform like Kestra offers several benefits for migration: improved readability and maintainability of workflows (YAML), easier version control and rollbacks (GitOps), enhanced collaboration between engineers and non-technical stakeholders, and greater portability across different environments (cloud, on-prem, air-gapped). It reduces cognitive load and operational complexity."
+---
+```
+Legacy orchestration systems, while once foundational, often become bottlenecks in modern, fast-paced environments. High maintenance costs, limited scalability, and integration headaches with new cloud-native tools are common frustrations. Teams find themselves trapped in a cycle of managing technical debt instead of innovating.
+
+This guide provides a comprehensive roadmap for legacy orchestration migration. We'll explore the critical reasons for modernization, outline effective strategies, and detail how Kestra, a declarative and polyglot orchestration platform, can streamline your transition. Learn how to move beyond outdated systems to a flexible, future-proof architecture that unifies your data, AI, and infrastructure workflows.
+
+## Understanding legacy orchestration migration
+
+### What is legacy system migration?
+
+Legacy system migration is the process of moving from outdated technology to a modern platform. In the context of orchestration, this means replacing old job schedulers and workflow managers that are often costly, inflexible, and difficult to maintain. The goal is not just a technology swap, but a strategic shift to improve agility, reduce operational overhead, and unlock new capabilities.
+
+These legacy systems can range from mainframe schedulers and cron jobs to first-generation data orchestrators. The migration might involve completely replacing the old system, rebuilding its functionality on a new platform, or incrementally phasing it out. The core idea is to adopt a solution that better fits today's distributed, cloud-native, and data-intensive environments.
+
+### Why migrate legacy orchestrators?
+
+The decision to migrate is driven by tangible business and technical pressures. Legacy systems impose constraints that modern enterprises can no longer afford.
+
+- **High Cost of Ownership**: Legacy platforms often come with expensive licenses, specialized hardware, and the need for a dwindling pool of experts with specific skills. Maintenance alone consumes a significant portion of IT budgets.
+- **Lack of Agility**: Rigid, monolithic architectures make it slow and difficult to deploy new workflows or modify existing ones. This slows down development cycles and hinders the ability to respond to market changes.
+- **Scalability and Performance Limits**: Many older systems were not designed for the volume and velocity of data in modern applications. They struggle to scale efficiently, leading to performance bottlenecks and missed SLAs.
+- **Integration Challenges**: Connecting legacy orchestrators to modern cloud services, APIs, and AI tools is often complex and brittle. This creates data silos and prevents the adoption of best-in-class technologies.
+- **Vendor Lock-In**: Proprietary systems can lock you into a single vendor's ecosystem, limiting your flexibility and negotiating power. A move to an open, [modern orchestration platform](https://kestra.io/vs/broadcom) breaks this dependency.
+
+For organizations like Crédit Agricole, migrating from fragmented scripts and cron jobs to a unified orchestration layer was essential for scaling their secure infrastructure operations. It's a move from managing complexity to enabling innovation.
+
+### Challenges of legacy data orchestration modernization
+
+Modernizing [data orchestration](https://kestra.io/resources/data/data-orchestration) is not without its difficulties. A successful migration requires careful planning to navigate several common challenges:
+
+- **Complexity and Interdependencies**: Legacy workflows are often poorly documented and deeply intertwined with other systems. Uncovering these dependencies is a critical but time-consuming first step.
+- **Risk of Disruption**: Critical business processes often rely on these legacy systems. Any downtime or error during migration can have significant financial and operational impacts.
+- **Data Integrity and Security**: Moving data and processes to a new system must be done without compromising data quality, security, or compliance requirements.
+- **Skill Gaps and Cultural Resistance**: Teams may be accustomed to the old way of working. A migration requires not only new technical skills but also a shift in mindset towards modern practices like GitOps and declarative configurations. The problem isn't always the old technology itself, but the [un-orchestrated systems](https://kestra.io/blogs/claude-cobol) that grew around it.
+
+## Key strategies for legacy system migration
+
+Choosing the right strategy is crucial for a low-risk, successful migration. The approach should align with your organization's resources, risk tolerance, and long-term goals.
+
+### Rebuilding vs. replacing legacy systems
+
+- **Rebuilding**: This involves re-implementing the logic of your legacy workflows on a modern platform. It offers a high degree of customization but can be time-consuming and expensive. It's best suited for highly specific, business-critical workflows that have no off-the-shelf equivalent.
+- **Replacing**: This involves adopting a new platform and configuring it to meet your needs. It's generally faster and less resource-intensive.
+
+A hybrid approach, often called "wrap and replace," offers a pragmatic middle ground. With a platform like Kestra, you can initially "wrap" your existing legacy jobs (scripts, binaries, or even other orchestrator tasks) within a modern orchestration layer. This gives you immediate benefits like centralized logging, alerting, and dependency management. Over time, you can incrementally replace the wrapped components with native Kestra tasks, reducing risk and spreading the migration effort.
+
+### Modernizing data orchestration with cloud solutions
+
+The cloud offers immense benefits for orchestration, including on-demand scalability, managed services, and consumption-based pricing. However, migrating directly to a cloud-specific solution like [AWS Step Functions](https://kestra.io/vs/aws-step-functions) or Azure Data Factory can lead to a new form of vendor lock-in.
+
+A better strategy is to adopt a cloud-agnostic platform that can operate across any environment. Kestra is designed for [multi-cloud orchestration](https://kestra.io/resources/infrastructure/multi-cloud-orchestration), allowing you to run workflows on any cloud provider, on-premises, or in a hybrid setup. This gives you the flexibility to choose the best services for each task without being tied to a single ecosystem.
+
+### Phased migration approaches for success
+
+A "big bang" migration, where the entire system is switched over at once, is extremely risky. A phased approach is almost always preferable.
+
+- **Incremental Migration**: Start by moving a small, non-critical subset of workflows to the new platform. This allows the team to learn, build confidence, and demonstrate value quickly.
+- **Strangler Fig Pattern**: Run the new system in parallel with the old one. Gradually route more and more traffic and workflows to the new system until the legacy system is "strangled" and can be decommissioned.
+- **Hybrid Model**: Use the new orchestrator as a control plane that coordinates tasks across both new and legacy systems. This is where Kestra excels, acting as a single point of control for a heterogeneous environment. As Leroy Merlin demonstrated, a modern orchestration platform can effectively manage complex [cloud data pipelines](https://kestra.io/blogs/2022-02-22-leroy-merlin-usage-kestra) while integrating with existing systems.
+
+## Planning a successful legacy orchestration migration
+
+A solid plan is the foundation of any successful migration. It transforms an overwhelming project into a series of manageable steps.
+
+### Assessing your current legacy environment
+
+Before you can plan your journey, you need to know your starting point. This involves a thorough audit of your current orchestration landscape:
+- **Inventory Workflows**: Catalog all existing jobs, scripts, and dependencies.
+- **Analyze Performance**: Identify bottlenecks, failure points, and areas with high operational toil.
+- **Document Costs**: Calculate the total cost of ownership (TCO) for your legacy system, including licensing, hardware, and personnel.
+- **Identify Dependencies**: Map out how your workflows interact with other applications, databases, and services.
+
+### Defining clear migration goals and objectives
+
+What does success look like for your migration? Define clear, measurable goals. These might include:
+- **Cost Reduction**: e.g., "Reduce orchestration TCO by 30% within 18 months."
+- **Increased Agility**: e.g., "Reduce the average time to deploy a new data pipeline from 4 weeks to 4 days."
+- **Improved Reliability**: e.g., "Decrease the rate of pipeline failures by 50%."
+- **New Capabilities**: e.g., "Enable event-driven workflows for real-time data processing."
+
+### Building a robust migration roadmap
+
+With your assessment and goals in hand, you can build a detailed roadmap. This should include:
+- **Pilot Project**: Select a representative workflow to migrate first. This will serve as a proof-of-concept and a learning opportunity.
+- **Phased Rollout**: Group remaining workflows into logical batches for migration based on business priority and technical complexity.
+- **Resource Allocation**: Assign clear ownership for each phase of the project.
+- **Timeline**: Set realistic timelines with key milestones.
+- **Rollback Plan**: Define a clear plan for reverting to the legacy system if a critical issue arises during cutover.
+
+This planning phase is essential to [solve orchestration problems](https://kestra.io/resources/infrastructure/orchestration-problems-complexity) without introducing new ones.
+
+## Best practices for data migration from legacy systems
+
+Execution matters as much as planning. Adhering to best practices during the migration itself will ensure a smooth and secure transition.
+
+### Ensuring data integrity and security
+
+Data is your most valuable asset. Protecting it during migration is non-negotiable.
+- **Validation**: Implement checks at each stage to ensure data is not lost or corrupted.
+- **Encryption**: Use encryption for data both in transit and at rest.
+- **Access Control**: Enforce strict access controls on the new platform from day one. Kestra's [audit logs](https://kestra.io/docs/enterprise/governance/audit-logs) provide a complete record of all actions for compliance and security.
+- **Transactional Operations**: For critical data movements, use tasks that support transactional semantics to ensure atomicity.
+
+### Minimizing downtime during migration
+
+For many businesses, orchestration downtime means lost revenue.
+- **Parallel Runs**: Run the new and old systems in parallel for a period, comparing outputs to ensure consistency before cutting over.
+- **Blue-Green Deployments**: Maintain two identical production environments. Deploy the new system to the inactive environment, test it, and then switch traffic over.
+- **Canary Releases**: Gradually roll out the new system to a small subset of users or workflows before a full deployment.
+
+### Testing and validation strategies
+
+Thorough testing is the best way to build confidence in your new system.
+- **Unit Tests**: Validate individual components of your new workflows. Kestra supports [unit tests for flows](https://kestra.io/docs/enterprise/governance/unit-tests), allowing you to catch issues before deployment.
+- **Integration Tests**: Verify that your workflows interact correctly with other systems and services.
+- **End-to-End Tests**: Simulate a full business process to ensure the entire system works as expected.
+- **Automated Retries**: Configure robust [retry mechanisms](https://kestra.io/docs/workflow-components/retries) to handle transient failures gracefully.
+
+FILA's ERP migration success depended heavily on Kestra's ability to ensure data synchronization across multiple systems, a testament to its reliability in complex, real-world scenarios.
+
+## Tools and technologies for modern data orchestration
+
+The right tooling can dramatically simplify your migration and set you up for future success.
+
+### Moving from legacy schedulers to modern platforms
+
+Modern orchestration platforms like Kestra offer a fundamentally different approach than legacy schedulers. Instead of imperative scripts, you define workflows declaratively in YAML. This makes them easier to read, version, and manage. Kestra's [powerful features](https://kestra.io/features), such as its language-agnostic design and extensive plugin library, allow you to orchestrate any tool and any system from a single control plane.
+
+### Leveraging cloud composers for data orchestration
+
+Managed services like [Google Cloud Composer](https://kestra.io/vs/cloud-composer) offer a way to run Apache Airflow without managing the underlying infrastructure. While this can be a valid step, it often keeps you locked into the Airflow paradigm and a single cloud provider. Kestra provides a more flexible, platform-agnostic alternative that extends beyond data engineering to cover infrastructure, AI, and business workflows.
+
+### AI and automation in legacy system understanding
+
+Understanding complex legacy systems can be a major bottleneck. Modern tools can help. Kestra's [AI Copilot](https://kestra.io/docs/ai-tools/ai-copilot) can help generate new workflows from natural language descriptions, reducing the manual effort of translation. As the [orchestration control plane of the AI era](https://kestra.io/blogs/kestra-series-a), Kestra is designed to integrate AI seamlessly into your automation strategy.
+
+## Migrating specific legacy orchestrators with Kestra
+
+Kestra's flexibility makes it an ideal destination for migrations from a wide range of legacy systems.
+
+### Transitioning from Autosys, Control-M, or IBM Workload Automation
+
+These traditional workload automation tools are powerful but often complex and expensive. Migrating to Kestra offers a path to a more agile, developer-friendly model. The migration can be incremental: use Kestra's SSH or script tasks to trigger existing jobs on the legacy system, then gradually rewrite them as native Kestra flows. This approach allows you to modernize without disrupting decades of established business logic.
+
+### Modernizing from Apache Airflow
+
+With Airflow 2.x now end-of-life, many teams are evaluating their options. While upgrading to Airflow 3.0 is one path, it's also an opportunity to address the operational overhead and Python-centric limitations of Airflow. Kestra offers a compelling alternative for [enterprise Airflow users](https://kestra.io/blogs/enterprise-airflow-alternatives). Its declarative YAML approach is easier to manage, and its polyglot nature supports diverse teams. Kestra's Airflow plugin even allows you to [trigger and monitor existing DAGs](https://kestra.io/blogs/2024-10-22-orchestrate-dags-with-kestra), providing a seamless migration path.
+
+### Orchestrating Databricks Workflows and other cloud-native tools
+
+Platform-specific orchestrators like [Databricks Workflows](https://kestra.io/vs/databricks-workflows) or [Azure Data Factory](https://kestra.io/vs/azure-data-factory) are effective within their ecosystems but struggle to manage tasks outside of it. Kestra acts as a universal control plane, orchestrating your Databricks jobs alongside your ingestion tools, infrastructure provisioning, and business applications. This provides a unified view and control over your entire end-to-end process. BHP successfully used Kestra to replace a vendor-locked automation tool, reducing infrastructure provisioning time from months to days.
+
+## Post-migration optimization and management
+
+Migration is not the end of the journey; it's the beginning of a more agile and efficient way of working.
+
+### Monitoring and maintaining new orchestration systems
+
+Kestra provides comprehensive observability out of the box. Its UI offers a real-time view of all executions, detailed logs, and performance metrics. You can configure proactive alerts to be notified of failures or performance degradation, allowing you to address issues before they impact the business.
+
+### Continuous improvement of data workflows
+
+A modern orchestration platform enables continuous improvement. With Kestra, your workflows are just code. You can manage them using [GitOps practices](https://kestra.io/resources/infrastructure/gitops), with every change going through version control, code review, and automated testing. Kestra's support for [flow revisions](https://kestra.io/docs/concepts/revision) makes it easy to track changes and roll back to previous versions if needed.
+
+### Future-proofing your data orchestration
+
+The technology landscape is constantly evolving. The orchestration platform you choose today must be able to adapt to the tools of tomorrow. Kestra's extensible, plugin-based architecture and its vision to unify data, AI, infrastructure, and business workflows make it a future-proof choice. By building on an open, declarative foundation, you ensure that your orchestration layer can evolve with your business. To understand the full scope of this vision, explore [Why Kestra](https://kestra.io/docs/why-kestra).


### PR DESCRIPTION
## Summary
- Import du brouillon SEO `brief-legacy-orchestration-migration` ([vfanucci/kestra-seo#116](https://github.com/vfanucci/kestra-seo/pull/116)) dans le template `resources`
- Nouvelle page : `/resources/legacy-orchestration-migration`
- Slug, frontmatter (title, metaTitle, description, FAQ, tag, date) et contenu repris à l'identique du draft

## Test plan
- [ ] Vérifier le rendu de la page `/resources/legacy-orchestration-migration` en preview
- [ ] Vérifier la FAQ et les liens internes

🤖 Generated with [Claude Code](https://claude.com/claude-code)