### PR TITLE
feat(seo): FAQPage schema on /enterprise & /pricing + featureList on /features

### DIFF
--- a/src/components/common/SchemaSoftwareApplication.astro
+++ b/src/components/common/SchemaSoftwareApplication.astro
@@ -5,9 +5,10 @@ interface Props {
     description?: string
     url?: string
     isVariantOf?: string
+    featureList?: string[]
 }
 
-const { id, name, description, url, isVariantOf } = Astro.props
+const { id, name, description, url, isVariantOf, featureList } = Astro.props
 
 const canonicalUrl =
     url ?? new URL(Astro.url.pathname, Astro.site ?? "https://kestra.io").toString().replace(/\/$/, "")
@@ -64,6 +65,10 @@ const schema: Record<string, unknown> = {
 
 if (isVariantOf) {
     schema.isVariantOf = { "@id": isVariantOf }
+}
+
+if (featureList && featureList.length > 0) {
+    schema.featureList = featureList
 }
 ---
 

--- a/src/components/price/PriceBottom.astro
+++ b/src/components/price/PriceBottom.astro
@@ -1,6 +1,7 @@
 ---
 import SeeHow from "~/components/common/SeeHow.astro"
 import Faq from "~/components/common/Faq.vue"
+import SchemaFAQ from "~/components/common/SchemaFAQ.astro"
 
 const SELF_HOSTED_FAQ = [
     {
@@ -38,6 +39,8 @@ const CLOUD_HOSTED_FAQ = [
     },
 ]
 ---
+
+<SchemaFAQ items={[...SELF_HOSTED_FAQ, ...CLOUD_HOSTED_FAQ]} />
 
 <div data-host="self-hosted" data-usal="fade-u">
     <SeeHow cta={{ text: "Contact Sales", href: "/demo" }}>

--- a/src/pages/enterprise/index.astro
+++ b/src/pages/enterprise/index.astro
@@ -1,6 +1,8 @@
 ---
 import Layout from "~/components/layout.astro"
 import SchemaSoftwareApplication from "~/components/common/SchemaSoftwareApplication.astro"
+import SchemaFAQ from "~/components/common/SchemaFAQ.astro"
+import Faq from "~/components/common/Faq.vue"
 
 import Hero from "~/components/enterprise/Hero.vue"
 import SeeHow from "~/components/common/SeeHow.astro"
@@ -37,6 +39,33 @@ const STATS = [
         label: "Deployment Speed",
     },
 ]
+
+const items = [
+    {
+        question: "What does the Enterprise Edition add over open-source Kestra?",
+        answer: "Everything in the open-source edition, plus enterprise governance and security: RBAC, SSO/SCIM, audit logs, multi-tenancy, secrets management, worker isolation, and high availability. <a href='/pricing'>Compare editions →</a>",
+    },
+    {
+        question: "Can Kestra Enterprise be self-hosted?",
+        answer: "Yes. Enterprise Edition runs fully self-hosted in your own infrastructure — including air-gapped environments — or as a managed deployment. You keep your data in your environment.",
+    },
+    {
+        question: "What security and compliance features are included?",
+        answer: "Role-based access control (RBAC), single sign-on (SSO) and SCIM provisioning, granular audit logs, encrypted secrets, namespace-level isolation, and tenant separation for regulated and mission-critical workloads.",
+    },
+    {
+        question: "How does Enterprise scale for large teams?",
+        answer: "Horizontal scalability across workers, multi-tenancy to isolate teams and environments, and high availability for production-critical orchestration. Teams replace vRO, Rundeck, Cron, and Jenkins with a single platform.",
+    },
+    {
+        question: "What support comes with the Enterprise Edition?",
+        answer: "Dedicated support with SLAs, onboarding, and training from the Kestra team. <a href='/demo'>Talk to our team →</a>",
+    },
+    {
+        question: "How is the Enterprise Edition priced?",
+        answer: "Enterprise is an annual subscription tailored to your team size and deployment. <a href='/demo'>Contact sales for a quote →</a>",
+    },
+]
 ---
 
 <Layout {title} {description} headerTheme="lightText">
@@ -48,6 +77,7 @@ const STATS = [
             url="https://kestra.io/enterprise"
             isVariantOf="https://kestra.io/#software"
         />
+        <SchemaFAQ items={items} />
     </Fragment>
     <Hero client:load />
     <div class="enterprise">
@@ -58,6 +88,7 @@ const STATS = [
     <StatsHeader stats={STATS} />
     <PluginsBlock />
     <CustomerQuotes />
+    <Faq {items} client:load />
     <SeeHow
         cta={{
             text: "Let's Talk",

--- a/src/pages/features/index.astro
+++ b/src/pages/features/index.astro
@@ -18,6 +18,20 @@ const title = "Powerful Features for Reliable Workflows"
 const description =
     "Create and Deploy all kinds Data Pipelines with Ease and Speed with Kestra | Your All-in-One Solution for Orchestrating Workflows"
 
+const featureList = [
+    "Declarative YAML workflows",
+    "Language-agnostic tasks (Python, SQL, R, Bash, and more)",
+    "Event-driven triggers (S3, GCS, Azure, webhooks, Kafka, database changes, message queues)",
+    "Scheduling and cron-based automation",
+    "API-first — fully managed via REST API",
+    `${totalPlugins}+ plugins and integrations`,
+    "Built-in observability and monitoring",
+    "Error handling, retries, and automatic recovery",
+    "Unlimited executions",
+    "RBAC, SSO, audit logs, and multi-tenancy (Enterprise)",
+    "Deploy via Docker, Kubernetes (Helm), single-VM, managed Cloud, or air-gapped",
+]
+
 const items = [
     {
         question: "What workflows can Kestra orchestrate?",
@@ -52,7 +66,7 @@ const items = [
 
 <Layout {title} {description} headerTheme="lightText">
     <Fragment slot="head">
-        <SchemaSoftwareApplication url="https://kestra.io/features" />
+        <SchemaSoftwareApplication url="https://kestra.io/features" featureList={featureList} />
         <SchemaFAQ items={items} />
     </Fragment>
     <div class="core">


### PR DESCRIPTION
## Context

Part of the **Agents Taskforce — Pillar 1 (Product Clarity)**: making product pages machine-parseable for AI agents / LLM crawlers. This is **PR 1 of 2** (structured schemas). PR 2 will cover copy (titles/meta + pricing cascade language).

## What this does

| Page | Change |
|---|---|
| `SchemaSoftwareApplication.astro` | Add optional `featureList` prop (no impact on pages that don't pass it) |
| `/features` | Emit `featureList` with 11 real capabilities on the SoftwareApplication schema (was missing) |
| `/enterprise` | Add `FAQPage` schema + visible `<Faq>` block (6 enterprise Q&A) — none before |
| `/pricing` | Emit `FAQPage` schema from the **existing visible FAQ** (`PriceBottom`, self-hosted + cloud) — schema only, no duplicated copy |

## Why FAQPage + visible content together

Google requires FAQPage structured data to reflect FAQ content actually visible on the page. `/enterprise` gets a new visible FAQ; `/pricing` already had a visible FAQ and just lacked the JSON-LD.

## Verification

- `astro check` → **0 errors** (396 files)
- Rendered via dev server, all JSON-LD blocks parse cleanly:
  - `/features`: FAQPage (7 Q), featureList (11 items) ✅
  - `/enterprise`: FAQPage (6 Q) ✅
  - `/pricing`: FAQPage (7 Q) ✅

## Out of scope (tracked separately)

- Titles & meta descriptions, `/pricing` "Everything in Open Source, plus…" cascade → **PR 2**
- Cloud `Offer` pricing detail → blocked until Cloud pricing is public
- `/cloud` page structure → waiting on new Cloud PM

🤖 Generated with [Claude Code](https://claude.com/claude-code)