### PR TITLE
seo: make plugin task page titles/H1 unique and descriptive

### DIFF
--- a/src/utils/plugins/buildPluginPageProps.ts
+++ b/src/utils/plugins/buildPluginPageProps.ts
@@ -148,11 +148,20 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
         )
     })()
 
+    // Title of the plugin/subgroup container this page belongs to, e.g.
+    // "AWS S3", "Google Cloud BigQuery", "PostgreSQL".
+    const containerTitle =
+        (rootPlugin
+            ? getPluginTitle(currentSubgroupPlugin ?? rootPlugin, metadataMap)
+            : undefined) ?? pluginName
+
+    // Task pages prefix the bare class name with their container title (e.g.
+    // "AWS S3 Trigger") so <title> and <h1> are unique and descriptive. Without
+    // this, every plugin's "Trigger"/"Query"/"Create"/"Delete" task shared the
+    // same short, duplicated title across hundreds of pages.
     const headingTitle = pluginType
-        ? formatElementName(pluginType)
-        : ((rootPlugin
-              ? getPluginTitle(currentSubgroupPlugin ?? rootPlugin, metadataMap)
-              : undefined) ?? pluginName)
+        ? `${containerTitle} ${formatElementName(pluginType)}`
+        : containerTitle
 
     const rootPluginTitle = rootPlugin
         ? getPluginTitle(rootPlugin, metadataMap)


### PR DESCRIPTION
## Context
Technical SEO audit (Screaming Frog, 2026-06-15), highest-volume on-page issue. **Single root cause**: plugin task pages (`io.kestra.*`, 1361 pages) use the bare class name as both `<title>` and `<h1>`.

| Title | Pages |
|---|---|
| `Trigger \| Kestra` | 74 |
| `Delete \| Kestra` | 66 |
| `Query \| Kestra` | 52 |
| `Create \| Kestra` | 51 |

Because most plugins expose those same task names, this single branch produces **~1,204 duplicate titles, ~1,204 duplicate H1s and ~1,862 titles under 30 characters**. (`/blueprints` is not affected: 19 duplicate titles, 0 duplicate H1s.)

This is complementary to #4688 (which added "how to use" markdown + FAQs to plugin **parent** pages). That work never touched the auto-generated **task** pages — the 2026-06-15 crawl, taken after #4688 rolled out, still showed these duplicates.

## Change
In `buildPluginPageProps.ts`, task pages now prefix the task name with their plugin/subgroup **container title** (the same title group/subgroup pages already use) instead of the bare class name:

| Page | Before | After |
|---|---|---|
| `aws/s3/…Trigger` | Trigger | **AWS S3 Trigger** |
| `gcp/bigquery/…Query` | Query | **Google Cloud BigQuery Query** |
| `slack/chats/…Create` | Create | **Slack Chats Create** |
| `jdbc-postgres/…Query` | Query | **PostgreSQL Query** |

A single variable (`headingTitle`) is changed, resolving duplicate titles, duplicate H1s and short titles at once, and adding integration keywords to every task page. Group/subgroup pages are unchanged; `elementTitle` (sidebar/breadcrumb) is unchanged.

## Verified
- Container titles confirmed live ("AWS S3", "Google Cloud BigQuery", "PostgreSQL"…), so the rendered format matches "Plugin Subgroup Task".
- ⚠️ Not built locally (worktree without `node_modules`) → please rely on CI + preview to validate the rendered `<title>`/`<h1>` on a few task pages.

## Out of scope (intentional)
Task-page meta descriptions: short (~35 chars) but **unique** and accurate → "Opportunity/Low", low ROI (Google rewrites short metas). Can be revisited later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)