### PR TITLE
seo: add explicit width/height to high-volume card images (CLS)

### DIFF
--- a/src/components/blogs/BlogCard.vue
+++ b/src/components/blogs/BlogCard.vue
@@ -2,7 +2,7 @@
     <div class="cards">
         <a :href="blog.path" :target="target">
             <div class="img-container">
-                <img :src="blog.image" :alt="blog.title" />
+                <img :src="blog.image" :alt="blog.title" width="1600" height="900" />
             </div>
             <div class="content">
                 <small class="meta">

--- a/src/components/plugins/PluginCard.vue
+++ b/src/components/plugins/PluginCard.vue
@@ -29,7 +29,7 @@
         <div class="plugin">
             <div class="top-row">
                 <div class="icon-content">
-                    <img :src="iconSrc" :alt="props.plugin.title" loading="lazy" />
+                    <img :src="iconSrc" :alt="props.plugin.title" loading="lazy" width="45" height="45" />
                 </div>
                 <div class="content">
                     <div class="title-row">

--- a/src/components/plugins/SubgroupCard.vue
+++ b/src/components/plugins/SubgroupCard.vue
@@ -3,7 +3,7 @@
         <div class="plugin" :class="{'is-active': isActive}">
             <div class="top-row">
                 <div class="icon-content">
-                    <img v-if="iconSrc" :src="iconSrc" :alt="`${text} icon`">
+                    <img v-if="iconSrc" :src="iconSrc" :alt="`${text} icon`" width="45" height="45">
                 </div>
                 <div class="text-content">
                     <h6>{{ text }}</h6>


### PR DESCRIPTION
## Context
Technical SEO audit (Screaming Frog, 2026-06-15): **~19,600 `<img>` instances** missing `width`/`height`, dominated by listing cards repeated across many pages (blog grid, plugin catalog). Possible cause of **Cumulative Layout Shift (CLS)**.

## Changes (high-volume components with known aspect ratios)
- **`BlogCard.vue`** → `width="1600" height="900"` (container already `aspect-ratio: 16/9`, `object-fit: cover`) — ~193 imgs/page on `/blogs`.
- **`PluginCard.vue`** / **`SubgroupCard.vue`** → `width="45" height="45"` (icon fixed at 45px in CSS) — plugin listings, /plugins = 58% of the site.

Dimensions **match the existing CSS exactly**, so rendered sizes are unchanged — no distortion risk.

## Out of scope (intentional)
Partner/enterprise logos (`Logos.astro`) and use-case hero images have **variable aspect ratios**; hardcoding dimensions would distort them. To be handled in a follow-up via CSS `aspect-ratio` or per-image dimensions, with **visual QA**.

## Note
The plugin carousel icon (`TaskIcon.astro`) **already** has `width/height` — not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)