### PR TITLE
fix(plugins): fix plugin version list ordering and completeness

### DIFF
--- a/src/pages/api/github-releases.ts
+++ b/src/pages/api/github-releases.ts
@@ -43,19 +43,16 @@ export async function retrieveRepoReleases(repo: string) {
 
     try {
         const versions: ReleaseInfo[] = releases
-            .filter((release) => !release.draft)
+            .filter((release) => !release.draft && !release.tag_name.includes("SNAPSHOT"))
             .map((release) => ({
                 version: release.tag_name.replace(/^v/, ""),
                 publishedAt: release.published_at,
             }))
-            .filter((v) => {
-                const major = parseInt(v.version.split(".")[0])
-                return !isNaN(major) && major >= 1
-            })
             .toSorted((a, b) => {
-                const aTime = a.publishedAt ? Date.parse(a.publishedAt) : 0
-                const bTime = b.publishedAt ? Date.parse(b.publishedAt) : 0
-                return bTime - aTime
+                const parseParts = (v: string) => v.split(".").map((p) => parseInt(p, 10) || 0)
+                const [aMaj, aMin, aPat] = parseParts(a.version)
+                const [bMaj, bMin, bPat] = parseParts(b.version)
+                return bMaj - aMaj || bMin - aMin || bPat - aPat
             })
 
         return { versions }

--- a/src/utils/plugins/fetchPluginPageData.ts
+++ b/src/utils/plugins/fetchPluginPageData.ts
@@ -60,6 +60,15 @@ export async function fetchInitialPluginData(pluginName: string, githubReleaseRe
                 ).find(
                     (a) => a.version === v.version && normalizeRepoUrl(a.repository) === repoUrl,
                 )?.minCoreCompatibilityVersion
+
+                // Fallback for pre-1.0.0 versions not in the artifacts index:
+                // plugin 0.X.Y always required Kestra 0.X.0 by convention.
+                if (!v.minCoreCompatibilityVersion) {
+                    const parts = v.version.split(".")
+                    if (parts.length >= 2 && parseInt(parts[0]) === 0) {
+                        v.minCoreCompatibilityVersion = `0.${parts[1]}.0`
+                    }
+                }
             })
         } catch (e) {
             console.error("Artifacts annotation failed", e)


### PR DESCRIPTION
## Summary
- Show pre-1.0.0 plugin releases (`0.x`) in the version list — they were previously dropped
- Filter out SNAPSHOT releases from the version list
- Sort versions by semver descending (major → minor → patch) instead of by publish date — fixes cases where `0.x` releases appeared before `2.x` ones due to newer timestamps

## Test plan
- [ ] Open a plugin with `0.x` releases and confirm they appear in the list
- [ ] Confirm no SNAPSHOT entries appear in the version list
- [ ] Confirm version order is `2.4.1, 2.4.0, …, 0.22.4, 0.22.0, …` (newest semver first)