### PR TITLE
fix(seo): emit final /customers/* URLs in use-cases sitemap

### DIFF
--- a/src/pages/sitemap/use-cases.xml.ts
+++ b/src/pages/sitemap/use-cases.xml.ts
@@ -20,6 +20,10 @@ export const GET: APIRoute = async () => {
 
     const allUseCases = await getCollection("customerStories")
 
+    // Mirror the canonical slug logic from src/pages/customers/[slug].astro
+    const toSlug = (story: (typeof allUseCases)[number]) =>
+        story.data.companyName ? slugify(story.data.companyName) : story.id
+
     const storyUrls = allUseCases.map((story) => {
         const updatedField = (story.data as any).updated ?? (story.data as any).updatedAt ?? null
         let lastmod = formatLastMod(updatedField)
@@ -28,7 +32,7 @@ export const GET: APIRoute = async () => {
         }
 
         return {
-            loc: `https://kestra.io/use-cases/stories/${story.id}-${slugify(story.data.title ?? "--")}`,
+            loc: `https://kestra.io/customers/${toSlug(story)}`,
             lastmod,
         }
     })


### PR DESCRIPTION
## Contexte
Le sitemap `/sitemap/use-cases.xml` générait des URLs legacy `/use-cases/stories/<id>-<title-slug>` qui redirigent vers `/customers/*`. Un sitemap ne devrait lister que des **URLs canoniques 200**.

## Changement
- `src/pages/sitemap/use-cases.xml.ts` : génère désormais `/customers/<slug>` en réutilisant **exactement** la logique de slug de `src/pages/customers/[slug].astro` (`companyName → slugify`, sinon `id`).

## Validation (build local)
- `astro build` ✅ (0 erreur).
- Sitemap généré : **0** URL `/use-cases/stories/`, **29** URLs `/customers/`.
- Les 29 URLs du sitemap correspondent exactement aux 29 pages `/customers/` générées → **aucun 404**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)