### PR TITLE
docs: document namespace and subkey arguments for secret()

### DIFF
--- a/src/contents/docs/06.concepts/04.secret/index.md
+++ b/src/contents/docs/06.concepts/04.secret/index.md
@@ -57,6 +57,19 @@ For a concrete example of using secrets in flows, check out our dedicated [How-T
 
 Kestra [Enterprise Edition](../../07.enterprise/index.mdx) provides additional secret management backends and integrations with secrets managers. See the [Secrets Manager](../../07.enterprise/02.governance/secrets-manager/index.md) page for more details.
 
+### Reading secrets from another namespace
+
+By default, `secret()` reads from the flow's own namespace. Pass a `namespace` argument to read a secret stored in a different namespace:
+
+```yaml
+tasks:
+  - id: use_shared_secret
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ secret('SHARED_TOKEN', namespace='shared.secrets') }}"
+```
+
+The secret is resolved using the target namespace's own secret backend, so a flow can read a value from a namespace backed by a different secrets manager. Cross-namespace reads stay within the same tenant. Access to another namespace's secrets is allowed by default; restrict it by configuring `allowedNamespaces` on the target namespace.
+
 ## Secrets in the Open-Source version
 
 When using the open-source version, sensitive variables can be managed using base64-encoded environment variables. The section below demonstrates several ways to encode those values and use them in your Kestra instance.

--- a/src/contents/docs/expressions/04.functions/02.data-access/index.mdx
+++ b/src/contents/docs/expressions/04.functions/02.data-access/index.mdx
@@ -10,12 +10,22 @@ These functions bridge expressions to external or stored data. Use them when the
 
 ## `secret()`
 
-Use `secret()` for sensitive values that should not appear in the flow definition:
+Use `secret()` for sensitive values that should not appear in the flow definition. The namespace defaults to the flow's namespace; pass a `namespace` to read a secret stored in another namespace, and a `subkey` to extract a single field from a JSON secret:
 
 ```twig
 {{ secret('API_KEY') }}
 {{ secret('GITHUB_ACCESS_TOKEN') }}
+{{ secret('SHARED_SECRET', namespace='other.namespace') }}
+{{ secret('DB_CREDENTIALS', subkey='password') }}
 ```
+
+Arguments:
+
+- `key` — the secret key
+- `namespace` — defaults to the flow's namespace; the secret is resolved using that namespace's secret backend, with values inherited from parent namespaces
+- `subkey` — optional field to extract when the secret holds a JSON object
+
+Cross-namespace reads stay within the same tenant. In the Enterprise Edition, a flow may read another namespace's secrets by default; restrict this by configuring `allowedNamespaces` on the target namespace.
 
 ## `credential()`
 


### PR DESCRIPTION
- Document the optional `namespace` argument on `secret()` — reads a secret from another namespace using that namespace's own secret backend (available as of 1.3).
- Document the `subkey` argument for extracting a field from a JSON secret.
- Add a cross-namespace example and security note to the Secrets concept page (same-tenant only; allowed by default, restrict via `allowedNamespaces`).

Companion PR: kestra-io/kestra (basic.md in-app reference).