### PR TITLE
seo(resources): add 6 new W27 resource pages (AI, data, infrastructure)

### DIFF
--- a/src/contents/resources/ai-code-generation-workflow/index.md
+++ b/src/contents/resources/ai-code-generation-workflow/index.md
@@ -1,0 +1,245 @@
+---
+title: "AI Code Generation Workflows: Orchestrate & Govern with Kestra"
+description: "Explore a complete guide to AI code generation workflows, covering best practices from prompt to production. Learn to integrate LLM-powered development, validate AI-generated code, and orchestrate the entire process with Kestra's declarative platform."
+metaTitle: "AI Code Generation Workflow: Orchestration & Governance"
+metaDescription: "Master AI code generation workflows, from idea to production. Learn best practices for LLM-powered development, validating code, and orchestrating with Kestra."
+tag: "ai"
+date: 2026-06-29
+slug: "ai-code-generation-workflow"
+faq:
+  - question: "How do you implement AI into your coding workflow?"
+    answer: "Implementing AI into your coding workflow involves integrating AI tools like Copilot for suggestions, using LLMs for code generation, and orchestrating these steps in a structured pipeline. This includes defining clear prompts, validating AI output, and incorporating human review and refinement stages."
+  - question: "Does AI-generated workflow code work on the first run?"
+    answer: "AI-generated code rarely works perfectly on the first run. It typically requires validation, debugging, and refinement by a human developer. An effective workflow includes automated testing and a clear feedback loop to iterate on AI outputs, improving reliability over time."
+  - question: "How do you maintain code quality with AI-generated code?"
+    answer: "Maintaining code quality with AI-generated code requires robust validation, automated testing, and human oversight. Establish clear coding standards, integrate static analysis tools, and use declarative orchestration platforms like Kestra to enforce quality gates and ensure maintainability."
+  - question: "What are the benefits of an AI coding workflow?"
+    answer: "An AI coding workflow accelerates development cycles, reduces boilerplate code, and helps developers focus on complex logic. It enhances productivity, improves code consistency, and can significantly speed up the software delivery pipeline when properly governed and integrated."
+  - question: "How does Kestra support AI code generation workflows?"
+    answer: "Kestra supports AI code generation workflows by providing a declarative orchestration layer. It enables you to integrate AI Copilot for YAML generation, orchestrate LLM-powered tasks, manage validation steps, and ensure auditability and governance across the entire code lifecycle."
+  - question: "What are the key tools for AI code generation?"
+    answer: "Key tools for AI code generation include large language models (LLMs) like GPT-5 and Claude Opus 4, AI coding assistants such as GitHub Copilot and Cursor, and specialized AI agents. These tools assist with idea clarification, code drafting, debugging, and optimization."
+  - question: "Why is orchestration important for AI code generation?"
+    answer: "Orchestration is crucial for AI code generation to manage the multi-stage, often iterative, process. It ensures that AI tools are used effectively, validation steps are executed, human approvals are integrated, and the entire workflow is auditable, reliable, and scalable in production environments."
+---
+
+The rise of AI in software development is fundamentally reshaping how code is written, tested, and deployed. From intelligent code completion to generating entire functions, AI tools promise a significant boost in developer productivity. However, simply using these tools in isolation isn't enough to build reliable, production-ready systems.
+
+An effective AI code generation workflow requires structure, governance, and seamless integration with existing development practices. This guide will explore how to design, implement, and orchestrate an AI-powered coding pipeline that enhances efficiency, maintains code quality, and ensures auditability from prompt to deployment.
+
+## Understanding the Shift to AI-Assisted Coding
+
+The integration of artificial intelligence into software development has moved beyond a novelty to become a core component of the modern engineer's toolkit. This shift represents a significant evolution from basic syntax highlighting and linting to a collaborative partnership between human developers and AI models.
+
+### What AI code generation means for developers
+
+AI code generation is the use of machine learning models, particularly large language models (LLMs), to produce source code from natural language prompts or existing code context. For developers, this means:
+*   **Accelerated Prototyping:** Quickly scaffolding new applications, APIs, or components.
+*   **Reduced Boilerplate:** Automating the creation of repetitive code for tasks like setting up configurations, writing unit tests, or defining data structures.
+*   **Enhanced Problem-Solving:** Using AI as a sounding board to explore different algorithmic approaches or debug complex issues.
+*   **Lowering Barriers:** Helping developers learn new languages or frameworks by generating idiomatic code examples.
+
+The goal isn't to replace the developer but to augment their capabilities, allowing them to focus on high-level architecture, complex business logic, and creative problem-solving rather than routine implementation details.
+
+### Why structured workflows are crucial for AI in development
+
+Without a structured process, using AI for code generation can lead to inconsistent quality, security vulnerabilities, and unmaintainable codebases. A defined workflow establishes a systematic approach that ensures every piece of AI-generated code is planned, validated, and integrated responsibly.
+
+Structured workflows provide:
+*   **Consistency:** Standardized methods for prompting, generating, and reviewing code across teams.
+*   **Quality Control:** Built-in gates for testing, security scanning, and human review.
+*   **Auditability:** A clear, traceable path from the initial requirement to the final deployed code.
+*   **Scalability:** The ability to apply AI-assisted development practices reliably across large projects and organizations.
+
+By treating AI code generation as a formal process rather than an ad-hoc activity, teams can harness its full potential while mitigating the associated risks. For more in-depth guides on building these systems, you can explore a wide range of orchestration [resources](/resources).
+
+## The Core Phases of an Effective AI Code Generation Workflow
+
+A robust AI code generation workflow is an iterative, multi-stage process that transforms an idea into production-ready code. Each phase has a distinct purpose, with feedback loops connecting them to ensure continuous improvement and quality.
+
+### From prompt to plan: Clarifying intent with AI
+
+The workflow begins not with code, but with an idea. The first step is to translate this idea into a clear, unambiguous prompt that an AI can understand. This phase often involves a conversational loop with an LLM to refine the requirements.
+
+*   **Initial Prompt:** Start with a high-level description of the desired feature or function.
+*   **Clarification:** The AI might ask for more details on inputs, outputs, edge cases, and constraints.
+*   **Planning:** The AI can help break down the problem into smaller, manageable steps, outlining the classes, functions, and logic required. This stage produces a blueprint before any code is written.
+
+### Generating code with precision
+
+With a detailed plan in place, the AI can now generate the code. This is where tools like GitHub Copilot or dedicated AI agents shine. Best practices include:
+
+*   **Generating in Chunks:** Request smaller, self-contained functions or classes rather than an entire application at once. This makes the output easier to validate.
+*   **Providing Context:** Supply the AI with relevant existing code, style guides, or documentation to ensure the generated code is consistent with the project.
+*   **Specifying Constraints:** Include requirements for performance, library usage, and error handling directly in the prompt.
+
+### Validating and debugging AI-generated code
+
+AI-generated code is a first draft, not a final product. It must be rigorously validated. This phase is a critical human-in-the-loop step, augmented by automated tools.
+
+*   **Human Review:** A developer must read and understand the generated code, checking for logical errors, and adherence to architectural patterns.
+*   **Automated Testing:** Integrate the new code into a test harness. Unit tests, integration tests, and static analysis tools should be run automatically.
+*   **AI-Assisted Debugging:** If tests fail, the developer can feed the error messages and relevant code back to the AI to get suggestions for fixes.
+
+### Iteration and refinement: Optimizing for performance and quality
+
+The final phase involves refining the validated code. This may involve multiple cycles of feedback and generation.
+
+*   **Refactoring:** Improve the code's structure, readability, and maintainability.
+*   **Optimization:** Use profiling tools to identify and address performance bottlenecks.
+*   **Documentation:** Generate comments, docstrings, and README files to explain the code's functionality.
+
+This entire lifecycle mirrors a structured [AI pipeline](/resources/ai/ai-pipeline), where each stage is a distinct, orchestratable step. For a deeper dive into automating these stages, see our guide on [AI code generation pipelines](/resources/ai/ai-code-generation-pipelines).
+
+## Key Tools and Technologies for AI-Powered Development
+
+An effective AI code generation workflow relies on a stack of specialized tools working in concert. These range from foundational language models to sophisticated agents that can perform complex tasks autonomously.
+
+### Leveraging Large Language Models (LLMs) for code
+
+At the core of AI code generation are Large Language Models (LLMs) trained on vast datasets of source code. Models like OpenAI's GPT-5 and Anthropic's Claude Opus 4 possess a deep understanding of programming languages, frameworks, and common software patterns. They serve as the engine for most AI coding tools, capable of generating snippets, entire functions, or even complex algorithms from natural language prompts. A critical aspect of using them effectively is continuous [LLM evaluation](/resources/ai/llm-evaluation) to ensure the outputs meet quality and performance standards.
+
+### Popular AI coding assistants and their roles
+
+Several tools have emerged to integrate LLMs directly into the developer's environment:
+
+*   **GitHub Copilot:** The most widely adopted AI pair programmer, it provides real-time, context-aware code suggestions directly within the IDE. It excels at autocompleting lines, generating boilerplate, and writing unit tests.
+*   **Cursor:** An AI-native code editor that offers more interactive features than Copilot. It allows developers to chat with their codebase, perform complex refactoring, and debug with AI assistance in a dedicated environment.
+*   **ChatGPT Search:** The web-enabled version of ChatGPT can access up-to-date documentation and external resources, making it useful for researching new libraries, understanding API changes, or finding solutions to obscure errors.
+*   **Claude Opus 4:** Known for its large context window, Claude is particularly effective at understanding and reasoning about large codebases. It can be used for high-level architectural planning, code review, and documentation generation.
+
+### Beyond basic generation: Automated issue detection and modular agents
+
+The workflow extends beyond simple code generation. Advanced tools and concepts are becoming integral:
+
+*   **Automated Issue Detection:** Static analysis tools (e.g., SonarQube, CodeQL) can be integrated into the workflow to automatically scan AI-generated code for security vulnerabilities, bugs, and code smells before it's ever committed.
+*   **Modular AI Agents:** Instead of a single monolithic AI, a modern workflow can use a team of specialized agents. One agent might be an expert in database schema design, another in frontend component creation, and a third in writing secure authentication logic. These agents can be orchestrated to collaborate on a single project. Kestra's [AI tools](/docs/ai-tools) provide the framework to build and manage such multi-agent systems, even enabling [AI orchestration for non-technical teams](/resources/ai/ai-orchestration-for-non-technical-teams) through user-friendly interfaces.
+
+## Architecting Reliable AI Code Generation Workflows
+
+To move from ad-hoc AI usage to a systematic, enterprise-grade process, you need to architect a workflow that prioritizes reliability, quality, and maintainability. This involves establishing clear principles and leveraging the right structural patterns.
+
+### The importance of separating planning from execution
+
+One of the most effective strategies for getting reliable results from AI is to separate the "planning" phase from the "execution" (code generation) phase.
+
+1.  **Planning Phase:** Work with an LLM to break down a high-level feature request into a detailed technical specification. This plan should outline the required functions, their signatures, data structures, and the logical flow of operations. The output of this phase is not code, but a structured plan.
+2.  **Execution Phase:** Feed the detailed plan, one component at a time, to the code generation model. By providing a pre-validated, granular task, you constrain the AI's output, significantly increasing the likelihood of getting correct, relevant code.
+
+This separation forces clarity of thought and makes the AI's task simpler and less ambiguous, reducing hallucinations and logical errors.
+
+### Ensuring code quality and maintainability with AI
+
+AI can write code quickly, but that code must be maintainable. Enforcing quality standards is critical.
+
+*   **Style Guides and Linters:** Provide the AI with your team's style guide as part of the context. Automatically run linters and formatters on all generated code to enforce consistency.
+*   **Human-in-the-Loop Reviews:** All significant AI-generated code must be reviewed by a human developer. This is not just about finding bugs but ensuring the code aligns with the project's architecture and long-term goals.
+*   **Declarative Definitions:** For infrastructure and workflow code, using a declarative format like YAML is often more reliable for AI generation than a procedural language like Python. The structured, non-executable nature of YAML makes it easier for an AI to generate valid configurations. This is a core reason to explore the differences between [YAML vs Python workflows](/blogs/yaml-vs-python-workflow) for orchestration.
+*   **Organized Structure:** Use clear organizational structures like [namespaces](/docs/workflow-components/namespace) to keep generated code and workflows properly segmented and manageable.
+
+### Optimizing AI-generated code for production readiness
+
+Code that works in isolation may not be ready for production. The final steps in the workflow should focus on hardening the generated assets.
+
+*   **Performance Testing:** Profile the generated code to identify and address any performance issues.
+*   **Security Scanning:** Use automated tools to scan for common vulnerabilities (e.g., injection attacks, insecure dependencies).
+*   **Dependency Management:** Ensure that any new libraries introduced by the AI are approved, secure, and properly managed.
+*   **Comprehensive Logging and Monitoring:** Instruct the AI to include structured logging and metrics instrumentation within the code it generates.
+
+## Kestra's Role in Orchestrating AI Code Generation Workflows
+
+While AI tools generate code, an orchestration platform is needed to manage the end-to-end workflow, ensuring governance, reliability, and integration with the broader software development lifecycle. Kestra serves as the control plane for these complex, multi-stage processes.
+
+### Declarative YAML for auditable AI workflows
+
+Kestra's foundation in declarative YAML provides a powerful framework for defining AI code generation pipelines. Each step—from prompting an LLM to running tests and deploying code—can be defined as a task in a Kestra flow.
+
+This approach offers several advantages:
+*   **Auditability:** The entire workflow is captured in a version-controlled YAML file, providing a clear audit trail of how code was generated and validated.
+*   **Readability:** YAML is human-readable, making it easy for both technical and non-technical stakeholders to understand the process.
+*   **Reliability:** Declarative definitions are less prone to side effects than imperative scripts, making them easier for AI models to generate and for humans to review.
+
+### Integrating AI Copilot and agentic capabilities
+
+Kestra is not just a platform for orchestrating external AI tools; it's an [AI-native orchestration platform](/resources/ai/ai-native-orchestration-platform) with built-in capabilities.
+
+*   **AI Copilot:** Kestra's Copilot can generate entire workflow YAML from a natural language prompt. A developer can simply describe the desired pipeline—"Create a flow that takes a code snippet from a Git commit, sends it to Claude Opus 4 for review, runs unit tests in a Docker container, and creates a Jira ticket if tests fail"—and Copilot will generate the corresponding declarative flow.
+*   **Agentic Tasks:** Kestra can orchestrate AI agents as first-class citizens within a workflow. As described in our [release 1.1 update](/blogs/release-1-1), you can create multi-agent systems where one agent writes code, another writes tests, and a third performs security analysis, all coordinated by a single Kestra flow.
+
+Here is an example of a Kestra task using an OpenAI model to generate code:
+
+```yaml
+id: generate-python-function
+namespace: dev.code-gen
+tasks:
+  - id: generate-code
+    type: io.kestra.plugin.openai.ChatCompletion
+    apiKey: "{{ secret('OPENAI_API_KEY') }}"
+    model: "gpt-4-turbo"
+    messages:
+      - role: "system"
+        content: "You are a senior Python developer. Write a single, concise Python function based on the user's request. Include a docstring and type hints."
+      - role: "user"
+        content: "Write a Python function that takes a list of integers and returns the sum of all even numbers."
+```
+
+### Unifying the dev lifecycle: From code generation to deployment
+
+Kestra's power lies in its ability to connect the AI code generation process with the rest of the DevOps toolchain. It can orchestrate tasks across any system, using any programming language, thanks to its [language-agnostic](/features/code-in-any-language) architecture.
+
+A unified Kestra workflow can:
+1.  Trigger on a new feature request in Jira.
+2.  Use an AI agent to generate a draft merge request in GitLab.
+3.  Run automated tests and security scans using containerized tasks.
+4.  Assign the merge request to a human for review upon test success.
+5.  After approval, automatically deploy the code to a staging environment.
+
+This holistic approach, deeply integrated with Git-based processes via tools like our [Git orchestration](/orchestration/git) features, ensures that AI-generated code is not created in a vacuum but is part of a governed, end-to-end software delivery pipeline.
+
+## Addressing the Challenges of AI in Software Development
+
+While AI code generation offers immense potential, its practical application comes with a set of challenges that must be managed proactively. Acknowledging and addressing these issues is key to building a sustainable and responsible AI-assisted development practice.
+
+### Managing rework and ensuring accuracy
+
+AI models can and do make mistakes. They can misinterpret prompts, generate inefficient or buggy code, or "hallucinate" APIs that don't exist. Relying on AI output without verification leads to significant rework.
+
+**Solution:**
+*   **Assume a "First Draft" Mentality:** Treat all AI-generated code as an initial draft that requires validation.
+*   **Invest in Automated Testing:** A comprehensive test suite is the most effective way to catch functional errors in AI-generated code automatically.
+*   **Iterative Feedback Loop:** Structure your workflow to allow for quick feedback cycles, where incorrect code and error messages are fed back to the AI for correction.
+
+### Security, compliance, and human oversight
+
+Using external AI models to process proprietary code raises significant security and compliance concerns.
+
+*   **Data Privacy:** Ensure that sensitive code or data is not being sent to third-party APIs without proper anonymization or contractual safeguards.
+*   **IP and Licensing:** Be aware of the licensing implications of code generated by models trained on open-source repositories.
+*   **The Human Supervisor:** The developer's role shifts from a pure creator to a supervisor and quality gatekeeper. Human judgment is irreplaceable for architectural decisions, security reviews, and ensuring the code aligns with business objectives. When choosing tools, it's important to compare how different [SimplyAsk alternatives](/resources/ai/simplyask-alternatives) handle data privacy and governance.
+
+### Overcoming prompt ambiguity for better results
+
+The quality of the output is directly proportional to the quality of the input. Vague or ambiguous prompts lead to generic or incorrect code.
+
+**Solution:**
+*   **Prompt Engineering:** Train developers in prompt engineering techniques to be specific about requirements, constraints, and context.
+*   **Provide Examples:** Include examples of desired input and output (few-shot prompting) to guide the model.
+*   **Deconstruct Problems:** Break down complex problems into smaller, well-defined prompts. This is similar to designing a [machine learning pipeline](/resources/ai/what-is-a-machine-learning-pipeline), where each component has a single, clear responsibility.
+
+## The Future of AI Code Generation and Development
+
+The field of AI-assisted development is evolving at an unprecedented pace. The trends that began to emerge in previous years are now accelerating, pointing toward a future where AI is not just an assistant but a fundamental part of the entire software delivery fabric.
+
+### Advanced agentic orchestration and personalized assistants
+
+The next frontier is the move from single-purpose tools to collaborative, multi-agent systems. We can expect to see:
+*   **Specialized Agent Teams:** Workflows where a "planning" agent designs the architecture, a "coding" agent writes the implementation, a "testing" agent generates validation cases, and a "security" agent hardens the code, all working in concert.
+*   **Hyper-Personalization:** AI assistants will move beyond generic models to become highly personalized. They will learn an individual developer's coding style, a team's architectural patterns, and a company's specific codebase to provide highly contextual and relevant assistance.
+
+### AI's impact on DevOps and software delivery
+
+AI will be integrated into every stage of the DevOps lifecycle, creating a more automated and intelligent software delivery pipeline. The [2025 data engineering & AI trends](/blogs/2025-data-engineering-and-ai-trends) already pointed toward this convergence, which is now becoming a reality.
+
+*   **Automated Remediation:** AI will not just detect issues in production but will also be able to propose and, with approval, implement fixes automatically.
+*   **Predictive Analysis:** AI models will analyze development patterns to predict potential integration conflicts, performance bottlenecks, or security risks before they happen.
+*   **End-to-End Orchestration:** The entire process, from idea to production monitoring, will be managed by a unified control plane. Platforms like Kestra are built for this future, providing the backbone to [stop writing glue code around your AI pipelines](/ai-automation) and orchestrate these complex, intelligent systems declaratively.

--- a/src/contents/resources/awx-alternatives/index.md
+++ b/src/contents/resources/awx-alternatives/index.md
@@ -1,0 +1,154 @@
+---
+title: "Top AWX Alternatives for Modern Automation in 2026"
+description: "Explore the best AWX alternatives, from open-source tools to enterprise platforms, to find a flexible and scalable automation solution that fits your infrastructure needs."
+metaTitle: "AWX Alternatives: Top Automation Platforms for 2026"
+metaDescription: "Compare the top AWX alternatives for 2026 — Kestra, Ansible Semaphore, Rundeck and more — for flexible, scalable infrastructure automation and orchestration."
+tag: "infrastructure"
+date: 2026-07-02
+slug: "awx-alternatives"
+faq:
+  - question: "Is AWX still being actively developed?"
+    answer: "AWX is still maintained by Red Hat, but new releases have been paused since version 24.6.1 (July 2, 2024) while the team refactors it into a service-oriented architecture (and moves from semantic versioning to CalVer). Red Hat has acknowledged that the existing application architecture limits how far AWX can innovate, which is why many teams now evaluate alternatives."
+  - question: "What is the difference between AWX and Ansible Semaphore?"
+    answer: "AWX is the upstream open-source project for Red Hat Ansible Automation Platform, providing a comprehensive web UI, RBAC, and job scheduling. Ansible Semaphore is a lighter, simpler open-source web UI specifically for managing Ansible playbooks, often favored for smaller-scale or less complex environments."
+  - question: "What does AWX stand for?"
+    answer: "AWX has no official expansion — Red Hat treats 'AWX' as the product name rather than an acronym (you may see informal backronyms like 'Ansible Worx,' but none are official). It is the open-source upstream project for Ansible Tower, now known as Red Hat Ansible Automation Platform (AAP), providing a web-based UI, REST API, and task engine on top of Ansible."
+  - question: "What can replace Ansible?"
+    answer: "While Ansible remains a powerful configuration management tool, alternatives for broader infrastructure automation and orchestration include Kestra (declarative, polyglot), Puppet (config management), Chef (infrastructure as code), Salt (event-driven config), Terraform/OpenTofu (IaC provisioning), and Rundeck (runbook automation)."
+  - question: "Why should I consider an alternative to AWX?"
+    answer: "Teams often seek AWX alternatives due to its architectural limitations, operational complexity at scale, and its focus primarily on Ansible playbooks. Alternatives offer greater flexibility for multi-tool orchestration, diverse language support, and cloud-native deployments."
+  - question: "Is Kestra a suitable alternative to AWX for infrastructure automation?"
+    answer: "Yes, Kestra is a powerful AWX alternative. It offers a declarative YAML-based approach for infrastructure automation, supporting polyglot tasks, event-driven orchestration, and integration with tools like Ansible, Terraform, and Kubernetes. It unifies operations beyond just Ansible playbooks."
+---
+
+The landscape of IT automation is constantly evolving, with teams seeking more flexible, scalable, and unified solutions. While AWX has served as a reliable open-source web interface for Ansible automation, its architectural limitations have led many organizations to explore alternatives. The challenge for platform engineers and DevOps teams is finding a platform that not only manages Ansible playbooks but also orchestrates a broader array of tools and workflows across diverse environments.
+
+This article dives into the top alternatives to AWX in 2026, helping you navigate the options available. The leading alternatives to AWX include Kestra, Ansible Semaphore, Rundeck, and Red Hat's own Ansible Automation Platform, each suited to different infrastructure and operational needs. We'll examine why teams are moving beyond AWX, the key criteria for evaluating new platforms, and provide a detailed comparison of open-source and commercial solutions.
+
+## The Evolving Need for AWX Alternatives in Modern IT
+
+For years, AWX has been the go-to open-source solution for adding a web-based UI, REST API, and task engine to Ansible. As the upstream project for what became the Red Hat Ansible Automation Platform (AAP), it provided essential features for teams looking to operationalize their Ansible playbooks.
+
+### What AWX Offers and Where It Falls Short
+
+AWX brought structure to Ansible automation with key capabilities like:
+*   **Centralized UI:** A web interface for managing and running Ansible jobs.
+*   **Role-Based Access Control (RBAC):** Granular permissions for users and teams.
+*   **Job Scheduling:** The ability to run playbooks on a schedule.
+*   **Credential Management:** Secure storage for SSH keys and other secrets.
+*   **Inventory Management:** A centralized place to define and manage infrastructure inventories.
+
+However, as infrastructure has grown more complex, AWX's limitations have become more apparent. Red Hat has acknowledged that the existing monolithic architecture limits innovation. Since mid-2024, development has been paused while the project undergoes a significant refactor into a more modern, service-oriented architecture. This pause, combined with its inherent focus on a single tool, has accelerated the search for more versatile [automation](/resources/infrastructure/automation) platforms.
+
+### Why Teams Seek Automation Beyond AWX's Scope
+
+The primary driver for seeking AWX alternatives is the need for a tool that can orchestrate more than just Ansible. Modern infrastructure stacks are polyglot, relying on a mix of Terraform, Kubernetes, custom scripts, and cloud APIs. AWX's Ansible-centric model creates an automation silo.
+
+Teams are looking for solutions that address challenges like:
+*   **Multi-Tool Orchestration:** Coordinating workflows that involve Terraform provisioning, Ansible configuration, Kubernetes deployments, and database updates in a single, auditable sequence.
+*   **Operational Complexity:** The operational overhead of maintaining a standalone AWX instance, its database, and dependencies can be significant.
+*   **Architectural Rigidity:** The need for more flexible, event-driven, and API-first automation that fits naturally into a GitOps workflow.
+
+The ideal solution isn't just a better UI for Ansible; it's a true orchestration control plane. For a deeper dive into other [Ansible alternatives](/resources/infrastructure/alternatives-to-ansible), see our detailed comparison.
+
+## Evaluating Automation Platforms: Key Criteria for AWX Replacements
+
+When choosing an AWX alternative, it's crucial to evaluate platforms based on a consistent set of criteria that reflect modern infrastructure needs.
+
+*   **License Model:** Is the tool fully open-source (like Kestra or Semaphore), open-core, or a purely commercial product? Understanding the total cost of ownership and potential for vendor lock-in is critical.
+*   **Deployment Flexibility:** Can the platform be deployed on-premises, in the cloud, in a hybrid model, or even in air-gapped environments? Kubernetes-native support is often a key requirement.
+*   **Core Capabilities:** Does the tool provide robust RBAC, centralized secret management, audit logs, and flexible job scheduling? These are table stakes for enterprise-grade [workflow orchestration security](/resources/infrastructure/workflow-orchestration-security).
+*   **Extensibility:** How easy is it to extend the platform with new integrations? A rich plugin ecosystem and a well-documented API are signs of a healthy, adaptable tool.
+*   **Language and Tool Agnosticism:** Does the platform force you into a single language or tool, or does it embrace a polyglot approach, allowing you to use the best tool for each task?
+*   **Community and Support:** For open-source tools, a vibrant community is essential. For commercial offerings, the quality and availability of enterprise support can be a deciding factor. Considering the benefits of [open source orchestration cost savings](/resources/infrastructure/open-source-orchestration-cost-savings) is also important.
+
+## 1. Kestra: The Declarative Control Plane for All Workflows
+
+Kestra is a modern, open-source orchestration platform that provides a unified control plane for all your workflows—not just Ansible. It's built on a declarative, language-agnostic foundation, allowing you to define complex workflows in simple YAML files.
+
+Instead of being just a UI for one tool, Kestra acts as the brain that coordinates your entire stack. A Kestra workflow can seamlessly integrate Ansible playbooks, Terraform plans, Kubernetes jobs, Python scripts, and SQL queries. This declarative approach aligns perfectly with [GitOps for operations](/resources/infrastructure/gitops-for-operations), making your automation auditable, versionable, and easy to manage.
+
+For example, Germany's public-sector IT provider, Dataport, uses Kestra to standardize API-driven cloud orchestration on its private cloud, creating a government-grade control plane.
+
+**Best for:** Teams needing a unified, declarative control plane to orchestrate diverse tools (Ansible, Terraform, Kubernetes, scripts) and workflows across infrastructure, data, and AI domains.
+
+## 2. Ansible Semaphore: A Lighter Open-Source UI for Ansible
+
+Ansible Semaphore is a straightforward, open-source web UI for Ansible. If your primary frustration with the command line is the lack of a simple, multi-user interface for running playbooks, Semaphore is a compelling alternative.
+
+It provides the core features you need—inventory and credential management, a job dashboard, and basic user access controls—without the complexity of a full AWX installation. It is lightweight, easy to deploy, and focuses exclusively on doing one thing well: providing a clean UI for Ansible.
+
+However, its strength is also its limitation. Semaphore is not a general-purpose orchestrator. It manages Ansible playbooks and nothing else. If your needs extend beyond Ansible, you will quickly outgrow it.
+
+**Best for:** Small to medium-sized teams who are committed to Ansible and need a simple, self-hosted UI without the operational overhead of AWX.
+
+## 3. Rundeck (PagerDuty Process Automation): Self-Service Runbook Orchestration
+
+Rundeck, now part of PagerDuty Process Automation, is a powerful platform for runbook automation. Its primary strength is enabling self-service for operations teams. You can create pre-defined jobs that encapsulate scripts, API calls, or Ansible playbooks, and then safely delegate the execution of these jobs to other teams or individuals through a clean UI with strong RBAC.
+
+Rundeck excels at incident response and routine operational tasks. For example, you could create a "Restart Application" job that a junior operator can run without needing direct server access. While it integrates well with Ansible, its focus is on creating a library of executable runbooks rather than orchestrating complex, multi-stage workflows. For more details, see our comparison of [Rundeck alternatives](/resources/infrastructure/rundeck-alternatives).
+
+**Best for:** Operations teams looking to build a self-service catalog of automated runbooks for incident response and routine tasks, reducing manual intervention and escalations.
+
+## 4. Red Hat Ansible Automation Platform (AAP): The Commercial Evolution of AWX
+
+For organizations heavily invested in the Red Hat ecosystem, the Ansible Automation Platform (AAP) is the logical, enterprise-grade successor to AWX. AAP is a commercial product that includes everything in AWX plus enterprise support, certified content collections, advanced analytics, and features like Automation Mesh for scaling automation across different networks and locations.
+
+AAP is designed for large-scale, mission-critical Ansible deployments. It provides the governance, security, and scalability that enterprises require. The trade-off is cost and vendor lock-in. It solidifies your commitment to Ansible as the core automation engine, which may not align with a strategy aimed at embracing a more diverse set of automation tools.
+
+**Best for:** Large enterprises that have standardized on Ansible and require a fully supported, scalable, and secure platform from a commercial vendor.
+
+## 5. Argo Workflows: Kubernetes-Native Container Orchestration
+
+Argo Workflows is an open-source, container-native workflow engine for orchestrating jobs on Kubernetes. If your infrastructure and applications are heavily containerized, Argo offers a powerful way to manage complex dependencies and sequences.
+
+Workflows are defined as Kubernetes Custom Resource Definitions (CRDs) in YAML, making them a natural fit for a Kubernetes-centric GitOps model. Each step in a workflow is a container, providing excellent isolation and reproducibility. While you can run Ansible inside a container as part of an Argo workflow, it's not a direct replacement for AWX's inventory and credential management features. Argo is best suited for orchestrating containerized tasks, such as CI/CD pipelines, data processing jobs, or ML model training. You can explore other [Argo Workflows alternatives](/resources/infrastructure/argo-workflows-alternatives) to find the best fit for your needs.
+
+**Best for:** Teams with a deep investment in [Kubernetes](/resources/infrastructure/kubernetes) who need a powerful, native engine for orchestrating container-based workflows.
+
+## 6. CI/CD Tools: Jenkins, GitHub Actions, and GitLab CI/CD
+
+For many teams, existing CI/CD tools can serve as a pragmatic alternative to AWX for running Ansible playbooks, especially when the automation is tied to code changes.
+
+### Jenkins: The Veteran of Continuous Integration
+
+Jenkins is a highly extensible CI/CD server with a massive plugin ecosystem. With plugins for Ansible, credential management, and scheduling, it can be configured to replicate much of AWX's functionality. Its flexibility is its greatest strength, but also its weakness, as managing a complex Jenkins setup can become a full-time job.
+
+### GitHub Actions & GitLab CI/CD: Git-Native Automation
+
+Modern, Git-native platforms like GitHub Actions and GitLab CI/CD provide a more streamlined approach. You can define pipelines as code directly in your repository, triggering Ansible playbook runs on events like a pull request or a merge. This tightly integrates your infrastructure automation with your source code management, which is ideal for [CI/CD orchestration](/resources/infrastructure/ci-cd-orchestration).
+
+However, these tools are fundamentally designed for software delivery pipelines, not as general-purpose orchestrators for scheduled or event-driven operational tasks. Using them for broader infrastructure automation can feel like forcing a square peg into a round hole. For a deeper look, compare [Kestra vs. GitHub Actions](/resources/infrastructure/kestra-vs-github-actions) or [Kestra vs. GitLab](/resources/infrastructure/kestra-vs-gitlab).
+
+**Best for:** Engineering teams that want to integrate Ansible-based infrastructure changes directly into their existing software delivery pipelines.
+
+| Tool | License | Deployment | Best for | Language Support |
+|---|---|---|---|---|
+| **Kestra** | Open-Source (Apache 2.0) & Enterprise | Docker, Kubernetes, Bare Metal | Unified orchestration across all tools | Polyglot (Python, Shell, SQL, etc.) |
+| **Ansible Semaphore** | Open-Source (MIT) | Docker, Bare Metal | Simple, lightweight Ansible UI | Ansible only |
+| **Rundeck** | Open-Source & Commercial | Docker, Kubernetes, Bare Metal | Self-service runbook automation | Polyglot |
+| **Ansible Automation Platform** | Commercial | Kubernetes, On-premise | Enterprise-scale Ansible automation | Ansible only |
+| **Argo Workflows** | Open-Source (Apache 2.0) | Kubernetes only | Kubernetes-native container workflows | Container-based (any language) |
+| **CI/CD Tools** | Open-Source & Commercial | Cloud-hosted, Self-hosted | Integrating Ansible into code pipelines | Polyglot |
+
+## Choosing the Right AWX Alternative for Your Team
+
+The best AWX alternative depends entirely on your team's specific context, scale, and strategic goals.
+
+### For Data Engineering Teams
+
+While not a traditional AWX use case, data engineering teams often need to orchestrate infrastructure alongside their data pipelines. For them, a platform like Kestra is a natural fit, as it can manage both Terraform/Ansible jobs and dbt/Spark tasks from a single control plane. Explore more resources for [data engineering](/resources/data).
+
+### For Infrastructure and DevOps Teams
+
+If your goal is to build a robust, scalable, and future-proof automation platform, a tool-agnostic orchestrator like Kestra offers the most flexibility. It allows you to use Ansible where it excels while integrating other best-in-class tools like Terraform and Kubernetes without creating silos. For enterprises committed to Ansible, AAP provides a supported, scalable path. For teams focused on self-service, Rundeck is a strong contender. See our complete guide to [infrastructure automation](/infra-automation).
+
+### For Small Teams and Open-Source Enthusiasts
+
+For smaller teams or those with simpler needs, Ansible Semaphore provides a lightweight and easy-to-manage UI for Ansible. If your environment is entirely Kubernetes-based, Argo Workflows is a powerful, open-source choice for container orchestration.
+
+## Beyond AWX: Embracing a Unified Automation Future
+
+The conversation around AWX alternatives highlights a broader trend in IT: the move away from tool-specific schedulers towards unified, declarative orchestration platforms. While AWX capably serves its purpose as a UI for Ansible, modern infrastructure demands a control plane that can see and manage the entire workflow, regardless of the underlying tools.
+
+Platforms like [Kestra](/) represent this future, where automation is defined as code, workflows are language-agnostic, and orchestration spans every domain of the enterprise. By adopting a true orchestration layer, you not only solve the immediate limitations of AWX but also build a more resilient and adaptable foundation for all your future automation needs.

--- a/src/contents/resources/data-retention-automation/index.md
+++ b/src/contents/resources/data-retention-automation/index.md
@@ -1,0 +1,178 @@
+---
+title: "Data Retention Automation: Policies, Compliance & Orchestration"
+description: "Automating data retention policies is crucial for compliance, risk reduction, and efficient data lifecycle management. This guide explores strategies, best practices, and how Kestra orchestrates automated data governance."
+metaTitle: "Data Retention Automation: Policies & Compliance | Kestra"
+metaDescription: "Automate data retention policies for regulatory compliance, reduced legal risk, and efficient data lifecycle management. Learn how Kestra helps."
+tag: "data"
+date: 2026-07-15
+slug: "data-retention-automation"
+faq:
+  - question: "What is data retention automation?"
+    answer: "Data retention automation uses automated workflows to manage data lifecycle based on predefined policies. For data, this means automatically identifying, archiving, or deleting information that has reached its retention period, ensuring compliance and reducing storage costs."
+  - question: "What is a data retention example?"
+    answer: "An example of data retention automation is a workflow that automatically identifies customer transaction records older than seven years, archives them to a cold storage tier, and then deletes them after ten years, all while logging each action for audit purposes."
+  - question: "What is the 7-year retention policy?"
+    answer: "The '7-year retention policy' is a common guideline, particularly in finance and healthcare, for retaining tax, employment, or medical records. While not universally mandated, it serves as a baseline for many organizations to ensure compliance with various regulations."
+  - question: "What is a data retention strategy?"
+    answer: "A data retention strategy defines how long specific data types are kept, who can access them, and how they are managed throughout their lifecycle. It involves data classification, policy enforcement, and regular auditing to meet legal, regulatory, and business requirements."
+  - question: "What are the 4 types of automation?"
+    answer: "The four types of automation are: basic automation (simple tasks), process automation (sequential steps), integration automation (connecting systems), and AI-driven automation (intelligent decision-making). Data retention often involves a mix of process and integration automation."
+  - question: "What are the 5 C's of retention?"
+    answer: "The '5 C's of retention' typically refer to customer retention, not data retention. They are often cited as: Customer Satisfaction, Communication, Customer Service, Community, and Cost-Effectiveness. For data, analogous principles might be Compliance, Cost, Control, Clarity, and Consistency."
+---
+
+Data is a double-edged sword: a valuable asset, but also a significant liability if not managed correctly. As regulations like GDPR and HIPAA tighten, and data volumes explode, manually enforcing retention policies becomes an impossible task, exposing organizations to compliance fines, security risks, and spiraling storage costs.
+
+This guide explores data retention automation, a strategic imperative for modern enterprises. We'll delve into its benefits, key components, best practices, and how Kestra provides a powerful, declarative platform to orchestrate policy-driven data lifecycle management across diverse systems.
+
+## Why Automating Data Retention is a Compliance and Cost Imperative
+
+The days of "keep everything forever" are over. Modern data management requires a disciplined approach to the data lifecycle, and automation is the only scalable way to enforce it. The shift from manual, often ad-hoc data cleanup to systematic, automated retention is driven by pressing needs for risk mitigation, cost control, and regulatory adherence.
+
+### Defining Automated Data Retention
+
+Automated data retention is the practice of using software and workflows to manage the lifecycle of data based on predefined rules, or policies. Instead of relying on manual intervention, these systems automatically identify, classify, archive, or delete data once it reaches the end of its required retention period. This process ensures that policies are applied consistently across the entire organization, from production databases to cloud storage buckets.
+
+### The Critical Need for Automated Policies
+
+Manual data retention is prone to human error, inconsistency, and oversight. As data becomes more distributed across hybrid environments, a manual approach simply cannot keep up. An automated system provides the necessary rigor to manage vast quantities of information effectively. It addresses several critical business drivers simultaneously:
+- **Compliance:** Regulations like GDPR have strict requirements for data minimization and the right to be forgotten. Automation is essential for demonstrating [GDPR-compliant orchestration](/resources/infrastructure/gdpr-compliant-orchestration) and avoiding penalties.
+- **Security:** Every piece of stored data, especially sensitive data, increases the potential attack surface. Automating the removal of unnecessary data reduces this risk.
+- **Cost:** Storing redundant, obsolete, or trivial data incurs significant costs for storage, backup, and management. Automation optimizes storage usage and reduces infrastructure spend.
+- **Efficiency:** Freeing data and platform teams from manual cleanup tasks allows them to focus on higher-value activities. Explore our [data engineering resources](/resources/data) for more on optimizing data workflows.
+
+## The Tangible Benefits of Automating Data Lifecycle Management
+
+Implementing an automated data retention strategy delivers clear, measurable benefits across legal, financial, and operational domains. It transforms data governance from a reactive, compliance-driven chore into a proactive, value-adding business function.
+
+### Ensuring Regulatory Compliance and Mitigating Legal Risks
+
+The primary driver for many organizations is compliance. Automated retention workflows provide an auditable trail demonstrating that policies are being enforced consistently. This is crucial for regulations that mandate time limits on holding personal data. For example, financial institutions like JPMorgan Chase use orchestration for cybersecurity analytics workflows that process billions of rows securely; a core part of that security posture is ensuring data that is no longer needed is properly disposed of. A robust automation platform helps meet these obligations, reducing the risk of fines and legal challenges associated with data spillage or non-compliance.
+
+### Lowering Operational Costs and Optimizing Storage
+
+Data storage is not free. Costs accumulate from primary storage, backups, and disaster recovery systems. Automated retention policies help control these expenses in several ways:
+- **Tiered Storage:** Workflows can automatically move older, less-frequently accessed data from expensive, high-performance storage (hot tier) to cheaper, long-term storage (cold or archive tier).
+- **Deletion of ROT:** The system can identify and delete Redundant, Obsolete, and Trivial (ROT) data, freeing up valuable capacity.
+- **Reduced Management Overhead:** Automation eliminates the hours engineers would otherwise spend writing custom scripts or manually deleting files.
+
+### Bolstering Data Security and Minimizing Exposure
+
+The less data you hold, the less data can be compromised in a breach. Data retention automation is a fundamental security practice. By systematically purging old data, you reduce the "blast radius" of a potential security incident. This is particularly important for sensitive information like PII (Personally Identifiable Information) or financial records. Having a clear, automated process for data disposal ensures that your security posture improves over time, rather than degrading under the weight of accumulated data.
+
+### Streamlining Data Governance and Lifecycle Workflows
+
+Automation brings order and predictability to data lifecycle management. It codifies your governance policies into executable workflows, ensuring that every dataset is subject to the same rules. This creates a transparent and manageable system where actions are logged and auditable. Effective [audit logs orchestration](/resources/infrastructure/audit-logs-orchestration) is a direct outcome of this approach, providing clear visibility into what data was modified, accessed, or deleted, and by which process. This level of control is essential for enterprise governance, and Kestra's [audit logs](/docs/enterprise/governance/audit-logs) are designed to provide this deep insight.
+
+## Core Components of an Effective Data Retention Strategy
+
+A successful automation strategy is built on a solid foundation of clear policies and classifications. The technology serves to enforce these business rules, not to create them in a vacuum.
+
+### Developing Clear Data Classification Standards
+
+Before you can automate, you must classify. Data classification involves categorizing data based on its sensitivity, business value, and regulatory requirements. A typical scheme might include tiers such as:
+- **Public:** Data with no confidentiality requirements.
+- **Internal:** Business data not intended for public disclosure.
+- **Confidential:** Sensitive data that could cause damage if disclosed (e.g., financial reports, employee data).
+- **Restricted:** Highly sensitive data with strict access controls and retention rules (e.g., PII, health records).
+
+Each class should have a clearly defined retention period. This classification provides the logic that your automation workflows will use to make decisions.
+
+### Implementing Automated Policy Enforcement
+
+Once data is classified, policies must be translated into automated rules. This is where an orchestration platform comes in. A policy like "Delete customer support tickets 180 days after resolution" becomes a scheduled workflow that queries for closed tickets, checks the resolution date, and triggers a deletion API call for those that meet the criteria. This is the operational heart of data retention automation, turning abstract policy into concrete, repeatable action. Global leaders like Acxiom have modernized their Big Data orchestration by integrating such policy-driven workflows into their existing DevOps practices.
+
+### Understanding Common Retention Periods (e.g., the 7-Year Rule)
+
+While there is no single rule for all data, certain standards have emerged. The "7-year rule" is a well-known benchmark, often applied to tax records, accounting information, and employee files to comply with various financial and labor regulations. However, different data types have different requirements. For example, HIPAA may require patient records to be kept for six years from the last date of service, while GDPR requires personal data to be deleted as soon as it's no longer needed for its original purpose. An effective strategy defines specific periods for each data classification, all managed within the same [data storage](/docs/concepts/storage) framework. Kestra's concept of [Assets](/blogs/hello-assets) helps track lineage and metadata, making it easier to apply these time-based policies to specific [datasets and tables](/docs/enterprise/governance/assets).
+
+## Orchestrating Data Retention with Kestra
+
+Kestra provides a powerful, flexible control plane for implementing data retention automation. Its declarative, language-agnostic approach is perfectly suited for creating auditable, policy-driven workflows that can interact with any data source.
+
+### Declarative Workflows for Auditable Data Lifecycle Management
+
+Kestra workflows are defined in simple YAML files. This declarative approach makes your retention policies transparent and easy to understand. The entire logic—what data to target, what action to perform, and when to run—is codified in a version-controllable file. This provides a clear audit trail. Anyone can review the YAML to understand the exact retention policy being enforced, and any changes to that policy are tracked in Git. This is a significant improvement over opaque scripts or manual processes.
+
+### Flexible Policy Enforcement Across Diverse Data Sources
+
+Data rarely lives in one place. A comprehensive retention strategy must cover databases, data lakes, object storage, and SaaS applications. Kestra's extensive library of plugins allows you to build workflows that connect to virtually any system. You can create a single retention workflow that:
+1. Queries a PostgreSQL database for old user records.
+2. Scans an AWS S3 bucket for temporary files older than 30 days.
+3. Calls a Salesforce API to archive inactive contacts.
+4. Runs a Spark job on a data lake to anonymize historical data.
+
+This ability to orchestrate across different technologies makes Kestra an ideal platform for unifying your data retention efforts.
+
+### Automated Purging and Archiving for Cost Efficiency
+
+Kestra includes built-in tasks for managing data lifecycle events like purging old execution logs and files. The same principles can be applied to your business data. A scheduled workflow can run daily or weekly to enforce retention policies, automatically archiving data to cheaper storage or deleting it entirely.
+
+Here is a simple example of a Kestra flow that purges old log files from an S3 bucket every Sunday at 2 AM:
+
+```yaml
+id: s3-log-file-purge
+namespace: com.acme.governance
+
+tasks:
+  - id: find-old-logs
+    type: io.kestra.plugin.aws.s3.List
+    prefix: "application-logs/"
+    regExp: '.*\.log\.gz'
+    filter: ALL
+
+  - id: delete-old-logs
+    type: io.kestra.plugin.aws.s3.DeleteList
+    uri: "{{ outputs['find-old-logs'].objects | jq('.[] | select(.lastModified < (now() | date_add(-90, 'DAYS'))) | .uri') | join('\n') }}"
+    
+triggers:
+  - id: weekly-schedule
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 2 * * 0"
+```
+
+This workflow demonstrates a common pattern: listing files, filtering them based on a time-based condition, and then performing an action. You can find more advanced examples, including how to [purge Kestra's own data](/docs/administrator-guide/purge), in our [Blueprints library](/blueprints/purge). This approach makes it easy for modern [data engineers](/data) to implement and manage complex retention rules.
+
+## Best Practices for Implementing Data Retention Automation
+
+A successful implementation goes beyond just technology. It requires careful planning, clear communication, and a commitment to best practices in governance and change management.
+
+### Crafting a Precise Records Retention Schedule
+
+A records retention schedule is a formal document that outlines your data retention policies. It should detail:
+- The types of records your organization keeps.
+- The retention period for each record type.
+- The legal or business justification for that period.
+- The designated "owner" of each data type.
+
+Start with your most critical and regulated data first. Implement automation for these categories, validate the results, and then incrementally expand the program to cover other data domains.
+
+### Ensuring Comprehensive Auditability and Reporting
+
+Every action taken by your automation system must be logged. Your orchestration tool should provide detailed execution logs that show which workflow ran, what data it processed, and what actions it took. This is non-negotiable for compliance. Reports should be generated regularly to demonstrate that policies are being followed and to identify any exceptions or failures. Strong [workflow governance](/resources/infrastructure/workflow-governance) and [role-based access control (RBAC)](/resources/infrastructure/rbac-workflow-orchestration) ensure that only authorized processes can modify or delete data.
+
+### Fostering Team Buy-In and Continuous Training
+
+Data retention is a shared responsibility. Legal, compliance, IT, and business teams must all be involved in defining the policies that automation will enforce. It's crucial to communicate the "why" behind the program—its benefits for security, cost, and compliance. Provide training on the new policies and systems to ensure everyone understands their role. A successful program is one that becomes an integrated part of the organization's data culture.
+
+## Navigating Challenges and Future Trends in Data Retention
+
+The landscape of data management is constantly changing. A successful data retention strategy must be adaptable enough to handle new data sources, evolving regulations, and emerging technologies like AI.
+
+### Managing Data Diversity and Distributed Environments
+
+Organizations today deal with a mix of structured and unstructured data spread across on-premise data centers, multiple clouds, and dozens of SaaS applications. The biggest challenge is applying retention policies consistently across this fragmented landscape. An orchestration platform acts as a unifying layer, providing a single place to define and manage retention workflows regardless of where the data resides. This unified approach is key to achieving comprehensive [data observability](/resources/data/data-observability).
+
+### Adapting to Evolving Regulations and AI's Impact
+
+New data privacy laws are being enacted worldwide, and existing ones are frequently updated. Your retention strategy must be flexible enough to adapt quickly. Furthermore, the rise of AI and machine learning creates new challenges. How do you manage the retention of training data, models, and AI-generated content? An automated, policy-as-code approach allows you to update your workflows centrally and roll out changes efficiently, ensuring you can keep pace with both regulatory demands and technological shifts through [AI governance workflows](/resources/ai/ai-governance-workflows).
+
+### The Role of Automation in Broader Data Governance
+
+Data retention is just one pillar of a comprehensive data governance framework. Automation plays a role in other areas as well, including data quality monitoring, access control management, and metadata management. By using a universal orchestration platform, you can build a cohesive set of automated workflows that collectively manage the entire data lifecycle, ensuring your data is not only compliant but also secure, reliable, and fit for purpose.
+
+## Kestra: Your Platform for Unified Data Retention Automation
+
+Data retention automation is no longer an optional extra; it is a fundamental component of modern data strategy. It's about more than just deleting old files—it's about managing risk, controlling costs, and building a secure, compliant, and efficient data ecosystem.
+
+Kestra is uniquely positioned to serve as the control plane for this critical function. By combining a declarative YAML interface with a powerful, language-agnostic engine, Kestra enables you to codify your retention policies into auditable, version-controlled workflows. Whether you're managing data, [infrastructure automation](/infra-automation), or complex [AI pipelines](/ai-automation), Kestra provides a single platform to orchestrate it all. Explore our [infrastructure resources](/resources/infrastructure) to see how unified orchestration can transform your operations.

--- a/src/contents/resources/keycloak-sso-integration/index.md
+++ b/src/contents/resources/keycloak-sso-integration/index.md
@@ -1,0 +1,157 @@
+---
+title: "Keycloak SSO Integration: Securing Workflows with Declarative Orchestration"
+description: "Learn how to integrate Keycloak for Single Sign-On (SSO) to centralize user authentication and enhance security across your applications and workflows. This guide covers setup, protocols, and best practices."
+metaTitle: "Keycloak SSO Integration for Workflow Orchestration | Kestra"
+metaDescription: "Integrate Keycloak SSO to secure apps and automate access management — configure Keycloak, master protocols, and orchestrate workflow security with Kestra."
+tag: "infrastructure"
+date: 2026-07-08
+slug: "keycloak-sso-integration"
+faq:
+  - question: "How does SSO work with Keycloak?"
+    answer: "Keycloak centralizes user authentication, allowing users to log in once and access multiple integrated applications without re-authenticating. This simplifies user experience and security management for applications, including Kestra, by offloading authentication concerns."
+  - question: "Can Keycloak support SAML?"
+    answer: "Yes, Keycloak functions as an identity provider (IdP) for SAML, allowing it to integrate seamlessly with service providers (SPs) that use SAML for authentication. This offers broad flexibility for various enterprise integration scenarios and legacy systems."
+  - question: "Can OAuth be used for SSO?"
+    answer: "Yes, OAuth 2.0, specifically with OpenID Connect (OIDC), is widely used for SSO. OIDC builds an identity layer on top of OAuth 2.0, providing authentication and user information alongside authorization, making it an ideal choice for modern, API-driven SSO implementations."
+  - question: "How do you integrate with SSO?"
+    answer: "Integrating with SSO typically involves configuring your application to redirect authentication requests to an identity provider like Keycloak. Keycloak handles the user login process and then returns an authentication token or assertion, standardizing access across disparate systems."
+  - question: "What are the disadvantages of Keycloak?"
+    answer: "Keycloak can face scalability challenges, particularly with a very high number of realms or complex role structures. Its architectural reliance on specific JPA collection loads and recursive role traversal can become inefficient for extremely large-scale, multi-tenanted deployments."
+  - question: "Is there a better alternative to Keycloak?"
+    answer: "The 'best' alternative depends on specific organizational needs. Options include managed cloud services like Okta, Auth0, or Azure AD for reduced operational burden, or other open-source solutions like Authentik or FusionAuth, offering different feature sets or scalability models. Kestra integrates with many of these for SSO."
+---
+
+In today's complex enterprise environments, managing user access across a multitude of applications and automated workflows is a significant challenge. Manual credential management is not only time-consuming but also a major security risk. Single Sign-On (SSO) emerges as a critical solution, centralizing authentication and simplifying the user experience while strengthening security.
+
+Keycloak, as a leading open-source identity and access management solution, provides the robust capabilities needed for effective SSO integration. When combined with a powerful orchestration platform like Kestra, Keycloak ensures that your automated processes are not only efficient but also securely governed, with streamlined user access and auditable control over every execution. This guide explores how to achieve this integration.
+
+## Understanding Keycloak and the Power of Single Sign-On
+
+Single Sign-On is a foundational component of modern IT security and operations. Instead of requiring users to maintain separate credentials for every application, SSO enables them to authenticate once with a central authority and gain access to all their permitted resources. This reduces password fatigue, minimizes the risk of credential theft, and simplifies access management for administrators.
+
+### How Keycloak centralizes identity and access management
+
+Keycloak is an open-source Identity and Access Management (IAM) solution that acts as this central authority, or Identity Provider (IdP). When an application needs to authenticate a user, it redirects them to Keycloak. Keycloak handles the login process—including multi-factor authentication—and, upon success, sends the user back to the application with a secure token that verifies their identity.
+
+This model decouples authentication from your applications. Your development teams no longer need to build and maintain complex, high-risk authentication logic. Instead, they integrate with Keycloak using standard protocols like OpenID Connect (OIDC) or SAML. This approach is fundamental to building a secure and scalable system, forming the basis for a comprehensive [Enterprise SSO Workflow Orchestration Guide](/resources/infrastructure/enterprise-sso-workflow-orchestration). For platforms like Kestra, this means that user login and API access can be managed consistently and securely, with detailed guidance available on [Kestra Enterprise authentication](/docs/enterprise/auth/authentication).
+
+## Key Advantages of Using Keycloak for Secure Workflow Orchestration
+
+Integrating Keycloak into your automation and orchestration stack provides immediate and significant benefits, moving beyond simple convenience to fundamentally improve security and efficiency.
+
+### Enhancing user experience and operational efficiency
+
+For users, the primary benefit is seamless access. A single login provides entry to all necessary tools, from dashboards to orchestration platforms, eliminating the friction of multiple passwords. For operations teams, this centralization simplifies user lifecycle management. Onboarding a new team member or revoking access for a departing one becomes a single action in Keycloak, which then propagates across all connected systems. This drastically reduces administrative overhead and the chance of human error.
+
+### Strengthening security posture with centralized control
+
+Security is the most critical advantage. Keycloak provides a single point for enforcing authentication policies, such as strong password requirements, session timeouts, and multi-factor authentication (MFA). All authentication events are logged and audited in one place, providing clear visibility into who is accessing what, and when. This centralized model is key to effective [workflow orchestration security](/resources/infrastructure/workflow-orchestration-security). It also enables fine-grained access control, where user roles and permissions defined in Keycloak can be used to implement [Role-Based Access Control (RBAC) in your workflows](/resources/infrastructure/rbac-workflow-orchestration), ensuring users can only view or execute the processes relevant to their function.
+
+### Leveraging open-source flexibility and a vibrant community
+
+As an Apache 2.0 licensed open-source project, Keycloak offers complete control and transparency. You can deploy it on your own infrastructure, whether on-premise or in a private cloud, ensuring data sovereignty and avoiding vendor lock-in. This is particularly important for organizations in regulated industries. The vibrant community contributes to a rich ecosystem of extensions, themes, and integrations, allowing you to customize Keycloak to fit your exact needs without the high costs associated with proprietary solutions.
+
+## Configuring Keycloak for Single Sign-On Integration
+
+Setting up Keycloak for SSO involves a few core concepts: realms and clients. Understanding these is the first step toward a successful integration.
+
+### Setting up realms and clients in Keycloak
+
+A **Realm** in Keycloak is an isolated space that manages a set of users, credentials, roles, and groups. A single Keycloak instance can manage multiple realms, allowing you to create distinct security domains for different departments, environments (dev, staging, prod), or customer tenants.
+
+A **Client** is an entity that requests authentication from Keycloak. This could be a web application, a service, or an orchestration platform like Kestra. When you register a client in a Keycloak realm, you define how that application is allowed to interact with Keycloak, including its redirect URIs and the specific authentication protocol it will use. You can find detailed instructions on how to [configure SSO with various providers in Kestra](/docs/enterprise/auth/sso), which provides a solid foundation for understanding the client setup process. The overall platform [configuration settings](/docs/configuration) also play a role in how Kestra integrates with external services like Keycloak.
+
+### Choosing the right protocol: SAML vs. OpenID Connect (OIDC)
+
+Keycloak supports the two most common protocols for SSO: SAML 2.0 and OpenID Connect (OIDC).
+
+*   **SAML (Security Assertion Markup Language)** is an older, XML-based standard that is well-established in enterprise environments. It's often used for integrating with legacy systems or third-party services that have long-standing SAML support. SAML operates on the principle of exchanging assertions between an IdP (Keycloak) and a Service Provider (your application).
+
+*   **OpenID Connect (OIDC)** is a modern identity layer built on top of the OAuth 2.0 authorization framework. It uses lightweight JSON Web Tokens (JWTs) and is designed for today's API-driven, mobile-first world. OIDC is generally easier to implement, more flexible, and provides a richer set of user information through a standardized endpoint. For modern applications and platforms like Kestra, OIDC is the recommended protocol for SSO integration.
+
+The choice depends on your application stack. If you are integrating with modern, cloud-native applications, OIDC is almost always the better choice. If you need to connect with older, on-premise enterprise software, you will likely need to use SAML.
+
+## Integrating Keycloak SSO with Kestra for Declarative Workflows
+
+Kestra Enterprise is designed to integrate seamlessly with identity providers like Keycloak, enabling secure access to the UI and API, and automating user management at scale.
+
+### Setting up OpenID Connect (OIDC) SSO for Kestra Enterprise
+
+Integrating Kestra with Keycloak is a straightforward process using OIDC. The goal is to configure Kestra to trust Keycloak as its authentication source. This involves creating a client in your Keycloak realm specifically for Kestra and then providing the client credentials and discovery endpoint to your Kestra configuration file. The process ensures that when a user tries to access the Kestra UI, they are redirected to Keycloak for login. Once authenticated, Kestra receives an ID token and grants access based on the user's identity and group memberships. A detailed, step-by-step guide is available in the documentation for [setting up Keycloak as an OIDC identity provider](/docs/enterprise/auth/sso/keycloak).
+
+### Automating user and group provisioning with SCIM
+
+Beyond authentication, managing user lifecycle is critical. **SCIM (System for Cross-domain Identity Management)** is a standard protocol for automating user provisioning. By configuring SCIM between Keycloak and Kestra, you can automatically create, update, and deactivate users and groups in Kestra whenever changes are made in Keycloak. For example, when a new engineer joins the team and is added to the "PlatformEngineers" group in Keycloak, a corresponding user and group can be created in Kestra automatically, with the correct permissions assigned. This eliminates manual administration and ensures access rights are always in sync. You can learn more about this in the guide to [Keycloak SCIM provisioning in Kestra](/docs/enterprise/auth/scim/keycloak).
+
+### Orchestrating Keycloak-secured tasks and processes with Kestra
+
+The integration extends beyond just user access to the platform itself. Kestra workflows often need to interact with services that are secured by Keycloak. A Kestra flow can be configured to obtain an OAuth 2.0 token from Keycloak and use it to authenticate API calls to other services.
+
+Here is a conceptual YAML example of a Kestra task that retrieves a token from Keycloak to call a secured API:
+
+```yaml
+id: call-secured-api-with-keycloak
+namespace: company.team.production
+
+tasks:
+  - id: get-keycloak-token
+    type: io.kestra.plugin.core.http.Request
+    uri: https://keycloak.yourcompany.com/realms/myrealm/protocol/openid-connect/token
+    method: POST
+    contentType: application/x-www-form-urlencoded
+    body:
+      grant_type: client_credentials
+      client_id: "kestra-service-account"
+      client_secret: "{{ secrets.KEYCLOAK_CLIENT_SECRET }}"
+
+  - id: call-protected-service
+    type: io.kestra.plugin.core.http.Request
+    uri: https://api.internal/data-endpoint
+    headers:
+      Authorization: "Bearer {{ outputs['get-keycloak-token'].body | json.access_token }}"
+```
+
+This declarative approach to [Keycloak workflow integration](/resources/infrastructure/keycloak-workflow-integration) ensures that even automated processes adhere to your central security policies.
+
+## Advanced Keycloak Features for Enterprise-Grade Orchestration
+
+For large-scale or complex environments, Keycloak offers advanced features that are crucial for maintaining security and operational agility.
+
+### Implementing identity brokering and user federation
+
+**Identity Brokering** allows Keycloak to act as a bridge between your applications and other identity providers. For example, you can configure Keycloak to allow users to log in with their Google, GitHub, or an enterprise SAML provider account. Keycloak handles the protocol translation, presenting a consistent OIDC interface to your applications while managing the upstream authentication. This is useful for organizations that use multiple identity sources.
+
+**User Federation** enables Keycloak to connect to existing user directories like LDAP or Active Directory. Instead of importing users, Keycloak can query these directories in real-time for authentication and user attribute lookups, making it a single control plane over existing identity stores.
+
+### Ensuring secure sessions with single logout (SLO)
+
+While SSO simplifies login, Single Logout (SLO) ensures a secure exit. When a user logs out of one application, SLO ensures their session is terminated across all other applications in the SSO session, as well as their session with Keycloak itself. This prevents orphaned, active sessions that could be exploited.
+
+### Customizing Keycloak with themes and extensions
+
+Keycloak's appearance and functionality can be fully customized. You can apply custom themes to the login pages to match your company's branding, creating a seamless user experience. You can also develop custom extensions using Java to add new features, integrate with proprietary systems, or implement custom authentication flows. This extensibility allows you to adapt Keycloak to fit any enterprise requirement, whether it's integrating with [Authentik as an OIDC provider](/docs/enterprise/auth/sso/authentik) or setting up [Google OIDC SSO](/docs/enterprise/auth/sso/google-oidc).
+
+## Best Practices and Troubleshooting Keycloak SSO Deployments
+
+A successful Keycloak deployment relies on careful planning and adherence to security best practices.
+
+### Common challenges and effective solutions for Keycloak integration
+
+One common issue is misconfigured redirect URIs, which can lead to authentication failures. Always ensure that the valid redirect URIs registered in your Keycloak client configuration exactly match the URLs your application uses. Another challenge can be token validation; ensure your application correctly verifies the signature, issuer, and expiration of JWTs received from Keycloak. For complex integrations, understanding how to secure interactions, such as implementing [webhook security best practices](/resources/infrastructure/webhook-security-best-practices), is essential. Securely managing service account credentials within your orchestration platform is also critical, as outlined in the documentation on [Kestra credentials](/docs/enterprise/auth/credentials).
+
+### Secure deployment and operational guidelines
+
+For production environments, always run Keycloak in a high-availability cluster behind a load balancer with SSL/TLS termination. Use a robust external database like PostgreSQL instead of the default embedded H2 database. Regularly back up your Keycloak database, as it contains all your configuration and user data. Monitor the health of your Keycloak instance, paying attention to performance metrics and logs to proactively identify issues.
+
+## Keycloak Alternatives and When to Consider Other Identity Providers
+
+While Keycloak is a powerful and flexible open-source solution, it's not the only option. The right choice depends on your organization's scale, resources, and specific needs.
+
+### Evaluating the landscape of identity and access management solutions
+
+The IAM market includes both commercial SaaS products and other open-source projects:
+*   **Managed Cloud Services (IDaaS):** Providers like **Okta**, **Auth0 (now part of Okta)**, and **Azure Active Directory** offer fully managed SSO solutions. They reduce operational burden but come with subscription costs and less customization. Kestra provides direct documentation for integrations like [setting up Okta OIDC SSO](/docs/enterprise/auth/sso/okta).
+*   **Other Open-Source Solutions:** Projects like **Authentik** or **FusionAuth** offer alternative feature sets and architectural approaches that might better suit certain use cases.
+*   **Directory Services:** For simpler needs, direct integration with an [LDAP directory](/docs/enterprise/auth/sso/ldap) might be sufficient, although this lacks the broader protocol support of a full IAM solution.
+
+Keycloak excels when you need a powerful, customizable, and self-hosted solution without licensing fees. However, if your team lacks the resources to manage the infrastructure, or if your needs are fully met by a managed service, an alternative might be a better fit. Platforms like Kestra remain flexible, designed to integrate with the identity provider that best suits your enterprise architecture.

--- a/src/contents/resources/qlik-alternatives/index.md
+++ b/src/contents/resources/qlik-alternatives/index.md
@@ -1,0 +1,177 @@
+---
+title: "Top Qlik Alternatives and Competitors in 2026"
+description: "Explore the leading alternatives to Qlik Sense for business intelligence and Qlik Replicate/Talend for data integration. Find the right tool for your data, analytics, and platform engineering needs."
+metaTitle: "Top Qlik Alternatives & Competitors in 2026"
+metaDescription: "Comparing the best Qlik alternatives for BI, analytics, and data integration in 2026. Discover features, pricing, and fit for your enterprise data stack."
+tag: "data"
+date: 2026-06-29
+slug: "qlik-alternatives"
+faq:
+  - question: "Is QlikView end of life?"
+    answer: "Qlik announced that support for QlikView 11 ended on March 31, 2018. While QlikView is still in use, it is no longer actively marketed to new customers. Organizations are encouraged to upgrade to QlikView 12 or migrate to Qlik Sense for continued support and new features."
+  - question: "Is Qlik like Power BI or Tableau?"
+    answer: "Qlik, Power BI, and Tableau are all leading business intelligence platforms, but they differ in approach. Qlik excels at exploratory data analysis with its unique associative engine, while Tableau is known for visual polish and storytelling. Power BI offers strong integration within the Microsoft ecosystem and a user-friendly interface. The best choice depends on specific organizational needs, existing tech stack, and user skill sets."
+  - question: "Is QlikView still relevant in 2026?"
+    answer: "While QlikView is still utilized by some organizations, it is not actively marketed to new customers, with Qlik Sense being the primary focus for modern BI. Qlik provides annual releases for compatibility and improvements, but teams seeking cutting-edge features, cloud-native capabilities, and broader integration often look to Qlik Sense or other modern BI tools."
+  - question: "What is the best free alternative to Qlik?"
+    answer: "For teams seeking a free alternative to Qlik, options like Apache Superset offer robust open-source data visualization. For data integration, open-source tools like Airbyte provide flexible ETL capabilities. Kestra also offers a powerful open-source edition for orchestrating data pipelines and integrating various BI tools."
+  - question: "Can Kestra replace Qlik directly?"
+    answer: "Kestra does not directly replace Qlik's business intelligence or data visualization capabilities. Instead, Kestra serves as an orchestration control plane that can unify and automate data pipelines, feeding data into Qlik Sense or other BI tools. It excels at connecting diverse systems, managing data integration workflows (similar to Qlik Replicate/Talend), and ensuring data quality before it reaches your analytics platform."
+  - question: "How does Kestra compare to Power BI for data analytics?"
+    answer: "Kestra and Power BI serve different functions. Power BI is a business intelligence and data visualization tool, designed for creating dashboards and reports. Kestra is an orchestration platform that automates the underlying data pipelines, ensuring data is prepared, transformed, and delivered reliably to tools like Power BI. They are complementary, with Kestra managing the data backend and Power BI handling the frontend analytics."
+---
+
+Qlik has long been a powerhouse in business intelligence and data integration, known for its powerful associative engine and comprehensive platform. However, as data ecosystems evolve and organizations seek greater flexibility, cost efficiency, or specific cloud-native capabilities, many are evaluating alternatives. The market is dynamic, with new solutions emerging and established players refining their offerings, creating a compelling landscape for change.
+
+This article explores the top Qlik alternatives across both its Business Intelligence (Qlik Sense) and Data Integration (Qlik Replicate/Talend) product lines. We'll delve into each competitor's strengths, ideal use cases, and how they stack up against Qlik's offerings, helping you navigate the options and choose the platform that best aligns with your enterprise data strategy in 2026.
+
+## The Evolving Need for Qlik Alternatives
+
+### Why Organizations Seek New BI and Data Integration Solutions
+
+While Qlik remains a strong contender, several factors drive organizations to explore the market for alternatives. Cost of ownership is a primary concern, as licensing and maintenance for comprehensive enterprise platforms can be significant. Teams also face challenges with the complexity of managing and scaling a monolithic BI suite, leading them to seek more modular, best-of-breed solutions.
+
+The rise of open-source software has created a strong desire for flexibility and the avoidance of vendor lock-in. Many data teams now prefer tools that integrate seamlessly into their existing GitOps and Infrastructure-as-Code practices. Furthermore, a specific cloud strategy, such as standardizing on AWS, Azure, or GCP, can make a cloud-native BI tool a more natural fit. Finally, there's a growing need for broader [data orchestration](/resources/data/data-orchestration) that extends beyond the capabilities of traditional [ETL orchestration tools](/resources/data/etl-orchestration-tool-alternatives), unifying data pipelines, infrastructure automation, and business processes under a single control plane.
+
+## How We Evaluated Top Qlik Competitors
+
+To provide a balanced comparison, we evaluated each alternative based on a consistent set of criteria relevant to modern data teams. We considered the deployment model (cloud-native, hybrid, or on-premise), licensing and pricing transparency, and the primary use case fit—whether the tool specializes in BI, data integration, or offers a combined platform. We also assessed the breadth and depth of the integration ecosystem, the health of the community for open-source projects, scalability for enterprise workloads, and the overall operational overhead required to maintain the solution.
+
+## Kestra: The Open-Source Orchestration Control Plane for Your Data Stack
+
+Kestra is not a direct replacement for Qlik's BI visualization layer. Instead, it serves as a powerful, open-source orchestration control plane that automates, schedules, and manages the complex data pipelines that feed BI tools like Qlik Sense, Power BI, or Tableau.
+
+Workflows in Kestra are defined in declarative YAML, making them easy to version, review, and manage alongside your other code. The platform is language-agnostic, capable of running tasks in Python, SQL, Bash, and more, all within a single workflow. This flexibility is critical for teams using a diverse set of technologies. Kestra's event-driven architecture enables real-time data flows, ensuring that your BI dashboards are always powered by the freshest data.
+
+With an extensive plugin ecosystem, Kestra connects to virtually any tool in the modern data stack, including databases, cloud services, messaging queues, and specialized tools like dbt and Airbyte. This makes it an ideal solution for replacing legacy data integration jobs or building a robust foundation for a modern [data platform](/data). For instance, JPMorgan Chase uses Kestra for cybersecurity analytics orchestration, processing billions of rows of data that feed their analytical systems. Similarly, Leroy Merlin France leveraged Kestra to build a DataMesh at scale, increasing their data production by 900%.
+
+**Best for:** Data, analytics, and platform engineering teams seeking a unified, flexible, and auditable platform to prepare and deliver data to BI tools. It's a strong alternative for the data integration and automation capabilities found in Qlik Replicate or Qlik Talend Cloud, providing a more versatile and open control plane for all your [data pipeline](/resources/data/data-pipeline) needs.
+
+## Top Qlik Sense Alternatives for Business Intelligence and Analytics
+
+### Microsoft Power BI: Deep Integration within the Microsoft Ecosystem
+
+Power BI is a market leader in business intelligence, renowned for its strong data visualization capabilities and user-friendly interface. Its primary strength lies in its deep integration with the Microsoft ecosystem, including Azure services, Office 365, and Dynamics 365. This makes it a highly cost-effective and seamless choice for organizations already invested in Microsoft's technology stack.
+
+**Limitation:** While powerful within its ecosystem, Power BI can be less flexible when dealing with non-Microsoft data sources. Managing very large or disparate datasets from multiple external systems can introduce complexity.
+
+**Best for:** Organizations deeply invested in the Microsoft stack who need a powerful, user-friendly BI tool that integrates effortlessly with their existing software.
+
+### Tableau (Salesforce): Visual Storytelling and Data Exploration
+
+Tableau has built its reputation on best-in-class visual analytics and interactive dashboards. It empowers users to create compelling data stories and explore complex datasets through an intuitive drag-and-drop interface. The platform is supported by a large and active community that provides extensive resources and support.
+
+**Limitation:** Tableau can be one of the more expensive options, and its advanced features come with a steeper learning curve. Its focus is primarily on visualization and exploration, with less emphasis on the data preparation and ETL functionalities that are part of Qlik's broader suite.
+
+**Best for:** Teams with dedicated data analysts who prioritize advanced data visualization, interactive data exploration, and powerful data storytelling capabilities.
+
+### Domo: Cloud-Native Business Management Platform
+
+Domo positions itself as more than just a BI tool; it's a comprehensive, cloud-native business management platform. It offers strong capabilities in data integration, connecting hundreds of data sources out of the box. Its strengths include real-time executive dashboards, mobile BI, and an all-in-one approach to data management and analytics.
+
+**Limitation:** Domo's all-in-one model can lead to higher costs and potential vendor lock-in. Teams may find they have less granular control over the underlying infrastructure compared to more modular solutions.
+
+**Best for:** Enterprises looking for a fully managed, all-in-one cloud BI and data management solution to deliver executive and operational insights.
+
+### Looker (Google Cloud): Data Modeling and Governed Analytics
+
+Looker, now part of Google Cloud, differentiates itself with a powerful semantic data modeling layer called LookML. This allows organizations to define business logic and metrics centrally, ensuring consistency and governance across all reports and dashboards. It also offers strong embedded analytics capabilities and deep integration with the Google Cloud ecosystem.
+
+**Limitation:** The LookML modeling layer introduces a steeper learning curve, particularly for non-technical users. Looker is primarily a cloud-based solution and can be a costly option for some organizations.
+
+**Best for:** Data-driven organizations that prioritize strong data governance, consistent metrics across the business, and deep integration with Google Cloud Platform.
+
+### ThoughtSpot: AI-Powered Analytics and Search-Driven BI
+
+ThoughtSpot takes a different approach to BI, focusing on AI-powered analytics and a search-driven interface. Users can ask questions of their data using natural language and receive instant, AI-generated insights and visualizations. This democratizes data access, allowing business users to perform self-service analytics without needing to build dashboards.
+
+**Limitation:** ThoughtSpot places less emphasis on traditional, pixel-perfect dashboard creation. Its advanced, AI-driven capabilities also mean it can be a premium-priced solution.
+
+**Best for:** Organizations aiming to empower business users with self-service analytics through natural language queries and AI-powered insights.
+
+## Leading Qlik Replicate and Data Integration Alternatives
+
+### Fivetran HVR: High-Volume Enterprise Data Replication
+
+Fivetran's High Volume Replicator (HVR) is a specialized tool for real-time Change Data Capture (CDC) and high-performance data replication. It excels at moving large volumes of data with low latency from a wide variety of sources, including relational databases and enterprise applications, to destinations like data warehouses and data lakes.
+
+**Limitation:** Fivetran HVR is primarily focused on the replication part of the data pipeline. It offers fewer capabilities for complex data transformations or broader workflow orchestration compared to a full-fledged ETL or orchestration platform.
+
+**Best for:** Enterprises that require high-fidelity, low-latency data replication to power their data warehousing and real-time analytics initiatives.
+
+### Airbyte: Open-Source Data Integration for ELT
+
+Airbyte is a rapidly growing open-source data integration platform with a strong focus on the ELT (Extract, Load, Transform) paradigm. Its main strength is a massive and expanding ecosystem of over 300 pre-built connectors. It offers flexible deployment options, allowing teams to self-host the open-source version or use Airbyte's managed cloud offering.
+
+**Limitation:** The open-source version requires self-hosting and operational management. While it supports CDC, it may not match the real-time performance of dedicated replication tools like Fivetran HVR for high-volume use cases.
+
+**Best for:** Data teams looking for a flexible, extensible, and cost-effective open-source ELT platform to integrate data from a diverse range of sources.
+
+### Informatica: Enterprise Data Management and Integration
+
+Informatica is an established leader in the enterprise data management space. Its Intelligent Data Management Cloud (IDMC) offers a comprehensive suite of tools covering ETL, data quality, master data management (MDM), and data governance. It is designed to handle complex, heterogeneous data environments in large enterprises.
+
+**Limitation:** The platform's extensive feature set can be complex to implement and manage. The cost can be prohibitive for smaller teams, and the sheer breadth of capabilities can be overwhelming if you only need a subset of its functionality.
+
+**Best for:** Large enterprises with complex data landscapes, stringent data governance requirements, and the need for a comprehensive, end-to-end data management solution.
+
+### Striim: Real-Time Data Integration and Streaming Analytics
+
+Striim is a unified platform focused on real-time data integration and streaming analytics. It specializes in ingesting, processing, and analyzing high-velocity data from various sources using CDC and event processing. This enables organizations to build real-time data pipelines and derive immediate insights from their operational data.
+
+**Limitation:** Striim's niche focus on real-time stream processing makes it more complex than batch-oriented [ETL pipeline tools](/resources/data/etl-pipeline-tools) for simple data movement tasks. It is best suited for use cases where real-time is a mandatory requirement.
+
+**Best for:** Organizations that need to build real-time data pipelines for use cases like fraud detection, operational monitoring, and streaming analytics.
+
+## Qlik Alternatives Comparison Table
+
+| Tool | License | Deployment | Primary Use Case | Key Strengths | Starting Price |
+|---|---|---|---|---|---|
+| **Kestra** | Open-Source & Enterprise | Cloud, Hybrid, On-Prem | Data & Workflow Orchestration | Declarative YAML, Language-Agnostic, Event-Driven | Free Open-Source |
+| **Power BI** | Commercial | Cloud, On-Prem | Business Intelligence | Microsoft Ecosystem Integration, Ease of Use | Per User/Month |
+| **Tableau** | Commercial | Cloud, On-Prem | Business Intelligence | Advanced Visualization, Data Storytelling | Per User/Month |
+| **Domo** | Commercial | Cloud | BI & Data Management | All-in-One Platform, Executive Dashboards | Contact Sales |
+| **Looker** | Commercial | Cloud | Business Intelligence | Data Governance, Semantic Modeling (LookML) | Contact Sales |
+| **ThoughtSpot** | Commercial | Cloud | Business Intelligence | AI-Powered, Natural Language Search | Contact Sales |
+| **Fivetran HVR** | Commercial | Cloud, Hybrid, On-Prem | Data Replication (CDC) | Real-Time, High-Volume Replication | Contact Sales |
+| **Airbyte** | Open-Source & Commercial | Cloud, Self-Hosted | Data Integration (ELT) | Large Connector Ecosystem, Open-Source | Free Open-Source |
+| **Informatica** | Commercial | Cloud, Hybrid | Enterprise Data Management | Comprehensive Suite, Data Governance | Contact Sales |
+| **Striim** | Commercial | Cloud, Hybrid, On-Prem | Streaming Data Integration | Real-Time Processing, Streaming Analytics | Contact Sales |
+
+## Choosing the Right Qlik Alternative for Your Enterprise
+
+### For Data Engineering Teams
+
+Data engineering teams should prioritize robustness, scalability, and integration capabilities. Open-source options are often favored for their flexibility.
+*   **Kestra:** Ideal for orchestrating the entire data lifecycle, from ingestion to delivery, with auditable, code-based workflows.
+*   **Airbyte:** A strong choice for teams needing a wide range of connectors for ELT pipelines.
+*   **Fivetran HVR:** The best fit when the primary requirement is high-performance, real-time data replication.
+
+### For Business Intelligence and Analytics Teams
+
+These teams focus on visualization quality, ease of use for business users, and strong data governance features.
+*   **Power BI:** The go-to for organizations heavily invested in the Microsoft ecosystem.
+*   **Tableau:** Best for teams that need to create sophisticated visualizations and compelling data narratives.
+*   **ThoughtSpot:** A great option for empowering non-technical users to explore data independently through search.
+
+Find more resources on building a modern data platform on our [Data Engineering Resources page](/data).
+
+### For Infrastructure and Platform Teams
+
+Platform teams value deployment flexibility, adherence to [GitOps](/resources/infrastructure/gitops) principles, and the ability to manage workflows as code.
+*   **Kestra:** A natural fit due to its declarative YAML interface, API-first design, and flexible deployment on Kubernetes or standalone.
+*   **Airbyte (Self-Hosted):** Offers the control and customization that platform teams require for managing data integration infrastructure.
+
+Explore how to build a unified control plane for all your automation needs on our [Infrastructure Automation page](/infra-automation).
+
+## Future-Proofing Your Data and Analytics Stack
+
+The modern data landscape is defined by constant change. To stay agile, organizations are moving away from monolithic, all-in-one platforms toward more flexible, composable architectures. This approach, often aligned with the principles of [Everything as Code](/resources/infrastructure/everything-as-code), allows teams to select the best tool for each specific job—be it visualization, replication, or transformation.
+
+An agnostic orchestration layer is the key to making this composable stack work. By separating the "how" (the workflow logic) from the "what" (the individual tools), a platform like Kestra provides a stable, unified control plane. This enables you to swap tools in and out of your [data pipelines](/resources/data/data-pipeline) without rewriting your entire orchestration logic, ensuring your data stack is resilient and future-ready.
+
+## Conclusion: Beyond Qlik – Orchestrating Your Modern Data Ecosystem
+
+The search for a Qlik alternative reveals a diverse and specialized market. The "best" choice is highly contextual, depending on whether your primary need is for intuitive BI dashboards, high-volume data replication, or a comprehensive enterprise data management suite.
+
+Rather than seeking a single tool to do everything, leading organizations are building composable data platforms. In this new paradigm, the most critical component is the orchestration backbone that connects and automates these specialized tools. [Kestra](/) provides this open-source, declarative control plane, allowing you to build reliable, scalable, and adaptable data workflows that power your entire data and analytics ecosystem.

--- a/src/contents/resources/talend-alternatives/index.md
+++ b/src/contents/resources/talend-alternatives/index.md
@@ -1,0 +1,254 @@
+---
+title: "Top Talend Alternatives for Modern Data Integration in 2026"
+description: "Talend users exploring new options? Discover leading Talend alternatives for ETL, ELT, and data orchestration, comparing cloud-native, open-source, and unified platforms like Kestra."
+metaTitle: "Talend Alternatives: Top Data Integration Tools (2026)"
+metaDescription: "Find top Talend alternatives for 2026. Explore cloud-native, open-source, and unified platforms for modern data integration and orchestration needs."
+tag: "data"
+date: 2026-07-01
+slug: "talend-alternatives"
+faq:
+  - question: "What is similar to Talend?"
+    answer: "Talend's capabilities in data integration, ETL, and data quality are shared by several modern alternatives. These include cloud-native platforms like Fivetran and Matillion, open-source tools such as Airbyte and Apache NiFi, and unified orchestration platforms like Kestra that offer declarative, polyglot workflow management."
+  - question: "Is Talend outdated?"
+    answer: "While Talend (now Qlik Talend Cloud) remains a capable data integration platform, its legacy architecture and commercial model can feel less aligned with modern cloud-native, open-source, and developer-centric trends. Many users seek alternatives due to perceived operational overhead or a desire for more flexible, code-first approaches."
+  - question: "What are the top ETL tools in 2026?"
+    answer: "In 2026, top ETL tools span various categories. Leading cloud-native options include Matillion, AWS Glue, and Azure Data Factory. For open-source, Airbyte and Apache NiFi are popular. Kestra offers a declarative, event-driven approach to orchestrate ETL alongside other workflows, making it a strong contender for unified platforms."
+  - question: "Which ETL tool is in demand in 2026?"
+    answer: "In 2026, tools emphasizing cloud-native integration, strong developer experience, and broad orchestration capabilities are in high demand. Kestra, with its declarative YAML and polyglot execution, addresses the need for unified orchestration. Managed ELT services like Fivetran and cloud-native ETL platforms like Matillion also see strong demand for their specialized capabilities."
+  - question: "Can Kestra replace Talend for data integration?"
+    answer: "Kestra offers a powerful, declarative orchestration engine that can manage complex data integration workflows, including ETL and ELT. While Kestra isn't a direct drag-and-drop replacement for Talend's visual data mapping, it excels at orchestrating diverse data tools (dbt, Airbyte, SQL scripts) with YAML, providing a flexible and auditable alternative for data engineers."
+  - question: "How does Kestra compare to Fivetran for data ingestion?"
+    answer: "Fivetran specializes in automated, managed data ingestion, offering a vast library of connectors to replicate data into a warehouse. Kestra, on the other hand, is an orchestration platform that can trigger and manage Fivetran connectors as part of a larger workflow, or handle custom ingestion via its own plugins and polyglot tasks, offering more control and broader workflow capabilities."
+  - question: "What is Qlik Talend Cloud?"
+    answer: "Qlik Talend Cloud is the current commercial offering for Talend's data integration and data management platform, following Qlik's acquisition of Talend in May 2023. It provides a cloud-native suite for data integration, data quality, and data governance, integrated within the broader Qlik data analytics ecosystem."
+---
+
+For years, Talend has been a familiar name in data integration, empowering organizations with its comprehensive suite for ETL, data quality, and master data management. However, as the data landscape shifts towards cloud-native architectures, real-time processing, and unified orchestration, many data teams are re-evaluating their tool stack. The acquisition by Qlik in 2023 further prompted a fresh look at long-term strategies, with a growing number of data professionals exploring alternatives that better align with modern developer practices and hybrid cloud environments.
+
+The search for Talend alternatives isn't about discarding past investments, but about adapting to new demands: declarative workflows, polyglot execution, and the ability to orchestrate data, AI, and infrastructure from a single control plane. This article will guide you through the leading alternatives to Talend in 2026, including open-source projects, cloud-native platforms, and unified orchestration engines like Kestra. We'll compare their core strengths, highlight their ideal use cases, and provide a framework to help you choose the right solution to future-proof your data strategy.
+
+## The Evolving Need for Talend Alternatives
+
+Talend established itself as a leader in an era dominated by on-premise data warehouses and structured ETL jobs. Its visual, job-based designer became a standard for many data professionals. But the ground has shifted, and the drivers for seeking alternatives are rooted in the architectural and cultural changes reshaping the data industry.
+
+### Why Teams Seek Modern Data Integration Solutions
+
+Modern data teams operate in a more complex, heterogeneous environment than ever before. Several factors drive the search for new tools:
+
+*   **Shift to Cloud-Native and Hybrid Models:** The center of gravity for data has moved to the cloud. Teams need tools that are not just "cloud-enabled" but are fundamentally built for services like Snowflake, BigQuery, Redshift, and Databricks. This includes seamless integration with cloud storage, serverless compute, and containerization.
+*   **Developer-Centric Workflows:** There is a growing preference for declarative, code-based approaches (like YAML or SQL) over purely visual, drag-and-drop interfaces. Code-first workflows align better with GitOps practices, enabling version control, automated testing, and CI/CD for data pipelines.
+*   **Cost and Licensing Complexity:** Traditional enterprise licensing models can be opaque and expensive. Per-user or per-connector pricing can become prohibitive as teams and data sources scale. Many organizations are now exploring [open-source ETL tools](/resources/data/open-source-etl-tool) or platforms with more transparent, consumption-based pricing.
+*   **Demand for Broader Orchestration:** Data pipelines no longer exist in a silo. They are part of a larger ecosystem that includes infrastructure provisioning (Terraform), ML model training, and business process automation. A tool that only handles data integration may create another silo, leading to a desire for a single control plane that can orchestrate workflows across all these domains.
+
+### Is Talend Outdated for Today's Data Challenges?
+
+Calling Talend "outdated" is an oversimplification. Qlik Talend Cloud is a powerful and feature-rich platform. However, its architectural roots and primary authoring paradigm can feel less aligned with the needs of modern, agile data teams.
+
+The core friction often arises from its legacy as a Java-based, visual-first tool. While this approach is accessible, it can lead to challenges in versioning, debugging, and collaboration compared to declarative systems where the workflow definition is a simple text file. For teams that have embraced Infrastructure as Code and Everything as Code principles, forcing data pipelines into a different, UI-driven paradigm can feel like a step backward. The post-acquisition integration into the Qlik ecosystem also raises valid concerns about vendor lock-in and long-term roadmap alignment for non-Qlik users.
+
+## Key Criteria for Evaluating Talend Alternatives
+
+When moving on from an established platform, it's crucial to evaluate replacements against a clear set of criteria. Beyond a simple feature-for-feature comparison, consider the architectural and operational impact of each potential tool.
+
+*   **Deployment Flexibility:** Can the tool run where your data and applications live? Look for support for multi-cloud, hybrid, on-premise, and Kubernetes-native deployments.
+*   **Authoring Model:** Does the tool align with your team's workflow? Compare declarative YAML, code-first SDKs (Python, SQL), and visual drag-and-drop interfaces. The best tools often combine these, with a declarative core.
+*   **Data Processing Capabilities:** Assess support for modern data patterns. This includes not just traditional ETL but also ELT, Reverse ETL, and event-driven streaming. Understanding the [key differences between ETL and ELT](/resources/data/etl-vs-elt) is fundamental to this evaluation.
+*   **Ecosystem and Connectivity:** A rich library of pre-built connectors and plugins is essential for rapid integration. Also, evaluate the ease of building custom connectors for bespoke applications or internal APIs.
+*   **Scalability and Performance:** How does the tool scale with data volume and workflow complexity? Look for architectures that support distributed execution, parallel processing, and efficient resource management.
+*   **Data Governance and Quality:** Features like data lineage, observability, and built-in data quality checks are critical for building trust in your data pipelines.
+*   **Pricing and Total Cost of Ownership (TCO):** Analyze the pricing model (consumption-based, per-user, per-node) and factor in the operational overhead of managing the platform. Open-source solutions may have no license fee but require more engineering effort to maintain.
+
+## Top Talend Alternatives for Modern Data Orchestration
+
+The market offers a diverse range of alternatives, each with a different architectural philosophy and target audience. Here are ten leading options to consider.
+
+### 1. Kestra: The Declarative Orchestration Control Plane
+
+**One-line positioning:** Kestra is an open-source, declarative, event-driven orchestration platform unifying data, AI, and infrastructure workflows with YAML.
+
+**Best for:** Data and platform engineering teams seeking a language-agnostic, code-first orchestration layer that scales across diverse technical domains and integrates with existing tools.
+
+Kestra's philosophy is that orchestration should be as auditable, versionable, and scalable as the infrastructure it runs on. By defining all workflows as YAML, Kestra enables teams to treat their pipelines as code, integrating them seamlessly into GitOps and CI/CD processes. Its language-agnostic design means you can run Python scripts, SQL queries, shell commands, and Docker containers as first-class citizens within the same workflow, eliminating the need for wrapper code. For enterprises like Leroy Merlin, Kestra was key to implementing a DataMesh architecture at scale, increasing data production by 900%. Kestra is one of the most versatile [ETL orchestration tools](/resources/data/etl-orchestration-tool-alternatives).
+
+**Distinctive features:**
+*   **Declarative YAML Interface:** All workflows are defined in simple, readable YAML files.
+*   **Polyglot Task Execution:** Natively run Python, R, Julia, SQL, Shell, Node.js, and any code packaged in a Docker container.
+*   **Event-Driven Architecture:** Build reactive workflows that trigger on events from message queues (Kafka, SQS), webhooks, or file system changes.
+*   **Unified Orchestration:** A single platform for [data orchestration](/data), [infrastructure automation](/infra-automation), and [AI pipelines](/ai-automation).
+
+**Honest limitation:** Kestra is not a visual drag-and-drop data mapping tool like legacy Talend Studio; it requires comfort with a declarative, code-adjacent authoring experience in YAML.
+
+### 2. Fivetran: Automated ELT for Data Warehouses
+
+**One-line positioning:** A managed ELT service providing automated data replication from hundreds of sources to data warehouses.
+
+**Best for:** Data teams prioritizing fast, reliable, and low-maintenance data ingestion from a wide array of SaaS applications and databases into a central data warehouse.
+
+Fivetran's core value proposition is simplicity and reliability for the "Extract" and "Load" phases of data integration. It abstracts away the complexity of API changes, schema evolution, and pipeline maintenance. Teams can set up connectors in minutes and trust that data will be reliably delivered to their destination. This focus on managed ingestion has made it a popular choice for organizations that want to free up engineering time for higher-value transformation and analytics work.
+
+**Distinctive features:**
+*   **Vast Connector Library:** Over 300 pre-built, fully managed connectors for SaaS apps, databases, and events.
+*   **Automated Schema Evolution:** Automatically detects and propagates source schema changes to the destination.
+*   **Managed Service:** A zero-maintenance platform with consumption-based pricing.
+
+**Honest limitation:** Fivetran is primarily focused on ingestion (E and L in ELT); transformation (T) often happens downstream with tools like dbt. This means it solves one part of the data puzzle, and as one of our articles states, [data ingestion will never be fully solved](/blogs/2023-10-11-why-ingestion-will-never-be-solved) by a single tool.
+
+### 3. Matillion: Cloud-Native ETL for Data Warehouses
+
+**One-line positioning:** A cloud-native ETL platform designed for visual data transformation within cloud data warehouses.
+
+**Best for:** Cloud data teams that prefer a visual, low-code interface for building complex data transformations directly within their cloud data warehouse (e.g., Snowflake, BigQuery, Redshift).
+
+Matillion is designed to leverage the power of modern cloud data warehouses. Its push-down ETL architecture transforms data directly within the target warehouse, using its compute resources for maximum efficiency. This makes it a strong choice for teams that want to perform complex, large-scale transformations without moving data out of their cloud environment. Its visual interface provides a familiar experience for those coming from tools like Talend but is built from the ground up for the cloud.
+
+**Distinctive features:**
+*   **Push-Down ETL:** Leverages the native processing power of cloud data warehouses.
+*   **Rich Component Library:** A wide array of pre-built components for data transformation, cleansing, and enrichment.
+*   **Deep Integration:** Tightly integrated with Snowflake, BigQuery, Redshift, and Databricks.
+
+**Honest limitation:** Matillion is tightly coupled to specific cloud data warehouses; it is less flexible for multi-cloud or on-premise scenarios. It excels at [data warehouse ETL](/resources/data/data-warehouse-etl) but is less of a general-purpose orchestrator.
+
+### 4. Informatica: Enterprise Data Management Suite
+
+**One-line positioning:** A comprehensive suite of data management products covering integration, quality, governance, and master data management.
+
+**Best for:** Large enterprises with complex, heterogeneous data environments, strict regulatory requirements, and a need for a broad, integrated data management platform.
+
+Informatica is one of the original leaders in the data integration space and offers an enterprise-grade platform with a vast set of capabilities. Its Intelligent Data Management Cloud (IDMC) provides a unified experience for everything from data integration and application integration to data cataloging and governance. For large organizations with deep investments in legacy systems and complex compliance needs, Informatica remains a formidable option.
+
+**Distinctive features:**
+*   **Mature, Enterprise-Grade Platform:** Battle-tested with extensive features for security, governance, and compliance.
+*   **Broad Capabilities:** Goes far beyond ETL to include API management, data quality, and master data management.
+*   **Hybrid Integration:** Strong support for both cloud and on-premise data sources.
+
+**Honest limitation:** Informatica can be expensive, complex to implement and manage, and may have a steeper learning curve for modern cloud-native teams.
+
+### 5. Airbyte: Open-Source Data Integration Platform
+
+**One-line positioning:** An open-source data integration platform with a large and growing catalog of connectors for ELT.
+
+**Best for:** Developers and data engineers seeking an open-source, customizable, and extensible solution for data ingestion, with options for self-hosting or a managed cloud service.
+
+Airbyte has gained significant traction with its open-source, community-driven approach to data integration. It aims to commoditize data movement with a massive library of connectors that can be run on any Docker-compatible infrastructure. Its Connector Development Kit (CDK) makes it easy for developers to build new connectors, fostering a vibrant ecosystem.
+
+**Distinctive features:**
+*   **Open-Source and Extensible:** A large community contributes to a rapidly growing list of 350+ connectors.
+*   **Flexible Deployment:** Can be self-hosted on Docker or Kubernetes, or used via Airbyte Cloud.
+*   **Developer-Focused:** Features like a CDK, Terraform provider, and API-first design appeal to engineering teams.
+
+**Honest limitation:** Self-hosting Airbyte requires more operational effort to manage, scale, and maintain than fully managed SaaS solutions.
+
+### 6. Apache NiFi: Flow-Based Dataflow Automation
+
+**One-line positioning:** An open-source, flow-based data processing system for automating data movement and transformation between systems.
+
+**Best for:** Operations teams and data architects needing robust, real-time data routing, transformation, and provenance for streaming data, especially in complex, distributed environments.
+
+Apache NiFi excels at managing continuous data flows. Its visual, drag-and-drop interface allows users to build complex data routing and processing logic. It provides fine-grained control over data in motion, with features like guaranteed delivery, backpressure, and detailed data provenance that tracks every piece of data as it moves through the system.
+
+**Distinctive features:**
+*   **Visual Dataflow Programming:** An interactive, canvas-based UI for designing and monitoring dataflows.
+*   **Data Provenance:** Automatically records and indexes a complete, queryable history of all data that flows through the system.
+*   **Extensive Processor Library:** Over 300 built-in processors for data ingestion, routing, transformation, and delivery.
+
+**Honest limitation:** NiFi can have a steeper learning curve for basic batch ETL tasks; its model is better suited for continuous dataflow management than for orchestrating complex, multi-step batch transformations. There are several modern [Apache NiFi alternatives](/resources/data/apache-nifi-alternatives) that may be a better fit for batch workloads.
+
+### 7. AWS Glue: Serverless ETL in the AWS Cloud
+
+**One-line positioning:** A serverless data integration service that makes it easy to discover, prepare, move, and integrate data for analytics, machine learning, and application development.
+
+**Best for:** AWS-native organizations and data teams deeply invested in the AWS ecosystem, needing serverless ETL, data cataloging, and integration with other AWS services.
+
+AWS Glue is a fully managed ETL service that automates the heavy lifting of data integration. It can automatically discover and catalog your data, generate ETL scripts, and run them on a serverless Apache Spark-based platform. Its tight integration with the AWS ecosystem (S3, Redshift, RDS, etc.) makes it a natural choice for teams building their data platforms on AWS.
+
+**Distinctive features:**
+*   **Fully Serverless:** No infrastructure to provision or manage; pay only for the resources consumed during job execution.
+*   **Integrated Data Catalog:** A central metadata repository that can be shared across AWS services.
+*   **Spark-Based:** Leverages the power of Apache Spark for distributed data processing.
+
+**Honest limitation:** AWS Glue results in vendor lock-in; it is less suitable for multi-cloud or on-premise data integration strategies.
+
+### 8. Azure Data Factory: Cloud ETL/ELT for Azure
+
+**One-line positioning:** A fully managed, cloud-based data integration service that orchestrates and automates data movement and transformations across various data sources.
+
+**Best for:** Azure-centric data teams needing managed data integration, ETL/ELT pipelines, and orchestration within the Microsoft Azure ecosystem.
+
+Similar to AWS Glue for AWS, Azure Data Factory (ADF) is the native data integration service for the Microsoft Azure cloud. It offers a visual interface for building code-free ETL and ELT pipelines, with a rich set of connectors to Azure services and other data sources. It serves as the orchestration backbone for data-driven workflows within Azure.
+
+**Distinctive features:**
+*   **Visual Pipeline Designer:** A web-based UI for creating, scheduling, and monitoring pipelines.
+*   **Broad Connectivity:** Over 90 built-in connectors for ingesting data from various sources.
+*   **Integration with Azure Ecosystem:** Seamlessly works with Azure Synapse Analytics, Azure Databricks, and other Azure services.
+
+**Honest limitation:** Azure Data Factory creates strong vendor lock-in to the Azure ecosystem and is less ideal for multi-cloud or on-premise data integration needs.
+
+### 9. Coalesce: Data Transformation for Data Warehouses
+
+**One-line positioning:** A data transformation platform that enables analytics engineers to build, test, and deploy data transformations directly in their data warehouse.
+
+**Best for:** Analytics engineering teams using dbt and modern cloud data warehouses, who want a code-first, column-level approach to data transformation with built-in data quality and governance.
+
+Coalesce focuses specifically on the "T" in ELT, providing a powerful and efficient way to model data once it's inside a warehouse like Snowflake. It combines the speed of a visual interface with the rigor of code-based development, automatically generating standardized SQL from user-defined specifications. Its column-level lineage provides deep visibility into how data is transformed.
+
+**Distinctive features:**
+*   **Column-Level Lineage:** Granular visibility into data dependencies and transformations.
+*   **Automated Code Generation:** Generates standardized, templated SQL for dbt, improving consistency and productivity.
+*   **Focus on Analytics Engineering:** Built with the workflows of modern analytics engineers in mind.
+
+**Honest limitation:** Coalesce is primarily focused on transformation, assuming data is already loaded into the warehouse; it is not a tool for data ingestion.
+
+### 10. Domo: BI Platform with Integrated Data Integration
+
+**One-line positioning:** A cloud-native business intelligence platform that combines data integration, analytics, and visualization capabilities.
+
+**Best for:** Business users and analysts who need an all-in-one platform for data integration, visualization, and analytics, often without deep technical expertise.
+
+Domo is a BI and analytics platform first, but it includes robust data integration capabilities as part of its end-to-end offering. It provides a large number of connectors to bring data into its platform, where it can then be transformed, visualized, and analyzed. This all-in-one approach is appealing for departments or smaller companies that want a single tool to handle their entire data workflow from source to dashboard.
+
+**Distinctive features:**
+*   **End-to-End Platform:** Covers the entire analytics lifecycle from data connection to visualization and reporting.
+*   **User-Friendly Interface:** Designed for business users, with a focus on ease of use.
+*   **Strong Visualization and Mobile Capabilities:** Powerful tools for building interactive dashboards.
+
+**Honest limitation:** Domo can be expensive for large-scale data engineering tasks; it is primarily a BI tool with integration features, not a dedicated, standalone data orchestration platform for engineers.
+
+## Comparison of Leading Talend Alternatives
+
+Choosing the right tool depends on your specific needs. This table provides a high-level comparison of the alternatives discussed.
+
+| Tool | License | Deployment | Primary Focus | Authoring Model | Scalability | Pricing Model |
+|---|---|---|---|---|---|---|
+| **Kestra** | Open-Source (Apache 2.0) & Enterprise | Kubernetes, Docker, On-Prem, Cloud | Unified Orchestration (Data, AI, Infra) | Declarative YAML, UI | High (Distributed) | Open-Source (Free), Enterprise (Per-instance) |
+| **Fivetran** | Commercial | Managed SaaS | ELT (Ingestion) | UI | High (Managed) | Consumption-based |
+| **Matillion** | Commercial | Cloud (VPC) | ETL/ELT (Transformation) | Visual, Low-Code | High (Push-down) | Per-credit/instance |
+| **Informatica** | Commercial | Cloud, On-Prem, Hybrid | Enterprise Data Management | Visual, Low-Code | High (Enterprise) | Custom/Subscription |
+| **Airbyte** | Open-Source (MIT) & Commercial | Self-hosted (Docker, K8s), Cloud | ELT (Ingestion) | UI, API | High (Distributed) | Open-Source (Free), Cloud (Consumption) |
+| **Apache NiFi** | Open-Source (Apache 2.0) | On-Prem, Docker, K8s | Real-time Dataflow | Visual | High (Clustered) | Free |
+| **AWS Glue** | Commercial (Pay-as-you-go) | Managed SaaS (AWS) | Serverless ETL | Python/Scala Script, Visual | High (Serverless) | Consumption-based |
+| **Azure Data Factory** | Commercial (Pay-as-you-go) | Managed SaaS (Azure) | Cloud ETL/ELT | Visual, JSON | High (Serverless) | Consumption-based |
+| **Coalesce** | Commercial | Managed SaaS | ELT (Transformation) | Visual, SQL | High (Push-down) | Custom/Subscription |
+| **Domo** | Commercial | Managed SaaS | BI & Analytics | Visual | High (Managed) | Custom/Subscription |
+
+When considering performance and ease of use, there is a clear trade-off. Managed services like Fivetran and Matillion offer high performance with low operational burden but less control. Open-source tools like Kestra, Airbyte, and NiFi provide maximum flexibility and control but require more expertise to deploy and manage effectively. Declarative tools like Kestra strike a balance, offering a developer-friendly experience that is easier to manage at scale than imperative code-based systems.
+
+## Choosing the Right Talend Alternative for Your Organization
+
+The best alternative is the one that aligns with your team's skills, architectural strategy, and business goals. Use these profiles as a guide to narrow down your options.
+
+### Assessing Your Specific Data Integration Needs
+
+*   **For Data Engineering Teams:** If your priority is building robust, version-controlled, and scalable data pipelines, focus on declarative and polyglot orchestration platforms like **Kestra**. For specialized needs, consider **Fivetran** for automated ingestion or **Matillion** for visual, in-warehouse transformation.
+*   **For Infrastructure & DevOps Teams:** If you need to integrate data workflows with broader infrastructure automation and follow GitOps principles, a unified, event-driven platform like **Kestra** is the strongest fit. **Apache NiFi** is also a powerful option for complex data routing and operational dataflows.
+*   **For AI & ML Platform Teams:** Your primary need is flexibility to orchestrate heterogeneous tasks—from data preprocessing to model training and deployment. **Kestra**'s language-agnostic capabilities make it ideal for managing these complex, multi-step AI pipelines.
+*   **For Small Teams & Startups:** Cost-effectiveness and rapid iteration are key. Open-source platforms like **Kestra (OSS)**, **Airbyte**, and **Apache NiFi** offer powerful capabilities without the upfront license cost. Consider one of the many [free ETL tools](/resources/data/free-etl-tools) available.
+
+### Future-Proofing Your Data Stack
+
+When selecting a tool, think beyond your immediate needs. The data landscape is converging, and the lines between data engineering, MLOps, and platform engineering are blurring. A tool that can grow with you and extend beyond a single domain will provide more long-term value. Platforms that embrace open standards, declarative principles, and event-driven architectures are best positioned to adapt to future challenges.
+
+## Conclusion: Modernizing Your Data Integration Strategy
+
+Moving away from a long-standing tool like Talend is a significant decision, but it's an opportunity to modernize your data stack and align it with current best practices. The shift towards cloud-native, developer-centric, and unified platforms reflects a broader industry trend of treating data pipelines with the same rigor as production software.
+
+The "best" alternative depends entirely on your context. If you need a managed, fire-and-forget ingestion tool, Fivetran is a strong contender. If you need open-source data movement with a huge connector library, Airbyte is excellent. But if your goal is to build a scalable, resilient, and unified orchestration layer that can manage not just your data pipelines but your entire technical ecosystem, a platform like [Kestra](/) offers a compelling, future-proof solution. Explore our [data engineering resources](/resources/data) to learn more about building modern data workflows.


### PR DESCRIPTION
## Summary

Imports the W27 SEO drafts from [`vfanucci/kestra-seo`](https://github.com/vfanucci/kestra-seo) into the resources hub, one `src/contents/resources/{slug}/index.md` per page, following the resource page template (front-matter + `/resources/{tag}/{slug}` URLs).

| Page | Tag | URL | Source PR |
|------|-----|-----|-----------|
| AWX Alternatives | infrastructure | `/resources/infrastructure/awx-alternatives` | kestra-seo#177 |
| Qlik Alternatives | data | `/resources/data/qlik-alternatives` | kestra-seo#178 |
| Talend Alternatives | data | `/resources/data/talend-alternatives` | kestra-seo#179 |
| AI Code Generation Workflow | ai | `/resources/ai/ai-code-generation-workflow` | kestra-seo#180 |
| Data Retention Automation | data | `/resources/data/data-retention-automation` | kestra-seo#181 |
| Keycloak SSO Integration | infrastructure | `/resources/infrastructure/keycloak-sso-integration` | kestra-seo#182 |

No slug collisions with existing resources. Each page only adds an `index.md` (pages are auto-discovered — no nav/registry changes needed).

## Template-compliance fixes applied on import

- **ai-code-generation-workflow**: `metaTitle` trimmed 61 → 55 chars (≤60).
- **keycloak-sso-integration**: `metaDescription` trimmed 214 → 157 chars (140–160).

## Remaining soft warnings (editorial, not blocking)

Carried over from the source PRs — flagged for reviewer, not auto-fixed:

- **talend-alternatives**: word count 3528 (outline target 2700–3300) — slightly long.
- **qlik-alternatives**: duplicate internal-link destinations (`/data`, `/resources/data/data-pipeline` used twice each).
- All pages: some AI-cliché stems present (`robust`, `seamless`, `comprehensive`, `however`, `leverage`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)