### PR TITLE
fix: Learn menu

### DIFF
--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -426,6 +426,7 @@
                         height: headerMenuSize.height,
                         pointerEvents: headerMenuPointerEvents,
                     }"
+                    ref="headerMenu"
                     class="header-menu"
                     @mouseover="mouseOverMenu"
                     @mouseleave="mouseLeaveMenu"
@@ -706,7 +707,7 @@
     import Magnify from "vue-material-design-icons/Magnify.vue"
     import Close from "vue-material-design-icons/Close.vue"
     import Segment from "vue-material-design-icons/Segment.vue"
-    import { menuSize } from "~/utils/menu-sizes"
+    import { menuWidths } from "~/utils/menu-sizes"
     import { menuItems } from "~/utils/menu-items"
     import LogoBlack from "~/assets/logo-black.svg?raw"
     import LogoWhite from "~/assets/logo-white.svg?raw"
@@ -728,6 +729,8 @@
         height: "0px",
     })
     const headerMenuPointerEvents = ref<"none" | "auto">("none")
+    const headerMenu = ref<HTMLElement | null>(null)
+    const menuHeights = ref<Record<string, string>>({})
     const navbar = ref<HTMLElement | null>(null)
     const isMobile = ref(false)
     const isScrolled = ref(false)
@@ -759,7 +762,10 @@
     onMounted(() => {
         nextTick(() => {
             getCollapseInstance()
+            measureAllMenuHeights()
         })
+
+        document.fonts?.ready.then(() => measureAllMenuHeights())
 
         isMobile.value = window.innerWidth <= 1199
         window.addEventListener("resize", () => {
@@ -807,6 +813,51 @@
         }, 100)
     }
 
+    function measureMenuHeight(id: string, width: string): string | null {
+        const menu = headerMenu.value
+        const card = menu?.querySelector<HTMLElement>(".header-menu-card")
+        const section = document.getElementById(id)
+        if (!menu || !card || !section) return null
+
+        const fill = [
+            section.querySelector<HTMLElement>(".header-menu-content"),
+            ...section.querySelectorAll<HTMLElement>(".h-100"),
+        ].filter((el): el is HTMLElement => el !== null)
+
+        const touched = [menu, card, section, ...fill]
+        const saved = touched.map((el) => el.style.cssText)
+
+        menu.style.transition = "none"
+        menu.style.width = width
+        menu.style.height = card.style.height = "auto"
+        section.style.position = "static"
+        section.style.height = "auto"
+        fill.forEach((el) => (el.style.height = "auto"))
+
+        const height = `${menu.offsetHeight}px`
+
+        touched.forEach((el, i) => (el.style.cssText = saved[i]))
+        void menu.offsetHeight
+
+        return height
+    }
+
+    function measureAllMenuHeights() {
+        if (window.innerWidth <= 1199) return
+        for (const id in menuWidths) {
+            const height = measureMenuHeight(id, menuWidths[id])
+            if (height) menuHeights.value[id] = height
+        }
+    }
+
+    function menuHeight(id: string): string {
+        if (!menuHeights.value[id]) {
+            const measured = measureMenuHeight(id, menuWidths[id])
+            if (measured) menuHeights.value[id] = measured
+        }
+        return menuHeights.value[id] ?? "0px"
+    }
+
     function mouseOver(id: string, event: MouseEvent) {
         if (window.innerWidth <= 1199) return
 
@@ -831,9 +882,12 @@
         showMenuId.value = id
         mouseoverMenu.value = false
         headerMenuPointerEvents.value = "auto"
-        headerMenuSize.value = menuSize(id)
+        headerMenuSize.value = {
+            width: menuWidths[id],
+            height: menuHeight(id),
+        }
 
-        const { left, width } = (
+        const { left } = (
             event.currentTarget as HTMLElement
         ).getBoundingClientRect()
         const menuWidth = parseInt(headerMenuSize.value.width)
@@ -1651,7 +1705,7 @@
                             position: absolute;
                             top: 0;
                             bottom: 0;
-                            padding: $rem-1;
+                            padding: 20px $rem-1;
 
                             &.opacity-100 {
                                 transition: opacity 700ms ease;

--- a/src/utils/menu-sizes.ts
+++ b/src/utils/menu-sizes.ts
@@ -1,24 +1,6 @@
-type MenuSize = { width: string; height: string }
-
-const menuSizes: Record<string, MenuSize> = {
-    product:   {
-        width: "305px",
-        height: "228px"
-    },
-    solutions: {
-        width: "782px",
-        height: "340px"
-    },
-    resources: {
-        width: "285px",
-        height: "310px"
-    },
-    company: {
-        width: "305px",
-        height: "228px"
-    },
-}
-
-export function menuSize(name: string): MenuSize {
-    return menuSizes[name]
+export const menuWidths: Record<string, string> = {
+    product: "305px",
+    solutions: "782px",
+    resources: "285px",
+    company: "305px",
 }

--- a/src/utils/menu-sizes.ts
+++ b/src/utils/menu-sizes.ts
@@ -11,7 +11,7 @@ const menuSizes: Record<string, MenuSize> = {
     },
     resources: {
         width: "285px",
-        height: "330px"
+        height: "290px"
     },
     company: {
         width: "305px",

--- a/src/utils/menu-sizes.ts
+++ b/src/utils/menu-sizes.ts
@@ -11,7 +11,7 @@ const menuSizes: Record<string, MenuSize> = {
     },
     resources: {
         width: "285px",
-        height: "290px"
+        height: "310px"
     },
     company: {
         width: "305px",

--- a/src/utils/menu-sizes.ts
+++ b/src/utils/menu-sizes.ts
@@ -11,7 +11,7 @@ const menuSizes: Record<string, MenuSize> = {
     },
     resources: {
         width: "285px",
-        height: "272px"
+        height: "330px"
     },
     company: {
         width: "305px",


### PR DESCRIPTION
Closes https://github.com/kestra-io/docs/issues/4882

It's too cramped at the top and bottom. Probably due to Integrations being added

Before:
<img width="343" height="327" alt="Screenshot 2026-06-04 at 15 14 33" src="https://github.com/user-attachments/assets/ffb83608-8465-4686-86ca-8c41ccc12141" />
