### PR TITLE
Add resources article: Runbook Automation Tools for 2026 (infrastructure)

### DIFF
--- a/src/contents/resources/runbook-automation-tools-2026/index.md
+++ b/src/contents/resources/runbook-automation-tools-2026/index.md
@@ -1,0 +1,224 @@
+---
+title: "Runbook Automation Tools for 2026: Modernizing IT Operations"
+description: "Runbook automation is evolving fast in 2026. This guide explores the benefits, key features, and leading tools that speed up IT operations, incident response, and compliance with declarative, event-driven workflows."
+metaTitle: "Runbook Automation Tools 2026: Modernizing IT | Kestra"
+metaDescription: "Compare the best runbook automation tools for 2026 and how declarative, event-driven platforms speed up IT operations, incident response, and compliance."
+tag: infrastructure
+date: 2026-06-17
+faq:
+  - question: "What is runbook automation?"
+    answer: "Runbook automation transforms documented operational procedures into executable workflows. Instead of manual steps, a modern runbook automates tasks like incident response, system provisioning, and maintenance, often triggered by events or schedules. This approach ensures consistency, reduces human error, and accelerates operational processes."
+  - question: "Why is runbook automation important for modern IT operations?"
+    answer: "In 2026, runbook automation is central to modern IT because it automates routine tasks, drastically improves incident response times, and enforces consistency across complex, hybrid environments. It minimizes manual effort, reduces mean time to resolution (MTTR), and supports stringent compliance requirements through auditable, automated procedures."
+  - question: "What are the key features of a modern runbook automation tool?"
+    answer: "Key features include deep integration with existing IT ecosystems, a powerful workflow orchestration engine for complex sequences, detailed reporting and audit trails for compliance, and the flexibility to scale across diverse cloud and on-premise environments. Support for declarative definitions and event-driven triggers is also essential."
+  - question: "How does AI impact the future of runbook automation?"
+    answer: "AI is transforming runbook automation by enabling proactive and intelligent operations. AI can analyze operational data to predict incidents, suggest optimal remediation runbooks, and even autonomously execute corrective actions. This moves runbook automation from reactive responses to predictive, self-healing systems, enhancing efficiency and resilience."
+  - question: "Can runbook automation be used for disaster recovery?"
+    answer: "Yes, runbook automation is highly effective for disaster recovery (DR). It allows organizations to codify and automate complex DR procedures, ensuring that recovery steps are executed consistently and quickly. This reduces recovery time objectives (RTOs) and recovery point objectives (RPOs) by minimizing manual intervention during critical outages."
+  - question: "How does Kestra approach runbook automation?"
+    answer: "Kestra treats runbook automation as a core component of its unified orchestration platform. Workflows are defined declaratively in YAML, enabling GitOps practices for IT operations. Kestra's event-driven architecture and extensive plugin ecosystem allow it to orchestrate runbooks across diverse infrastructure, data, and AI systems, providing centralized governance and observability."
+  - question: "What are the benefits of declarative runbook automation?"
+    answer: "Declarative runbook automation offers several benefits, including improved version control and auditability, easier collaboration between teams (DevOps, SRE, data), and enhanced reliability through idempotent and testable workflows. It simplifies managing complex operational procedures by defining the desired state, letting the orchestrator handle the execution details."
+---
+In the complex landscape of modern IT, operational teams are constantly battling repetitive tasks, slow incident response, and the challenge of maintaining consistent procedures. Traditional runbooks, while essential, often remain static documents, failing to keep pace with dynamic infrastructure and the need for rapid execution.
+
+This guide explores the evolution of runbook automation in 2026, moving beyond manual scripts to embrace declarative, event-driven workflows. We'll cover the core benefits, essential features, and leading tools, including how platforms like Kestra are transforming the way organizations manage their IT operations, incident response, and compliance.
+
+## The Evolution of Runbook Automation: From Manual Steps to Executable Workflows
+
+Runbook automation isn't a new concept, but its definition and scope have changed dramatically. What began as a way to document procedures for system administrators has become a cornerstone of modern IT operations, driven by the need to manage complexity and scale.
+
+### Defining Runbook Automation in 2026: Beyond Documentation
+
+Historically, a runbook was a physical or digital document detailing the steps required to perform a specific operational task, such as responding to a server outage or deploying a new application. It was a human-readable guide for a human operator.
+
+In 2026, runbook automation transforms these documented procedures into executable, machine-readable workflows. The focus shifts from *describing* the process to *codifying* it. A modern runbook is a series of automated actions, triggered by a specific event, schedule, or manual request, that executes a complex operational task without human intervention. This shift is a critical component of what we now call [infrastructure automation](/resources/infrastructure/automation), where the goal is to manage infrastructure as code.
+
+### The Shift to Declarative and Event-Driven Runbooks
+
+The earliest forms of runbook automation relied on imperative scripts—sequences of commands telling the system *how* to perform a task. While an improvement over manual execution, this approach created brittle, hard-to-maintain script libraries that were often siloed within specific teams or tools.
+
+The modern approach, and the standard for 2026, is declarative and event-driven.
+*   **Declarative:** Instead of scripting every step, teams define the desired end state in a configuration file (like YAML). The automation platform is responsible for figuring out how to achieve that state. This makes runbooks more readable, versionable, and auditable—a practice often referred to as GitOps for operations.
+*   **Event-Driven:** Rather than relying solely on scheduled execution, modern runbooks are triggered by events from monitoring systems, ITSM platforms, or cloud services. An alert from Prometheus, a new ticket in ServiceNow, or an S3 bucket event can all initiate an automated remediation workflow, enabling real-time response to operational issues.
+
+This evolution turns runbooks from static, reactive documents into dynamic, proactive components of a self-healing IT ecosystem.
+
+## Why Modern IT Operations Demand Automated Runbooks
+
+The pressure on IT operations and site reliability engineering (SRE) teams has never been greater. Hybrid cloud environments, microservices architectures, and the sheer volume of operational data make manual management untenable. Automated runbooks have become essential for survival, not just efficiency.
+
+### Reducing Manual Effort and Streamlining Routine Tasks
+
+Every IT environment has a long list of routine, repetitive tasks: restarting services, clearing disk space, managing user access, applying patches, and performing health checks. These tasks consume valuable engineering time and are prone to human error.
+
+Runbook automation eliminates this toil by converting these procedures into reliable, repeatable workflows. This frees up engineers to focus on higher-value work, such as improving system architecture and performance, rather than fighting fires. At CAGIP, the IT production arm of Crédit Agricole, a unified orchestration layer became the foundation for transforming infrastructure operations and scaling workflows across more than 100 clusters.
+
+### Accelerating Incident Response and Minimizing Downtime
+
+When an incident occurs, time is critical. Mean Time To Resolution (MTTR) is a key metric for any operations team, and manual incident response is a major bottleneck. Engineers must diagnose the issue, consult documentation, and manually execute remediation steps, all while under pressure.
+
+Automated runbooks dramatically accelerate this process. An alert from a monitoring system can automatically trigger a diagnostic runbook that gathers relevant logs and metrics. A subsequent remediation runbook can then execute predefined steps, such as restarting a service, failing over to a secondary system, or rolling back a recent deployment. This reduces MTTR from hours to minutes, minimizing the impact of outages on customers and the business.
+
+### Ensuring Consistency, Compliance, and Auditability
+
+Inconsistency is the enemy of reliability. When different engineers perform the same task in slightly different ways, it introduces variability and risk. Runbook automation enforces consistency by ensuring that operational procedures are executed exactly the same way every time.
+
+This consistency is also vital for compliance and security. In regulated industries such as finance or government, organizations must prove that they follow specific procedures for tasks like data handling, access control, and change management. Automated runbooks provide a complete, immutable audit trail for every action taken. Every execution is logged, providing clear evidence for auditors and security teams. This is particularly important for [government and public sector workflow automation](/use-cases/public-services), where auditability is non-negotiable.
+
+## Essential Features of Top Runbook Automation Tools in 2026
+
+Choosing the right runbook automation tool requires looking beyond basic script execution. The leading platforms of 2026 are distinguished by their ability to integrate, orchestrate, and provide deep visibility across the entire IT landscape.
+
+### Deep Integration with Existing IT Ecosystems
+
+A runbook automation tool is only as useful as its ability to connect to your existing systems. A modern platform must offer a rich library of pre-built plugins and connectors for a wide range of technologies, including:
+*   **Cloud Providers:** AWS, Azure, GCP
+*   **Monitoring & Observability:** Prometheus, Datadog, Grafana
+*   **ITSM & Collaboration:** ServiceNow, Jira, Slack, Microsoft Teams
+*   **Infrastructure as Code:** Terraform, Ansible, Puppet
+*   **Databases & Messaging Systems:** PostgreSQL, Snowflake, Kafka
+
+The ability to easily interact with these systems via APIs or native integrations is what allows a runbook to orchestrate complex, multi-system workflows.
+
+### Powerful Workflow Orchestration and Execution Engines
+
+At its core, a runbook is a workflow. A powerful orchestration engine is essential for defining and executing these workflows with the necessary control and resilience. Key capabilities include:
+*   **Complex Flow Control:** Support for sequential, parallel, and conditional task execution.
+*   **Error Handling and Retries:** Sophisticated mechanisms for managing failures, with configurable retry policies and branching logic for different error conditions.
+*   **State Management:** The ability to pass data and context between tasks within a workflow.
+*   **Dynamic Tasks:** Generating tasks at runtime based on the output of previous steps, allowing for flexible and adaptive runbooks.
+
+### Centralized Observability, Reporting, and Audit Trails
+
+You can't manage what you can't see. A centralized dashboard for visualizing workflow executions, logs, and metrics is the baseline. This provides a single pane of glass for understanding what's happening in your environment.
+*   **Real-time Visibility:** Live tracking of running workflows, with detailed logs for each task.
+*   **Audit Trails:** An immutable record of every runbook execution, including who triggered it, when it ran, and what actions were performed.
+*   **Reporting & Analytics:** Dashboards and reports that provide insights into operational performance, such as runbook success rates, execution times, and MTTR improvements.
+
+### Scalability and Flexibility for Hybrid Cloud Environments
+
+Modern IT is rarely confined to a single data center or cloud. Runbook automation tools must be able to operate consistently across hybrid and multi-cloud environments. This requires a flexible architecture that can be deployed on-premises, in any cloud, or in air-gapped environments. The platform should be able to manage workloads and trigger actions on diverse infrastructure without being tied to a specific vendor.
+
+## Leading Runbook Automation Tools: A Comparative Overview
+
+The market for runbook automation is diverse, ranging from specialized incident response tools to broad enterprise orchestration platforms. Understanding the different categories is key to selecting the right solution.
+
+### Traditional Tools vs. Modern Orchestration Platforms
+
+Traditional runbook automation tools often focus on executing scripts and providing a UI for manual triggers. While valuable, they can perpetuate silos, with separate tools for infrastructure, data, and application automation.
+
+Modern orchestration platforms take a more holistic approach. They provide a unified control plane to define, execute, and govern workflows across all domains. They emphasize declarative definitions (YAML, HCL), event-driven triggers, and a rich plugin ecosystem, treating runbooks as a core component of a larger automation strategy. The choice between these approaches often comes down to whether you need a point solution for a specific problem or a scalable platform for enterprise-wide automation. You can explore a wide range of [Kestra vs. alternatives](/vs) to see how these philosophies compare.
+
+### Specialized Incident-Response Platforms
+
+A class of tools focuses purely on incident management. Their strength lies in integrating with collaboration tools like Slack and providing a structured workflow for declaring incidents, communicating with stakeholders, and running post-mortems. Their runbook capabilities are tightly focused on the incident lifecycle, making them a strong choice for teams looking to optimize their on-call and response processes — and less suited for general-purpose IT automation beyond the scope of an active incident.
+
+### Rundeck and Control-M: Established Players and Their Evolution
+
+Established tools like Rundeck (now PagerDuty Process Automation) and Control-M have been mainstays in IT operations for years.
+*   **Rundeck** excels at providing self-service access to operational tasks, allowing non-experts to safely execute pre-defined jobs and scripts. It's a strong choice for democratizing operations, but can be more script-centric. For a detailed comparison, see these [Rundeck alternatives](/resources/infrastructure/rundeck-alternatives).
+*   **Control-M** is an enterprise-grade workload automation platform with deep roots in batch scheduling. It offers strict governance and proven reliability for mission-critical jobs but can be complex and less aligned with modern DevOps practices. Teams often look for [Control-M alternatives](/resources/infrastructure/control-m-alternatives) when moving to more agile, code-driven workflows.
+
+### Kestra: The Declarative Control Plane for Runbook Automation
+
+Kestra represents the modern orchestration approach. It is a declarative, language-agnostic platform that treats runbooks as first-class, version-controlled workflows. Its key differentiators include:
+*   **Declarative YAML:** All workflows are defined as code, enabling GitOps practices for IT operations.
+*   **Event-Driven Architecture:** Natively supports triggers from a wide range of sources, enabling real-time automation.
+*   **Unified Platform:** Orchestrates runbooks across infrastructure, data pipelines, and AI workflows from a single control plane, breaking down operational silos.
+
+Kestra is designed for teams that see runbook automation not just as a way to execute scripts, but as a strategic capability for managing complex, interdependent systems at scale.
+
+## Practical Use Cases for Runbook Automation in 2026
+
+The applications of runbook automation span the entire IT operations lifecycle. Here are some of the most impactful use cases for 2026.
+
+### Automating Infrastructure Provisioning and Configuration
+
+Manually provisioning servers, virtual machines, or cloud resources is slow and error-prone. An automated runbook can orchestrate the entire process, from creating a Jira ticket to provisioning infrastructure with Terraform, configuring it with Ansible, and updating the CMDB in ServiceNow. This is a core principle of Infrastructure as Code, and runbook automation provides the workflow layer to connect the tools. Amdocs' Foundation team applies this pattern to deliver integration environments as a service, orchestrating end-to-end environment provisioning, deployment, and automated validation at scale. For teams looking to modernize their stack, exploring [alternatives to Ansible](/resources/infrastructure/alternatives-to-ansible) or other configuration management tools is a common starting point.
+
+### Enhancing Security Operations with Automated Procedures
+
+Security Operations (SecOps) teams are often overwhelmed with alerts. Runbook automation can be used to handle initial alert triage, enrich alerts with threat intelligence data, and execute initial containment actions, such as isolating a compromised host or blocking a malicious IP address. This allows security analysts to focus their attention on high-priority, complex threats. The auditable nature of automated runbooks also provides a clear record of actions taken during a security incident.
+
+### Simplifying Routine Maintenance and System Health Checks
+
+Routine maintenance tasks, such as database backups, index rebuilding, certificate rotation, and application restarts, are perfect candidates for automation. A runbook can execute these tasks on a schedule, perform health checks before and after, and send notifications to the appropriate team if something goes wrong. This ensures that maintenance is performed consistently and reliably without manual intervention. It also prevents the accumulation of "script debt" by managing these procedures as version-controlled workflows.
+
+### Facilitating Disaster Recovery and Business Continuity
+
+A disaster recovery (DR) plan is only effective if it can be executed quickly and reliably. Automated DR runbooks codify the entire failover process, from switching DNS records and promoting backup databases to spinning up infrastructure in a secondary region. By automating these steps, organizations can significantly reduce their Recovery Time Objective (RTO) and ensure that the DR process is executed flawlessly, even under extreme pressure. This turns the DR plan from a static document into a testable, executable asset. Many organizations find that legacy tools like Puppet are not sufficient for these dynamic workflows, leading them to search for more flexible [Puppet alternatives](/resources/infrastructure/puppet-alternatives).
+
+## The Future of Runbook Automation: AI and Proactive Operations
+
+The next frontier for runbook automation is the integration of artificial intelligence. AI is transforming IT operations from a reactive discipline to a proactive, predictive one.
+
+### Integrating AI for Predictive Automation and Decision Making
+
+AI and machine learning models can analyze historical monitoring data to predict potential issues before they become incidents. For example, an AI model might detect a memory leak pattern and predict that a server will crash within the next 24 hours. This prediction can automatically trigger a proactive runbook to restart the service during a maintenance window, preventing an outage altogether.
+
+### From Reactive to Proactive: Self-Healing IT Systems
+
+The ultimate goal is to create self-healing systems. When an issue is detected, an AI agent can analyze the symptoms, identify the likely root cause, and select the appropriate remediation runbook from a library of automated procedures. The runbook is then executed automatically, resolving the issue without any human intervention. This creates a closed-loop system where the infrastructure can monitor, diagnose, and heal itself.
+
+### The Role of Unified Orchestration in Governing AI Agents
+
+As AI agents become more autonomous, governance becomes critical. An orchestration platform is essential for managing how these agents interact with production systems. It provides the necessary guardrails, such as human-in-the-loop approvals for critical actions, audit trails for all AI-driven operations, and a centralized control plane for defining the tools and permissions available to each agent. This is a key aspect of [multi-agent collaboration and evolving orchestration](/resources/ai/multi-agent-collaboration-evolving-orchestration), ensuring that AI-powered automation is both powerful and safe.
+
+## Why Kestra is the Modern Choice for Runbook Automation
+
+Kestra's architecture is uniquely suited to the challenges of modern runbook automation. It provides a declarative, event-driven, and unified platform that aligns with the principles of GitOps, DevOps, and DataOps.
+
+### Declarative YAML: GitOps for Your Operations
+
+With Kestra, every runbook is a YAML file. This allows operations teams to manage their automation workflows the same way developers manage application code:
+*   **Version Control:** Store runbooks in Git for a complete history of changes.
+*   **Code Review:** Use pull requests to review and approve changes to operational procedures.
+*   **Collaboration:** Enable direct collaboration between DevOps, SRE, and platform engineering teams.
+
+Here is a simple example of a runbook that restarts a web server and sends a notification to Slack:
+
+```yaml
+id: restart-web-server
+namespace: prod.operations
+
+tasks:
+  - id: restart-service
+    type: io.kestra.plugin.fs.ssh.Command
+    host: web-server-01
+    username: "{{ secret('SSH_USER') }}"
+    password: "{{ secret('SSH_PASSWORD') }}"
+    commands:
+      - sudo systemctl restart nginx
+
+  - id: notify-slack
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    payload: |
+      {
+        "text": "Nginx restarted on web-server-01"
+      }
+```
+This declarative approach makes runbooks more reliable, auditable, and easier to manage at scale. You can find more examples in our library of [infrastructure automation resources](/resources/infrastructure).
+
+### Event-Driven Agility Across Any System
+
+Kestra's event-driven core allows it to react instantly to events from any system. Whether it's a PagerDuty alert, a Kafka message, or a new file in a cloud storage bucket, Kestra can trigger the corresponding runbook in real-time. This agility is essential for building responsive, self-healing systems and moving beyond the limitations of traditional cron-based scheduling.
+
+### Unifying Data, AI, and Infrastructure Workflows
+
+Modern operational issues often span multiple domains. A performance problem might require a runbook that pulls logs from an observability platform (infra), queries a data warehouse for usage patterns (data), and then uses an AI model to identify the root cause (AI). Kestra's ability to orchestrate tasks across these domains on a single platform eliminates the "glue code" and complexity of stitching together multiple specialized tools. It allows teams to build end-to-end runbooks that reflect the true nature of their interconnected systems, whether they span data pipelines, AI models, or core infrastructure.
+
+## Selecting the Right Runbook Automation Tool for Your Organization
+
+Choosing a runbook automation tool for 2026 and beyond is a strategic decision. It's not just about automating a few scripts; it's about building a foundation for scalable, resilient, and proactive IT operations.
+
+When evaluating tools, consider the following criteria:
+*   **Declarative & Code-First:** Does the tool treat automation as code, enabling GitOps and collaboration?
+*   **Integration & Extensibility:** Can it easily connect to your entire tech stack, both now and in the future?
+*   **Unified Orchestration:** Can it manage workflows across infrastructure, data, and AI, or will it create another silo?
+*   **Event-Driven Capabilities:** Does it support real-time, event-driven triggers beyond simple scheduling?
+*   **Future-Proof Architecture:** Is it prepared for the rise of AI-driven automation and the need for governed, autonomous operations?
+
+By prioritizing a platform that is declarative, unified, and event-driven, you give your organization the foundation to handle modern IT complexity and turn operational procedures into a strategic advantage. See how Kestra lets you [orchestrate your entire infrastructure from one control plane](/infra-automation).


### PR DESCRIPTION
## What

New `/resources/infrastructure/` article: **Runbook Automation Tools for 2026: Modernizing IT Operations** (`runbook-automation-tools-2026`).

## Quality checklist

- Front-matter matches the resources template (metaTitle 54 chars incl. `| Kestra` suffix, metaDescription 153 chars, `tag: infrastructure`, 7 FAQ entries)
- 10 internal links, all verified against the live site, absolute paths, no duplicate destinations, single conversion-hub CTA (`/infra-automation`, end of article)
- Customer mentions sourced from published case studies only: Amdocs (integration environments as a service), CAGIP / Crédit Agricole (100+ clusters)
- YAML example uses verified plugin types: `io.kestra.plugin.fs.ssh.Command`, `io.kestra.plugin.notifications.slack.SlackIncomingWebhook`
- No FAQ H2 in body, no manual JSON-LD (template handles schema from front-matter)

cc @vfanucci

🤖 Generated with [Claude Code](https://claude.com/claude-code)