### PR TITLE
fix: explicitly add remark-gfm to markdown plugins

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,7 @@ import mdx from "@astrojs/mdx"
 import icon from "astro-icon"
 import expressiveCode from "astro-expressive-code"
 
+import remarkGfm from "remark-gfm"
 import remarkDirective from "remark-directive"
 import customRemarkLinkRewrite from "./src/markdown/remark/link-rewrite.ts"
 import remarkCustomElements from "./src/markdown/remark/remark-custom-elements/index.mjs"
@@ -60,6 +61,7 @@ export default defineConfig({
     ],
     markdown: {
         remarkPlugins: [
+            remarkGfm,
             remarkMermaid,
             remarkClassname,
             remarkDirective,


### PR DESCRIPTION
Problem

GFM tables in all .mdx doc pages (configuration, enterprise, expressions, kestra-cli, tasks, triggers, filters, and others — 9 files total) were rendering as raw pipe-separated text inside <p> elements instead of as <table> elements. .md files were unaffected.

Root cause: @astrojs/mdx relies on a gfm: true option to add remark-gfm to its pipeline. This option is inherited from the markdown config via extendMarkdownConfig: true, but it is not being applied reliably in the production build (likely a regression between astro@6.1.5 and astro@6.4.4). Without remark-gfm, the MDX compiler treats GFM table syntax as an ordinary paragraph.

<img width="1920" height="600" alt="Screenshot 2026-06-08 at 10 41 10" src="https://github.com/user-attachments/assets/6cca45a5-7e85-4ea8-8484-665a383863d0" />

Fix

Explicitly import remark-gfm and add it to markdown.remarkPlugins. Because extendMarkdownConfig: true is the default for @astrojs/mdx, user-defined remark plugins always flow into the MDX pipeline — bypassing the conditional path that was failing. Adding remark-gfm twice (once via the gfm option if it ever works, once via user plugins) is safe and idempotent.

Files changed

- astro.config.mjs — import remark-gfm; add as first entry in markdown.remarkPlugins

Pages fixed

/docs/configuration, /docs/enterprise, /docs/expressions, /docs/expressions/filters, /docs/expressions/syntax, /docs/expressions/context, /docs/kestra-cli, /docs/workflow-components/tasks, /docs/workflow-components/triggers