### PR TITLE
docs(logshipper): add Huawei Cloud LTS log exporter

### DIFF
--- a/src/contents/docs/07.enterprise/02.governance/logshipper/index.md
+++ b/src/contents/docs/07.enterprise/02.governance/logshipper/index.md
@@ -18,7 +18,7 @@ Manage and distribute logs across your entire infrastructure.
 
 Log Shipper can distribute Kestra logs from across your instance to an external logging platform. Log synchronization fetches logs and batches them into optimized chunks automatically. The batch process is done intelligently through defined synchronization points. Once batched, the Log Shipper delivers consistent and reliable data to your monitoring platform.
 
-Log Shipper is built on top of [Kestra plugins](/plugins), ensuring it can integrate with popular logging platforms and expand as more plugins are developed. Supported observability platforms include ElasticSearch, Datadog, New Relic, Azure Monitor, Google Operational Suite, AWS Cloudwatch, Splunk, OpenSearch, and OpenTelemetry.
+Log Shipper is built on top of [Kestra plugins](/plugins), ensuring it can integrate with popular logging platforms and expand as more plugins are developed. Supported observability platforms include ElasticSearch, Datadog, New Relic, Azure Monitor, Google Operational Suite, AWS Cloudwatch, Splunk, OpenSearch, Huawei Cloud LTS, and OpenTelemetry.
 
 ## Log shipper properties
 
@@ -489,6 +489,40 @@ tasks:
         graylogHost: "Kestra"
         chunk: 1000
 ```
+
+### Huawei Cloud LTS
+
+This example exports logs to [Huawei Cloud Log Tank Service (LTS)](https://www.huaweicloud.com/intl/en-us/product/lts.html). The following example flow triggers a daily batch and ships logs to an LTS log stream. Refer to the [Huawei EE Plugin Documentation](/plugins/plugin-ee-huawei) for more property details.
+
+```yaml
+id: log_shipper
+namespace: company.team
+
+triggers:
+  - id: daily
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "@daily"
+
+tasks:
+  - id: log_export
+    type: io.kestra.plugin.ee.core.log.LogShipper
+    logLevelFilter: INFO
+    lookbackPeriod: P1D
+    offsetKey: logShipperOffset
+    delete: false
+    logExporters:
+      - id: huawei_lts
+        type: io.kestra.plugin.ee.huawei.lts.LogExporter
+        region: eu-west-101
+        projectId: "{{ secret('HUAWEI_PROJECT_ID') }}"
+        accessKeyId: "{{ secret('HUAWEI_ACCESS_KEY_ID') }}"
+        secretAccessKey: "{{ secret('HUAWEI_SECRET_ACCESS_KEY') }}"
+        logGroupId: "{{ secret('HUAWEI_LOG_GROUP_ID') }}"
+        logStreamId: "{{ secret('HUAWEI_LOG_STREAM_ID') }}"
+        chunk: 1000
+```
+
+The Huawei Cloud LTS exporter authenticates with Huawei Cloud using either static AK/SK credentials (`accessKeyId` and `secretAccessKey`), a pre-obtained `securityToken`, or inline IAM STS credential exchange via `temporaryCredentials`. The `logGroupId` and `logStreamId` are UUIDs that you can copy from the LTS console (they are not the human-readable group and stream names).
 
 ## Audit log shipper
 


### PR DESCRIPTION
## What

Adds documentation for the new **Huawei Cloud Log Tank Service (LTS)** log exporter to the [Log Shipper](https://kestra.io/docs/enterprise/governance/logshipper) page.

Documents the new exporter from [kestra-io/plugin-ee-huawei#5](https://github.com/kestra-io/plugin-ee-huawei/pull/5).

## Changes

- Added **Huawei Cloud LTS** to the list of supported observability platforms in the intro.
- Added a new `### Huawei Cloud LTS` example section with a daily-scheduled `LogShipper` flow using `io.kestra.plugin.ee.huawei.lts.LogExporter`, covering the required properties (`region`, `projectId`, `logGroupId`, `logStreamId`) plus auth credentials and `chunk`.
- Added a note on the three supported authentication methods (static AK/SK, pre-obtained `securityToken`, inline IAM STS via `temporaryCredentials`) and that `logGroupId`/`logStreamId` are UUIDs from the LTS console.

> [!NOTE]
> The `/plugins/plugin-ee-huawei` link will 404 until the plugin is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Wait for https://github.com/kestra-io/plugin-ee-huawei/pull/5 to be merged/releases