### PR TITLE
fix(footer): add missing space between year and before Hiring badge next to Careers

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -128,9 +128,12 @@ const FOOTER_SECTIONS: Section[] = [
                                             >
                                                 {link.text}
                                                 {link.badge && (
-                                                    <span class="badge">
-                                                        {link.badge}
-                                                    </span>
+                                                    <>
+                                                        {" "}
+                                                        <span class="badge">
+                                                            {link.badge}
+                                                        </span>
+                                                    </>
                                                 )}
                                             </a>
                                         </li>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -147,7 +147,7 @@ const FOOTER_SECTIONS: Section[] = [
         <div class="d-flex d-100">
             <div class="flex-grow-1">
                 <p class="mb-0 d-none d-md-inline">
-                    © {new Date().getFullYear()}
+                    © {new Date().getFullYear()}{" "}
                     <a href="/">Kestra Technologies</a>. Developed with
                     <span class="text-danger">♥</span> on 🌎.
                 </p>


### PR DESCRIPTION
footer spacing

<img width="1278" height="1080" alt="Screenshot 2026-06-25 at 12 07 31 PM" src="https://github.com/user-attachments/assets/83f0e111-34cf-4a90-8265-8ff2d7d89bcc" />
