### PR TITLE
docs(configuration): document kestra.webserver.ui.enabled flag

### DIFF
--- a/src/contents/docs/configuration/03.observability-and-networking/index.md
+++ b/src/contents/docs/configuration/03.observability-and-networking/index.md
@@ -258,6 +258,7 @@ These settings are lighter-weight than the Micronaut server settings above. Use 
 
 The webserver-related configuration also includes:
 
+- disabling the UI to run the webserver API-only
 - Google Analytics ID
 - additional HTML tags
 - mail server settings
@@ -278,6 +279,24 @@ kestra:
 ```
 
 Mail server settings are useful when you need platform emails for invitations and notifications.
+
+### Disabling the UI (API-only mode)
+
+The bundled web UI is enabled by default. Set `kestra.webserver.ui.enabled` to `false` to run the webserver as an API-only service — useful when Kestra is driven entirely through the REST API or fronted by your own application, and you don't want the UI exposed.
+
+```yaml
+kestra:
+  webserver:
+    ui:
+      enabled: false
+```
+
+When the UI is disabled:
+
+- requests to `/ui/**` return `404`, and `/` no longer redirects to the UI;
+- the REST API (`/api/v1/**`) and health endpoints keep working as usual.
+
+The setting can also be provided through the `KESTRA_WEBSERVER_UI_ENABLED` environment variable.
 
 ## Typical use cases
 


### PR DESCRIPTION
## Summary
Documents the new `kestra.webserver.ui.enabled` configuration flag (default `true`) on the **Observability & Networking** configuration page, under *UI and webserver settings*.

Setting it to `false` runs the webserver API-only: `/ui/**` returns 404, `/` no longer redirects to the UI, and the REST API keeps working. The docs also note the `KESTRA_WEBSERVER_UI_ENABLED` env-var form.

This surfaces the feature added in kestra-io/kestra#16748.

## Changes
- `src/contents/docs/configuration/03.observability-and-networking/index.md`: add the flag to the settings list and a new *Disabling the UI (API-only mode)* subsection with a YAML example.

## Notes
- Content-only addition to an existing page — no new routes or files.