### PR TITLE
docs(resources): add open source orchestration cost savings page

### DIFF
--- a/src/contents/resources/open-source-orchestration-cost-savings/index.md
+++ b/src/contents/resources/open-source-orchestration-cost-savings/index.md
@@ -1,0 +1,192 @@
+```yaml
+---
+title: "Open Source Orchestration Cost Savings: A Comprehensive Guide"
+description: "Discover how open source orchestration tools deliver significant cost savings beyond just licensing. Learn to reduce expenses, boost efficiency, and unify your data, AI, and infrastructure workflows with Kestra."
+metaTitle: "Open Source Orchestration: Maximize Cost Savings with Kestra"
+metaDescription: "Unlock significant cost savings with open source orchestration. This guide explores direct & indirect financial benefits, tool comparisons (Airflow, Kestra), and strategies for efficient, unified workflow management."
+tag: "infrastructure"
+date: 2026-05-28
+slug: "open-source-orchestration-cost-savings"
+faq:
+  - question: "What are the primary cost savings of open source orchestration?"
+    answer: "Open source orchestration primarily saves costs by eliminating licensing fees and reducing vendor lock-in. Indirectly, it drives savings through increased operational efficiency, optimized resource utilization, and access to a vibrant community for support and innovation, minimizing reliance on paid support contracts."
+  - question: "How does open source orchestration reduce vendor lock-in?"
+    answer: "Open source tools provide transparent codebases and standardized formats, preventing reliance on proprietary technologies. This flexibility allows organizations to switch tools or customize solutions without incurring hefty migration costs or being tied to a single vendor's pricing and roadmap."
+  - question: "Can open source orchestration improve operational efficiency?"
+    answer: "Yes, by automating complex, repetitive tasks across various systems, open source orchestrators significantly reduce manual effort and human error. This leads to faster execution, fewer delays, and more consistent operations, freeing up engineering time for higher-value activities."
+  - question: "Are there hidden costs associated with open source orchestration?"
+    answer: "While direct licensing costs are eliminated, potential hidden costs include initial setup complexity, the need for internal expertise for customization and maintenance, and integration challenges. These can be mitigated by choosing mature tools with strong communities and well-documented best practices."
+  - question: "How does Kestra contribute to cost savings in open source orchestration?"
+    answer: "Kestra's declarative YAML-based approach simplifies workflow definition and management, reducing development and maintenance overhead. Its ability to unify data, AI, and infrastructure workflows on a single platform eliminates the need for multiple specialized tools, further consolidating costs and operational complexity."
+  - question: "Is open source orchestration suitable for AI model deployment?"
+    answer: "Absolutely. Open source orchestrators provide the flexibility and control needed to manage complex AI pipelines, from data preparation and model training to deployment and monitoring. Tools like Kestra, with native AI agent capabilities, can further optimize these workflows by automating decision-making and resource allocation."
+  - question: "What are the main differences in cost structure between open source and proprietary orchestration?"
+    answer: "Open source typically involves upfront investment in internal expertise and infrastructure, with ongoing operational costs. Proprietary solutions often have high recurring licensing fees, bundled support, and potential for escalating costs with scale or feature upgrades, with less flexibility to self-manage."
+author: ""
+image: "/images/blogs/open-source-orchestration-cost-savings/cover.png"
+---
+```
+In an era where every dollar counts, optimizing operational expenses is paramount for engineering teams. Workflow orchestration, essential for managing complex data, AI, and infrastructure pipelines, often comes with a hefty price tag when relying on proprietary solutions. Yet, a powerful alternative exists: open source orchestration.
+
+This guide delves into how leveraging open source tools can unlock significant cost savings for your organization, far beyond merely eliminating licensing fees. We'll explore direct financial benefits, indirect efficiencies, and strategic advantages, including how a unified, declarative platform like Kestra empowers teams to achieve more with less.
+
+## Understanding open source orchestration and its benefits
+
+Orchestration is the automated configuration, coordination, and management of complex computer systems and services. In modern engineering, this translates to managing the entire lifecycle of workflows across different domains: [data pipelines](https://kestra.io/resources/data/data-orchestration), [infrastructure automation](https://kestra.io/resources/infrastructure/automation), and AI model training and deployment. The goal is to ensure that multiple interdependent tasks execute correctly, in the right order, and with the necessary resources.
+
+Open source orchestration tools are built on the principles of free access to source code, community-driven development, and transparency. This model offers several core benefits:
+- **Flexibility**: Adapt the tool to your specific needs without vendor constraints.
+- **Transparency**: Understand exactly how the orchestrator works, making it easier to debug and secure.
+- **Innovation**: Benefit from a global community of developers constantly improving the software.
+
+Platforms like Kestra embody these principles, providing a declarative, polyglot, and event-driven orchestration layer. By defining [workflows](https://kestra.io/docs/workflow-components/flow) in simple YAML, teams can manage complex processes as code, gaining visibility and control while benefiting from the open source cost model. If you're wondering [why Kestra](https://kestra.io/docs/why-kestra) was built this way, it comes down to making powerful orchestration accessible and manageable for all engineers.
+
+## Direct cost savings with open source orchestration
+
+The most apparent financial benefits of adopting open source orchestration are direct and immediately impact your budget.
+
+### Eliminating licensing fees and subscription costs
+
+The most straightforward cost saving comes from the absence of licensing fees. Proprietary orchestration platforms often charge based on the number of users, tasks, or execution hours, leading to costs that can scale unpredictably. A high-tier enterprise license for a commercial workload automation tool can easily run into six figures annually.
+
+By choosing an open source solution, you eliminate this significant recurring expense. This frees up the budget for other critical areas, such as hiring skilled engineers, investing in better infrastructure, or exploring new technologies. Kestra’s [open-source edition](https://kestra.io/docs/oss-vs-paid) provides a full-featured orchestration engine without any licensing fees, offering a powerful alternative to costly commercial products.
+
+### Reducing vendor lock-in expenses
+
+Vendor lock-in occurs when you become so dependent on a specific vendor's proprietary technology that switching to an alternative is prohibitively expensive or complex. This gives the vendor immense leverage over pricing, feature roadmaps, and support quality.
+
+Open source orchestration mitigates this risk. With access to the source code and open standards, you retain control. If a project's direction no longer aligns with your needs, you can fork the code, build custom extensions, or migrate to another tool with less friction. For instance, Kestra's use of declarative YAML for workflow definitions means your business logic isn't trapped in a proprietary format or a specific programming language. This portability is a long-term cost-saving strategy, as it prevents you from being cornered during contract renewals. This freedom is a key factor for teams looking for [alternatives to platform-specific tools like Databricks Workflows](https://kestra.io/resources/data/databricks-workflows-alternatives).
+
+### Lowering operational and support outlays
+
+While proprietary software includes support in its subscription price, this often comes at a premium. Open source projects, especially mature ones, are supported by vibrant communities through forums, Slack channels, and extensive documentation. This collective knowledge base can often resolve issues faster and more effectively than a traditional support ticket system.
+
+Furthermore, open source gives you the flexibility to choose your own infrastructure, avoiding dependencies on expensive, vendor-specific hardware or cloud services. For organizations that need guaranteed response times or enterprise-grade features, projects like Kestra offer an [Enterprise Edition](https://kestra.io/docs/oss-vs-paid) with dedicated support, providing a cost-effective and predictable alternative to the all-or-nothing pricing of many commercial vendors. This model allows you to pay only for the level of support you actually need, as reflected in a transparent [pricing structure](https://kestra.io/pricing).
+
+## Indirect cost savings and advantages
+
+Beyond direct financial benefits, open source orchestration drives significant value by improving how your teams work and how your systems operate.
+
+### Improved efficiency and automation for cost reduction
+
+The core function of orchestration is automation, which is a direct driver of efficiency. By automating manual, error-prone tasks, you reduce the hours engineers spend on repetitive work and minimize costly mistakes. This leads to faster development cycles, quicker time-to-market for new features, and more reliable operations.
+
+Modern orchestrators like Kestra, which run natively on platforms like Kubernetes, can dynamically allocate resources, spinning them up for a task and down afterward. This prevents over-provisioning and dramatically reduces cloud computing costs. Kestra's event-driven architecture further enhances efficiency by allowing workflows to react to real-time events, ensuring that processes run exactly when needed, not just on a fixed schedule.
+
+### Flexibility and customization for optimized resource use
+
+Open source tools can be tailored to fit your exact requirements. You aren’t forced to pay for a suite of features you’ll never use. Instead, you can build a lean, optimized system that does precisely what you need.
+
+This flexibility extends to integrations. With a vast [plugin ecosystem](https://kestra.io/plugins), Kestra can connect to virtually any tool in your stack, whether it's a modern data warehouse, a legacy system, or a custom in-house application. This ability to orchestrate a diverse, polyglot environment prevents the costly process of replacing existing tools just to fit into a new, rigid workflow system. You can even start with pre-built solutions from a library of [blueprints](https://kestra.io/blueprints) to accelerate development.
+
+### Community support and continuous innovation
+
+An active open source community is a powerful asset. When you encounter a problem, it's likely someone else has already solved it and shared the solution. This collective intelligence, accessible through channels like the Kestra [Community Slack](https://kestra.io/community), is an invaluable and free resource.
+
+Moreover, community-driven development often outpaces the innovation cycle of proprietary vendors. New features, integrations, and bug fixes are contributed by a global network of developers, ensuring the tool evolves rapidly to meet emerging needs. This means you benefit from cutting-edge technology without waiting for a vendor's next major release cycle.
+
+### Enhanced transparency and auditability
+
+With open source, the codebase is fully transparent. Your security teams can audit the software for vulnerabilities, and your compliance teams can verify that it meets regulatory requirements. This level of visibility is rarely possible with closed-source, proprietary products.
+
+In Kestra, this transparency extends to the workflows themselves. Because all flows are defined as auditable YAML files, you have a clear, version-controlled record of your business logic. The UI provides a detailed history of every execution, making it simple to trace data lineage, debug failures, and provide evidence for compliance audits.
+
+## Comparing open source vs. proprietary orchestration solutions
+
+Choosing between open source and proprietary tools requires a careful evaluation of their respective models, not just in terms of cost but also in scalability, security, and integration.
+
+### Cost structures: open source vs. commercial products
+
+- **Open Source**: The Total Cost of Ownership (TCO) is primarily driven by internal resources. This includes the engineering time for setup, customization, and maintenance, as well as the underlying infrastructure costs. While there are no license fees, you may opt for paid enterprise support, like with [Kestra Enterprise Edition](https://kestra.io/enterprise), for mission-critical applications.
+- **Proprietary**: TCO is dominated by recurring license or subscription fees. These costs can escalate with usage, number of users, or additional features. While support and maintenance are typically bundled, you have less control over the cost structure and are subject to vendor price increases.
+
+### Scalability and performance considerations
+
+Both open source and proprietary solutions can scale to handle massive workloads, but their approaches differ. Proprietary tools often provide scalability as a managed feature, but at a significant cost premium.
+
+Open source tools like Kestra are designed to scale horizontally on commodity hardware or cloud infrastructure like Kubernetes. This gives you fine-grained control over your architecture and costs. You can engineer for the specific performance profile you need, rather than paying for a one-size-fits-all solution.
+
+### Security and reliability in open source environments
+
+A common misconception is that open source is less secure. In reality, the "many eyes" principle—where a global community of developers reviews the code—can lead to faster discovery and patching of vulnerabilities. Mature projects like Kubernetes and Kestra are battle-tested in thousands of production environments.
+
+For organizations with stringent security and compliance needs, open source projects often offer enterprise-grade versions. [Kestra's Enterprise Edition](https://kestra.io/docs/oss-vs-paid) adds features like Role-Based Access Control (RBAC), Single Sign-On (SSO), audit logs, and worker isolation to meet these requirements.
+
+### Integration capabilities and ecosystem compatibility
+
+Open source tools thrive on interoperability, typically using open standards and APIs. Kestra’s library of over 1400 plugins and its language-agnostic design mean it can orchestrate almost any tool or system.
+
+Proprietary solutions may offer deep integrations with a specific vendor's ecosystem but can be restrictive when connecting to outside or competing tools. This can force you into a walled garden, limiting your flexibility and increasing long-term costs.
+
+## Top open source orchestration tools for cost optimization
+
+Different domains of orchestration have their own set of powerful, cost-effective open source tools.
+
+### Container orchestration: Docker Swarm, Kubernetes
+
+Kubernetes has become the de facto standard for container orchestration, enabling efficient resource management and automated scaling of applications. Docker Swarm offers a simpler alternative for less complex use cases. Both help optimize cloud spend by ensuring you only use the compute resources you need. Kestra integrates seamlessly, allowing you to run tasks as isolated pods using its [Kubernetes Task Runner](https://kestra.io/docs/task-runners/types/kubernetes-task-runner).
+
+### Data orchestration: Airflow, Dagster, Kestra
+
+- **Airflow**: The long-standing incumbent, with a massive ecosystem of operators. Its Python-based DAGs are familiar to many data engineers but can introduce operational complexity.
+- **Dagster**: An asset-centric orchestrator that provides strong data lineage and testing capabilities, well-suited for analytics engineering.
+- **Kestra**: A declarative, language-agnostic platform. Its YAML-based workflows simplify development and maintenance, and its ability to unify different domains makes it a powerful cost-saving tool by reducing tool sprawl. See how it compares to [Airflow](https://kestra.io/vs/airflow) and [Dagster](https://kestra.io/vs/dagster).
+
+### Cloud expense optimization tools (general)
+
+Tools like OpenCost and Kubecost provide visibility into Kubernetes spending. An orchestrator can integrate with these tools to take action based on their insights—for example, automatically shutting down idle development environments or resizing clusters based on utilization reports.
+
+### AI model orchestration: open source alternatives
+
+Orchestrating [AI pipelines](https://kestra.io/resources/ai/ai-pipeline) involves complex, multi-stage workflows. While specialized platforms exist, a universal orchestrator can manage the entire end-to-end process. Kestra's native [AI Agents](https://kestra.io/docs/ai-tools/ai-agents) and support for tools like MLflow and Kubeflow allow you to build, train, and deploy models within the same control plane you use for your data and infrastructure, a concept known as [agentic orchestration](https://kestra.io/resources/ai/agentic-orchestration).
+
+## Strategies for maximizing open source orchestration cost savings
+
+Adopting open source tools is the first step. To truly maximize ROI, you need a sound strategy for implementation and management.
+
+### Effective implementation and management practices
+
+Start with a well-defined scope and scale gradually. Standardize on a declarative approach to define your workflows. Using a tool like Kestra, where workflows are defined in YAML, allows you to apply [GitOps best practices](https://kestra.io/docs/best-practices/git). This means your workflows are version-controlled, peer-reviewed, and auditable, which drastically reduces errors and maintenance overhead.
+
+### Leveraging community resources and contributions
+
+Engage with the community. Participate in forums, ask questions in the Slack channel, and read the documentation. Utilize shared resources like [Kestra's Blueprints](https://kestra.io/blueprints), which are pre-built workflow templates that can solve common problems and accelerate your development.
+
+### Measuring ROI and tracking cost reductions
+
+Define what success looks like and track it. Key metrics could include:
+- Reduction in monthly cloud bills.
+- Decrease in man-hours spent on manual operations.
+- Faster time-to-deployment for new pipelines.
+- Reduction in software licensing fees.
+
+Regularly review these metrics to demonstrate the value of your open source strategy and identify areas for further optimization.
+
+### Future-proofing your orchestration strategy
+
+Choose a platform that is flexible and extensible. Avoid solutions that lock you into a single programming language, cloud provider, or domain. A unified platform like Kestra, which serves as a central control plane for [infrastructure](https://kestra.io/infra-automation), data, and AI, provides a future-proof foundation that can adapt as your technology stack evolves.
+
+## Challenges and considerations for open source adoption
+
+While the benefits are substantial, a successful open source adoption requires a clear-eyed view of the potential challenges.
+
+### Initial setup and learning curve
+
+Open source tools can sometimes require more initial configuration than their proprietary counterparts. However, modern tools have greatly simplified this process. Kestra, for example, can be up and running in minutes with a simple Docker command, and its [Quickstart guide](https://kestra.io/docs/quickstart) helps new users build their first flow quickly.
+
+### Internal expertise and training requirements
+
+To get the most out of open source software, you need skilled engineers who can manage, customize, and troubleshoot it. This represents an investment in your team's skills. However, this investment builds valuable internal knowledge and reduces dependence on external vendors.
+
+### Potential hidden costs and their mitigation
+
+Hidden costs can arise from underestimated operational overhead, complex integrations, or the need for specialized skills. To mitigate these:
+- **Choose mature projects**: Select tools with strong documentation, active communities, and a proven track record.
+- **Factor in management time**: Allocate resources for maintenance, upgrades, and monitoring.
+- **Consider managed services**: For teams that want the benefits of open source without the operational burden, managed offerings like [Kestra Cloud](https://kestra.io/cloud) can provide a cost-effective balance.
+
+## Conclusion: Smart Savings with Open Source Orchestration
+
+Open source orchestration offers a compelling path to significant cost savings that extend far beyond the absence of licensing fees. By reducing vendor lock-in, improving operational efficiency, and fostering rapid innovation, these tools provide a powerful strategic advantage.
+
+The key is to look beyond individual tools and embrace a unified approach. A platform like Kestra acts as a universal control plane, breaking down silos between [data](https://kestra.io/data), [AI](https://kestra.io/ai-automation), and [infrastructure](https://kestra.io/infra-automation) teams. This consolidation not only cuts direct costs but also streamlines operations, accelerates development, and positions your organization for future growth. By making a strategic investment in open source orchestration, you are not just cutting costs—you are building a more flexible, efficient, and resilient engineering practice. Explore our [resources](https://kestra.io/resources) to learn more.


### PR DESCRIPTION
## Summary
- Import du brouillon SEO `brief-open-source-orchestration-cost-savings` ([vfanucci/kestra-seo#122](https://github.com/vfanucci/kestra-seo/pull/122)) dans le template `resources`
- Nouvelle page : `/resources/open-source-orchestration-cost-savings`
- Slug, frontmatter (title, metaTitle, description, FAQ, tag, date) et contenu repris à l'identique du draft

## Test plan
- [ ] Vérifier le rendu de la page `/resources/open-source-orchestration-cost-savings` en preview
- [ ] Vérifier la FAQ et les liens internes

🤖 Generated with [Claude Code](https://claude.com/claude-code)