### PR TITLE
fix(seo): remove internal links pointing to 404s

### DIFF
--- a/src/contents/blogs/yaml-vs-python-workflow/index.md
+++ b/src/contents/blogs/yaml-vs-python-workflow/index.md
@@ -187,6 +187,6 @@ Kestra's [AI Copilot](/docs/ai-tools/ai-copilot) extends this further: describe 
 
 - **Read the architectural case.** [YAML-First Orchestration](/blogs/yaml-for-workflow-orchestration) makes the argument for why separating the coordination layer from the execution layer is the right call, with examples from infrastructure and analytics tooling that already went declarative.
 - **Browse more workflows.** Kestra's [260+ Blueprints](/blueprints) are production-ready YAML workflow templates covering data pipelines, infrastructure automation, and business processes.
-- **Try Python orchestration.** The [Python orchestration docs](docs/how-to-guides/python) show how Python scripts run as Kestra tasks, with full access to libraries and dependencies.
+- **Try Python orchestration.** The Python orchestration docs show how Python scripts run as Kestra tasks, with full access to libraries and dependencies.
 - **Try it live.** [Install Kestra](/docs/quickstart) (one Docker command), open the editor, and paste any example from this post. The visual editor shows the DAG topology updating as you type.
 - **Why Kestra.** For a broader look at the design decisions behind YAML-first orchestration, [Why Kestra](/docs/why-kestra) covers the architectural reasoning.

--- a/src/contents/orchestration/gitlab.yaml
+++ b/src/contents/orchestration/gitlab.yaml
@@ -175,7 +175,6 @@ quotes:
   - quote: "Thank you Kestra for your great support and for providing a best-in-class platform to power our integrations!"
     author: "Patrick Ferreira, CleverConnect"
     logoFile: "cleverconnect"
-    storyLink: "/customers/cleverconnect-enhances-hr-integration-platform-with-kestra"
     kpis:
       - name: "Increase in connector dev speed"
         value: "10x"

--- a/src/contents/resources/ai-native-orchestration-platform/index.md
+++ b/src/contents/resources/ai-native-orchestration-platform/index.md
@@ -136,7 +136,7 @@ For teams seeking flexibility and control, open-source frameworks are a compelli
 *   **Kestra** stands out with its declarative, YAML-based approach that unifies data, AI, and infrastructure workflows. Its language-agnostic design and extensive plugin library make it a versatile choice for multi-domain orchestration.
 *   **[Prefect](https://kestra.io/vs/prefect)** is a strong choice for Python-centric teams, offering a modern developer experience for defining workflows as Python code.
 *   **Dagster** appeals to analytics engineering teams with its asset-centric paradigm, which provides strong data lineage and observability.
-*   **[Argo Workflows](https://kestra.io/vs/argo-workflows)** is a powerful, Kubernetes-native solution ideal for teams that want their orchestration to live entirely within the Kubernetes control plane.
+*   **Argo Workflows** is a powerful, Kubernetes-native solution ideal for teams that want their orchestration to live entirely within the Kubernetes control plane.
 
 ### Agentic AI Orchestration for Autonomous Workflows
 

--- a/src/contents/resources/argo-workflows-alternatives/index.md
+++ b/src/contents/resources/argo-workflows-alternatives/index.md
@@ -24,7 +24,7 @@ The leading alternatives to Argo Workflows in 2026 include Kestra, Flyte, Prefec
 
 ## Understanding Argo Workflows and its Core Purpose
 
-Argo Workflows is an open-source, container-native workflow engine designed specifically to orchestrate parallel jobs on Kubernetes. Workflows are defined as Kubernetes Custom Resources (CRs), allowing them to be managed with standard Kubernetes tools like `kubectl`. It excels at tasks requiring container-level parallelism and dependency management, making it a strong choice for CI/CD pipelines, batch processing, and machine learning model training. Its core strength is its tight integration with the Kubernetes ecosystem, using YAML to define complex Directed Acyclic Graphs (DAGs) of containerized tasks. For a direct comparison, see our [Kestra vs. Argo Workflows](https://kestra.io/vs/argo-workflows) page.
+Argo Workflows is an open-source, container-native workflow engine designed specifically to orchestrate parallel jobs on Kubernetes. Workflows are defined as Kubernetes Custom Resources (CRs), allowing them to be managed with standard Kubernetes tools like `kubectl`. It excels at tasks requiring container-level parallelism and dependency management, making it a strong choice for CI/CD pipelines, batch processing, and machine learning model training. Its core strength is its tight integration with the Kubernetes ecosystem, using YAML to define complex Directed Acyclic Graphs (DAGs) of containerized tasks.
 
 ## Why Look for an Alternative to Argo Workflows?
 

--- a/src/contents/resources/cloud-composer-alternatives/index.md
+++ b/src/contents/resources/cloud-composer-alternatives/index.md
@@ -93,7 +93,7 @@ Argo Workflows is an open-source, container-native workflow engine for orchestra
 
 While powerful, its tight coupling to Kubernetes means it's not a fit for non-containerized workloads or teams without strong K8s expertise.
 
-**Best for:** Teams with a strong Kubernetes footprint and expertise, needing to orchestrate containerized workloads, CI/CD, or ML training pipelines directly within their K8s clusters. Discover how it compares to a broader orchestrator in our [Kestra vs. Argo Workflows](https://kestra.io/vs/argo-workflows) page. See also [Kubernetes workflow orchestration](/resources/infrastructure/kubernetes-workflow-orchestration) for related patterns.
+**Best for:** Teams with a strong Kubernetes footprint and expertise, needing to orchestrate containerized workloads, CI/CD, or ML training pipelines directly within their K8s clusters. See also [Kubernetes workflow orchestration](/resources/infrastructure/kubernetes-workflow-orchestration) for related patterns.
 
 ### 7. Databricks Workflows: Lakehouse-Native Data & AI Orchestration
 

--- a/src/contents/resources/kubernetes-workflow-orchestration/index.md
+++ b/src/contents/resources/kubernetes-workflow-orchestration/index.md
@@ -47,7 +47,7 @@ The market for Kubernetes workflow orchestration is diverse, with tools tailored
 
 ### Argo Workflows: The Kubernetes-Native Approach
 
-[Argo Workflows](https://kestra.io/vs/argo-workflows) is a popular open-source, container-native workflow engine. Its defining feature is its deep integration with Kubernetes; workflows are defined as Custom Resource Definitions (CRDs) and managed directly via `kubectl`. This makes it a natural choice for platform engineering teams already fluent in Kubernetes.
+Argo Workflows is a popular open-source, container-native workflow engine. Its defining feature is its deep integration with Kubernetes; workflows are defined as Custom Resource Definitions (CRDs) and managed directly via `kubectl`. This makes it a natural choice for platform engineering teams already fluent in Kubernetes.
 
 Argo is primarily used for orchestrating parallel jobs on Kubernetes. It excels at CI/CD pipelines, machine learning workflows, and large-scale batch processing where each step can be encapsulated in a container. Its strengths lie in its lightweight design and efficient handling of container-based parallelism. However, its UI is more functional than user-friendly for non-Kubernetes experts, and its plugin ecosystem is less mature than that of other orchestrators.
 

--- a/src/contents/resources/kubernetes-workflow/index.md
+++ b/src/contents/resources/kubernetes-workflow/index.md
@@ -49,7 +49,7 @@ Kubernetes provides the building blocks that workflows manipulate. Understanding
 
 ### Argo Workflows: a container-native engine for Kubernetes
 
-When discussing Kubernetes workflows, [Argo Workflows](https://kestra.io/vs/argo-workflows) is often the first tool that comes to mind. It's an open-source, container-native workflow engine designed specifically for orchestrating parallel jobs on Kubernetes. Its key strength lies in its tight integration with the Kubernetes ecosystem.
+When discussing Kubernetes workflows, Argo Workflows is often the first tool that comes to mind. It's an open-source, container-native workflow engine designed specifically for orchestrating parallel jobs on Kubernetes. Its key strength lies in its tight integration with the Kubernetes ecosystem.
 
 Workflows in Argo are defined as Kubernetes CRDs in YAML, making them first-class citizens of the cluster. Each step in a workflow runs as a separate container inside a pod. This model is exceptionally well-suited for CI/CD pipelines, machine learning tasks, and any process that can be broken down into discrete, containerized steps. For teams deeply invested in a Kubernetes-native approach, Argo provides a powerful and familiar paradigm for automation. Its focus on container-level parallelism makes it a strong contender among [enterprise Airflow alternatives](https://kestra.io/blogs/enterprise-airflow-alternatives) for platform engineering teams.
 

--- a/src/contents/resources/self-hosted-workflow-orchestration/index.md
+++ b/src/contents/resources/self-hosted-workflow-orchestration/index.md
@@ -62,7 +62,7 @@ Kestra is language-agnostic, allowing you to run scripts in Python, R, Shell, No
 
 ### Other notable self-hosted workflow engines
 
-*   **Argo Workflows:** A Kubernetes-native workflow engine where workflows are defined as Kubernetes Custom Resource Definitions (CRDs). It's an excellent choice for teams deeply invested in the Kubernetes ecosystem, particularly for ML and data processing jobs. See how it compares to [Kestra vs. Argo Workflows](https://kestra.io/vs/argo-workflows).
+*   **Argo Workflows:** A Kubernetes-native workflow engine where workflows are defined as Kubernetes Custom Resource Definitions (CRDs). It's an excellent choice for teams deeply invested in the Kubernetes ecosystem, particularly for ML and data processing jobs.
 *   **Prefect:** A modern, Python-based orchestrator known for its developer-friendly experience and dynamic workflow capabilities. It offers a strong alternative to Airflow for Python-heavy teams. Explore the differences in our [Prefect vs. Kestra comparison](https://kestra.io/vs/prefect).
 *   **n8n:** A visual workflow automation tool that can be self-hosted. It excels at connecting SaaS applications and APIs, making it a powerful "self-hosted Zapier" for business and operational teams. For more details, check out [n8n vs. Kestra](https://kestra.io/vs/n8n).
 

--- a/src/contents/resources/windmill-alternatives/index.md
+++ b/src/contents/resources/windmill-alternatives/index.md
@@ -115,7 +115,7 @@ Argo Workflows is an open-source, Kubernetes-native workflow engine designed to 
 
 **Honest Limitation:** Argo Workflows is tightly coupled to Kubernetes, making it inflexible for hybrid or on-premise environments that are not managed by a K8s cluster. Its plugin ecosystem is container-centric, requiring users to containerize all tasks.
 
-**Best for:** Platform engineers and ML Ops teams operating entirely on Kubernetes, seeking a native workflow engine for batch jobs, ML training pipelines, and CI/CD-adjacent workloads within their K8s clusters. See how it compares in our [Argo Workflows vs. Kestra breakdown](https://kestra.io/vs/argo-workflows).
+**Best for:** Platform engineers and ML Ops teams operating entirely on Kubernetes, seeking a native workflow engine for batch jobs, ML training pipelines, and CI/CD-adjacent workloads within their K8s clusters.
 
 ## Comparison table
 


### PR DESCRIPTION
## What

Removes dead internal links flagged in the latest crawl. Three destinations return 404, so per request the links are removed (not repointed) in the pages that referenced them.

| Page | Removed link | Anchor |
|------|--------------|--------|
| `/resources/argo-workflows-alternatives` | `/vs/argo-workflows` | Kestra vs. Argo Workflows |
| `/resources/kubernetes-workflow-orchestration` | `/vs/argo-workflows` | Argo Workflows |
| `/resources/self-hosted-workflow-orchestration` | `/vs/argo-workflows` | Kestra vs. Argo Workflows |
| `/resources/kubernetes-workflow` | `/vs/argo-workflows` | Argo Workflows |
| `/resources/ai-native-orchestration-platform` | `/vs/argo-workflows` | Argo Workflows |
| `/resources/windmill-alternatives` | `/vs/argo-workflows` | Argo Workflows vs. Kestra breakdown |
| `/resources/data/cloud-composer-alternatives` | `/vs/argo-workflows` | Kestra vs. Argo Workflows |
| `/blogs/yaml-vs-python-workflow` | `docs/how-to-guides/python` (resolved to `/blogs/docs/how-to-guides/python`) | Python orchestration docs |
| `/orchestration/gitlab` | `/customers/cleverconnect-...-with-kestra` | Read the Story |

## How

- Inline noun mentions of "Argo Workflows" are **unlinked** but the text is kept (no readability loss).
- Sentences whose sole purpose was the dead CTA (e.g. "For a direct comparison, see our … page.") are **removed** to avoid dangling filler.
- In `gitlab.yaml` the `storyLink` field (which rendered the "Read the Story" button) is dropped; the quote, KPIs and logo are kept.
- A valid internal link to `/resources/infrastructure/kubernetes-workflow-orchestration` in the cloud-composer page is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)