### PR TITLE
seo(resources): refresh publish dates to 2026-07-01

### DIFF
--- a/src/contents/resources/data-retention-automation/index.md
+++ b/src/contents/resources/data-retention-automation/index.md
@@ -4,7 +4,7 @@ description: "Automating data retention policies is crucial for compliance, risk
 metaTitle: "Data Retention Automation: Policies & Compliance | Kestra"
 metaDescription: "Automate data retention policies for regulatory compliance, reduced legal risk, and efficient data lifecycle management. Learn how Kestra helps."
 tag: "data"
-date: 2026-07-15
+date: 2026-07-01
 slug: "data-retention-automation"
 faq:
   - question: "What is data retention automation?"

--- a/src/contents/resources/keycloak-sso-integration/index.md
+++ b/src/contents/resources/keycloak-sso-integration/index.md
@@ -4,7 +4,7 @@ description: "Learn how to integrate Keycloak for Single Sign-On (SSO) to centra
 metaTitle: "Keycloak SSO Integration for Workflow Orchestration | Kestra"
 metaDescription: "Integrate Keycloak SSO to secure apps and automate access management — configure Keycloak, master protocols, and orchestrate workflow security with Kestra."
 tag: "infrastructure"
-date: 2026-07-08
+date: 2026-07-01
 slug: "keycloak-sso-integration"
 faq:
   - question: "How does SSO work with Keycloak?"


### PR DESCRIPTION
## What

Updates the `date:` frontmatter on two resource pages that were dated in the future, setting them to today (2026-07-01) so they surface as freshly published.

| Page | Before | After |
|------|--------|-------|
| [/resources/data/data-retention-automation](https://kestra.io/resources/data/data-retention-automation) | 2026-07-15 | 2026-07-01 |
| [/resources/infrastructure/keycloak-sso-integration](https://kestra.io/resources/infrastructure/keycloak-sso-integration) | 2026-07-08 | 2026-07-01 |

## Why

The pages carried scheduled future publish dates. Aligning them to today reflects their actual publication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)