### PR TITLE
fix(seo): point "Customer Stories" nav link to /customers directly

### DIFF
--- a/src/utils/menu-items.ts
+++ b/src/utils/menu-items.ts
@@ -165,7 +165,7 @@ export const menuItems: MenuItems = {
             {
                 icon: FormatQuoteCloseOutline,
                 title: "Customer Stories",
-                link: "/use-cases/stories"
+                link: "/customers"
             },
             {
                 icon: School,


### PR DESCRIPTION
## Contexte
L'entrée de navigation globale « Customer Stories » pointait vers `/use-cases/stories`, qui redirige (meta-refresh) vers `/customers`. Étant présent sur l'ensemble du site, c'était la **plus grosse source de sauts de redirection internes** (~7 400 inlinks dans le crawl).

## Changement
- `src/utils/menu-items.ts` : `link: "/use-cases/stories"` → `link: "/customers"` (destination finale 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)