### PR TITLE
seo: fix duplicated slug in use-cases sitemap URLs (21 × 404)

### DIFF
--- a/src/pages/sitemap/use-cases.xml.ts
+++ b/src/pages/sitemap/use-cases.xml.ts
@@ -1,6 +1,5 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { slugify } from "~/utils/slugify"
 import { sitemapResponse, formatLastMod, gitLastModified } from "~/utils/sitemap.ts"
 
 export const GET: APIRoute = async () => {
@@ -28,7 +27,7 @@ export const GET: APIRoute = async () => {
         }
 
         return {
-            loc: `https://kestra.io/use-cases/stories/${story.id}-${slugify(story.data.title ?? "--")}`,
+            loc: `https://kestra.io/use-cases/stories/${story.id}`,
             lastmod,
         }
     })


### PR DESCRIPTION
## Problem

`https://kestra.io/sitemap/use-cases.xml` listed **21 customer-story URLs that returned 404**. Each had its slug duplicated, e.g.:

```
/use-cases/stories/when-your-api-writes-its-own-docs-with-kestra-when-your-api-writes-its-own-docs-with-kestra
```

(spotted via a Screaming Frog crawl of the sitemap)

## Root cause

[`src/pages/sitemap/use-cases.xml.ts`](https://github.com/kestra-io/docs/blob/main/src/pages/sitemap/use-cases.xml.ts) built each story URL as:

```ts
loc: `https://kestra.io/use-cases/stories/${story.id}-${slugify(story.data.title ?? "--")}`,
```

But `story.id` **is already the route slug** — see [`use-cases/stories/[slug].astro`](https://github.com/kestra-io/docs/blob/main/src/pages/use-cases/stories/%5Bslug%5D.astro): `params: { slug: entry.id }`. Appending `slugify(title)` doubled the slug. The punctuation variants in the dead URLs (`:`, `'`, missing hyphens in the 2nd half) came from `slugify(title)` re-normalizing the title differently from the stored id.

## Fix

Emit `${story.id}` only — matching the real page routes and the existing internal links (`Card.vue`, `StoryRow.vue`, which were already correct). Removed the now-unused `slugify` import.

```diff
-import { slugify } from "~/utils/slugify"
-            loc: `https://kestra.io/use-cases/stories/${story.id}-${slugify(story.data.title ?? "--")}`,
+            loc: `https://kestra.io/use-cases/stories/${story.id}`,
```

## Verification

- `astro build` ✅ — generated `dist/client/sitemap/use-cases.xml` now lists all **27 stories with clean single slugs**, each matching a real generated page directory under `dist/client/use-cases/stories/`. No remaining duplicates.
- `oxlint` ✅ — 0 warnings, 0 errors.

No 301 redirects needed: the duplicated URLs only ever 404'd, so they were never indexed. The "404" entries in GSC will clear once the sitemap is recrawled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)