### PR TITLE
seo(features): add FAQPage structured data to /features

### DIFF
--- a/src/pages/features/index.astro
+++ b/src/pages/features/index.astro
@@ -1,6 +1,7 @@
 ---
 import Faq from "~/components/common/Faq.vue"
 import Layout from "~/components/layout.astro"
+import SchemaFAQ from "~/components/common/SchemaFAQ.astro"
 import SchemaSoftwareApplication from "~/components/common/SchemaSoftwareApplication.astro"
 import Run from "~/components/features/core/Run.astro"
 import Stacked from "~/components/common/Stacked.astro"
@@ -52,6 +53,7 @@ const items = [
 <Layout {title} {description} headerTheme="lightText">
     <Fragment slot="head">
         <SchemaSoftwareApplication url="https://kestra.io/features" />
+        <SchemaFAQ items={items} />
     </Fragment>
     <div class="core">
         <Intro />


### PR DESCRIPTION
## What

Adds `FAQPage` JSON-LD structured data to the **/features** page.

## Why

Agents Taskforce — Pillar 1 (Product Clarity) to-do item: *"/features page: No FAQPage schema"*.

The page already renders 7 FAQ items (via `Faq.vue`), but no `FAQPage` schema was emitted, so AI crawlers and search engines couldn't parse the Q&A content as structured data.

## How

Reuses the existing `SchemaFAQ.astro` component — already used on `/vs/`, `/use-cases/` and `/orchestration/` pages — wired to the same `items` array that feeds the visible FAQ. The component strips HTML tags from answers (links, `<strong>`), so the JSON-LD output is clean plain text.

2-line diff, no content changes, no visual changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)