### PR TITLE
redirect: /customers/vissimo-how-vissimo-... → /customers/vissimo-group

### DIFF
--- a/src/contents/redirects/customers.yml
+++ b/src/contents/redirects/customers.yml
@@ -1,0 +1,3 @@
+# Customer page slug changes — /customers/* → /customers/*
+- regexp: "^/customers/vissimo-how-vissimo-consolidated-an-ipaas-and-aws-lambdas-onto-one-orchestration-platform/?$"
+  to: "/customers/vissimo-group"

--- a/src/contents/redirects/use-cases.yml
+++ b/src/contents/redirects/use-cases.yml
@@ -40,7 +40,7 @@
 - regexp: "/use-cases/stories/htch-building-the-best-architect-collaborative-web-tool-with-kestra"
   to: "/customers/htch-building-the-best-architect-collaborative-web-tool-with-kestra"
 - regexp: "/use-cases/stories/modernizing-mission-critical-e-commerce-integrations-with-kestra"
-  to: "/customers/vissimo"
+  to: "/customers/vissimo-group"
 - regexp: "/use-cases/stories/modernizing-mission-critical-workflows-in-a-highly-regulated-environment"
   to: "/customers/pharmacy-retailer"
 - regexp: "/use-cases/stories/ntico-manage-geospatial-data-operations-with-kestra"


### PR DESCRIPTION
## What

Adds a 301 redirect from the long legacy customer-story URL:

`/customers/vissimo-how-vissimo-consolidated-an-ipaas-and-aws-lambdas-onto-one-orchestration-platform`

→ canonical `/customers/vissimo-group`

## Why

The legacy descriptive slug 404s; consolidating to the canonical `/customers/vissimo-group` page preserves link equity and fixes the broken URL.

## How

New file `src/contents/redirects/customers.yml`, auto-loaded by `src/middleware.ts` (globs `./contents/redirects/*.yml`). The regexp is anchored (`^...$`, optional trailing slash) to avoid partial matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)