### PR TITLE
docs(resources): 6 SEO pages — AI, infra, data (W23 batch)

### DIFF
--- a/src/contents/resources/ai-governance-workflows/index.md
+++ b/src/contents/resources/ai-governance-workflows/index.md
@@ -1,0 +1,263 @@
+---
+title: "AI Governance Workflows: Reduce Risk & Ensure Compliance"
+description: "Enhance your AI governance workflows for production. Manage dependencies, enforce policies, and reduce AI risk across your organization. Learn best practices today!"
+metaTitle: "AI Governance Workflows: Reduce Risk & Ensure Compliance"
+metaDescription: "Enhance your AI governance workflows for production. Manage dependencies, enforce policies, and reduce AI risk. Learn best practices for enterprise AI systems."
+tag: "ai"
+date: 2026-05-27
+slug: "ai-governance-workflows"
+faq:
+  - question: "What are AI governance workflows?"
+    answer: "AI governance workflows are structured processes that ensure AI systems operate ethically, compliantly, and transparently throughout their lifecycle. They involve defining policies, implementing controls, monitoring performance, and managing risks associated with AI models, from development to deployment and ongoing operation."
+  - question: "Why is AI governance important for businesses?"
+    answer: "AI governance is crucial for businesses to mitigate risks such as bias, privacy breaches, and regulatory non-compliance. It fosters trust, improves operational efficiency, and helps maintain accountability, ensuring that AI initiatives drive value without introducing unforeseen liabilities or reputational damage."
+  - question: "How can AI governance be integrated into existing development processes?"
+    answer: "Integrating AI governance involves embedding policies and controls directly into the AI development lifecycle. This includes establishing clear approval gates, utilizing automated checks within CI/CD pipelines, and ensuring that data, model, and deployment changes are traceable and auditable. Declarative orchestration platforms can automate these integration points."
+  - question: "What role do automated platforms play in AI governance?"
+    answer: "Automated platforms streamline AI governance by automating policy enforcement, dependency management, and continuous monitoring. They provide a centralized control plane for defining, executing, and auditing governance workflows, reducing manual effort and ensuring consistent application of policies across diverse AI systems."
+  - question: "What are the key benefits of effective AI governance?"
+    answer: "Effective AI governance leads to reduced AI-related risks, improved operational efficiency through standardized processes, and enhanced trust among stakeholders. It also ensures adherence to evolving regulatory landscapes, promoting the development and deployment of responsible and transparent AI systems."
+  - question: "How does Kestra support AI governance workflows?"
+    answer: "Kestra supports AI governance through its declarative YAML-based workflows, enabling policy-as-code. It provides robust capabilities for orchestrating diverse AI pipelines (data prep, model training, inference), managing dependencies, and integrating with external systems for approvals and auditing. Its AI-native features like Copilot and AI Agents can also be governed directly within the platform."
+---
+
+As AI systems move from experimental labs to production environments, the need for robust governance becomes paramount. Organizations grapple with managing the inherent risks, ensuring compliance with evolving regulations, and maintaining ethical standards. Without a clear framework, AI initiatives can quickly become liabilities, undermining trust and exposing the business to significant operational and reputational damage.
+
+This guide explores the critical role of AI governance workflows in today's enterprise. We'll delve into what constitutes effective AI governance, outline a six-step process for operationalizing it, and highlight best practices for integrating governance throughout your AI development lifecycle. Discover how a declarative orchestration platform can streamline these processes, reduce risk, and foster responsible AI adoption.
+
+## Understanding AI Governance Workflows
+
+Before implementing AI governance, it's essential to understand its core concepts, importance, and components. This foundation ensures that governance initiatives are comprehensive, effective, and aligned with organizational goals.
+
+### What are AI governance workflows?
+
+AI governance workflows are the structured, repeatable processes and automated systems that operationalize an organization's AI policies. They go beyond a static document of rules by defining the exact steps, controls, and approval gates required to ensure AI systems are developed, deployed, and maintained responsibly. This includes everything from data ingestion and model training to deployment and continuous monitoring.
+
+Unlike traditional IT governance, which often focuses on infrastructure and software, AI governance must address unique challenges like model bias, data privacy in training sets, and the explainability of algorithmic decisions. These workflows provide a practical framework for managing the entire [AI pipeline](https://kestra.io/resources/ai/ai-pipeline), making governance an active, integrated part of the AI lifecycle rather than a reactive checklist.
+
+### Importance of robust AI governance
+
+Robust AI governance is not a bureaucratic hurdle; it's a strategic imperative. Its importance stems from several key areas:
+
+*   **Risk Mitigation:** AI models can introduce new risks, including biased decision-making, privacy violations, and security vulnerabilities. Governance workflows identify, assess, and mitigate these risks before they impact the business or its customers.
+*   **Regulatory Compliance:** Governments worldwide are introducing regulations like the EU AI Act. A strong governance framework ensures that AI systems comply with these legal requirements, avoiding hefty fines and legal challenges.
+*   **Ethical AI:** Governance provides the mechanism to enforce ethical principles like fairness, transparency, and accountability, ensuring that AI systems align with societal values.
+*   **Building Trust:** Demonstrating responsible AI practices builds trust with customers, partners, and internal stakeholders, which is critical for long-term adoption and success.
+
+### Key components of an effective AI governance framework
+
+An effective AI governance framework is built on several key components that work together to provide comprehensive oversight:
+
+*   **Policy Definition:** Clear, unambiguous policies that outline the organization's principles for AI development and use.
+*   **Risk Assessment:** Processes to identify and evaluate potential risks at each stage of the AI lifecycle.
+*   **Continuous Monitoring:** Mechanisms to track model performance, detect drift or bias, and ensure ongoing compliance in production.
+*   **Audit Trails:** Immutable logs of all actions, decisions, and changes related to AI models, providing a complete history for accountability and debugging.
+*   **Human Oversight:** Clearly defined points for human review and approval, especially for high-stakes decisions.
+*   **Model Lifecycle Management:** A systematic approach to managing models from conception through to retirement, including versioning, documentation, and dependency tracking.
+
+## Six Steps to Operationalize AI Governance
+
+A governance framework is only effective if it's put into practice. Operationalizing AI governance involves translating high-level principles into concrete, automated workflows. Here’s a six-step process to guide implementation.
+
+### Step 1: Anchoring policy to business objectives
+
+Governance should enable, not hinder, business goals. Start by aligning AI policies with your organization's strategic objectives. Define what responsible AI means in the context of your industry, customers, and values. This ensures that governance efforts are focused on the most critical areas and are perceived as a core part of the business strategy.
+
+### Step 2: Translating principles into concrete controls
+
+Abstract principles like "fairness" or "transparency" must be translated into verifiable, technical controls. For example:
+*   **Fairness:** Implement a control that automatically runs a bias detection tool (e.g., AIF360) on training data and model outputs.
+*   **Transparency:** Mandate the generation of a "model card" as part of the deployment workflow, documenting the model's performance, limitations, and intended use.
+
+### Step 3: Defining roles and operating models for AI governance
+
+Establish clear ownership and responsibilities. An effective operating model typically includes a cross-functional team of data scientists, ML engineers, legal experts, compliance officers, and platform engineers. Define who is responsible for creating policies, implementing controls, reviewing model performance, and responding to incidents.
+
+### Step 4: Integrating governance into existing workflows
+
+AI governance should not be a separate, siloed process. Instead, it should be integrated directly into the tools and workflows your teams already use. This involves embedding governance checks into your CI/CD pipelines, data processing jobs, and model deployment processes. Adopting [workflow best practices](https://kestra.io/docs/best-practices) ensures that governance becomes a natural part of the development lifecycle. This approach, often managed through a [CI/CD pipeline](https://kestra.io/docs/version-control-cicd/cicd), minimizes friction and encourages adoption.
+
+### Step 5: Automating AI governance processes
+
+Manual governance is slow, error-prone, and impossible to scale. Use an orchestration platform to automate the enforcement of your governance controls. A declarative approach allows you to define these controls as code, making them versionable, auditable, and consistently applied.
+
+For instance, a simple Kestra workflow can automate a data quality check before allowing a model training script to run.
+
+```yaml
+id: governed-model-training
+namespace: company.team.ai
+
+tasks:
+  - id: data-quality-check
+    type: io.kestra.plugin.jdbc.duckdb.Query
+    sql: |
+      SELECT count(*) FROM read_parquet('{{ inputs.data_uri }}') WHERE user_id IS NULL;
+    fetchOne: true
+
+  - id: check-for-nulls
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ outputs['data-quality-check'].row.count > 0 }}"
+    then:
+      - id: fail-on-bad-data
+        type: io.kestra.plugin.core.execution.Fail
+        message: "Data quality check failed: Found NULL user_id values."
+    else:
+      - id: train-model
+        type: io.kestra.plugin.scripts.python.Script
+        script: |
+          # Your model training code here
+          print("Data quality check passed. Starting model training...")
+```
+
+### Step 6: Monitoring and adapting AI governance policies
+
+AI governance is not a one-time setup. Models degrade, data distributions shift, and regulations change. Implement continuous monitoring to track model performance and compliance in real-time. Use this feedback loop to adapt and update your governance policies as needed. A strong foundation in [data observability](https://kestra.io/resources/data/data-observability) is critical for this step.
+
+## Best Practices for AI Governance Workflows
+
+Adopting best practices ensures your governance workflows are robust, efficient, and capable of managing the complexities of production AI.
+
+### Managing risk across AI pipelines
+
+Effective risk management requires visibility and control over the entire AI pipeline. This includes:
+*   **Data Provenance and Lineage:** Track the origin, transformations, and usage of data to ensure its integrity and suitability for model training. Tools that support [data lineage](https://kestra.io/resources/data/data-lineage) are essential.
+*   **Model Versioning:** Maintain a clear record of all model versions, including the code, data, and parameters used to train them. This is crucial for reproducibility and rollbacks.
+*   **Dependency Management:** Explicitly define and manage dependencies between data sources, feature engineering scripts, models, and deployment environments. Kestra's [Assets](https://kestra.io/docs/enterprise/governance/assets) feature provides a way to track these dependencies automatically.
+
+### Ensuring compliance and ethical AI
+
+To meet regulatory and ethical standards, your workflows must incorporate:
+*   **Explainability (XAI):** Integrate tools and steps that generate explanations for model predictions, making them more transparent to stakeholders.
+*   **Bias Detection:** Automate checks for demographic and social biases in both data and model behavior.
+*   **Auditability:** Ensure every action within the AI lifecycle is logged and traceable, providing a clear audit trail for compliance reviews.
+
+### Building responsible and transparent AI systems
+
+Transparency builds trust. Implement workflows that automatically generate documentation like model cards, which detail a model's performance characteristics, limitations, and ethical considerations. Establish clear communication channels to inform stakeholders about how AI systems are operating.
+
+### Leveraging automated AI governance platforms
+
+A centralized orchestration platform like [Kestra](https://kestra.io/) acts as the control plane for AI governance. By defining policies and controls as declarative code, you create a single source of truth that is both human-readable and machine-executable. This policy-as-code approach, combined with enterprise-grade [governance features](https://kestra.io/docs/enterprise/governance), ensures that your rules are applied consistently across all AI projects.
+
+This Kestra flow demonstrates a simple approval gate for model deployment, a core governance practice.
+
+```yaml
+id: model-deployment-with-approval
+namespace: company.team.mlops
+
+tasks:
+  - id: pre-deployment-checks
+    type: io.kestra.plugin.scripts.shell.Commands
+    commands:
+      - echo "Running model validation and compliance checks..."
+      # Add your automated checks here
+
+  - id: human-approval-gate
+    type: io.kestra.plugin.core.flow.Pause
+    description: "Deployment requires manual approval from the ML Governance team."
+
+  - id: deploy-model
+    type: io.kestra.plugin.scripts.shell.Commands
+    commands:
+      - echo "Approval received. Deploying model to production..."
+      # Your deployment script here
+```
+
+## Integrating AI Governance into the SDLC
+
+For governance to be effective, it must be an integral part of the Software Development Lifecycle (SDLC), not an afterthought.
+
+### AI governance intake prioritization workflows
+
+Before a project begins, use a standardized workflow to assess its potential risks and governance requirements. This intake process helps prioritize resources, identify necessary controls early, and ensure that high-risk projects receive appropriate oversight from the start.
+
+### Facilitating AI adoption with built-in governance
+
+Make it easy for developers to do the right thing. Provide pre-built, governed workflow templates that embed best practices for security, data privacy, and ethical AI. Kestra's [Custom Blueprints](https://kestra.io/docs/enterprise/governance/custom-blueprints) allow platform teams to create and share these reusable patterns, accelerating development while ensuring compliance.
+
+### Tracking AI impact and scaling safely
+
+As you scale your AI initiatives, it's crucial to track their impact on business metrics, operational performance, and ethical goals. Implement workflows that automatically collect and report on these KPIs, providing the visibility needed to make informed decisions and scale AI adoption safely.
+
+## Types of AI Workflows and Their Governance
+
+AI workflows can be broadly categorized into non-agentic and agentic systems, each requiring a tailored governance approach.
+
+### Non-agentic AI workflows
+
+These are traditional, deterministic workflows common in MLOps, such as [ETL for ML](https://kestra.io/resources/data/etl-workflow) and batch inference jobs. Governance for these workflows focuses on data quality, model versioning, and the reproducibility of the [machine learning pipeline](https://kestra.io/resources/ai/what-is-a-machine-learning-pipeline).
+
+### Agentic AI workflows for execution
+
+These workflows involve [AI agents](https://kestra.io/resources/ai/ai-agent) that can use tools and make basic decisions to complete tasks. Governance here must also cover the agent's autonomy, ensuring its actions are constrained, auditable, and aligned with predefined rules. Kestra's platform allows you to build and manage these [AI agents](https://kestra.io/docs/ai-tools/ai-agents) within a controlled environment.
+
+### Agentic AI with strong governance for scale
+
+For complex, multi-agent systems, robust governance is non-negotiable. This requires a platform capable of [agentic orchestration](https://kestra.io/resources/ai/agentic-orchestration), which coordinates multiple agents, systems, and human actors within a single, auditable process. Governance must include human-in-the-loop approval gates, strict control over the tools and skills available to agents, and complete traceability of every decision and action. Kestra's [agent skills](https://kestra.io/docs/ai-tools/agent-skills) framework provides this level of declarative control.
+
+Here is an example of a Kestra flow that orchestrates an AI agent with a mandatory human review step before executing its plan.
+
+```yaml
+id: governed-ai-agent
+namespace: company.team.automation
+
+tasks:
+  - id: run-agent
+    type: io.kestra.plugin.ai.agent.AIAgent
+    prompt: "Analyze last week's sales data from '{{ inputs.sales_data_uri }}' and draft an email summary for the leadership team."
+    tools:
+      - type: io.kestra.plugin.ai.tool.CodeExecution
+
+  - id: review-agent-plan
+    type: io.kestra.plugin.core.flow.Pause
+    description: |
+      Review the AI agent's proposed email draft before sending.
+      Draft: {{ outputs['run-agent'].files['email_draft.txt'] }}
+
+  - id: send-email
+    type: io.kestra.plugin.email.MailSend
+    subject: "Weekly Sales Summary"
+    from: "noreply@kestra.io"
+    to: "leadership@example.com"
+    html: "{{ outputs['run-agent'].files['email_draft.txt'] | fileRead | nl2br }}"
+```
+
+## Benefits of Streamlined AI Governance Workflows
+
+Implementing structured, automated AI governance workflows delivers tangible benefits across the organization.
+
+### Reducing AI-related risks
+
+By embedding controls and monitoring throughout the AI lifecycle, you proactively identify and mitigate financial, reputational, and legal risks before they escalate.
+
+### Improving operational efficiency
+
+Automation and standardization eliminate manual review cycles, reduce errors, and accelerate the deployment of compliant AI models. This frees up data scientists and engineers to focus on innovation rather than administrative tasks.
+
+### Fostering trust and accountability
+
+Transparent, auditable workflows demonstrate a commitment to responsible AI, building trust with customers, regulators, and employees. Clear roles and responsibilities ensure accountability for the entire lifecycle of an AI system.
+
+### Maintaining regulatory compliance
+
+An automated governance framework allows you to adapt quickly to new and evolving regulations. Whether for [government and public sector](https://kestra.io/use-cases/public-services) compliance or industry-specific standards, workflows can be updated to enforce new rules consistently across all systems.
+
+## Implementing Secure and Efficient AI Governance Workflows with Kestra
+
+Kestra provides a unified platform to implement all aspects of AI governance, from data pipelines to agentic systems.
+
+### Establishing clear approval gates
+
+Kestra’s human-in-the-loop tasks, such as `Pause`, allow you to insert manual approval steps at critical points in your workflows, ensuring that high-impact actions are reviewed before execution.
+
+### Utilizing structured workflows and automated checks
+
+With Kestra, all workflows are defined as declarative YAML, creating a version-controlled, auditable record of your governance processes. You can use a wide range of [workflow components](https://kestra.io/docs/workflow-components) and plugins to build automated checks for everything from data quality to model fairness. This is particularly powerful for complex processes like [RAG workflows](https://kestra.io/docs/ai-tools/ai-rag-workflows).
+
+### Managing dependencies across pipelines
+
+Kestra's architecture makes it easy to manage complex dependencies. You can design modular [flows](https://kestra.io/docs/best-practices/flows) using subflows and trigger downstream processes based on the completion of upstream tasks, creating a clear and manageable dependency graph for your entire AI ecosystem.
+
+### Kestra as your AI orchestration control plane
+
+By unifying data, AI, infrastructure, and business workflows, Kestra provides a single control plane for holistic governance. You can enforce consistent policies across all your automated processes, from simple data ingestion to complex, multi-agent systems. With Kestra's [AI tools](https://kestra.io/docs/ai-tools), you can build, govern, and scale your [AI automation](https://kestra.io/ai-automation) initiatives with confidence. Explore our [use cases](https://kestra.io/use-cases) to see how orchestration can transform your approach to AI governance.

--- a/src/contents/resources/ai-native-orchestration-platform/index.md
+++ b/src/contents/resources/ai-native-orchestration-platform/index.md
@@ -1,0 +1,191 @@
+---
+title: "AI-Native Orchestration Platform Options & Tools"
+description: "Explore the best AI-Native Orchestration Platforms. Discover benefits, compare top tools, and streamline your AI workflows today!"
+metaTitle: "AI-Native Orchestration Platforms: Tools & Comparison"
+metaDescription: "Discover leading AI-native orchestration platforms. Learn about key features like agentic AI, data integration, and multi-model support to streamline your enterprise AI workflows."
+tag: "ai"
+date: 2026-05-27
+slug: "ai-native-orchestration-platform"
+faq:
+  - question: "What is an AI-native orchestration platform?"
+    answer: "An AI-native orchestration platform coordinates the deployment, integration, and management of diverse AI models, data pipelines, and systems. Unlike traditional orchestrators, it's designed from the ground up to handle the unique demands of AI workloads, including model versioning, GPU resource management, and complex agentic workflows."
+  - question: "Why is AI-native orchestration crucial for enterprises?"
+    answer: "For enterprises, AI-native orchestration is crucial because it enables scalable, secure, and efficient AI operations. It unifies fragmented AI tools, automates complex workflows, and provides the governance needed for production-grade AI, accelerating time-to-value and reducing operational overhead."
+  - question: "What are the key features of an AI-native orchestration platform?"
+    answer: "Key features include multi-agent orchestration and collaboration, seamless integration with data pipelines, support for diverse AI models and frameworks, and robust workflow automation capabilities. Declarative configuration, event-driven architecture, and built-in observability are also critical for managing complex AI systems."
+  - question: "How does agentic AI orchestration differ from traditional AI workflows?"
+    answer: "Agentic AI orchestration goes beyond sequential task execution by enabling autonomous AI agents to collaborate towards a goal. These agents can dynamically select tools, adapt to changing conditions, and self-correct, revolutionizing how complex business processes are automated and managed."
+  - question: "Which open-source tools are available for AI orchestration?"
+    answer: "Several open-source frameworks offer AI orchestration capabilities, including Kestra, which provides a declarative YAML-based approach for unifying data, AI, and infrastructure workflows. Other options like Argo Workflows and Prefect also offer solutions for specific aspects of AI pipeline management."
+  - question: "Can AI-native orchestration platforms integrate with existing data stacks?"
+    answer: "Yes, a core strength of effective AI-native orchestration platforms is their ability to integrate seamlessly with existing data stacks. They connect to various databases, data lakes, messaging queues, and ETL tools, ensuring that AI models have access to high-quality, up-to-date data for training and inference."
+  - question: "What is the future of AI orchestration?"
+    answer: "The future of AI orchestration is moving towards more autonomous, self-evolving, and multi-agent systems. Platforms will increasingly focus on providing robust governance for AI agents, enabling dynamic decision-making, and offering low-code interfaces to make AI workflow creation accessible to a broader range of users across the enterprise."
+---
+
+The rapid adoption of AI across enterprises has exposed a critical challenge: coordinating disparate AI models, data pipelines, and operational systems. Traditional orchestration tools, designed for simpler batch jobs, struggle to manage the dynamic, event-driven, and polyglot nature of modern AI workflows. This fragmentation leads to increased operational complexity, slower deployment cycles, and a lack of unified visibility.
+
+This article explores the emerging category of AI-native orchestration platforms. We'll define what makes these platforms distinct, examine their core benefits for businesses, and dive into essential features. You'll gain insights into leading tools, including open-source options, and understand how agentic AI is fundamentally reshaping the orchestration paradigm, offering a path to truly autonomous and scalable AI operations.
+
+## What is an AI-Native Orchestration Platform?
+
+An AI-native orchestration platform is a control plane designed specifically to manage the entire lifecycle of AI and machine learning applications. It goes beyond simple task scheduling to coordinate complex dependencies between data ingestion, model training, validation, deployment, and monitoring.
+
+### Defining AI Orchestration: Models, Data, and Workflows
+
+AI orchestration involves the automated management of three core components:
+
+1.  **AI Models:** This includes versioning, training, and deploying a variety of models, from classical machine learning algorithms to large language models (LLMs).
+2.  **Data:** The platform must manage the flow of data for training, validation, and real-time inference, ensuring data quality and lineage. This covers everything from batch ETL jobs to real-time data streams.
+3.  **Workflows:** It connects all the steps into a cohesive, automated process. This includes not only the technical [machine learning pipeline](https://kestra.io/resources/ai/what-is-a-machine-learning-pipeline) but also business logic, human-in-the-loop approvals, and integrations with other enterprise systems.
+
+The "native" aspect signifies that the platform is built from the ground up with AI-specific requirements in mind, such as GPU resource allocation, model registry integration, and handling of complex, non-linear dependencies.
+
+### The Evolution of AI Orchestration Platforms
+
+The concept of orchestration has evolved significantly. Initially, it was about running cron jobs and simple scripts. Then came data orchestration platforms like Airflow, which were designed for scheduled batch ETL pipelines. As MLOps emerged, specialized tools appeared to manage the machine learning lifecycle, but they often created another silo.
+
+Today, the most advanced platforms provide unified, [multi-domain orchestration](https://kestra.io/blogs/2026-03-05-data-eng-trends-2026). They act as a central control plane that can manage data pipelines, infrastructure provisioning, and AI model deployment within a single, coherent framework. The latest evolution is the integration of agentic capabilities, allowing autonomous AI agents to execute and adapt workflows dynamically.
+
+### Why AI-Native Orchestration is Crucial for Enterprises
+
+For enterprises, adopting an AI-native orchestration platform is no longer a luxury but a necessity. It addresses several critical challenges:
+
+*   **Scalability:** Manually managing hundreds of AI models and their associated data pipelines is not feasible. Orchestration automates these processes, allowing teams to scale their AI initiatives effectively.
+*   **Reproducibility:** To ensure model reliability and regulatory compliance, every step of the training and deployment process must be versioned and reproducible. An orchestration platform enforces this discipline.
+*   **Governance:** It provides a centralized point of control for managing access, securing data, and auditing AI workflows, which is essential for production-grade applications.
+*   **Complexity Management:** Modern [AI automation](https://kestra.io/ai-automation) involves a diverse ecosystem of tools, from vector databases to various LLM providers. An AI-native platform unifies this complexity, allowing developers to focus on building models rather than writing glue code.
+
+## Benefits of Robust AI Orchestration
+
+A mature AI orchestration strategy provides tangible business benefits by transforming AI projects from experimental silos into integrated, scalable, and secure enterprise operations.
+
+### Enabling Scalable and Efficient AI Operations
+
+By automating the end-to-end AI lifecycle, orchestration platforms dramatically increase operational efficiency. They enable the automated retraining of models based on data drift or performance degradation, manage resource allocation for training jobs (including expensive GPU clusters), and streamline the deployment process through CI/CD practices. This automation leads to faster iteration cycles, allowing data science teams to experiment and deliver value more quickly.
+
+### Ensuring Secure and Integrated AI Model Management
+
+Security and governance are paramount when deploying AI in an enterprise context. An orchestration platform provides a robust framework for managing these aspects. It tracks the lineage of data and models, ensuring that you know exactly what data was used to train which version of a model. Features like Role-Based Access Control (RBAC) ensure that only authorized personnel can access sensitive data or deploy models to production. By integrating with secrets management systems, the platform also secures the credentials needed to access various data sources and services. This level of [enterprise governance](https://kestra.io/docs/enterprise/governance) is critical for building trust and ensuring compliance.
+
+### Delivering Hyper-Personalized Experiences with AI-Native Orchestration
+
+The ability to deliver hyper-personalized customer experiences is a key driver of AI adoption. AI-native orchestration makes this possible by enabling real-time inference and dynamic decision-making. For example, a platform can trigger a recommendation model in real-time based on a user's clickstream data, or orchestrate a multi-agent system to generate personalized marketing copy. This requires an event-driven architecture that can react instantly to new data and trigger the appropriate AI workflows, moving beyond simple batch processing to power truly interactive applications.
+
+## Key Features to Look for in an AI-Native Orchestration Platform
+
+When evaluating platforms, several key features distinguish a truly AI-native solution from a repurposed traditional orchestrator.
+
+### Multi-Agent Orchestration and Collaboration
+
+The cutting edge of AI involves not just single models but systems of multiple, collaborating AI agents. A forward-looking platform must be able to orchestrate these multi-agent systems, managing their communication, state, and access to tools. This includes the ability to define workflows where [AI agents](https://kestra.io/docs/ai-tools/ai-agents) can be triggered, run in parallel, and hand off tasks to one another to achieve a common goal.
+
+### Data Pipeline Integration and Unification
+
+AI models are only as good as the data they are trained on. Therefore, seamless integration with the entire data ecosystem is non-negotiable. An AI-native platform must connect to a wide range of data sources, including data warehouses, data lakes, and streaming platforms. It should support both ETL and ELT patterns, allowing for robust [data orchestration](https://kestra.io/resources/data/data-orchestration) to ensure that data is cleaned, transformed, and made available to models in a timely and reliable manner. A rich plugin ecosystem is often a key indicator of a platform's integration capabilities.
+
+### Support for Diverse AI Models and Frameworks
+
+The AI landscape is polyglot. Teams use a variety of languages (Python, R, Go) and frameworks (TensorFlow, PyTorch, Scikit-learn). A modern orchestration platform must be language-agnostic, allowing teams to run their code in its native environment, often through containerization with Docker. Furthermore, with the rise of generative AI, the platform needs extensive [plugins](https://kestra.io/plugins) and integrations for various LLM providers, including OpenAI, Anthropic, Gemini, Mistral, and open-source models hosted on platforms like Hugging Face.
+
+### Workflow Automation and Management Capabilities
+
+At its core, the platform must excel at workflow automation. This means providing a clear, maintainable way to define complex processes. A declarative approach using YAML is often preferred, as it allows workflows to be version-controlled with Git, reviewed like code, and managed through CI/CD pipelines. Other essential capabilities include a visual editor for building and understanding flows, a robust system for handling errors and retries, and comprehensive monitoring and logging to ensure visibility into every [workflow execution](https://kestra.io/docs/workflow-components/flow).
+
+For example, a simple AI workflow in Kestra might look like this:
+
+```yaml
+id: ai-text-summary
+namespace: company.team.ai
+
+tasks:
+  - id: fetch-article
+    type: io.kestra.plugin.core.http.Request
+    uri: https://api.example.com/latest-article
+
+  - id: summarize-with-openai
+    type: io.kestra.plugin.openai.ChatCompletion
+    apiKey: "{{ secret('OPENAI_API_KEY') }}"
+    model: "gpt-4o"
+    messages:
+      - role: "user"
+        content: "Summarize the following text: {{ outputs['fetch-article'].body }}"
+
+  - id: post-summary-to-slack
+    type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    payload: |
+      {
+        "text": "Daily Article Summary: {{ outputs['summarize-with-openai'].choices[0].message.content }}"
+      }
+```
+
+This example demonstrates how a declarative workflow can chain together an API call, an AI model inference, and a notification, all within a single, auditable file.
+
+## Top AI Orchestration Platforms and Tools Compared
+
+The market for AI orchestration is diverse, with a range of enterprise solutions and open-source frameworks available.
+
+### Overview of Leading Enterprise Solutions
+
+Several major cloud providers and data platforms offer integrated orchestration solutions. **[Databricks Workflows](https://kestra.io/vs/databricks-workflows)** is excellent for teams deeply embedded in the Databricks ecosystem, providing native orchestration for Lakehouse-native jobs. Similarly, **AWS Step Functions** and **Azure AI Agent Service** offer powerful, cloud-native orchestration but can lead to vendor lock-in. Other platforms like **Metafore** focus specifically on enterprise-grade, self-evolving AI agents.
+
+### Open-Source AI Orchestration Frameworks
+
+For teams seeking flexibility and control, open-source frameworks are a compelling option.
+*   **Kestra** stands out with its declarative, YAML-based approach that unifies data, AI, and infrastructure workflows. Its language-agnostic design and extensive plugin library make it a versatile choice for multi-domain orchestration.
+*   **[Prefect](https://kestra.io/vs/prefect)** is a strong choice for Python-centric teams, offering a modern developer experience for defining workflows as Python code.
+*   **Dagster** appeals to analytics engineering teams with its asset-centric paradigm, which provides strong data lineage and observability.
+*   **[Argo Workflows](https://kestra.io/vs/argo-workflows)** is a powerful, Kubernetes-native solution ideal for teams that want their orchestration to live entirely within the Kubernetes control plane.
+
+### Agentic AI Orchestration for Autonomous Workflows
+
+A new category of platforms is emerging that is specifically designed for [agentic AI orchestration](https://kestra.io/resources/ai/agentic-orchestration). These tools provide the primitives needed for AI agents to collaborate, use tools, and make dynamic decisions. Kestra's AI Agents are a prime example, enabling the creation of autonomous workflows where agents can reason and act to achieve complex goals, all governed by the same declarative control plane used for other workflows.
+
+## Understanding the Agentic AI Orchestration Paradigm
+
+Agentic AI represents a fundamental shift from task automation to outcome automation. Instead of executing a predefined sequence of steps, autonomous agents can reason, plan, and act to achieve a specified goal.
+
+### From Tool to Autonomous Actor: What is Agentic AI?
+
+An [AI agent](https://kestra.io/resources/ai/ai-agent) is a system that can perceive its environment, make decisions, and take actions to achieve its goals. Unlike a simple script, an agent can use a variety of "tools" (e.g., calling an API, querying a database, running a script) and decide which one to use based on the context. This ability to reason and plan makes them far more powerful and flexible than traditional automation.
+
+### How Agentic AI Platforms Revolutionize Business
+
+The applications of agentic AI are vast. In cybersecurity, agents can autonomously detect threats and execute remediation workflows. In IT operations, they can diagnose system failures and attempt repairs without human intervention. Leading tech companies are already leveraging this paradigm; for instance, [Apple's ML team orchestrates large-scale data pipelines with Kestra](https://kestra.io/use-cases/stories/32-apple's-ml-team-orchestrates-large-scale-data-pipelines-with-kestra) to manage complex dependencies across their services. This level of automation frees up human experts to focus on more strategic tasks, driving significant efficiency gains.
+
+### Coordinating AI Agents for Collaborative Teams
+
+The true power of agentic AI is unlocked when multiple agents collaborate. A [multi-agent system](https://kestra.io/resources/ai/multi-agent-system) can tackle problems that are too complex for a single agent. However, this introduces new challenges, such as ensuring effective communication, resolving conflicts, and aligning agents towards a shared objective. This is where orchestration becomes critical. An orchestration platform acts as the "operating system" for the multi-agent team, providing the framework for them to interact, share information, and work together in a coordinated and auditable manner.
+
+## Implementing AI Orchestration: Best Practices
+
+Deploying an AI orchestration platform successfully requires a strategic approach that covers technology, process, and people.
+
+### Strategizing for Platform Deployment and Integration
+
+Choose a deployment model that fits your needs, whether it's self-hosting on [Kubernetes](https://kestra.io/docs/installation/kubernetes), using a managed cloud service, or a hybrid approach. Adopt GitOps principles by storing all your workflow definitions in a version control system. This enables CI/CD, peer reviews, and automated deployments, treating your workflows with the same rigor as application code. Securely manage all credentials and secrets using an integrated secrets manager.
+
+### Optimizing AI Workflows for Performance
+
+To maximize the return on your AI investment, workflows must be performant. Leverage platform features like parallel execution to run independent tasks simultaneously. Use caching to avoid re-running expensive computations on unchanged data. Monitor your workflows closely to identify bottlenecks and optimize resource allocation, ensuring that you are using compute resources efficiently. A well-tuned orchestration setup can significantly reduce both the time and cost associated with running AI [pipelines at scale](https://kestra.io/docs/performance).
+
+### Future-Proofing with Self-Evolving AI Agents
+
+A production AI workflow is never just a model call — it's data retrieval, model versioning, routing, guardrails, fallbacks, approval gates, retries, and policy checks, often with humans in the loop. To future-proof your implementation, design your workflows for that reality today: use platforms that treat AI components with the same engineering rigor as any other mission-critical process. Agentic orchestration is on the [Kestra 2.0 roadmap](https://kestra.io/blogs/kestra-2-0-engineering), with the explicit principle that agentic workflows should be as reliable as any other production system — orchestrating the AI stack rather than replacing orchestration with AI. By choosing a platform with a clear engineering direction for agentic workflows, you build a system prepared for the next wave of AI innovation without sacrificing reliability.
+
+## The Future of AI Orchestration Platforms
+
+The role of orchestration will only become more critical as AI becomes more deeply embedded in enterprise operations. Several key trends are shaping the future of this technology.
+
+### Trends in AI-Native Development
+
+We are seeing a move towards more specialized yet unified platforms. The rise of low-code and no-code interfaces, such as Kestra's [AI Copilot](https://kestra.io/docs/ai-tools/ai-copilot), is making it easier for a broader range of users, not just data scientists, to build and manage AI workflows. This democratization of AI development will accelerate adoption across the enterprise.
+
+### How Orchestration Will Drive AI Innovation
+
+Orchestration is the backbone that enables more complex and innovative AI applications. It is the key to building sophisticated [RAG pipelines](https://kestra.io/resources/ai/rag-pipeline) that can draw on multiple data sources, orchestrating multi-modal AI that can process text, images, and audio, and managing the intricate dependencies of advanced agentic systems. As AI models become more powerful, the orchestration layer that connects them to the real world becomes even more vital.
+
+### What's Next for AI Agent Orchestration
+
+The future of AI agent orchestration points towards greater autonomy and more sophisticated collaboration models. We will see platforms that provide even more robust governance and observability for AI agents, allowing them to operate safely and predictably within enterprise environments. The ultimate goal is to create a seamless control plane where human teams and [AI agents](https://kestra.io/docs/ai-tools/ai-agents) can collaborate effectively, with the orchestration platform providing the visibility, reliability, and security needed to manage this new, hybrid workforce.

--- a/src/contents/resources/ai-orchestration-for-non-technical-teams/index.md
+++ b/src/contents/resources/ai-orchestration-for-non-technical-teams/index.md
@@ -1,0 +1,191 @@
+---
+title: "AI Orchestration for Non-Technical Teams in 2026"
+description: "AI orchestration promises to automate complex workflows, but often seems out of reach for teams without deep technical expertise. This guide cuts through the complexity, showing how non-technical users can leverage AI for powerful automation, even in 2026. We'll explore user-friendly platforms, essential features, and practical implementation strategies to empower your entire organization."
+metaTitle: "AI Orchestration for Non-Technical Teams | Kestra"
+metaDescription: "Empower your non-technical teams with AI orchestration. Discover user-friendly platforms and guides to automate workflows without code. Get started today!"
+tag: "ai"
+date: 2026-05-27
+slug: "ai-orchestration-for-non-technical-teams"
+faq:
+  - question: "What are AI tools for non-technical people?"
+    answer: "AI tools for non-technical users are software that let people with little or no coding skills apply AI to real problems. Instead of building models or writing code, users interact through simple interfaces like drag-and-drop builders, natural-language prompts, templates, or visual flows, democratizing access to powerful AI capabilities."
+  - question: "What is the best AI orchestration platform for non-technical teams?"
+    answer: "The 'best' platform depends on specific needs, but leading options for non-technical teams prioritize intuitive interfaces, no-code/low-code builders, and robust integrations. Kestra, for example, offers declarative YAML definitions alongside a visual editor and AI Copilot, enabling non-technical users to build, manage, and govern complex AI workflows with ease and scalability."
+  - question: "How does AI benefit non-technical teams?"
+    answer: "AI benefits non-technical teams by mimicking human intelligence to automate repetitive tasks, analyze data, and make informed decisions. This frees up time for strategic work, boosts efficiency, and reduces errors. It empowers teams to achieve more with fewer resources, even without deep technical skills."
+  - question: "How can non-technical teams get started with AI orchestration?"
+    answer: "Non-technical teams can get started with AI orchestration by identifying a small, repetitive process to automate, choosing a user-friendly platform with visual builders and templates, and leveraging AI Copilot features for initial workflow generation. Start with simple tasks, gradually increasing complexity as confidence grows, and utilize available documentation and community support."
+  - question: "Is ChatGPT an LLM or NLP?"
+    answer: "ChatGPT is an LLM (Large Language Model), which is a specific type of NLP (Natural Language Processing) model. LLMs leverage deep learning techniques and are trained on massive datasets to process and generate human-like text. This allows them to produce coherent and contextually relevant text based on a given input, making them highly effective for conversational AI and various text-based tasks."
+  - question: "Can AI orchestration integrate with existing business tools?"
+    answer: "Yes, effective AI orchestration platforms are designed to integrate seamlessly with a wide array of existing business tools, including CRM, ERP, messaging apps, cloud services, and databases. This is typically achieved through pre-built connectors, APIs, and webhook triggers, ensuring that AI-powered workflows can span across an organization's entire technology stack without disruption."
+---
+```
+
+AI orchestration promises to automate complex workflows, but often seems out of reach for teams without deep technical expertise. The perception of requiring advanced coding skills or a dedicated engineering team can be a significant barrier for business users, founders, and operational staff. Yet, the demand for efficiency and intelligent automation continues to grow.
+
+This guide cuts through that complexity, showing how non-technical users can leverage AI for powerful automation. We'll explore user-friendly platforms, essential features, and practical implementation strategies. The goal is to empower your entire organization to harness the benefits of AI orchestration, even in 2026, making advanced automation accessible and manageable for all.
+
+## What is AI orchestration for non-technical teams?
+
+AI orchestration is no longer confined to the domain of data scientists and developers. For non-technical teams, it represents a powerful way to automate processes, make smarter decisions, and boost productivity by coordinating various AI-powered tasks into a cohesive workflow.
+
+### Defining AI orchestration: a straightforward approach
+
+At its core, AI orchestration is the process of managing and automating a sequence of tasks that involve one or more AI models or agents. Think of it as a conductor leading an orchestra. Each musician (an AI tool) is skilled at a specific task, such as summarizing text, analyzing customer sentiment, or generating images. The conductor (the orchestration platform) ensures they all work together in the right order to produce a final piece—a complete business process.
+
+For a non-technical user, this means you can design a workflow like:
+1.  **Trigger:** When a new customer support ticket arrives...
+2.  **Task 1:** An [AI agent](/resources/ai/ai-agent) reads the ticket and classifies its urgency.
+3.  **Task 2:** Another AI tool summarizes the issue.
+4.  **Task 3:** The summary is routed to the correct department's Slack channel.
+5.  **Task 4:** A draft response is generated for the support agent to review.
+
+The orchestration platform handles the handoffs, data transfers, and logic between each step, all without you needing to write any code.
+
+### Why non-technical teams need AI orchestration
+
+Non-technical teams in marketing, sales, operations, and finance are often closest to the business processes that can benefit most from automation. However, they typically lack the coding skills to build traditional software solutions. AI orchestration bridges this gap, providing several key benefits:
+*   **Empowerment:** It allows business users to build their own solutions to their own problems, reducing reliance on over-burdened IT and engineering departments.
+*   **Efficiency:** Automating repetitive, manual tasks like data entry, report generation, and customer follow-ups frees up time for more strategic work.
+*   **Agility:** Teams can quickly create and modify workflows in response to changing business needs, without waiting for a developer's release cycle.
+*   **Innovation:** It provides a playground for non-technical staff to experiment with AI and discover new ways to improve their daily operations.
+
+By making automation accessible, AI orchestration helps organizations become more efficient and data-driven from the ground up.
+
+### What are AI tools for non-technical people?
+
+AI tools for non-technical people are designed with simplicity and usability in mind. They abstract away the underlying technical complexity, allowing users to focus on the "what" rather than the "how." These tools typically fall into a few categories:
+*   **No-Code AI Builders:** Platforms that use visual interfaces, drag-and-drop components, and pre-built templates to construct AI-powered applications and workflows.
+*   **Prompt-Based Interfaces:** Tools where users interact with AI by writing instructions in plain English. This includes everything from chatbots to AI copilots that can generate workflows from a simple description.
+*   **Specialized AI Applications:** Software designed for specific business functions (e.g., AI-powered CRM, marketing automation, or financial analysis) that embed AI capabilities into a user-friendly package.
+
+The key characteristic is a focus on user experience, enabling anyone to leverage sophisticated [agentic AI](/resources/ai/agentic-ai) without needing to understand the algorithms behind it. This is [why Kestra](/docs/why-kestra) was built to be declarative, empowering both technical and non-technical teams.
+
+## Key features of user-friendly AI orchestration platforms
+
+When evaluating AI orchestration platforms for non-technical teams, certain features are non-negotiable. These capabilities ensure that the tool is not just powerful, but also accessible, adaptable, and easy to manage for users of all skill levels.
+
+### No-code and low-code functionalities explained
+
+The foundation of a user-friendly platform is its approach to workflow creation.
+*   **No-Code:** This refers to a purely visual development environment. Users can build entire workflows by dragging and dropping pre-built blocks, connecting them, and configuring their properties through simple forms. This approach is ideal for straightforward, linear processes and requires zero programming knowledge.
+*   **Low-Code:** This provides a middle ground. While much of the workflow can be built visually, the platform allows for small snippets of code (like YAML configurations or simple expressions) to handle more complex logic or custom transformations. This "escape hatch" provides flexibility without demanding full development skills.
+
+Kestra's platform embraces both, offering a [no-code flow builder](/docs/no-code/no-code-flow-building) for visual design alongside a declarative YAML interface that is easy for non-technical users to read and understand.
+
+### Intuitive interfaces for seamless workflow design
+
+A cluttered or confusing interface can stop adoption in its tracks. A great platform for non-technical users should have:
+*   **A Visual Canvas:** A clear, graphical representation of the workflow that shows how tasks connect and data flows between them.
+*   **Pre-built Templates:** A library of ready-to-use workflows for common use cases (e.g., "Summarize daily news and post to Slack") that users can adapt instead of starting from scratch.
+*   **Natural Language Prompting:** An "AI Copilot" feature where a user can describe the desired workflow in plain English, and the platform generates the initial structure for them.
+*   **Clear Error Messaging:** When something goes wrong, the platform should provide simple, understandable feedback about what failed and why, rather than cryptic error codes.
+
+### Integration with existing business tools
+
+An orchestration platform is only as useful as the tools it can connect to. A robust and accessible platform must offer a vast library of pre-built connectors or [plugins](/plugins). This allows non-technical users to easily integrate with the software they already use every day, such as:
+*   **Communication:** Slack, Microsoft Teams, Gmail
+*   **CRM:** Salesforce, HubSpot
+*   **Project Management:** Jira, Asana, Trello
+*   **Cloud Storage:** Google Drive, Dropbox, S3
+*   **Databases:** PostgreSQL, Snowflake, BigQuery
+
+These integrations should be configurable through simple authentication and form-based inputs, enabling users to build powerful, cross-platform automations without needing to understand APIs or webhooks. Effective [workflow management](/resources/infrastructure/workflow-management) hinges on this ability to connect disparate systems seamlessly.
+
+## Top AI orchestration platforms for non-technical users
+
+The market for AI automation is expanding rapidly, with several platforms catering specifically to non-technical teams. Choosing the right one depends on balancing ease of use with the need for power, scalability, and governance.
+
+### Comparing leading AI agent automation platforms
+
+For many non-technical users, the journey into AI automation begins with platforms known for their simplicity and extensive integrations:
+*   **Zapier:** A market leader in no-code automation, Zapier excels at connecting thousands of web applications with simple "if this, then that" logic. It's incredibly user-friendly for linear, task-based automations but can become complex and costly for multi-step, conditional workflows.
+*   **n8n:** An open-source, visual workflow automation tool that offers more flexibility and power than Zapier. Its node-based interface allows for more complex logic, branching, and data transformations. While more powerful, it can have a steeper learning curve for true beginners.
+
+These tools are excellent for SaaS-to-SaaS integrations and straightforward business process automation. However, as workflows grow in complexity or require more robust error handling and observability, teams may encounter limitations.
+
+### Which multi-agent AI platform is best for non-technical teams?
+
+As workflows become more sophisticated, they often require multiple specialized [AI agents](/docs/ai-tools/ai-agents) to collaborate. The best platform for managing these multi-agent systems for a non-technical audience is one that abstracts away the complexity of agent coordination. It should allow a user to define the roles and goals of each agent visually or through guided prompts, while the platform handles the communication and state management behind the scenes.
+
+### Kestra: The declarative AI orchestration control plane for all teams
+
+Kestra offers a unique approach that combines the accessibility of no-code tools with the power and governance of an enterprise-grade engineering platform. This makes it an ideal solution for organizations that want to empower non-technical users without sacrificing control and scalability.
+
+Key differentiators for non-technical teams include:
+*   **Declarative YAML:** While it sounds technical, Kestra's YAML workflow definitions are human-readable and easy to understand. They act as a clear blueprint of the workflow, which can be version-controlled and audited—a crucial feature for business-critical processes.
+*   **Visual Editor & AI Copilot:** Non-technical users don't have to write YAML from scratch. They can use the intuitive visual editor to build flows, or simply describe their goal to the AI Copilot, which generates the YAML for them. This provides the best of both worlds: easy creation and a structured, auditable result.
+*   **Multi-Domain Orchestration:** Unlike tools focused purely on app integration, Kestra is a true [agentic orchestration](/resources/ai/agentic-orchestration) platform. It can manage workflows that span across business applications, data pipelines, infrastructure tasks, and AI models from a single control plane.
+*   **Governance and Scalability:** As non-technical teams build more automations, governance becomes critical. Kestra provides features like role-based access control, audit logs, and robust error handling, ensuring that automation can scale safely and reliably.
+
+While tools like [n8n](/vs/n8n) and [Zapier](/vs/zapier) are excellent starting points, Kestra provides a path for growth, allowing teams to build production-grade, observable, and maintainable [AI automation](/ai-automation) workflows that can evolve with the business.
+
+## Implementing AI orchestration in your organization
+
+Rolling out a new automation platform can be transformative, but success depends on a thoughtful implementation strategy. For non-technical teams, the focus should be on building confidence, demonstrating value quickly, and providing strong support.
+
+### A practical guide for non-technical team rollout
+
+1.  **Start Small:** Don't try to automate everything at once. Identify a single, high-impact, and relatively simple process. A good candidate is a repetitive task that is well-documented and currently performed manually.
+2.  **Choose a Champion:** Designate one or two enthusiastic team members to be the first adopters. They can learn the platform, build the initial pilot project, and become internal advocates.
+3.  **Leverage Templates and Blueprints:** Encourage new users to start with pre-built [blueprints](/blueprints) or templates. Adapting an existing workflow is much less intimidating than starting with a blank canvas.
+4.  **Provide Training and Resources:** Point users to the platform's [quickstart guides](/docs/quickstart), documentation, and video tutorials. Host informal "lunch and learn" sessions where the champions can share what they've built.
+5.  **Establish a Support Channel:** Create a dedicated Slack channel or regular office hours where users can ask questions and get help from the champions or a technical mentor.
+6.  **Celebrate Early Wins:** When the first automated workflow is successful, celebrate it publicly. Showcase the time saved or the errors eliminated to build momentum and encourage others to get involved.
+
+### Understanding expected results and ROI
+
+The return on investment (ROI) from AI orchestration can be measured in several ways:
+*   **Time Saved:** Calculate the number of manual hours saved per week or month by automating repetitive tasks.
+*   **Error Reduction:** Track the decrease in human errors for processes that are now automated, which can lead to cost savings and improved quality.
+*   **Increased Throughput:** Measure how many more processes (e.g., customer tickets, sales leads, reports) can be handled by the same team in the same amount of time.
+*   **Employee Satisfaction:** While harder to quantify, freeing employees from tedious work often leads to higher morale and allows them to focus on more engaging, creative tasks.
+
+### Overcoming common challenges in adoption
+
+*   **Fear of the Unknown:** Some team members may be hesitant to adopt new technology. Address this with clear communication about the benefits and by starting with simple, non-critical workflows.
+*   **Lack of Ideas:** Users might not know what can be automated. Host brainstorming sessions to identify pain points and potential use cases.
+*   **Hitting a Technical Wall:** Sooner or later, a user will want to do something the no-code interface doesn't directly support. This is where a platform with low-code capabilities and a strong support community becomes invaluable.
+
+## Benefits of AI orchestration for small businesses
+
+For small businesses, founders, and startups, AI orchestration isn't just a "nice-to-have"—it's a powerful lever for growth and a competitive advantage. It allows lean teams to operate with the efficiency and sophistication of much larger organizations.
+
+### Boosting efficiency and productivity without complexity
+
+In a small business, every employee wears multiple hats. AI orchestration automates the time-consuming, administrative tasks that can bog down a small team. This could include:
+*   Automating social media posting and engagement reports.
+*   Syncing customer data between a CRM and an email marketing tool.
+*   Generating daily sales reports and sending them to the team.
+
+By offloading these tasks to an automated workflow, the team can focus its limited time on core business activities like product development, customer relationships, and strategic growth.
+
+### Empowering founders and non-technical staff
+
+Founders and early employees are often generalists, not technical specialists. AI orchestration platforms empower them to build the solutions they need without hiring expensive developers or consultants. A marketing manager can build a lead nurturing workflow, an operations lead can automate inventory checks, and a founder can create a system to track key business metrics—all on their own. This self-service capability is crucial for agile, fast-moving companies. As seen in [customer stories](/use-cases/stories), companies like [CleverConnect](/blogs/2023-11-21-clever-connect-hr-tech) leverage orchestration to scale their core business operations efficiently.
+
+### Scaling operations with AI, simply
+
+As a small business grows, its processes can quickly become chaotic. What worked with ten customers breaks down with a thousand. AI orchestration provides a way to build scalable, repeatable processes from day one. By defining workflows in a structured platform, a business ensures that operations can handle increased volume without a proportional increase in manual effort or headcount. This allows the business to scale efficiently, maintaining quality and consistency as it grows.
+
+## Future trends in AI orchestration accessibility
+
+The trend toward democratizing AI is only accelerating. The future of AI orchestration will be defined by even greater accessibility, intelligence, and ease of use, further blurring the lines between technical and non-technical users.
+
+### The evolution of AI agents for all skill levels
+
+AI agents will become more autonomous and easier to configure. Instead of building a step-by-step workflow, a non-technical user might simply state a high-level goal, such as "Monitor our top three competitors and send me a weekly summary of their product launches and marketing campaigns." A team of specialized AI agents would then self-organize to accomplish this task, handling the web scraping, text summarization, and report generation automatically. This evolution of [multi-agent collaboration](/resources/ai/multi-agent-collaboration-evolving-orchestration) will make even highly complex automation accessible.
+
+### Simplifying complex AI concepts for broader adoption
+
+Platforms will continue to abstract away technical jargon and complex concepts. Instead of configuring "model temperature" or "token limits," a user might interact with simple sliders for "creativity" or "conciseness." The user interface will become more conversational and guided, helping users build powerful workflows without needing a background in data science.
+
+### How AI helps non-technical teams
+
+The rise of AI-powered assistants within orchestration platforms will be a game-changer. Features like an [AI Copilot](/docs/ai-tools/ai-copilot) will become standard, offering capabilities such as:
+*   **Workflow Generation:** Creating entire workflows from a simple English description.
+*   **Intelligent Debugging:** Not just identifying errors, but suggesting concrete fixes in plain language.
+*   **Optimization Suggestions:** Proactively recommending ways to make existing workflows more efficient or resilient.
+
+Kestra is at the forefront of this trend, integrating AI deeply into the platform to create a partnership between the user and the orchestrator. This ensures that as the power of AI grows, its accessibility grows right along with it.

--- a/src/contents/resources/ai-orchestration-for-non-technical-teams/index.md
+++ b/src/contents/resources/ai-orchestration-for-non-technical-teams/index.md
@@ -20,7 +20,6 @@ faq:
   - question: "Can AI orchestration integrate with existing business tools?"
     answer: "Yes, effective AI orchestration platforms are designed to integrate seamlessly with a wide array of existing business tools, including CRM, ERP, messaging apps, cloud services, and databases. This is typically achieved through pre-built connectors, APIs, and webhook triggers, ensuring that AI-powered workflows can span across an organization's entire technology stack without disruption."
 ---
-```
 
 AI orchestration promises to automate complex workflows, but often seems out of reach for teams without deep technical expertise. The perception of requiring advanced coding skills or a dedicated engineering team can be a significant barrier for business users, founders, and operational staff. Yet, the demand for efficiency and intelligent automation continues to grow.
 

--- a/src/contents/resources/audit-logs-orchestration/index.md
+++ b/src/contents/resources/audit-logs-orchestration/index.md
@@ -22,9 +22,7 @@ faq:
   - question: "What are the four main types of audit?"
     answer: "The four main types of audit commonly recognized are: financial audits (examining financial statements), operational audits (assessing efficiency and effectiveness of processes), compliance audits (checking adherence to regulations), and IT audits (evaluating information systems and security controls)."
 author: "Virgile Fanucci"
-image: "/images/resources/audit-logs-orchestration.jpg"
 ---
-```
 
 In today's complex, interconnected systems, understanding "who did what, when, and where" is paramount. From debugging critical data pipelines to ensuring compliance in highly regulated industries, the ability to trace every action within your orchestration environment is no longer a luxury—it's a necessity. Audit logs orchestration provides this vital transparency, transforming raw event data into actionable insights for security, governance, and operational excellence. This article will explore the fundamentals of audit logs in an orchestration context, outline best practices for their management, and demonstrate how platforms like Kestra empower engineers to build robust, auditable workflows.
 

--- a/src/contents/resources/audit-logs-orchestration/index.md
+++ b/src/contents/resources/audit-logs-orchestration/index.md
@@ -1,0 +1,123 @@
+---
+title: "Audit logs orchestration: Overview and best practices"
+description: "Understand audit logs orchestration, its importance, and how it differs from other logging solutions. Enhance your system's security today!"
+metaTitle: "Audit Logs Orchestration: Overview & Best Practices"
+metaDescription: "Discover the critical role of audit logs in modern orchestration platforms. Learn best practices for implementing and managing audit trails to enhance security and compliance."
+tag: "infrastructure"
+date: 2026-05-27
+slug: "audit-logs-orchestration"
+faq:
+  - question: "What are audit logs and why are they important in orchestration?"
+    answer: "Audit logs are chronological records of events and actions within a system, crucial for security, compliance, and operational monitoring. In orchestration, they track workflow executions, user activities, and resource changes, providing an immutable trail for accountability and incident investigation."
+  - question: "How do audit logs differ from application logs?"
+    answer: "Audit logs focus on security and accountability, recording who did what, when, and where. Application logs, conversely, are for debugging and performance monitoring, detailing internal system operations and errors. While both are critical, their purpose and content are distinct, requiring different management strategies."
+  - question: "How can orchestration platforms help manage audit logs for compliance?"
+    answer: "Orchestration platforms centralize the collection, processing, and routing of audit logs from diverse systems. They automate log retention, ensure data integrity, and facilitate integration with SIEM tools, simplifying compliance with regulations like GDPR, HIPAA, or SOC 2 by maintaining a verifiable audit trail."
+  - question: "What are the key elements of an auditable event in an orchestration system?"
+    answer: "An auditable event typically includes the actor (user or system), the action performed (e.g., flow started, task failed, resource modified), the target resource (flow ID, task ID, namespace), the timestamp, and the outcome (success/failure). These elements ensure comprehensive accountability."
+  - question: "How can Kestra help with audit log orchestration?"
+    answer: "Kestra's Enterprise Edition provides comprehensive audit logs that track every user action and resource change, offering complete transparency. It enables streaming logs to external SIEM tools like Splunk or BigQuery and supports granular RBAC and worker isolation for enhanced security and compliance."
+  - question: "How to check audit logs in UiPath Orchestrator?"
+    answer: "As the organization administrator, you can view the audit logs by navigating to Admin > Audit Logs within a specific organization in UiPath Orchestrator. This page captures actions performed from Admin pages and user login activity for the organization."
+  - question: "What are the four main types of audit?"
+    answer: "The four main types of audit commonly recognized are: financial audits (examining financial statements), operational audits (assessing efficiency and effectiveness of processes), compliance audits (checking adherence to regulations), and IT audits (evaluating information systems and security controls)."
+author: "Virgile Fanucci"
+image: "/images/resources/audit-logs-orchestration.jpg"
+---
+```
+
+In today's complex, interconnected systems, understanding "who did what, when, and where" is paramount. From debugging critical data pipelines to ensuring compliance in highly regulated industries, the ability to trace every action within your orchestration environment is no longer a luxury—it's a necessity. Audit logs orchestration provides this vital transparency, transforming raw event data into actionable insights for security, governance, and operational excellence. This article will explore the fundamentals of audit logs in an orchestration context, outline best practices for their management, and demonstrate how platforms like Kestra empower engineers to build robust, auditable workflows.
+
+## What is audit logs orchestration?
+
+Audit logs are immutable, time-stamped records of the sequence of actions and events within a system. They serve as a chronological trail, providing a definitive source of truth for accountability, incident investigation, and compliance verification. In the context of a modern platform, [data orchestration](https://kestra.io/resources/data/data-orchestration) is the central nervous system for automated processes; therefore, its audit logs are critical for understanding the health and security of the entire system.
+
+While application logs are designed for developers to debug code and monitor performance, audit logs are created for security, operations, and compliance teams. They answer different questions:
+- **Application Logs:** "Why did this task fail? What was the stack trace?"
+- **Audit Logs:** "Who deployed the version of the flow that failed? When was the last time this user logged in? Which API key was used to trigger this execution?"
+
+Effective audit logs orchestration involves the centralized collection, processing, storage, and analysis of these records from all components of your stack. This ensures that every significant action, from a user login to a workflow deployment or a critical data transformation, is captured and available for review. This comprehensive visibility is essential for securing distributed systems and meeting stringent regulatory requirements.
+
+## Key aspects of auditable events for orchestration pipelines
+
+### Identifying auditable events in orchestration systems
+
+Not every system event needs to be an audit entry. The key is to identify actions that have security, compliance, or operational significance. In an orchestration system, this includes:
+
+- **User and Authentication Events:** Successful and failed login attempts, password changes, API token creation, and permission modifications.
+- **Resource Management:** Creation, modification, or deletion of workflows ([flows](https://kestra.io/docs/workflow-components/flow)), secrets, or configuration settings.
+- **Workflow Execution Events:** The start, completion, failure, or cancellation of any [workflow execution](https://kestra.io/docs/workflow-components/execution). This should include the trigger details (e.g., scheduled, webhook) and input parameters.
+- **Access Control Changes:** Any modification to roles and permissions, managed through [Role-Based Access Control (RBAC)](https://kestra.io/docs/enterprise/auth/rbac).
+
+Each audit log entry must contain sufficient metadata to be useful, including the actor (user or service), the action, the target resource, a precise timestamp, the source IP address, and the outcome.
+
+### Different types of audit logs and their value
+
+Audit logs can be categorized based on the system aspect they monitor, each providing a unique layer of visibility:
+
+- **User Activity Logs:** Track actions performed by human users, essential for accountability and detecting unauthorized access.
+- **System Configuration Logs:** Record changes to the orchestration platform itself, such as updates to security settings or plugin configurations. This helps maintain system integrity.
+- **Data Access Logs:** Monitor who accesses or modifies sensitive data or secrets within the platform. This is critical for data governance and compliance.
+- **Execution Traces:** Provide a detailed history of every workflow run, which is invaluable for debugging, performance analysis, and understanding data provenance. This forms a crucial part of your overall [data lineage](https://kestra.io/resources/data/data-lineage) strategy and can be enhanced with features like [Kestra's Assets](https://kestra.io/blogs/hello-assets).
+
+### Checking audit logs in other orchestration platforms (e.g., UiPath, Google Composer)
+
+Different platforms offer varying levels of auditability. In UiPath Orchestrator, an administrator can view audit logs by navigating to `Admin > Audit Logs`. These logs capture actions from admin pages and user login activity.
+
+In systems like [Apache Airflow](https://kestra.io/vs/airflow) or Google Cloud Composer, audit information is often distributed across multiple log types and sources, including webserver access logs, scheduler logs, and task logs. Centralizing these requires integrating external logging and monitoring tools. The challenge intensifies in multi-cloud or hybrid environments that use a variety of tools like [AWS Step Functions](https://kestra.io/vs/aws-step-functions) or [Azure Data Factory](https://kestra.io/vs/azure-data-factory), making a unified orchestration platform with built-in, centralized auditing a significant operational advantage.
+
+## Implementing and managing audit logs in an orchestrated environment with Kestra
+
+### Best practices for effective audit logging
+
+A robust audit log strategy is built on several key principles:
+
+1.  **Centralization:** Aggregate logs from all systems into a single, secure location. This provides a unified view for analysis and correlation.
+2.  **Immutability:** Ensure that once logs are written, they cannot be altered or deleted. This preserves their integrity as a legal and forensic record.
+3.  **Defined Retention Policies:** Establish clear policies for how long audit logs are stored, balancing compliance requirements with storage costs.
+4.  **Strict Access Control:** Limit access to audit logs to authorized personnel to prevent tampering and protect sensitive information contained within them.
+5.  **Integration with SIEM:** Forward logs to a Security Information and Event Management (SIEM) tool for real-time analysis, threat detection, and automated alerting.
+
+You can implement these practices by creating dedicated workflows to [export audit logs to CSV](https://kestra.io/blueprints/audit-logs-csv-export) for reporting or [stream them to a data warehouse like BigQuery](https://kestra.io/blueprints/auditlogs-to-bigquery) for long-term analysis.
+
+### How Kestra approaches audit log management
+
+Kestra's [Enterprise Edition](https://kestra.io/enterprise) is designed with governance and security at its core, providing comprehensive audit capabilities out of the box. Unlike the [open-source version](https://kestra.io/docs/oss-vs-paid), the Enterprise Edition captures a detailed audit trail of every user action and resource change, including:
+
+-   Flow creation, updates, and deletions.
+-   Workflow executions and their triggers.
+-   Changes to namespaces, secrets, and the Key-Value store.
+-   User management and permission changes.
+
+This functionality is critical for organizations in regulated industries like [financial services](https://kestra.io/use-cases/financial-services) and [automotive](https://kestra.io/use-cases/automotive), where a complete and verifiable audit trail is a non-negotiable requirement. Kestra further enhances security by allowing logs to be streamed to external aggregators like Splunk, Elasticsearch, or Datadog, and by enforcing security boundaries with features like granular RBAC and worker isolation.
+
+### Practical steps for showing and utilizing audit logs in Kestra
+
+Within the Kestra UI, authorized users can access the [Audit Logs](https://kestra.io/docs/enterprise/governance/audit-logs) page to view a chronological record of all significant events. The interface allows for powerful filtering by user, action type, and date range, making it simple to investigate specific incidents.
+
+For example, if a critical workflow starts failing unexpectedly, an administrator can quickly filter the audit log to see who last modified the flow and when. This accelerates root cause analysis from hours to minutes. Similarly, during a compliance audit, reports can be generated directly from the UI or by exporting the logs, providing tangible evidence that security policies are being enforced. This complements the real-time visibility available on the [Executions](https://kestra.io/docs/ui/executions) and [Logs](https://kestra.io/docs/ui/logs) pages, creating a comprehensive [monitoring](https://kestra.io/docs/administrator-guide/monitoring) framework.
+
+## Advanced considerations for audit logs orchestration
+
+### Security hardening through comprehensive auditing
+
+Audit logs are not just for reactive investigation; they are a proactive tool for security hardening. A complete audit trail enables the implementation of anomaly detection systems that can flag suspicious activities in real time, such as a user attempting to access unauthorized data or an unusual number of workflow deletions.
+
+When combined with [GitOps](https://kestra.io/resources/infrastructure/gitops) practices, where infrastructure and workflow changes are managed through version-controlled code, the orchestration platform's audit log provides a secondary layer of verification, ensuring that the state of the system matches the intended state defined in code.
+
+### Use cases and challenges of audit logs orchestration
+
+The applications of robust audit logs are extensive, spanning from regulatory compliance in [financial services](https://kestra.io/use-cases/financial-services) and the [public sector](https://kestra.io/use-cases/public-services) to ensuring supply chain integrity in [automotive manufacturing](https://kestra.io/use-cases/automotive) and maintaining platform stability for [software providers](https://kestra.io/use-cases/software-providers).
+
+However, managing audit logs at scale presents challenges. The sheer volume of logs can lead to significant storage costs and performance overhead. Ensuring the integrity and security of the logs themselves is another critical concern, as a compromised audit trail is worse than none at all. Modern orchestration platforms address these challenges by providing efficient storage mechanisms, log-shipping capabilities, and role-based access controls to protect the audit data.
+
+### Understanding the four types of audit in an orchestration context
+
+While there are several types of formal audits, four are particularly relevant to orchestration platforms:
+
+1.  **Financial Audits:** While seemingly unrelated, audit logs can provide supporting evidence for financial audits by proving that data processing workflows related to financial reporting ran as expected and were not tampered with.
+2.  **Operational Audits:** These assess the efficiency and effectiveness of processes. Orchestration audit logs are a primary source of data for evaluating workflow performance, identifying bottlenecks, and ensuring operational best practices are followed. You can view Kestra's [performance benchmarks](https://kestra.io/docs/performance/benchmark) to see how this is measured.
+3.  **Compliance Audits:** These verify adherence to specific laws and regulations (e.g., GDPR, HIPAA, SOC 2). Audit logs provide the necessary evidence that access controls, data handling policies, and other compliance requirements are being met.
+4.  **IT Audits:** These focus on the controls governing information systems. Audit logs are fundamental to IT audits, demonstrating how the system is secured, who has access, and how changes are managed.
+
+A comprehensive orchestration platform with robust auditing [features](https://kestra.io/features) provides the foundational data needed to satisfy the requirements of operational, compliance, and IT audits, making it an indispensable tool for any modern enterprise.

--- a/src/contents/resources/logistics-data-orchestration/index.md
+++ b/src/contents/resources/logistics-data-orchestration/index.md
@@ -1,0 +1,138 @@
+---
+title: "Logistics Data Orchestration: Future-Proofing Supply Chains"
+description: "Learn how logistics data orchestration streamlines supply chains, reduces costs, and enhances decision-making. Discover Kestra's declarative approach to unify data, AI, and operations for future-proof logistics."
+metaTitle: "Logistics Data Orchestration: Optimize Supply Chains with Kestra"
+metaDescription: "Achieve logistics orchestration through data analytics. Discover how Kestra integrates data, AI, and operations to enhance supply chains, reduce costs, and optimize now."
+tag: "data"
+date: 2026-05-30
+slug: "logistics-data-orchestration"
+faq:
+  - question: "What is logistics data orchestration?"
+    answer: "Logistics data orchestration involves automating and coordinating data flows across various systems in a supply chain. It integrates data from different sources like inventory, transport, and warehousing to provide a unified view, enabling real-time insights and automated decision-making for optimized operations."
+  - question: "How does data orchestration reduce logistics costs?"
+    answer: "By centralizing data and automating workflows, data orchestration reduces manual effort, minimizes errors, and optimizes resource allocation. It identifies inefficiencies, predicts potential disruptions, and allows for proactive adjustments, leading to significant savings in operational and inventory costs."
+  - question: "What are the key benefits of data analytics in logistics?"
+    answer: "Data analytics in logistics provides actionable insights into inventory levels, delivery routes, and demand forecasting. It enhances visibility across the supply chain, improves operational efficiency, enables faster problem-solving, and supports strategic decision-making for more resilient and cost-effective operations."
+  - question: "How does AI impact supply chain management?"
+    answer: "AI significantly impacts supply chain management by enabling predictive analytics for demand forecasting, optimizing routing and logistics, automating decision-making in real-time, and enhancing risk management. It allows for more adaptive and intelligent supply chains that can respond dynamically to market changes and disruptions."
+  - question: "What's the difference between Logistics Data Warehouse Management (LDWM) and Supply Chain Orchestration (SCO)?"
+    answer: "LDWM primarily focuses on analyzing historical logistics data for insights, often residing in a data warehouse. SCO, on the other hand, coordinates real-time processes across the entire supply chain, integrating various systems and data sources to automate and optimize end-to-end operations based on current conditions."
+  - question: "What are the 7 pillars of logistics?"
+    answer: "The seven pillars of logistics typically include: order processing, inventory management, warehousing, transportation, material handling, packaging, and information flow. Effective logistics data orchestration integrates and optimizes information flow across all these pillars to achieve seamless operations."
+author: "elliot"
+---
+
+Modern logistics operates in a complex, interconnected world where efficiency and resilience are paramount. Supply chains generate vast amounts of data from diverse sources—warehouses, fleets, inventory systems, and customer interactions—yet often struggle to unify and act upon it in real-time. This fragmentation leads to delays, increased costs, and missed opportunities.
+
+Logistics data orchestration emerges as the solution, providing a framework to seamlessly integrate, automate, and manage these critical data flows. This article will explore how a declarative, event-driven orchestration platform like Kestra can transform logistics operations, enabling organizations to unlock the full value of their supply chain data, reduce operational friction, and build a truly future-proof and responsive network.
+
+## Defining Logistics Data Orchestration
+
+Logistics data orchestration is the practice of automating, coordinating, and managing the flow of data across all systems and processes within a supply chain. It goes beyond simple data movement; it's about creating intelligent, event-driven workflows that connect disparate data sources—from warehouse management systems (WMS) and transportation management systems (TMS) to IoT sensors and ERP platforms. The goal is to create a unified, real-time view of the entire logistics network, enabling automated decision-making and proactive management.
+
+At its core, [data orchestration](https://kestra.io/resources/data/data-orchestration) provides a centralized control plane for all data-related tasks. In the context of logistics, this means defining, scheduling, and monitoring workflows that handle everything from inventory updates and shipment tracking to demand forecasting and route optimization. This unified approach ensures that data is consistent, timely, and accessible to all stakeholders, breaking down the silos that hinder efficiency.
+
+### The Imperative for Data Orchestration in Logistics
+
+The need for robust data orchestration in logistics is driven by several modern challenges. Supply chains are no longer linear; they are complex, global networks with numerous partners and systems. Data silos are rampant, with critical information locked away in proprietary applications, making end-to-end visibility nearly impossible.
+
+Furthermore, the demand for real-time responsiveness has never been higher. Customers expect instant updates, and businesses need to react immediately to disruptions, whether it's a delayed shipment, a weather event, or a sudden spike in demand. Manual processes and batch-based data updates are too slow and error-prone to meet these demands. Logistics data orchestration addresses these issues by providing an automated, resilient framework that ensures the right data gets to the right place at the right time, every time. For a deeper look into the principles behind this approach, explore [Why Kestra](https://kestra.io/docs/why-kestra).
+
+## Core Benefits: Transforming Logistics Operations
+
+Implementing a comprehensive data orchestration strategy delivers tangible benefits that transform logistics from a cost center into a strategic advantage. By creating a cohesive data ecosystem, organizations can drive efficiency, reduce costs, and make smarter, faster decisions across their entire supply chain. This move towards integrated [infrastructure automation](https://kestra.io/infra-automation) is critical for staying competitive.
+
+### Reducing Costs and Improving Efficiency with AI
+
+One of the most immediate impacts of logistics data orchestration is significant cost reduction. By automating data flows and processes, organizations can eliminate manual data entry, reduce human error, and free up personnel for more strategic tasks. Orchestration enables the optimization of inventory levels, reducing carrying costs and minimizing stockouts or overstock situations.
+
+When combined with Artificial Intelligence, the benefits multiply. An orchestration platform can seamlessly integrate AI models into workflows to perform predictive analytics for demand forecasting, optimize delivery routes in real-time to save fuel and time, and automate warehouse operations. This creates a self-optimizing system where [AI pipelines](https://kestra.io/resources/ai/ai-pipeline) continuously refine logistics processes, leading to compounding efficiency gains. The rise of [agentic AI](https://kestra.io/resources/ai/agentic-ai) further enhances this by allowing autonomous agents to manage and respond to logistics events within a governed framework.
+
+### Unlocking Value from Supply Chain Data
+
+Supply chain data is a valuable asset, but its value diminishes when it's fragmented and inaccessible. Data orchestration unlocks this value by creating a single, coherent view of the entire supply chain. This enhanced visibility allows businesses to track products from origin to final destination, monitor supplier performance, and understand customer behavior in granular detail.
+
+Effective orchestration also implements robust [data lineage](https://kestra.io/resources/data/data-lineage) and [data observability](https://kestra.io/resources/data/data-observability) practices. This means organizations can trace the journey of every piece of data, understand its transformations, and monitor its quality and health. This level of insight is crucial for compliance, troubleshooting, and building trust in the data that drives critical business decisions.
+
+### Enhancing Decision-Making with Data Analytics
+
+With a unified and reliable data foundation, organizations can leverage advanced analytics to gain a competitive edge. Logistics data orchestration ensures that analytics platforms are fed with clean, timely, and contextualized data, enabling more accurate reporting and more powerful insights.
+
+This empowers teams to move from reactive to proactive decision-making. Instead of just analyzing why a shipment was delayed last week, they can use predictive models to anticipate potential disruptions and take corrective action before they occur. Real-time dashboards can monitor key performance indicators (KPIs) across the network, allowing managers to identify bottlenecks and opportunities for improvement instantly.
+
+## Key Components for Effective Logistics Orchestration
+
+Successfully implementing logistics data orchestration requires a combination of the right technology and a solid data foundation. It's not just about installing a new tool, but about building an ecosystem that can support complex, interconnected workflows. A well-designed system is a cornerstone of any modern [automation](https://kestra.io/resources/infrastructure/automation) strategy.
+
+### Data Readiness: The Foundation for Orchestration
+
+Before you can orchestrate your logistics, you must get your data in order. This starts with identifying and integrating all relevant data sources, which typically include:
+-   **Enterprise Resource Planning (ERP) systems:** For financial data, order management, and overall business context.
+-   **Transportation Management Systems (TMS):** For carrier information, route planning, and shipment tracking.
+-   **Warehouse Management Systems (WMS):** For inventory levels, order picking, and warehouse operations.
+-   **IoT and Fleet Telematics:** For real-time location, temperature, and vehicle performance data.
+-   **Supplier and Partner Systems:** For visibility into upstream and downstream activities.
+
+Data orchestration platforms must provide robust connectors to these systems, enabling seamless data ingestion. The workflows themselves should include steps for data cleansing, validation, and transformation to ensure that the data is accurate and consistent before it's used for decision-making.
+
+### LDWM vs. Supply Chain Orchestration: A Comparison
+
+It's important to distinguish between Logistics Data Warehouse Management (LDWM) and Supply Chain Orchestration (SCO).
+
+-   **Logistics Data Warehouse Management (LDWM)** is primarily focused on **analytics**. It involves collecting, storing, and analyzing historical logistics data to identify trends, measure performance, and generate reports. The data warehouse is a repository for backward-looking analysis.
+-   **Supply Chain Orchestration (SCO)** is focused on **real-time operations**. It involves coordinating and automating processes across the entire supply chain based on live data. It's about executing actions and making decisions in the moment to optimize flow and respond to events.
+
+Data orchestration is the technology layer that enables true SCO. It connects the analytical insights from LDWM with the operational systems that run the supply chain, creating a closed loop where data drives action.
+
+## Kestra's Approach to Unified Logistics Orchestration
+
+Kestra provides a powerful, flexible platform for building and managing logistics data orchestration workflows. Its unique architecture is designed to handle the complexity and diversity of modern supply chains.
+
+-   **Declarative & YAML-Based:** Workflows are defined as simple YAML files, making them easy to create, version-control, and audit. This "infrastructure as code" approach brings governance and reproducibility to logistics processes.
+-   **Polyglot:** Logistics environments are heterogeneous. Kestra can run any type of code—Python, SQL, Shell, Java—in any container, allowing you to use the best tool for each job without being locked into a single language.
+-   **Event-Driven:** Kestra excels at building reactive workflows that can be triggered by a wide range of events, such as a new file arriving in [AWS S3](https://kestra.io/orchestration/aws), a message in a Kafka topic, or an API call from a partner system.
+-   **Cross-Domain:** True logistics orchestration spans data, infrastructure, and business processes. Kestra can coordinate a dbt transformation, an [Ansible](https://kestra.io/orchestration/ansible) playbook to provision a server, a [Docker](https://kestra.io/orchestration/docker) container for a custom script, and a [ServiceNow](https://kestra.io/orchestration/servicenow) ticket creation all within a single, unified workflow.
+
+Here is a simple example of a Kestra flow that processes a new shipping manifest from an S3 bucket:
+
+```yaml
+id: process-shipping-manifest
+namespace: com.logistics.inbound
+
+tasks:
+  - id: get-manifest
+    type: io.kestra.plugin.aws.s3.Download
+    bucket: logistics-data
+    key: "inbound/manifest-{{ trigger.date | date('yyyy-MM-dd') }}.csv"
+
+  - id: parse-and-load
+    type: io.kestra.plugin.scripts.python.Script
+    docker:
+      image: python:3.11-slim
+    script: |
+      import pandas as pd
+      from sqlalchemy import create_engine
+      
+      df = pd.read_csv("{{ outputs['get-manifest'].uri }}")
+      # ... data transformation logic ...
+      
+      engine = create_engine('postgresql://user:pass@host:5432/db')
+      df.to_sql('shipments', engine, if_exists='append', index=False)
+      print(f"Loaded {len(df)} records.")
+
+  - id: notify-operations
+    type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK') }}"
+    payload: |
+      {
+        "text": "Successfully processed manifest for {{ trigger.date | date('yyyy-MM-dd') }}. {{ outputs['parse-and-load'].stdout }} records loaded."
+      }
+```
+
+This example demonstrates how Kestra can chain together tasks from different domains—cloud storage, data processing with Python, and business communication—into a single, automated, and observable [data engineering pipeline](https://kestra.io/blueprints/data-engineering-pipeline). It can also manage complex dependencies on platforms like [Kubernetes](https://kestra.io/orchestration/kubernetes).
+
+## The Future of Logistics: AI and Advanced Automation
+
+The future of logistics is intelligent and autonomous. As AI and machine learning models become more sophisticated, their role in supply chain management will expand dramatically. We are moving towards a world where AI agents can independently manage inventory, negotiate with carriers, and dynamically reroute shipments to avoid disruptions.
+
+In this future, the orchestration platform becomes more critical than ever. It serves as the central control plane for [agentic orchestration](https://kestra.io/resources/ai/agentic-orchestration), providing the framework within which these intelligent agents operate. By defining the rules, managing the data flows, and providing a complete audit trail, the orchestrator ensures that even the most advanced AI-driven logistics network remains governed, reliable, and aligned with business objectives. Building a robust [multi-agent system](https://kestra.io/resources/ai/multi-agent-system) on a declarative platform like Kestra is the key to creating a truly adaptive and resilient supply chain for the future.

--- a/src/contents/resources/zapier-alternatives/index.md
+++ b/src/contents/resources/zapier-alternatives/index.md
@@ -1,0 +1,356 @@
+---
+title: "10 Best Zapier Alternatives & Competitors in 2026"
+description: "Explore the top Zapier alternatives to automate your workflows, cut costs, and find the perfect fit for your team. Find your best option!"
+metaTitle: "10 Best Zapier Alternatives & Competitors in 2026 - Kestra"
+metaDescription: "Seeking Zapier alternatives in 2026? Compare top competitors like Kestra, Make, and n8n to automate workflows, cut costs, and find your ideal solution for any team or use case."
+tag: "ai"
+date: 2026-05-27
+slug: "zapier-alternatives"
+faq:
+  - question: "Is there anything better than Zapier?"
+    answer: "Yes, several platforms may be better than Zapier depending on your needs. For visual workflow building, Make is a strong contender. For open-source flexibility, n8n is a popular choice. For technical teams needing to orchestrate complex data, AI, and infrastructure workflows, a declarative platform like Kestra offers more power, control, and cost-efficiency at scale."
+  - question: "Why is Zapier so expensive?"
+    answer: "Zapier's pricing is based on task volume. Every single action in a multi-step workflow (a 'Zap') counts as a task. This means complex or frequently-run automations can consume your task allowance quickly, pushing you into more expensive pricing tiers even if your core use case remains simple. This model becomes costly for users with high-frequency or intricate workflows."
+  - question: "Is n8n cheaper than Zapier?"
+    answer: "Yes, n8n is generally cheaper than Zapier, especially for technical users who can leverage its self-hosted open-source version, which has no task limits. Even its cloud-hosted plans offer more generous allowances than Zapier's entry-level tiers, making it a more cost-effective option for users with a high volume of tasks."
+  - question: "What's cheaper, Make or Zapier?"
+    answer: "Make is typically cheaper than Zapier. Make's pricing is based on 'operations,' and it offers a larger number of operations in its free and paid plans compared to Zapier's task-based limits. For multi-step automations, Make's model is often more economical as complex workflows consume fewer billable units than on Zapier."
+  - question: "Does Microsoft have anything similar to Zapier?"
+    answer: "Yes, Microsoft's alternative to Zapier is Power Automate. It is deeply integrated with the Microsoft 365, Dynamics 365, and Azure ecosystems. While Zapier excels at connecting a wide variety of third-party web apps, Power Automate is the stronger choice for organizations that primarily rely on Microsoft's suite of tools and services."
+  - question: "What is the best free alternative to Zapier?"
+    answer: "The best free alternative depends on your needs. For visual building, Make offers a generous free plan with 1,000 operations per month. For technical users, open-source platforms like n8n and Activepieces offer powerful free, self-hosted versions with no task limits, providing maximum flexibility for those comfortable with managing their own instance."
+  - question: "Can Kestra replace Zapier?"
+    answer: "Kestra can replace Zapier, especially for technical and enterprise use cases. While Zapier is ideal for simple, no-code SaaS integrations, Kestra provides a more powerful, declarative (YAML-based) platform for orchestrating complex workflows across data, AI, and infrastructure. It's a better fit for engineers who need version control, scalability, and cost-effective automation beyond simple app connections."
+---
+
+Zapier has long been the go-to platform for connecting web applications and automating simple workflows. Its intuitive interface and vast integration library make it a powerful tool for many. However, as teams scale, workflows grow in complexity, or budgets tighten, many users find themselves asking: "Is there anything better than Zapier?" The answer often lies in alternatives that offer greater control, more flexible pricing, or deeper technical capabilities.
+
+The automation landscape is rapidly evolving, with new platforms emerging and existing ones maturing, especially in the realm of AI-powered and open-source solutions. The leading alternatives to Zapier in 2026 include Kestra, Make, n8n, Workato, and others, each suited to different workloads such as SaaS-to-SaaS automation, enterprise-grade integration, or robust data and infrastructure orchestration. This guide reviews the top 10 Zapier alternatives, helping you navigate the options to find the platform that best fits your technical requirements, budget, and long-term automation strategy. We'll delve into their core strengths, typical use cases, and how they stack up against Zapier.
+
+## Why look for an alternative to Zapier?
+
+While Zapier excels at user-friendliness and has an extensive library of app connectors, several factors drive users to explore other options. These often revolve around cost, scalability, and technical limitations.
+
+### Why is Zapier so expensive?
+
+Zapier's pricing model is a primary driver for users seeking alternatives. It's based on the number of "tasks" executed per month. A task is any action your automation (a "Zap") performs. A simple two-step Zap that runs 100 times consumes 200 tasks. A more complex, 10-step Zap consumes 1,000 tasks over the same period.
+
+This task-based billing means costs can escalate quickly, especially for businesses with high-frequency automations or intricate, multi-step workflows. As your automation needs grow, you're quickly pushed into higher, more expensive pricing tiers, which may not be sustainable for startups or teams with tight budgets.
+
+### Addressing common pain points with Zapier
+
+Beyond cost, users often encounter other limitations as their needs become more sophisticated:
+
+*   **Vendor Lock-in:** Zapier's platform is proprietary and cloud-only. Your workflows, logic, and history are tied to their service, making it difficult to migrate or integrate with certain on-premise systems.
+*   **Limited Code Execution:** While Zapier offers "Code by Zapier" for Python and JavaScript, it's constrained and not designed for complex logic, dependency management, or integration with version control systems.
+*   **Operational Burden for Complex Flows:** Managing dozens or hundreds of Zaps becomes cumbersome. There is no easy way to version control, test, or deploy changes across multiple workflows, leading to a brittle and hard-to-maintain automation stack.
+*   **Lack of GitOps:** For technical teams, the absence of a declarative, code-first approach is a significant drawback. Workflows can't be stored in Git, reviewed via pull requests, or deployed as part of a CI/CD pipeline, which is a standard practice for modern software and infrastructure management.
+
+## How we evaluated these alternatives
+
+To provide a balanced comparison, we evaluated each platform against a set of key criteria relevant to users moving beyond Zapier:
+
+*   **Deployment Model:** Can the tool be self-hosted, used as a cloud service, or both?
+*   **License:** Is it open-source or a proprietary commercial product?
+*   **Primary Use Case:** Is it best for simple app connections, enterprise integration, or technical orchestration?
+*   **Pricing Transparency:** Is the pricing model clear, and does it offer better value than Zapier's task-based system?
+*   **Integration Ecosystem:** How extensive is its library of connectors, and how easy is it to build custom ones?
+*   **Technical Depth:** Does it support complex logic, custom code, version control, and developer-centric workflows?
+*   **Scalability:** Can it handle high-volume, mission-critical workflows without performance degradation or prohibitive costs?
+
+## The alternatives
+
+### 1. Kestra: Open-source, declarative, and cross-domain orchestration
+
+Kestra is not just an app-connector; it's a universal orchestration control plane. It's designed to manage workflows across an entire organization, from data pipelines and AI model training to infrastructure automation and business processes. Workflows are defined as declarative YAML files, bringing the principles of Infrastructure as Code to your automations.
+
+This YAML-first approach allows teams to version control workflows in Git, conduct peer reviews, and deploy changes through CI/CD pipelines. Kestra is language-agnostic, capable of running Python, R, SQL, shell scripts, and Docker containers as first-class citizens. Its event-driven architecture makes it highly responsive and scalable for real-time use cases. For organizations like Leroy Merlin, Kestra serves as the backbone for their data mesh architecture, proving its capability in complex, enterprise-grade environments.
+
+**Best for:** Kestra is best for technical teams and enterprises seeking a universal, declarative orchestration control plane to manage complex, polyglot workflows across data, AI, infrastructure, and business operations.
+
+### 2. Make (formerly Integromat): A powerful visual builder
+
+Make stands out with its powerful and intuitive visual workflow builder. Where Zapier uses a linear, step-by-step interface, Make provides a canvas where you can drag and drop apps, create complex branches, and visualize the entire flow of data. This makes it exceptionally good for building and debugging intricate scenarios that would be difficult to manage in Zapier.
+
+Its pricing is based on "operations" rather than tasks, which is often more cost-effective for multi-step workflows. Make is API-centric, giving users fine-grained control over the data being passed between services.
+
+**Best for:** Make is best for visual thinkers and small to medium-sized businesses that need a flexible, visually-driven automation tool for complex multi-step workflows with detailed control.
+
+### 3. n8n: Open-source flexibility and self-hosting options
+
+n8n is a powerful open-source alternative that offers a visual workflow editor similar to Make. Its biggest advantage is flexibility; you can use their cloud service or self-host it on your own infrastructure for complete control over data privacy and costs. The self-hosted version has no limits on the number of workflows or tasks, making it an incredibly cost-effective solution for technical users.
+
+With a strong community and a growing library of integrations, n8n has become a favorite among developers and startups. It also has expanding AI capabilities, allowing users to integrate LLMs and build more intelligent automations.
+
+**Best for:** n8n is best for technical users and small to medium-sized businesses who prioritize open-source flexibility, self-hosting options, and visual workflow building without Zapier's task-based pricing.
+
+### 4. Pabbly Connect: Comprehensive integration suite
+
+Pabbly Connect has carved out a niche by focusing on cost-effectiveness, often offering lifetime deals that are highly attractive to small businesses and solopreneurs. It provides a wide library of integrations and a straightforward, user-friendly interface for building workflows.
+
+While it may not have the enterprise-grade features of some other platforms, Pabbly Connect delivers exceptional value for standard SaaS-to-SaaS automations. It's a no-nonsense tool for users who want to escape Zapier's recurring subscription fees for a predictable, one-time cost.
+
+**Best for:** Pabbly Connect is best for small businesses and budget-conscious users seeking a cost-effective, high-value alternative to Zapier with a broad range of integrations and a straightforward interface.
+
+### 5. Activepieces: Open-source with a growing community
+
+Activepieces is another open-source, self-hostable alternative gaining traction. It combines a user-friendly visual builder with a developer-centric approach, making it easy for engineers to contribute new integrations (called "pieces"). This focus on transparency and community contributions means its library of connectors is growing rapidly.
+
+For teams that want the simplicity of a visual tool but the power and control of an open-source platform, Activepieces strikes a compelling balance.
+
+**Best for:** Activepieces is best for developers and teams looking for an open-source, self-hostable Zapier alternative that provides a visual builder and strong community support for custom integrations.
+
+### 6. Workato: Advanced integration and automation for enterprises
+
+Workato is an enterprise-grade Integration Platform as a Service (iPaaS) that goes far beyond simple app connections. It's designed for large organizations that need to automate complex business processes across hundreds of applications, both in the cloud and on-premise.
+
+Workato offers robust governance, security, and compliance features, along with a low-code/no-code interface that empowers both IT and business users to build automations. It's a powerful, scalable platform for mission-critical enterprise workflows.
+
+**Best for:** Workato is best for large enterprises that require advanced integration capabilities, robust governance, and a low-code platform to automate complex business processes across IT and business departments.
+
+### 7. Microsoft Power Automate: For businesses in the Microsoft ecosystem
+
+Formerly known as Microsoft Flow, Power Automate is Microsoft's answer to workflow automation. Its primary strength is its deep, native integration with the Microsoft 365, Dynamics 365, and Azure ecosystems. If your organization runs on Microsoft tools, Power Automate can create seamless automations that are difficult to replicate with third-party tools.
+
+It also includes Robotic Process Automation (RPA) capabilities, allowing it to automate tasks on legacy desktop applications, a feature not present in Zapier.
+
+**Best for:** Microsoft Power Automate is best for organizations deeply embedded in the Microsoft ecosystem (Azure, Microsoft 365, Dynamics) that need seamless automation across their existing tools.
+
+### 8. IFTTT: Simple applets for personal use
+
+IFTTT, which stands for "If This Then That," is one of the original automation platforms and remains a strong choice for simple, consumer-focused tasks. It operates on a model of "applets," which are simple conditional statements connecting two services (e.g., "If I post a photo on Instagram, then save it to my Dropbox").
+
+While it lacks the multi-step complexity of Zapier, it's excellent for personal productivity, smart home automation, and connecting social media accounts.
+
+**Best for:** IFTTT is best for individual users and small personal projects that require simple, event-driven automations across consumer apps and smart home devices.
+
+### 9. HubSpot's Operations Hub: CRM-focused automation
+
+For businesses that use HubSpot as their central CRM, Operations Hub offers powerful, native automation capabilities. It's designed to solve CRM-specific problems like data cleanup, quality control, and syncing data between apps.
+
+Instead of just triggering actions, it focuses on maintaining a clean and efficient database, which is critical for sales and marketing operations. It can automate data formatting, update records in bulk, and ensure data consistency across connected tools.
+
+**Best for:** HubSpot's Operations Hub is best for sales, marketing, and operations teams using HubSpot CRM who need to automate data management, cleanup, and customer-facing workflows directly within their CRM.
+
+### 10. Lindy AI: Intelligent automation workflows
+
+Lindy AI represents the next wave of automation tools that are powered by intelligent agents. Instead of manually building step-by-step workflows, you can describe your goal in natural language, and Lindy's AI will construct and execute the necessary tasks.
+
+It's designed for more complex, cognitive tasks like managing your email inbox, scheduling meetings, or triaging customer support tickets. This agentic approach makes it a powerful tool for teams looking to automate processes that traditionally require human judgment.
+
+**Best for:** Lindy AI is best for teams experimenting with or implementing AI-powered automation, offering natural language workflow creation and agentic capabilities for complex, adaptive tasks.
+
+## Comparing Zapier alternatives: features and pricing
+
+Choosing the right platform depends on a clear-eyed view of your needs. The table below summarizes the key characteristics of each alternative.
+
+| Tool | License | Deployment | Best for | Starting Price (monthly) | Key Differentiators |
+|---|---|---|---|---|---|
+| **Kestra** | Open-Source (Apache 2.0) & Enterprise | Cloud, Self-Hosted, Hybrid | Technical teams, Enterprise orchestration | $0 (OSS) | Declarative YAML, Polyglot, Cross-Domain |
+| **Make** | Proprietary | Cloud | Visual thinkers, SMBs | ~$10 | Visual canvas builder, Operation-based pricing |
+| **n8n** | Open-Source (Fair-code) & Enterprise | Cloud, Self-Hosted | Technical users, SMBs | $0 (Self-Hosted) | Open-source, Self-hosting, Visual editor |
+| **Pabbly Connect** | Proprietary | Cloud | Budget-conscious SMBs | Varies (often lifetime deals) | Cost-effectiveness, Lifetime deals |
+| **Activepieces** | Open-Source (MIT) | Cloud, Self-Hosted | Developers, Open-source enthusiasts | $0 (Self-Hosted) | Open-source, Community-driven integrations |
+| **Workato** | Proprietary | Cloud | Large enterprises | Contact Sales | Enterprise iPaaS, Governance, Low-code |
+| **Power Automate** | Proprietary | Cloud | Microsoft-centric organizations | ~$15 | Deep Microsoft integration, RPA |
+| **IFTTT** | Proprietary | Cloud | Personal use, Smart home | ~$2.50 | Simplicity, Consumer-focused applets |
+| **HubSpot Ops Hub** | Proprietary | Cloud | HubSpot CRM users | ~$45 | CRM-native automation, Data quality |
+| **Lindy AI** | Proprietary | Cloud | AI-powered task automation | Varies | AI agents, Natural language interface |
+
+## Which Zapier alternative is right for you?
+
+The ideal platform is the one that best aligns with your team's skills, budget, and the complexity of your workflows.
+
+### Factors for small businesses and startups
+
+For small teams, cost and ease of use are paramount. Make offers a powerful visual builder with a generous free tier. n8n and Activepieces are excellent open-source options if you have the technical ability to self-host, effectively eliminating task-based costs. Pabbly Connect's lifetime deals can also provide significant long-term value.
+
+### Considerations for large organizations and enterprises
+
+Enterprises need scalability, governance, and security. Workato is a leader in the enterprise iPaaS space, offering robust features for managing automations across the business. For organizations that need a universal control plane that can be managed like code, Kestra provides a powerful, declarative platform that integrates with existing GitOps and CI/CD practices. For those heavily invested in Microsoft, Power Automate is the natural choice.
+
+### Is there anything better than Zapier?
+
+Yes. "Better" depends entirely on your use case. If you need to connect two web apps quickly without writing code, Zapier is hard to beat. However, if you need to run complex, high-volume workflows, manage infrastructure, orchestrate data pipelines, or apply software engineering best practices to your automations, platforms like Kestra and n8n are objectively better tools for the job. If your primary concern is visual flow building, Make's interface is arguably superior.
+
+### Making the final decision for your automation needs
+
+To make the right choice, consider your trajectory. A tool that works today might become a bottleneck in a year.
+*   If your needs are centered on **data and analytics**, explore a data orchestrator like Kestra.
+*   If you're automating **infrastructure and DevOps** tasks, a declarative, code-first platform is essential.
+*   For **AI and ML pipelines**, look for tools that can handle diverse computational steps and integrate with the AI ecosystem.
+
+## Conclusion
+
+The automation market has matured far beyond simple app-to-app connections. While Zapier remains a valuable tool for its target audience, the alternatives available in 2026 offer a rich spectrum of capabilities tailored to different needs.
+
+For teams moving beyond basic SaaS integrations, the choice is no longer just about which platform has the most connectors. It's about finding a solution that aligns with your technical practices, budget, and long-term vision. Open-source, declarative platforms like Kestra represent a significant step forward, providing an engineering-centric approach to automation that offers unparalleled flexibility, scalability, and cost control. By evaluating your specific requirements against the options presented here, you can select an automation platform that not only solves today's problems but also grows with you.
+
+Ready to explore a more powerful, declarative approach to orchestration? [Check out our pricing](https://kestra.io/pricing) or [book a demo](https://kestra.io/demo) to see how Kestra can unify your workflows.
+
+## Structured data
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is there anything better than Zapier?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, several platforms may be better than Zapier depending on your needs. For visual workflow building, Make is a strong contender. For open-source flexibility, n8n is a popular choice. For technical teams needing to orchestrate complex data, AI, and infrastructure workflows, a declarative platform like Kestra offers more power, control, and cost-efficiency at scale."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why is Zapier so expensive?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Zapier's pricing is based on task volume. Every single action in a multi-step workflow (a 'Zap') counts as a task. This means complex or frequently-run automations can consume your task allowance quickly, pushing you into more expensive pricing tiers even if your core use case remains simple. This model becomes costly for users with high-frequency or intricate workflows."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is n8n cheaper than Zapier?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, n8n is generally cheaper than Zapier, especially for technical users who can leverage its self-hosted open-source version, which has no task limits. Even its cloud-hosted plans offer more generous allowances than Zapier's entry-level tiers, making it a more cost-effective option for users with a high volume of tasks."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What's cheaper, Make or Zapier?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Make is typically cheaper than Zapier. Make's pricing is based on 'operations,' and it offers a larger number of operations in its free and paid plans compared to Zapier's task-based limits. For multi-step automations, Make's model is often more economical as complex workflows consume fewer billable units than on Zapier."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Microsoft have anything similar to Zapier?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, Microsoft's alternative to Zapier is Power Automate. It is deeply integrated with the Microsoft 365, Dynamics 365, and Azure ecosystems. While Zapier excels at connecting a wide variety of third-party web apps, Power Automate is the stronger choice for organizations that primarily rely on Microsoft's suite of tools and services."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the best free alternative to Zapier?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The best free alternative depends on your needs. For visual building, Make offers a generous free plan with 1,000 operations per month. For technical users, open-source platforms like n8n and Activepieces offer powerful free, self-hosted versions with no task limits, providing maximum flexibility for those comfortable with managing their own instance."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can Kestra replace Zapier?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Kestra can replace Zapier, especially for technical and enterprise use cases. While Zapier is ideal for simple, no-code SaaS integrations, Kestra provides a more powerful, declarative (YAML-based) platform for orchestrating complex workflows across data, AI, and infrastructure. It's a better fit for engineers who need version control, scalability, and cost-effective automation beyond simple app connections."
+      }
+    }
+  ]
+}
+```
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Top 10 Zapier Alternatives",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Kestra",
+      "url": "https://kestra.io/resources/ai/zapier-alternatives#1-kestra-open-source-declarative-and-cross-domain-orchestration"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Make",
+      "url": "https://kestra.io/resources/ai/zapier-alternatives#2-make-formerly-integromat-a-powerful-visual-builder"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "n8n",
+      "url": "https://kestra.io/resources/ai/zapier-alternatives#3-n8n-open-source-flexibility-and-self-hosting-options"
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "name": "Pabbly Connect",
+      "url": "https://kestra.io/resources/ai/zapier-alternatives#4-pabbly-connect-comprehensive-integration-suite"
+    },
+    {
+      "@type": "ListItem",
+      "position": 5,
+      "name": "Activepieces",
+      "url": "https://kestra.io/resources/ai/zapier-alternatives#5-activepieces-open-source-with-a-growing-community"
+    },
+    {
+      "@type": "ListItem",
+      "position": 6,
+      "name": "Workato",
+      "url": "https://kestra.io/resources/ai/zapier-alternatives#6-workato-advanced-integration-and-automation-for-enterprises"
+    },
+    {
+      "@type": "ListItem",
+      "position": 7,
+      "name": "Microsoft Power Automate",
+      "url": "https://kestra.io/resources/ai/zapier-alternatives#7-microsoft-power-automate-for-businesses-in-the-microsoft-ecosystem"
+    },
+    {
+      "@type": "ListItem",
+      "position": 8,
+      "name": "IFTTT",
+      "url": "https://kestra.io/resources/ai/zapier-alternatives#8-ifttt-simple-applets-for-personal-use"
+    },
+    {
+      "@type": "ListItem",
+      "position": 9,
+      "name": "HubSpot's Operations Hub",
+      "url": "https://kestra.io/resources/ai/zapier-alternatives#9-hubspots-operations-hub-crm-focused-automation"
+    },
+    {
+      "@type": "ListItem",
+      "position": 10,
+      "name": "Lindy AI",
+      "url": "https://kestra.io/resources/ai/zapier-alternatives#10-lindy-ai-intelligent-automation-workflows"
+    }
+  ]
+}
+```
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://kestra.io/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Resources",
+      "item": "https://kestra.io/resources"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "AI",
+      "item": "https://kestra.io/resources/ai"
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "name": "10 Best Zapier Alternatives & Competitors in 2026",
+      "item": "https://kestra.io/resources/ai/zapier-alternatives"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Batch import of 6 SEO long-form pages from kestra-seo W23 briefs.

| Page URL | Tag | Source brief |
|---|---|---|
| `/resources/ai/ai-governance-workflows` | ai | [vfanucci/kestra-seo#107](https://github.com/vfanucci/kestra-seo/pull/107) |
| `/resources/ai/ai-native-orchestration-platform` | ai | [vfanucci/kestra-seo#108](https://github.com/vfanucci/kestra-seo/pull/108) |
| `/resources/ai/ai-orchestration-for-non-technical-teams` | ai | [vfanucci/kestra-seo#109](https://github.com/vfanucci/kestra-seo/pull/109) |
| `/resources/infrastructure/audit-logs-orchestration` | infrastructure | [vfanucci/kestra-seo#110](https://github.com/vfanucci/kestra-seo/pull/110) |
| `/resources/data/logistics-data-orchestration` | data | [vfanucci/kestra-seo#117](https://github.com/vfanucci/kestra-seo/pull/117) |
| `/resources/ai/zapier-alternatives` | ai | [vfanucci/kestra-seo#130](https://github.com/vfanucci/kestra-seo/pull/130) |

### Notes
- **Schema enum normalization** applied where the generator produced free-form tag values:
  - `"AI"` → `ai` (#108)
  - `"Orchestration"` → `infrastructure` (#110)
  - `"workflow-management"` → `ai` (#130)
- **Wrapper strip**: removed leading ```` ```yaml ```` fences from 4 generated drafts (#107, #109, #110, #130)
- **PR #108 editorial choice — Variant A shipped** for the H3 "Future-Proofing with Self-Evolving AI Agents":
  - Explicit "Kestra 2.0 roadmap" framing with internal link to [/blogs/kestra-2-0-engineering](https://kestra.io/blogs/kestra-2-0-engineering)
  - Content aligned strictly with the official Kestra 2.0 post (no "self-evolving" overclaim, no GA claims)
  - Variant B (industry-level framing, no Kestra 2.0 mention) remains documented in the source PR's outline if a revert is desired
- **PR #117 word count**: regenerated draft is 1621 body words — slightly below the 1800–2500 target but acceptable for publication

## Test plan
- [ ] Astro build passes (resources schema validation)
- [ ] All 6 pages render at their `/resources/<tag>/<slug>` URLs
- [ ] FAQ accordions render correctly
- [ ] Internal links (`/blogs/kestra-2-0-engineering`, `/resources/*`, `/docs/*`, `/vs/*`) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)