### PR TITLE
docs(resources): add AI code generation pipelines page

### DIFF
--- a/src/contents/resources/ai-code-generation-pipelines/index.md
+++ b/src/contents/resources/ai-code-generation-pipelines/index.md
@@ -1,0 +1,146 @@
+---
+title: "AI Code Generation Pipelines: Boost Your Workflow"
+description: "Streamline your development with AI code generation pipelines. Discover how to integrate AI for efficiency and accelerate your delivery with Kestra."
+metaTitle: "AI Code Generation Pipelines: Kestra for Faster Delivery"
+metaDescription: "Enhance your development with AI code generation pipelines. Integrate AI for efficiency, accelerate delivery, and ensure quality with Kestra's unified orchestration."
+tag: "ai"
+date: 2026-05-27
+slug: "ai-code-generation-pipelines"
+faq:
+  - question: "What is an AI code generation pipeline?"
+    answer: "An AI code generation pipeline is a multi-stage automated workflow that leverages artificial intelligence to generate, review, test, and deploy code. Unlike simple AI code assistants, these pipelines integrate AI throughout the entire software development lifecycle, from initial code suggestions to automated pull requests and release notes, ensuring quality and accelerating delivery."
+  - question: "How does AI code generation differ from AI code assistance?"
+    answer: "AI code assistance typically provides real-time suggestions or completions within an IDE, acting as a developer's co-pilot. An AI code generation pipeline, on the other hand, automates entire segments of the coding process, from generating new features or modules to automating tests and documentation, often without direct human intervention in the generation phase, relying instead on automated checks and reviews."
+  - question: "What are the key benefits of using AI for code generation?"
+    answer: "Key benefits include significantly boosted developer productivity, faster time-to-market, improved code consistency and quality through automated linting and testing, and reduced manual effort in repetitive coding tasks. It also helps manage increased code volume and allows engineers to focus on higher-value, complex problems."
+  - question: "Can AI code generation pipelines ensure code quality and security?"
+    answer: "Yes, an effective AI code generation pipeline integrates automated linting, static analysis, unit testing, and security scanning at various stages. By embedding these quality and security checks, the pipeline can identify and flag issues early, ensuring that AI-generated code adheres to established standards and best practices before deployment."
+  - question: "How does Kestra support AI code generation pipelines?"
+    answer: "Kestra provides a declarative, polyglot orchestration platform to manage every stage of an AI code generation pipeline. With its native AI Copilot for flow generation, AI agents for autonomous tasks, and deep integration with CI/CD tools, Kestra can orchestrate the entire workflow, from triggering AI code generation to running automated tests, approvals, and deployment, all defined in auditable YAML."
+  - question: "What challenges might arise when implementing AI code generation?"
+    answer: "Challenges include ensuring the generated code meets quality standards, managing the increased volume of code, integrating AI tools seamlessly into existing CI/CD, and establishing robust review and governance processes. It also requires careful prompt engineering and continuous evaluation of AI models to maintain relevance and accuracy."
+  - question: "Is AI code generation suitable for all programming languages?"
+    answer: "While AI code generation is highly effective with many languages, especially scripting languages like Python and TypeScript, its effectiveness can vary. Languages with extensive libraries and clear patterns often yield better results. Kestra's polyglot execution environment allows you to integrate AI tools regardless of the target code's language, running custom scripts or Dockerized generators as needed."
+author: "elliot"
+image: "/images/blogs/ai-code-generation-pipelines/cover.png"
+---
+
+The speed of software delivery is a constant challenge, but the rise of AI-powered code generation promises to fundamentally change how development teams operate. Beyond simple code completion, the real revolution lies in orchestrating entire AI code generation pipelines that can autonomously produce, test, and integrate code into your existing systems. This shift moves developers from writing every line to governing intelligent agents.
+
+This article explores the architecture and benefits of AI code generation pipelines, detailing how they accelerate delivery, improve code quality, and manage the increased velocity of development. We will dive into the essential components, practical implementation strategies, and how a declarative orchestration platform like Kestra can serve as the control plane for these advanced, AI-driven workflows.
+
+## Understanding AI Code Generation Pipelines
+
+To fully harness the power of AI in development, it's crucial to think beyond individual tools and consider the entire automated workflow.
+
+### What are AI code generation pipelines?
+
+An AI code generation pipeline is an automated, multi-stage workflow that uses AI to generate, test, review, and deploy code. Unlike a simple AI assistant that suggests code snippets in an IDE, a full pipeline automates the end-to-end process. This typically includes stages for pre-checks, code generation, quality and security reviews, and finally, integration and deployment. The goal is to create a reliable, repeatable system where [AI agents](https://kestra.io/docs/ai-tools/ai-agents) can perform complex coding tasks with minimal human intervention, governed by a robust orchestration layer. This approach moves from AI-assisted coding to a more comprehensive model of [agentic orchestration](https://kestra.io/resources/ai/agentic-orchestration).
+
+### Why are AI code generation pipelines essential for modern development?
+
+Modern development teams face pressure to deliver features faster without sacrificing quality. AI code generation pipelines address this by introducing a step-change in productivity. They automate repetitive and boilerplate coding, freeing engineers to focus on complex problem-solving and system design. This not only accelerates the development lifecycle but also enforces consistency and adherence to best practices. As noted in recent [data engineering trends](https://kestra.io/blogs/2026-03-05-data-eng-trends-2026), the quality of AI-generated work is directly tied to the clarity and structure of the tools it interacts with. A well-defined pipeline ensures AI contributes clean, maintainable code, making [AI automation](https://kestra.io/ai-automation) a scalable advantage rather than a source of technical debt.
+
+## Key Components of an Effective AI Code Generation Pipeline
+
+A successful pipeline is more than just a call to an LLM API. It requires a series of integrated checks and balances to ensure the output is production-ready.
+
+### Integrating AI for automated code generation
+
+The core of the pipeline is the generative AI model itself. This involves selecting the right Large Language Model (LLM)—such as those from OpenAI, Anthropic, or Google—and integrating it via API calls. Effective integration depends on sophisticated prompt engineering and often employs Retrieval-Augmented Generation (RAG) to provide the model with relevant context from existing codebases or documentation. For complex tasks, an [AI model router](https://kestra.io/blueprints/ai-model-router) can dynamically select the best model for a specific type of code generation, optimizing for both cost and quality. Building a [RAG pipeline](https://kestra.io/blogs/rag-with-gemini-and-langchain4j) to feed context is a common and powerful pattern.
+
+### The role of linting and code quality checks
+
+AI-generated code must meet the same quality standards as human-written code. Integrating automated linting and static analysis is non-negotiable. Tools like Black and Ruff for Python or ESLint for TypeScript can be run automatically after code generation to enforce style consistency and catch common errors. An orchestration platform allows you to run these checks as distinct tasks in the pipeline, using simple [Python scripts](https://kestra.io/docs/how-to-guides/python) or [shell commands](https://kestra.io/docs/scripts/shell) to validate the AI's output before it proceeds to the next stage.
+
+### Security and pre-check phases in the pipeline
+
+Security cannot be an afterthought. A robust AI code generation pipeline includes automated security scanning from the very beginning. This involves using Static Application Security Testing (SAST) tools to analyze the generated code for vulnerabilities and checking dependencies for known security issues. Policies, which can be enforced using tools like Open Policy Agent (OPA), ensure that all generated code complies with organizational security standards. These [SecOps workflows](https://kestra.io/docs/how-to-guides/secops-with-kestra) are a critical gate in the pipeline, preventing insecure code from ever reaching the main branch.
+
+## How AI Code Generation Pipelines Accelerate Delivery
+
+By automating key parts of the development cycle, these pipelines directly impact speed, efficiency, and scalability.
+
+### Boosting deployment velocity with AI code generators
+
+The most immediate impact of AI code generation is a dramatic reduction in the time it takes to go from idea to implementation. By automating the creation of boilerplate code, unit tests, and even entire modules, developers can iterate much faster. This leads to shorter development cycles and more frequent deployments, allowing teams to respond more quickly to business needs.
+
+### Automating code reviews and release notes
+
+The review process can be a significant bottleneck. AI can help by generating summaries of changes for pull requests, suggesting reviewers, and even performing a preliminary review to flag potential issues. After a successful merge, the same AI capabilities can be used to draft release notes, further reducing manual effort. Tools like Kestra's [AI Copilot](https://kestra.io/docs/ai-tools/ai-copilot) can be orchestrated to perform these text-generation tasks as part of the post-merge workflow.
+
+### Handling increased code volume efficiently
+
+As AI boosts developer productivity, the volume of code being produced and sent through the CI/CD pipeline increases. A manual or inefficient delivery pipeline will quickly become overwhelmed. A scalable orchestration engine is essential to manage this increased throughput, running tests, scans, and deployments in parallel. The ability of a platform to handle high-volume executions, as shown in [Kestra's performance benchmarks](https://kestra.io/docs/performance/benchmark), ensures that the delivery pipeline can keep pace with the accelerated rate of code generation.
+
+## Implementing AI Code Generation in CI/CD Workflows
+
+Integrating these pipelines into your existing development practices requires a flexible and powerful orchestration tool.
+
+### Setting up AI code review in your CI/CD pipeline with Kestra
+
+Kestra can act as the central control plane for your AI code generation pipeline, defined declaratively in YAML. By integrating with your [Git repository](https://kestra.io/docs/version-control-cicd/git), a Kestra workflow can be triggered on a new pull request. The workflow can then call an LLM to generate code, run it through a series of validation tasks, and post the results back to the PR.
+
+Here is a simplified example of a Kestra flow:
+```yaml
+id: ai-code-generation-and-review
+namespace: dev.cicd
+
+tasks:
+  - id: generate_code
+    type: io.kestra.plugin.ai.completion.ChatCompletion
+    provider: openai
+    prompt: "Generate a Python function for..."
+
+  - id: lint_generated_code
+    type: io.kestra.plugin.scripts.shell.Commands
+    commands:
+      - echo "{{ outputs.generate_code.message.content }}" > script.py
+      - pip install ruff
+      - ruff check script.py
+
+  - id: security_scan
+    type: io.kestra.plugin.scripts.shell.Commands
+    commands:
+      - pip install bandit
+      - bandit -r .
+```
+This declarative approach makes the entire pipeline auditable and easy to modify. It can be fully integrated with tools like [GitHub Actions](https://kestra.io/docs/version-control-cicd/cicd/github-action) for a seamless CI/CD experience.
+
+### Strategies for integrating generative AI
+
+There are several ways to integrate AI into your workflows. The most direct method is using API calls to LLM providers. For more specialized tasks, you can package your code generation logic into a [custom Docker container](https://kestra.io/docs/scripts/custom-docker-image) and run it as a task. This provides maximum flexibility and isolates dependencies. For real-time use cases, you can use [webhook triggers](https://kestra.io/docs/workflow-components/triggers/webhook-trigger) to initiate a code generation pipeline based on external events, such as a new feature request in a project management tool.
+
+### Examples from large-scale data pipelines
+
+Leading tech companies are already leveraging AI in their complex pipelines. Meta, for instance, used AI to map undocumented dependencies in their vast data processing systems. At Apple, Kestra is used to orchestrate [large-scale machine learning and data pipelines](https://kestra.io/use-cases/stories/apple-ml-team-orchestrates-large-scale-data-pipelines-with-kestra), where the principles of automated generation and validation are critical. These examples show that orchestrating complex, polyglot environments is key to successfully applying AI at scale, a task for which a universal orchestrator is perfectly suited when building [ETL pipelines](https://kestra.io/docs/how-to-guides/etl-pipelines).
+
+## Benefits and Challenges of AI Code Generation Pipelines
+
+While the advantages are significant, a successful implementation requires awareness of potential hurdles.
+
+### Productivity gains and improved code quality
+
+The primary benefit is a substantial boost in developer productivity. As highlighted in [industry trend reports](https://kestra.io/blogs/2025-data-engineering-and-ai-trends), generative AI helps teams work more efficiently by handling routine tasks. When governed by a pipeline that enforces standards, this leads not only to faster development but also to more consistent and higher-quality code across the organization.
+
+### Addressing the delivery pipeline overwhelm
+
+A common challenge is that the increased code output from AI-assisted developers can overwhelm a traditional CI/CD pipeline. The solution is not to slow down developers but to enhance the pipeline's capacity with a powerful orchestration layer. By managing dependencies, running tasks in parallel, and providing clear visibility, orchestration prevents the delivery pipeline from becoming a bottleneck.
+
+### Future of AI in software development
+
+The evolution of AI in software development is heading towards more autonomous systems. We are moving into an era of [multi-agent collaboration](https://kestra.io/resources/ai/multi-agent-collaboration-evolving-orchestration), where specialized AI agents will handle different aspects of the development lifecycle. These agents will require structured knowledge and skills to operate effectively, highlighting the growing importance of platforms that provide robust [agent skills](https://kestra.io/docs/ai-tools/agent-skills) and orchestration capabilities.
+
+## Kestra: The Orchestration Control Plane for AI Code Generation
+
+Kestra is uniquely positioned to serve as the backbone for AI code generation pipelines. Its declarative YAML interface makes workflows auditable and version-controllable, which is essential for governing AI-driven processes. As a polyglot platform, Kestra can run any tool or script, regardless of language, providing the flexibility needed to integrate various AI models, linters, and security scanners.
+
+With native [AI tools](https://kestra.io/docs/ai-tools) like the AI Copilot and autonomous agents, Kestra is not just an orchestrator but an active participant in the AI-driven development lifecycle. It provides the unified control plane needed to manage these complex workflows, from data ingestion for RAG systems to the final deployment of AI-generated code. This is [why Kestra](https://kestra.io/docs/why-kestra) is a powerful choice for teams looking to build the next generation of software delivery pipelines.
+
+## Conclusion
+
+AI code generation pipelines represent a transformative shift in software development, moving beyond simple assistance to full-cycle automation. By integrating AI with robust quality checks, security scans, and CI/CD practices, teams can significantly accelerate delivery while maintaining high standards.
+
+Building these sophisticated pipelines requires a powerful, flexible, and AI-native orchestration platform. Kestra provides the declarative foundation and unified control plane to manage every stage, ensuring that as your use of AI grows, your delivery pipeline scales with it.
+
+To explore more guides and playbooks for AI, data, and infrastructure, browse our [full list of resources](https://kestra.io/resources). Ready to stop writing glue code and start orchestrating your AI pipelines? Check out our [AI automation solutions](https://kestra.io/ai-automation).


### PR DESCRIPTION
## Summary
- Import du brouillon SEO `brief-ai-code-generation-pipelines` ([vfanucci/kestra-seo#106](https://github.com/vfanucci/kestra-seo/pull/106)) dans le template `resources`
- Nouvelle page : `/resources/ai-code-generation-pipelines`
- Slug, frontmatter (title, metaTitle, description, FAQ, tag, date) et contenu repris à l'identique du draft

## Test plan
- [ ] Vérifier le rendu de la page `/resources/ai-code-generation-pipelines` en preview
- [ ] Vérifier la FAQ et les liens internes

🤖 Generated with [Claude Code](https://claude.com/claude-code)