### PR TITLE
fix(blueprints): center info icon in topology controls toolbar

### DIFF
--- a/src/components/blueprints/Topology.client.vue
+++ b/src/components/blueprints/Topology.client.vue
@@ -101,6 +101,10 @@
         fill: var(--ks-content-primary) !important;
     }
 
+    :deep(.vue-flow__controls-button) {
+        font-size: 12px;
+    }
+
     :deep(.dot) {
         color: var(--ks-content-primary) !important;
     }


### PR DESCRIPTION
Fixes the misaligned info (i) icon in the blueprint topology controls toolbar by pinning the button font-size so the em-sized icon wrapper matches the SVG.

Closes #5055

After fix:

<img width="1278" height="1080" alt="Screenshot 2026-07-01 at 2 39 57 PM" src="https://github.com/user-attachments/assets/af380a50-7169-487a-8b82-93b6b5978adb" />


