### PR TITLE
seo(resources): add 8 new W27 resource pages (7 alternatives + what-is-uipath)

### DIFF
--- a/src/contents/resources/atlan-alternatives/index.md
+++ b/src/contents/resources/atlan-alternatives/index.md
@@ -1,0 +1,156 @@
+---
+title: "Top Atlan Alternatives: Orchestration for Data Governance & Lineage"
+description: "Explore leading Atlan alternatives, from dedicated data catalogs like Alation and Collibra to Kestra, an orchestration platform that automates data governance, lineage, and discovery processes."
+metaTitle: "Top Atlan Alternatives for Data Governance & Lineage"
+metaDescription: "Comparing Atlan alternatives for data catalogs, governance, and lineage. Discover how Kestra orchestrates data processes for enhanced control and automation."
+tag: "data"
+date: 2026-07-02
+slug: "atlan-alternatives"
+faq:
+  - question: "What are the primary reasons to seek an Atlan alternative?"
+    answer: "Organizations often seek Atlan alternatives due to concerns about licensing costs, the complexity of integrating with diverse data stacks, or a desire for a more code-centric, extensible solution that offers greater control over underlying data processes and metadata management."
+  - question: "Is Kestra a direct replacement for a data catalog like Atlan?"
+    answer: "Kestra is not a traditional data catalog with a direct UI for business users. Instead, it functions as an orchestration control plane that automates the technical workflows required for data governance, lineage, and discovery, enabling robust metadata management and data quality through code-driven processes. It can integrate with or complement existing catalogs."
+  - question: "What key features should I look for in an Atlan alternative?"
+    answer: "When evaluating Atlan alternatives, prioritize features such as comprehensive metadata management, automated data lineage tracking, robust data quality capabilities, flexible integration with your existing data stack, and strong collaboration features. Consider deployment options and pricing models that align with your budget and operational needs."
+  - question: "Are there open-source alternatives to Atlan for data cataloging?"
+    answer: "While direct open-source alternatives that match Atlan's full feature set are rare, tools like Amundsen or DataHub offer open-source foundations for data discovery and metadata management. Kestra, as an open-source orchestrator, can automate the processes that feed and manage these open-source data catalogs."
+  - question: "How does Kestra enhance data lineage capabilities?"
+    answer: "Kestra enhances data lineage by explicitly defining and tracking every step of a data workflow in declarative YAML. This provides an inherent, auditable record of data transformations, inputs, and outputs. By orchestrating data pipelines, Kestra can automatically generate and update lineage information, feeding it into metadata repositories or dedicated lineage tools."
+  - question: "Which Atlan alternative is best for highly technical data teams?"
+    answer: "For highly technical data teams who prioritize code-driven workflows, extensibility, and deep integration into their existing CI/CD and GitOps practices, Kestra offers a compelling alternative. Its declarative YAML and polyglot execution environment provide granular control over data processes, making it ideal for engineers building custom data governance solutions."
+author: "Kestra Team"
+---
+
+The modern data landscape demands more than just data storage; it requires clear visibility into *what* data exists, *where* it comes from, and *how* it's transformed. Atlan has emerged as a prominent player in the data catalog space, helping organizations tame their data sprawl. However, as data stacks grow in complexity and teams seek deeper automation, many find themselves evaluating alternatives that better align with their technical requirements, budget, or specific governance needs.
+
+This article explores the top Atlan alternatives in 2026, offering a comprehensive look at how different solutions, from dedicated data catalogs to powerful orchestration platforms like Kestra, address the evolving challenges of data governance, lineage, and discovery. We'll delve into each platform's strengths, ideal use cases, and how they stack up against Atlan, providing a framework to help you choose the best fit for your organization.
+
+## The Evolving Need for Data Catalogs and Atlan's Role
+
+A data catalog is a centralized inventory of an organization's data assets, enriched with metadata to help users discover, understand, and trust their data. In an era of distributed data systems, these catalogs are no longer optional; they are foundational to data governance, self-service analytics, and compliance. They provide answers to critical questions: What does this data mean? Who owns it? Is it reliable? How was it created?
+
+Atlan excels in this domain by providing a collaborative, user-friendly interface for data discovery and governance. Its core strengths lie in its intuitive UI, active metadata management, and features that promote collaboration between technical and business users. Atlan's "data workspace" concept helps teams organize assets, document knowledge, and manage governance policies effectively. Its visualization of [data lineage](/resources/data/data-lineage) is particularly valued for tracing the journey of data from source to consumption.
+
+## Why Organizations Seek Alternatives to Atlan
+
+Despite its strengths, no single tool fits every organization's needs. Teams often begin searching for Atlan alternatives for several concrete reasons:
+
+*   **Cost and Licensing Complexity:** Atlan is an enterprise-grade solution with a pricing model that reflects its comprehensive feature set. For smaller teams or organizations with tight budgets, the total cost of ownership can be a significant barrier.
+*   **Integration Challenges:** While Atlan offers a wide range of connectors, highly customized or legacy data stacks can present integration difficulties. Teams may require more flexible or extensible integration capabilities than what is offered out-of-the-box.
+*   **Code-centricity vs. UI-driven Approach:** Atlan's strength is its UI, designed for a mix of users. However, data engineering and platform teams often prefer a code-driven, API-first approach that integrates seamlessly with their existing GitOps and CI/CD workflows. They may seek a solution where governance and metadata management are defined and versioned as code.
+*   **Operational Overhead:** Deploying, configuring, and maintaining any enterprise platform requires effort. Organizations may look for simpler, more lightweight solutions or fully managed services to reduce this operational burden.
+*   **Scope Limitations:** Atlan is primarily a data catalog and governance tool. Organizations looking for a unified platform that can orchestrate not only metadata but also the data pipelines, infrastructure, and AI workflows themselves may find its scope too narrow.
+
+## How We Evaluated Top Atlan Alternatives
+
+To provide a balanced comparison, we evaluated each alternative based on a consistent set of criteria relevant to data management professionals:
+
+*   **Deployment Model:** Whether the solution is Cloud, Self-hosted, or offers a Hybrid model.
+*   **Core Functionality:** The depth of features in Metadata Management, Data Lineage, Governance, Discovery, and Data Quality.
+*   **Integration Ecosystem:** The breadth and extensibility of connectors, APIs, and overall ability to fit into a modern data stack.
+*   **Pricing Model:** The transparency, scalability, and structure of its pricing.
+*   **Target Persona:** The primary user, whether Data Stewards, Data Engineers, or Business Analysts.
+*   **Open-Source vs. Commercial:** The licensing model and the availability of a community-driven version.
+
+## Kestra: The Orchestration-First Approach to Data Governance
+
+Kestra takes a fundamentally different approach. Instead of being a passive repository for metadata, [Kestra](/) is an open-source orchestration platform that actively automates the processes of data governance, lineage, and discovery. It positions orchestration as the engine for a reliable data ecosystem.
+
+Workflows in Kestra are defined in declarative YAML, providing a code-native way to manage data processes. This allows data teams to version-control, test, and automate not just their data pipelines but also the governance rules that surround them. For example, a Kestra workflow can run a dbt transformation, then automatically extract metadata from the run, perform data quality checks, and populate a data catalog—all in one auditable, repeatable process.
+
+```yaml
+id: enrich-and-catalog-customer-data
+namespace: production.governance
+
+tasks:
+  - id: run_dbt_models
+    type: io.kestra.plugin.dbt.cli.DbtCLI
+    commands:
+      - dbt build --select customers
+
+  - id: extract_metadata
+    type: io.kestra.plugin.scripts.python.Script
+    script: |
+      # Python script to parse dbt manifest.json
+      # and extract column-level lineage
+      # then push to a metadata store (e.g., DataHub API)
+
+  - id: data_quality_checks
+    type: io.kestra.plugin.soda.SodaCore
+    commands:
+      - soda scan -d my_data_source -c configuration.yml checks.yml
+```
+
+This code-driven approach provides an inherent, auditable record of [data lineage](/resources/data/data-lineage), as every transformation and data movement is explicitly defined. With its polyglot nature and extensive plugin ecosystem, Kestra can connect to any tool in the data stack, making it a powerful control plane for end-to-end data processes. This approach has enabled organizations like Leroy Merlin France to manage their DataMesh at scale, increasing data production by 900%.
+
+**Best for:** Technical data teams and platform engineers who want to automate data governance and lineage through code, integrating these processes directly into their CI/CD and GitOps workflows.
+
+## Alation: Enterprise Data Intelligence Platform
+
+Alation is a market leader in the data intelligence space and a frequent Atlan competitor. It combines a machine learning-driven data catalog with robust collaboration and active data governance features. Alation's platform is designed to help large organizations create a single source of reference for their data.
+
+Its key strengths include behavioral intelligence, which analyzes data usage patterns to automatically surface popular and trusted datasets. It also fosters a collaborative environment where users can curate, annotate, and discuss data assets directly within the platform. Alation's active data governance capabilities allow for the creation and enforcement of policies, ensuring data is used correctly and securely.
+
+**Best for:** Large enterprises with complex, hybrid data landscapes that require a comprehensive data intelligence solution with strong collaborative features and automated curation.
+
+## Collibra: A Leader in Data Governance and Intelligence
+
+Collibra is another enterprise-grade platform that is often considered alongside Atlan and Alation. Its primary focus is on providing a robust, formal framework for data governance, risk, and compliance. Collibra excels at creating a system of record for an organization's data, with a strong emphasis on business glossaries, data stewardship workflows, and policy management.
+
+The platform is built around a flexible operating model that allows organizations to define their own governance structures, roles, and responsibilities. Its data quality and observability features are deeply integrated, helping teams monitor and improve the health of their data assets over time. Collibra is a powerful choice for organizations in regulated industries where auditable data governance is a top priority.
+
+**Best for:** Organizations prioritizing formal data governance, compliance, and data stewardship, especially in regulated industries like finance, healthcare, and insurance.
+
+## Secoda: Simplifying Data Discovery and Exploration
+
+Secoda targets a more modern, agile data stack and focuses on making data discovery and documentation as simple as possible. It offers a clean, intuitive user interface that feels more like a modern SaaS tool, aiming to reduce the friction for both technical and non-technical users to find and understand data.
+
+Secoda integrates tightly with tools like dbt, Snowflake, and BigQuery, automatically pulling in metadata and lineage to build a centralized knowledge base. Its standout features include a collaborative workspace, an integrated data dictionary, and AI-powered documentation assistance. Secoda is often favored by fast-growing startups and mid-market companies that need a powerful data catalog without the complexity and cost of enterprise-focused platforms.
+
+**Best for:** Growing data teams seeking an intuitive, user-friendly platform for data discovery and cataloging that integrates well with the modern data stack without heavy governance overhead.
+
+## Informatica Intelligent Data Management Cloud (IDMC)
+
+Informatica is a long-standing leader in the data management space, and its Intelligent Data Management Cloud (IDMC) offers a comprehensive suite of tools that includes a powerful data catalog. Unlike standalone catalogs, Informatica's offering is part of a broader platform that covers data integration (ETL/ELT), application integration, master data management (MDM), and data quality.
+
+This integrated approach is IDMC's main advantage. Organizations can manage the entire data lifecycle, from ingestion and transformation to governance and consumption, within a single cloud-native platform. Its AI-powered CLAIRE engine automates many aspects of metadata discovery, classification, and lineage mapping.
+
+**Best for:** Enterprises already invested in the Informatica ecosystem or those looking for a single, comprehensive platform to address all their data management needs, from integration to governance.
+
+## Microsoft Purview: Unified Data Governance for the Azure Ecosystem
+
+For organizations heavily invested in the Microsoft cloud, Microsoft Purview is a compelling Atlan alternative. As part of the Microsoft Fabric ecosystem, Purview provides unified data governance and discovery across the entire Azure data estate, including Azure Synapse Analytics, Azure SQL, and Power BI.
+
+Purview automatically scans and classifies data across on-premises, multi-cloud, and SaaS sources, creating a holistic map of an organization's data assets. It offers a business glossary for defining common terms and provides end-to-end data lineage visualization. Its deep integration with Azure services makes it a natural choice for managing governance and compliance within a Microsoft-centric environment, and it's a key consideration for companies evaluating [Microsoft Fabric alternatives](/resources/data/microsoft-fabric-alternatives).
+
+**Best for:** Organizations deeply integrated into the Microsoft Azure ecosystem that are seeking a native, unified data governance solution.
+
+## Comparison Table: Atlan Alternatives at a Glance
+
+| Tool | License | Deployment | Core Focus | Best For | Starting Price/Model |
+|---|---|---|---|---|---|
+| **Kestra** | Open-Source (Apache 2.0) & Enterprise | Self-hosted, Cloud | Orchestration for Data Governance & Lineage | Technical teams automating governance as code | Open-source free; Enterprise pricing per instance |
+| **Alation** | Commercial | Self-hosted, Cloud | Data Intelligence & Collaboration | Large enterprises with complex data landscapes | Enterprise pricing, quote-based |
+| **Collibra** | Commercial | Self-hosted, Cloud | Formal Data Governance & Compliance | Regulated industries needing strong stewardship | Enterprise pricing, quote-based |
+| **Secoda** | Commercial | Cloud | Data Discovery & Documentation | Growing teams with a modern data stack | Tiered, per-user pricing |
+| **Informatica** | Commercial | Cloud | Integrated Data Management Suite | Enterprises needing a comprehensive platform | Consumption-based (IPU) |
+| **Microsoft Purview** | Commercial | Cloud | Unified Governance for Azure | Organizations heavily invested in Microsoft Azure | Consumption-based (per vCore-hour, etc.) |
+
+## Choosing the Right Atlan Alternative for Your Organization
+
+The best choice depends entirely on your team's specific needs, existing stack, and long-term goals. Here’s a framework to guide your decision:
+
+*   **For Data Engineering Teams:** If your priority is extensibility, an API-first approach, and integrating governance into CI/CD pipelines, a tool like **Kestra** provides the ultimate code-driven control. For teams focused purely on discovery automation, **Secoda** offers a modern, engineer-friendly experience. Explore how Kestra can serve as the control plane for your [declarative data orchestration](/data).
+*   **For Data Governance & Stewardship Teams:** When the focus is on robust policy enforcement, creating a business glossary, and managing stewardship workflows, enterprise platforms like **Collibra** and **Alation** offer the most comprehensive feature sets.
+*   **For Azure-centric Organizations:** If your data ecosystem lives primarily within Azure, **Microsoft Purview** is the most logical choice due to its native integrations and unified governance capabilities.
+*   **For Comprehensive Data Management:** If you are looking to solve data cataloging as part of a broader data management strategy that includes ETL, MDM, and data quality, an integrated suite like **Informatica IDMC** may be the most efficient path.
+*   **For Small to Mid-sized Teams:** To balance powerful features with ease of use and predictable costs, **Secoda** is a strong contender. For technical teams in this segment, **Kestra's** open-source edition offers a powerful automation foundation without the licensing costs.
+
+## Conclusion: Orchestrating Your Data Governance Future
+
+Choosing an Atlan alternative is about more than finding a replacement data catalog. It's an opportunity to re-evaluate how your organization manages, governs, and trusts its data. While traditional catalogs like Alation and Collibra offer robust governance frameworks, a new paradigm is emerging where governance is not just a passive layer but an active, automated process.
+
+Platforms like [Kestra](/) represent this shift, providing the orchestration control plane to automate data quality checks, generate real-time lineage, and manage metadata as part of your core data workflows. By treating governance as code, you build a more reliable, auditable, and scalable data ecosystem. Whether you need a comprehensive enterprise suite or a flexible orchestration engine, the right tool will empower your entire organization to make better, data-driven decisions.
+
+Ready to see how orchestration can transform your data governance? Explore the [declarative data platform for modern data engineers](/data).

--- a/src/contents/resources/automation-anywhere-alternatives/index.md
+++ b/src/contents/resources/automation-anywhere-alternatives/index.md
@@ -1,0 +1,151 @@
+---
+title: "Top Automation Anywhere Alternatives for Modern Enterprise Automation in 2026"
+description: "Explore leading Automation Anywhere alternatives that offer declarative, event-driven orchestration across data, AI, and infrastructure workflows, moving beyond traditional RPA."
+metaTitle: "Top Automation Anywhere Alternatives (2026)"
+metaDescription: "Explore top Automation Anywhere alternatives like Kestra, UiPath, and Power Automate for your data, AI, and infrastructure automation workflows."
+tag: "infrastructure"
+date: 2026-07-01
+slug: "automation-anywhere-alternatives"
+faq:
+  - question: "What are the main reasons to consider an Automation Anywhere alternative?"
+    answer: "Users often seek alternatives due to high licensing costs, vendor lock-in, the operational complexity of managing bot fleets, and a desire for more developer-centric, code-based, or event-driven automation approaches that extend beyond traditional RPA use cases into data, AI, and infrastructure."
+  - question: "Is Kestra a direct replacement for Automation Anywhere?"
+    answer: "Kestra is not a direct RPA tool but an orchestration control plane that can automate and coordinate processes traditionally handled by RPA, alongside data pipelines, AI workflows, and infrastructure operations. It excels at unifying diverse automation tasks under a declarative YAML framework, often integrating with or triggering RPA bots where UI automation is still necessary."
+  - question: "Which alternatives offer a strong focus on AI and intelligent automation?"
+    answer: "Many modern alternatives, including Kestra, UiPath, and Microsoft Power Automate, are heavily investing in AI capabilities. Kestra offers AI Copilot for workflow generation and AI agents for complex tasks, while UiPath and Power Automate integrate AI for intelligent document processing, process mining, and enhanced bot capabilities."
+  - question: "What is the best open-source alternative to Automation Anywhere?"
+    answer: "For open-source alternatives, Kestra and n8n stand out. Kestra provides a powerful, declarative orchestration engine for technical teams across domains. n8n offers a visual, self-hosted platform ideal for SaaS API automation and quick prototyping, with growing AI features."
+  - question: "How does Kestra compare to UiPath for enterprise automation?"
+    answer: "UiPath is a market leader in RPA with strong visual builders and AI-powered bots, excelling in UI-based automation. Kestra, conversely, is a declarative, language-agnostic orchestration platform that unifies data, AI, and infrastructure workflows with YAML, ideal for engineering-led teams seeking a broader, code-driven automation strategy."
+  - question: "Are there more cost-effective Automation Anywhere alternatives?"
+    answer: "Yes, open-source options like Kestra and n8n can offer significant cost savings, especially for organizations looking to reduce high licensing fees associated with proprietary RPA platforms. Cloud-native solutions like AWS Step Functions also provide usage-based pricing models."
+author: "Benoit Martinet"
+---
+
+The landscape of enterprise automation is rapidly evolving, pushing organizations to look beyond traditional Robotic Process Automation (RPA) for more integrated and flexible solutions. While Automation Anywhere has been a prominent player, shifts towards cloud-native architectures, developer-centric tools, and the pervasive influence of AI are compelling many to re-evaluate their automation stacks. High licensing costs, vendor lock-in, and the operational overhead of managing bot fleets are common catalysts for this search.
+
+This article explores the top Automation Anywhere alternatives in 2026, offering a comprehensive guide for technical leaders and automation specialists. We’ll delve into platforms that not only match RPA capabilities but also extend automation into data, AI, and infrastructure domains, providing a clearer path to scalable, governed, and future-proof enterprise automation.
+
+## Why Look for an Alternative to Automation Anywhere?
+
+Organizations often start exploring alternatives when their automation needs outgrow the capabilities of a single-purpose RPA tool. The reasons for this shift are multifaceted, reflecting broader trends in software development and IT operations.
+
+-   **High Total Cost of Ownership (TCO):** Proprietary RPA platforms often come with complex, per-bot licensing models that can become prohibitively expensive as automation scales. Hidden costs for orchestrators, development studios, and specialized add-ons contribute to a TCO that is difficult to predict and control. [Open-source orchestration can offer significant cost savings](/resources/infrastructure/open-source-orchestration-cost-savings) by eliminating these licensing fees.
+-   **Vendor Lock-in and Limited Flexibility:** Committing to a single RPA vendor can create dependencies that stifle innovation. The core focus on UI automation can lead to brittle workflows that break with application updates, while integrations with modern developer tools and platforms may be limited or require custom development.
+-   **Operational Complexity at Scale:** Managing a large fleet of bots introduces significant operational overhead. Debugging, monitoring, and ensuring the resilience of hundreds of UI-driven automations can become a full-time job for a dedicated team, diverting resources from higher-value work. This highlights the inherent [complexity of modern orchestration problems](/resources/infrastructure/orchestration-problems-complexity).
+-   **Shift to Developer-Centric Automation:** Modern engineering teams prefer tools that align with their existing workflows. This means declarative configurations stored in Git, API-first integrations, and the ability to write business logic in any programming language. Traditional RPA platforms, with their graphical interfaces and proprietary scripting, often don't fit this model.
+-   **Need for Cross-Domain Orchestration:** Enterprise automation is no longer just about mimicking human clicks. It's about coordinating complex workflows that span data pipelines, AI models, infrastructure provisioning, and business applications. RPA tools are not designed to be the central control plane for these diverse, technical workloads.
+
+## How We Evaluated These Alternatives
+
+To provide a balanced comparison, we assessed each alternative against a set of criteria relevant to modern enterprise automation. Our evaluation focused on identifying tools that not only address the limitations of traditional RPA but also provide a strategic path forward.
+
+We evaluated each alternative on its deployment model, primary use case fit, developer experience, integration ecosystem, and overall cost-effectiveness. We also considered scalability and the operational burden required to run the platform in a production environment. The goal is to highlight the [best workflow automation tools](/resources/infrastructure/best-workflow-automation-tools) for different needs, from direct RPA replacement to broader, platform-level orchestration.
+
+## Top Automation Anywhere Alternatives for Modern Workflows
+
+The market offers a wide range of alternatives, each with a different architectural philosophy and target audience. Here are eight leading platforms that provide compelling options beyond traditional RPA.
+
+### 1. Kestra: The Declarative Orchestration Control Plane
+
+Kestra is an open-source, declarative orchestration platform designed to unify data, AI, and infrastructure workflows under a single control plane. Instead of focusing on UI automation, Kestra orchestrates any process through a language-agnostic and API-first approach, making it a powerful alternative for engineering-led teams.
+
+Workflows in Kestra are defined as simple YAML files, a practice that enables a [GitOps approach](/resources/infrastructure/gitops) to automation. This means every workflow can be versioned, reviewed, and audited like any other piece of code. Kestra's event-driven architecture allows it to react to triggers from various systems, such as message queues, webhooks, or file uploads, making it highly adaptable to dynamic environments.
+
+With over 1400 plugins, Kestra can connect to virtually any tool in the modern tech stack, from databases and data warehouses to cloud services and machine learning platforms. It can run Python scripts, shell commands, SQL queries, and Docker containers as first-class citizens, without forcing developers into a proprietary language. For use cases where UI automation is unavoidable, Kestra can trigger and manage RPA bots as part of a larger, end-to-end workflow. This allows organizations to modernize their automation stack without having to rip and replace existing bots immediately. Companies like Amdocs and Crédit Agricole use Kestra for complex infrastructure and operations automation.
+
+**Best for:** Engineering-led teams seeking a unified, code-first, and highly scalable [orchestration platform](/infra-automation) to manage workflows across data, AI, and infrastructure domains.
+
+### 2. UiPath: The RPA Market Leader with AI Vision
+
+UiPath is the most direct competitor to Automation Anywhere and a leader in the RPA market. Its platform is built around a powerful visual, drag-and-drop workflow designer that makes it accessible to both business users and developers. UiPath offers a comprehensive suite of tools that extends beyond basic RPA, including process mining, intelligent document processing, and AI capabilities.
+
+The platform's strength lies in its robust UI automation capabilities, enabling the creation of resilient bots that can interact with a wide range of desktop and web applications. UiPath has also invested heavily in AI, integrating machine learning models to handle more complex tasks and unstructured data. Its focus on end-to-end business process automation, including features for human-in-the-loop collaboration, makes it a strong contender for large enterprises looking to automate complex, multi-step business processes.
+
+**Best for:** Large enterprises with significant existing RPA investments that require extensive UI automation, advanced AI features, and a comprehensive platform for business process automation.
+
+### 3. Microsoft Power Automate: Microsoft Ecosystem Automation
+
+Microsoft Power Automate is a compelling alternative for organizations deeply embedded in the Microsoft ecosystem. It offers both cloud-based flows for API automation and a desktop client (Power Automate Desktop) for RPA. Its key differentiator is the seamless integration with Microsoft 365, Azure, Dynamics 365, and the broader Power Platform.
+
+This tight integration makes it incredibly easy to automate tasks involving Outlook, SharePoint, Excel, and Teams. The low-code/no-code interface empowers "citizen developers" to build their own automations, democratizing workflow creation across the organization. While its RPA capabilities may not be as deep as those of UiPath or Automation Anywhere, its accessibility and integration strength make it a powerful tool for departmental and productivity-focused automation.
+
+**Best for:** Organizations deeply invested in Microsoft products looking for accessible, low-code automation across business applications and desktop tasks.
+
+### 4. n8n: Open-Source Visual Automation
+
+n8n is an open-source, self-hostable workflow automation tool that is often described as a developer-friendly alternative to Zapier. While not a traditional RPA tool, it serves as an excellent alternative for automating processes that are API-driven. Its visual workflow builder and extensive library of pre-built nodes for SaaS applications and web services make it easy to connect different tools and build complex workflows without extensive coding.
+
+n8n's source-available model provides the flexibility to self-host on-premises or in a private cloud, giving organizations full control over their data and infrastructure. Its growing focus on AI and agentic features positions it as a modern tool for building intelligent automations. For a deeper dive, see our analysis of [top n8n alternatives](/resources/infrastructure/n8n-alternatives).
+
+**Best for:** Technical teams and small businesses seeking a flexible, self-hosted tool for SaaS integrations and quick automation prototyping, with a focus on API-driven workflows.
+
+### 5. Windmill: Open-Source Internal Tools and Workflow Engine
+
+Windmill is an open-source platform designed for developers to build internal tools, dashboards, and backend workflows. It allows you to turn scripts in Python, TypeScript, Go, or Bash into production-grade, auditable workflows and UIs. This code-first approach makes it a strong alternative for teams looking to replace brittle RPA scripts with robust, version-controlled code.
+
+Windmill's focus is on the developer experience, providing features like a local development server, Git sync, and tight integration with tools like Postgres and Redis. It's not an RPA tool for automating third-party UIs, but rather a platform for building custom, secure internal automations.
+
+**Best for:** Developer teams building internal applications, dashboards, and operational scripts, prioritizing flexibility and code-first approaches for their internal automation needs. You can explore more [Windmill alternatives](/resources/infrastructure/windmill-alternatives) for a broader view.
+
+### 6. AWS Step Functions: Serverless Workflow Orchestration on AWS
+
+For organizations heavily invested in the AWS cloud, AWS Step Functions offers a fully managed, serverless orchestration service. It allows you to design and run workflows that coordinate multiple AWS services, such as Lambda, Fargate, and S3, into a single, cohesive application. Its visual workflow designer provides a clear view of application logic, and its built-in error handling and state management ensure that workflows are resilient.
+
+Step Functions is not an RPA tool but an alternative for automating backend processes and data pipelines that run entirely within the AWS ecosystem. Its pay-per-use pricing model can be highly cost-effective for event-driven and variable workloads. For a detailed comparison, check out our guide on [AWS Step Functions alternatives](/resources/infrastructure/aws-step-functions-alternatives).
+
+**Best for:** AWS-native organizations looking for a scalable, managed, and highly integrated workflow orchestration service for serverless applications and cloud-centric data pipelines.
+
+### 7. Camunda: Business Process Orchestration with BPMN
+
+Camunda is a process orchestration platform that uses the industry-standard Business Process Model and Notation (BPMN). It excels at modeling and executing long-running, complex business processes that involve both human tasks and system integrations. This makes it a powerful alternative for use cases that require formal governance, auditability, and collaboration between business and IT teams.
+
+Unlike RPA tools that focus on tasks, Camunda orchestrates end-to-end processes. It can integrate with microservices, legacy systems, and even trigger RPA bots as part of a larger process. Its strength lies in its ability to handle complex logic, escalations, and human-in-the-loop workflows with precision.
+
+**Best for:** Enterprises requiring formal business process modeling, governance, and orchestration that involves both human tasks and system integrations. See our list of [Camunda alternatives](/resources/infrastructure/camunda-alternatives) for more options in this space.
+
+### 8. Ansible Automation Platform: Infrastructure Automation at Scale
+
+While not a direct competitor, Ansible Automation Platform is a relevant alternative for teams whose automation needs are focused on IT infrastructure. It is an enterprise-grade platform for automating configuration management, application deployment, and other IT operations at scale. Its agentless architecture and simple, human-readable YAML syntax for playbooks make it a popular choice for platform engineering and DevOps teams.
+
+Ansible is often used as a component within a larger orchestration strategy. For example, an orchestrator like Kestra could call an Ansible playbook to provision a server, and then proceed with application deployment and data pipeline execution.
+
+**Best for:** IT operations and platform engineering teams focused on large-scale infrastructure automation, configuration management, and runbook execution. For more tools in this category, explore these [alternatives to Ansible](/resources/infrastructure/alternatives-to-ansible).
+
+## Comparison Table: Automation Anywhere Alternatives
+
+| Tool | License | Deployment | Primary Use Case | Developer Experience | Key Differentiator |
+|---|---|---|---|---|---|
+| Automation Anywhere | Proprietary | Cloud, On-Prem | Enterprise RPA | Low-Code, Visual | Comprehensive RPA platform with AI |
+| **Kestra** | Open-Source (Apache 2.0) & Enterprise | Cloud, On-Prem, Hybrid | Unified Orchestration | Declarative YAML, Code-First | Language-agnostic, cross-domain control plane |
+| UiPath | Proprietary | Cloud, On-Prem | Enterprise RPA & Business Automation | Low-Code, Visual | Market leader with extensive AI/ML features |
+| Microsoft Power Automate | Proprietary | Cloud, On-Prem (Desktop) | Business & Desktop Automation | Low-Code/No-Code | Deep integration with Microsoft ecosystem |
+| n8n | Source-Available & Commercial | Cloud, Self-Hosted | SaaS API Automation | Visual, Low-Code | Open-source, self-hostable, developer-friendly |
+| Windmill | Open-Source (MIT) & Enterprise | Cloud, Self-Hosted | Internal Tools & Workflows | Code-First (Python, TS, Go) | Turns scripts into internal apps and workflows |
+| AWS Step Functions | Proprietary | Cloud (AWS) | Serverless Orchestration | Visual & JSON/YAML | Fully managed, deep AWS integration |
+| Camunda | Open-Source (Zeebe) & Enterprise | Cloud, Self-Hosted | Business Process Orchestration | BPMN, Code-First (Java, etc.) | Industry-standard BPMN for formal processes |
+| Ansible Automation Platform | Proprietary (Upstream is OSS) | On-Prem, Cloud | Infrastructure Automation | Declarative YAML | Agentless, dominant in configuration management |
+
+## Choosing Your Automation Anywhere Alternative
+
+Selecting the right tool depends entirely on your team's primary goals and technical capabilities.
+
+-   **For data engineering teams:** If your automation needs are centered around data movement and transformation, a tool like **Kestra** provides a robust, declarative framework for building and managing complex data pipelines. **AWS Step Functions** is a strong choice for teams operating entirely within the AWS ecosystem.
+-   **For infrastructure & DevOps teams:** **Kestra** offers a unified platform to orchestrate infrastructure-as-code tools, CI/CD processes, and operational runbooks. **Windmill** is excellent for building custom internal tools, while **Ansible** remains the standard for configuration management.
+-   **For AI & ML platform teams:** **Kestra** can orchestrate the entire MLOps lifecycle, from data preparation to model training and deployment. **UiPath** offers specialized AI capabilities for embedding intelligence into RPA bots.
+-   **For business process automation (RPA-centric):** If your core requirement is still UI automation, **UiPath** is the market-leading choice. **Microsoft Power Automate** is ideal for organizations standardized on Microsoft, and **Camunda** is best for formal, BPMN-driven processes.
+-   **For small teams & open-source preference:** **Kestra**, **n8n**, and **Windmill** all offer powerful, self-hostable open-source editions that provide flexibility and cost-effectiveness without vendor lock-in.
+
+## The Future of Automation: RPA and Beyond with AI
+
+The line between RPA, workflow orchestration, and AI is blurring. The future of automation lies not in siloed bots but in intelligent, integrated systems that can reason, act, and adapt. This shift is driving the rise of concepts like [agentic orchestration](/resources/ai/agentic-orchestration) and the need for platforms that can manage complex [AI pipelines](/resources/ai/ai-pipeline) from end to end.
+
+Kestra's vision aligns with this future, providing a control plane for governing [multi-agent systems](/resources/ai/multi-agent-system) and ensuring that all automated actions—whether performed by a human, a script, or an AI—are auditable, reliable, and aligned with business goals. The industry is moving from a bot-centric view to a workflow-centric one, where the orchestrator is the central nervous system of the automated enterprise.
+
+## Conclusion: Embracing a Broader Automation Strategy
+
+Moving beyond a single-purpose RPA tool like Automation Anywhere opens up a world of more flexible, scalable, and developer-friendly automation. The right alternative depends on whether your focus is on business process automation, API-driven workflows, infrastructure management, or unifying all of the above.
+
+Platforms like Kestra represent the next generation of automation, offering a declarative, event-driven control plane that can orchestrate your entire technical stack. By embracing a broader automation strategy, you can build more resilient, observable, and future-proof workflows that drive real business value.
+
+Explore the [differences between Kestra and other alternatives](/vs) or get started with one of our [infrastructure automation blueprints](/blueprints/infrastructure-automation) to see how declarative orchestration can transform your workflows.

--- a/src/contents/resources/databricks-alternatives/index.md
+++ b/src/contents/resources/databricks-alternatives/index.md
@@ -1,0 +1,233 @@
+---
+title: "Top Databricks Alternatives for Data & AI Orchestration in 2026"
+description: "Explore the leading Databricks alternatives for data engineering, AI, and lakehouse workloads. Compare open-source, commercial, and orchestration platforms for your needs."
+metaTitle: "Databricks Alternatives: Top Data & AI Platforms (2026)"
+metaDescription: "Compare top Databricks alternatives for data and AI orchestration in 2026. Evaluate open-source, commercial, and specialized platforms for your lakehouse needs."
+tag: "data"
+date: 2026-07-01
+slug: "databricks-alternatives"
+faq:
+  - question: "Who is bigger, Snowflake or Databricks?"
+    answer: "Both Snowflake and Databricks are significant players in the data platform market, but they specialize in different areas. Snowflake is a leader in cloud data warehousing, while Databricks pioneered the lakehouse architecture. Market capitalization and revenue can fluctuate, but both companies have substantial market presence, with Databricks showing rapid growth in the AI and lakehouse space."
+  - question: "What Microsoft tool is similar to Databricks?"
+    answer: "Microsoft Fabric is a unified SaaS analytics platform launched in 2023, designed to consolidate data engineering, warehousing, data science, and business intelligence in one integrated Azure environment. While Databricks focuses on the lakehouse and AI, Fabric offers a broader, end-to-end data platform experience within the Microsoft ecosystem, making it a key competitor."
+  - question: "Does AWS have something like Databricks?"
+    answer: "Amazon EMR is AWS's managed cluster platform for big data frameworks like Apache Spark, Hadoop, and Presto, directly competing with Databricks for large-scale data processing. Additionally, AWS Lake Formation helps build secure data lakes, and services like Amazon Redshift offer data warehousing capabilities, providing a suite of tools that can collectively serve similar needs to Databricks."
+  - question: "Who is Databricks' biggest competitor?"
+    answer: "Databricks' biggest competitor depends on the specific use case. For cloud data warehousing, Snowflake is a primary rival. For broader cloud analytics platforms, Microsoft Fabric and Google BigQuery are strong contenders. In the open-source realm, direct Spark-based solutions or other lakehouse platforms also compete for market share."
+  - question: "Why is Snowflake not profitable?"
+    answer: "Snowflake, like many rapidly growing technology companies, prioritizes market share expansion and investment in product development over immediate profitability. High growth expenses, research and development, and sales and marketing investments are common for companies in competitive, high-growth markets, impacting short-term profitability while aiming for long-term market leadership and sustained revenue growth."
+  - question: "Is Databricks a Palantir competitor?"
+    answer: "Databricks and Palantir operate in distinct but sometimes overlapping domains. Databricks focuses on unified data analytics and AI within a lakehouse architecture, empowering data teams to build and deploy models. Palantir specializes in operational AI and data integration for complex, often sensitive, decision-making environments, particularly in government and large enterprises. While both handle large datasets and AI, their core offerings and target markets differ significantly."
+---
+
+The rapid evolution of data architectures has made platforms like Databricks indispensable for many organizations seeking to unify data, analytics, and AI workloads. Its lakehouse paradigm, combining the flexibility of data lakes with the structure of data warehouses, has set a new standard. However, as data ecosystems grow more complex, and as organizations navigate diverse cloud strategies, budget constraints, or specific operational requirements, the need for Databricks alternatives becomes clear. Teams often seek solutions that offer more granular control, deeper integration with their existing tech stack, or a different cost model.
+
+Choosing the right data platform is a strategic decision that impacts everything from developer productivity to operational costs and future scalability. Whether you're grappling with vendor lock-in, searching for more open-source flexibility, or need a platform that extends beyond a singular lakehouse vision, the market offers a rich array of alternatives. This article will guide you through the leading Databricks alternatives in 2026, from commercial giants and cloud-native services to robust open-source projects and specialized platforms. We’ll evaluate each based on key criteria, providing a clear framework to help you identify the best fit for your unique data and AI orchestration needs.
+
+## Understanding Databricks: What It Offers and Why Seek Alternatives
+
+Databricks has established itself as a central player in the modern data stack, built on the foundation of Apache Spark. Its platform unifies data engineering, data science, machine learning, and analytics within a single collaborative environment.
+
+### Databricks' Core Strengths: Lakehouse, AI, and Analytics
+
+The primary appeal of Databricks lies in its lakehouse architecture, which aims to provide the best of both data warehouses and data lakes. This includes ACID transactions, schema enforcement, and governance features on top of cloud object storage. Key strengths include:
+
+*   **Unified Platform:** A single environment for data processing (ETL), analytics (SQL), and machine learning.
+*   **Spark-Optimized:** Offers a highly optimized runtime for Apache Spark, delivering superior performance.
+*   **Collaborative Notebooks:** Enables teams of data scientists, engineers, and analysts to work together.
+*   **Delta Lake:** An open-source storage layer that brings reliability and performance to data lakes.
+*   **AI and ML Lifecycle:** Integrated tools like MLflow for managing the end-to-end machine learning lifecycle.
+
+### Why Organizations Seek Databricks Alternatives
+
+Despite its powerful capabilities, no single platform is a perfect fit for every organization. Teams often explore alternatives for several strategic and operational reasons:
+
+*   **Cost Management:** Databricks pricing, based on Databricks Units (DBUs), can become complex and expensive at scale, prompting a search for more predictable or cost-effective models.
+*   **Vendor Lock-In:** While built on open-source components, the optimized environment and proprietary features can create a dependency on the Databricks platform, making future migrations difficult.
+*   **Operational Complexity:** Managing workflows that span both inside and outside the Databricks ecosystem can be challenging. Many teams require a more universal orchestration layer to coordinate tasks across different systems. Check out our deep dive into [Databricks Workflows alternatives](/resources/data/databricks-workflows-alternatives) for more on this topic.
+*   **Python-Centricity:** While powerful, the platform's focus on Python and Spark notebooks may not be ideal for polyglot teams or for workflows that are primarily SQL- or shell-based.
+*   **Desire for Open-Source Control:** Some organizations prefer the complete control and transparency offered by self-managed, fully open-source solutions.
+*   **Multi-Cloud and Hybrid Strategies:** Companies with a multi-cloud or hybrid infrastructure may seek a platform-agnostic solution that operates consistently across all environments.
+
+## How We Evaluated These Alternatives
+
+To provide a balanced comparison, we evaluated each Databricks alternative based on a consistent set of criteria. This framework is designed to help you assess which platform best aligns with your technical requirements, business goals, and operational model. We considered the following factors:
+
+*   **Deployment Model:** Whether the solution is cloud-native, on-premise, hybrid, or Kubernetes-native.
+*   **License:** The licensing model, distinguishing between fully open-source projects and commercial platforms.
+*   **Primary Use Case Fit:** The core problem the platform is designed to solve—be it data warehousing, lakehouse management, ETL, or ML/AI.
+*   **Pricing Transparency:** The clarity and predictability of the pricing model.
+*   **Ecosystem Integration:** The platform's ability to connect with and orchestrate other tools in the modern data stack.
+*   **Operational Flexibility:** The degree of control and customization the platform offers to engineering and operations teams.
+
+## The Leading Databricks Alternatives
+
+The market for data platforms is diverse, with options ranging from direct competitors to specialized tools and orchestration layers. Here are 13 of the top alternatives to consider in 2026.
+
+### 1. Kestra: The Declarative Orchestration Control Plane
+
+Kestra is not a direct, feature-for-feature replacement for Databricks' data processing capabilities. Instead, it offers a superior orchestration layer that sits *above* platforms like Databricks, providing a unified control plane for your entire data and AI stack. Workflows are defined in declarative YAML, making them easy to write, version, and manage.
+
+Kestra's language-agnostic architecture allows you to run Python, SQL, Shell, Docker containers, and more as first-class citizens within a single workflow. This is crucial for modern data teams that use a variety of tools. Instead of being locked into a single platform's orchestrator, Kestra lets you coordinate Databricks jobs, dbt transformations, cloud services, and infrastructure tasks from one place. Its event-driven capabilities enable complex, reactive workflows that can be triggered by file uploads, API calls, or messages.
+
+For example, Apple's ML team uses Kestra to orchestrate large-scale ETL and data pipelines, and Leroy Merlin France built its DataMesh at scale with Kestra, increasing data production by 900%. Kestra provides an open-source core with powerful enterprise features for governance, security, and scale, ensuring it fits both small teams and large organizations.
+
+**Best for:** Teams seeking a unified, language-agnostic orchestration layer that can coordinate Databricks jobs alongside other tools across diverse domains and environments.
+
+### 2. Snowflake: Cloud Data Warehouse with a Lakehouse Vision
+
+Snowflake is one of Databricks' most prominent competitors, particularly in the cloud data warehousing space. Its architecture, which decouples storage and compute, allows for immense scalability and concurrency. While traditionally a data warehouse, Snowflake has expanded its capabilities to embrace the lakehouse paradigm with support for open formats like Apache Iceberg and external tables.
+
+Its strengths lie in its fully managed SaaS offering, robust security and governance features, and a thriving data marketplace. Snowflake's Snowpark allows developers to write data processing logic in Python, Java, and Scala, which runs directly within the platform. This makes it a strong contender for organizations that prioritize a managed, SQL-first experience but also need to support more complex data engineering and ML workloads. When comparing size, both Snowflake and Databricks are market leaders, with Snowflake historically dominant in the data warehousing market and Databricks leading the charge in the lakehouse and AI space.
+
+**Best for:** Organizations prioritizing a fully managed, scalable cloud data warehouse with strong governance and a growing lakehouse story.
+
+### 3. Microsoft Fabric: Unified Analytics for the Azure Ecosystem
+
+Launched in 2023, Microsoft Fabric is a direct and compelling answer to the unified analytics platform vision. It is an all-in-one SaaS solution that integrates data engineering, data science, data warehousing, and business intelligence into a single, cohesive environment built on Microsoft Azure. Fabric aims to eliminate tool sprawl by providing a unified experience from the data lake (OneLake) to the end user's Power BI report.
+
+For organizations deeply embedded in the Azure ecosystem, Fabric is a natural choice. It offers seamless integration with services like Azure Data Factory, Azure Synapse Analytics, and Power BI. Unlike Databricks, which can run on any cloud, Fabric is an Azure-native service, offering a tightly integrated but less portable solution.
+
+**Best for:** Enterprises deeply committed to the Microsoft Azure ecosystem seeking a unified, end-to-end data and analytics platform.
+
+### 4. Amazon EMR: AWS's Managed Big Data Frameworks
+
+For teams that want to stick with open-source frameworks like Apache Spark, Hadoop, and Presto but want to offload cluster management, Amazon EMR is a leading choice. It's AWS's managed cluster platform, providing a flexible and cost-effective way to run large-scale distributed data processing jobs.
+
+EMR offers more granular control over cluster configuration and pricing than Databricks, allowing teams to optimize for specific workloads. With options like EMR Serverless and EMR on EKS, it provides deployment flexibility within the AWS ecosystem. While it lacks the unified, notebook-driven UI of Databricks, EMR is a powerful infrastructure-level alternative for engineering-heavy teams who want to build their own data platform on AWS.
+
+**Best for:** AWS-native teams requiring fine-grained control over big data frameworks and maximizing cost efficiency within their AWS infrastructure.
+
+### 5. Google BigQuery: Serverless Data Warehousing and Analytics
+
+Google BigQuery pioneered the serverless data warehouse, offering a fully managed, petabyte-scale analytics platform. Its primary differentiator is its serverless architecture, which automatically scales compute resources based on query demand, simplifying operations and cost management.
+
+BigQuery has strong SQL capabilities, integrated machine learning (BigQuery ML), and real-time analytics features. It is a formidable Databricks alternative for organizations on Google Cloud Platform (GCP) that prioritize speed, scalability, and a managed, serverless experience for their analytical workloads. While it started as a pure data warehouse, its support for external tables and open formats makes it a contender in the broader data lakehouse space.
+
+**Best for:** Organizations seeking a fully managed, serverless data warehouse for high-volume analytics and real-time insights within the Google Cloud ecosystem.
+
+### 6. Apache Spark: The Open-Source Foundation
+
+It's important to remember that Databricks itself is built on Apache Spark. For organizations wanting to avoid vendor lock-in entirely, using open-source Spark directly is a viable option. This approach offers maximum flexibility, control, and customization.
+
+Running your own Spark clusters on-premise or on a cloud provider like AWS, Azure, or GCP allows you to tailor the environment precisely to your needs and avoid proprietary platform fees. However, this path requires significant engineering expertise to manage, optimize, and maintain the infrastructure. It's a trade-off between control and operational overhead.
+
+**Best for:** Teams with strong engineering capabilities who want maximum control, customization, and open-source freedom for big data processing.
+
+### 7. Dremio: Open Data Lakehouse Platform
+
+Dremio is an open data lakehouse platform that enables high-performance SQL queries directly on data lake storage like S3, ADLS, and GCS. Its key feature is a powerful query engine that accelerates queries without requiring data to be moved or copied into a proprietary data warehouse.
+
+With a focus on self-service analytics and BI, Dremio empowers analysts to explore data directly. It supports open formats like Apache Iceberg and provides a semantic layer for data governance and consistency. Dremio offers both an open-source edition and a commercial cloud offering, providing flexibility for different organizational needs.
+
+**Best for:** Teams looking for an open data lakehouse platform that enables direct SQL queries on data lake storage without ETL.
+
+### 8. MotherDuck: Serverless Analytics with DuckDB
+
+MotherDuck is a serverless analytics platform built on top of the popular open-source in-process OLAP database, DuckDB. It targets a different scale than Databricks, focusing on providing a fast, simple, and cost-effective SQL analytics experience for datasets that don't necessarily require a massive distributed cluster.
+
+The unique value proposition of MotherDuck is its hybrid execution model, allowing users to run queries locally on their laptop using DuckDB and seamlessly scale out to the cloud for larger datasets or collaborative work. It's an excellent choice for developers and analysts who need fast, interactive SQL without the complexity of managing a large data platform.
+
+**Best for:** Developers and data analysts seeking fast, local-first, serverless SQL analytics for ad-hoc queries and interactive data exploration.
+
+### 9. Dataiku: End-to-End AI and Machine Learning Platform
+
+For organizations where the primary driver is machine learning and AI, Dataiku presents a compelling alternative. It is a collaborative, end-to-end platform that covers the entire AI lifecycle, from data preparation and feature engineering to model training, deployment, and monitoring.
+
+Dataiku caters to a wide range of personas, offering a visual interface for business analysts and full code-based flexibility for data scientists. While Databricks has strong ML capabilities with MLflow, Dataiku provides a more holistic and governed environment specifically designed for enterprise AI. It can connect to various data sources, including data lakes and warehouses, and act as the central hub for all AI projects.
+
+**Best for:** Data science teams and enterprises needing a collaborative platform for end-to-end AI and ML lifecycle management, blending visual and code-based approaches.
+
+### 10. Apache Flink: Real-Time Stream Processing
+
+While Databricks supports stream processing with Spark Structured Streaming, Apache Flink is a dedicated, best-in-class engine for real-time data processing. Flink is designed for high-throughput, low-latency, stateful computations over unbounded data streams.
+
+If your primary use case involves real-time analytics, event-driven applications, or complex event processing, Flink is a powerful open-source alternative. It provides more advanced features for stream processing than Spark, making it the preferred choice for organizations building sophisticated real-time data pipelines.
+
+**Best for:** Organizations focused on real-time data processing, stream analytics, and building event-driven applications that require high performance.
+
+### 11. IOMETE: Kubernetes-Native Data Lakehouse
+
+IOMETE is an open-source data lakehouse platform built to run natively on Kubernetes. It combines Apache Spark and Apache Iceberg to provide a cost-effective and flexible alternative to Databricks, particularly for organizations that have standardized on Kubernetes for their infrastructure.
+
+By leveraging Kubernetes, IOMETE offers efficient resource management and scalability. It provides a unified environment for data engineering and analytics, with a focus on open standards and avoiding vendor lock-in. It's a strong choice for platform engineering teams who want to manage their data infrastructure as part of their existing containerized ecosystem.
+
+**Best for:** Teams running on Kubernetes who want an open-source, managed data lakehouse that integrates natively with their containerized infrastructure.
+
+### 12. Qubole: Cost-Effective Analytics for Data Lakes
+
+Qubole offers a managed big data platform designed to simplify and optimize analytics on cloud data lakes. It supports multiple open-source engines, including Spark, Presto, and Hive, and provides intelligent automation to manage clusters and control costs.
+
+Qubole's main value proposition is its ability to reduce the total cost of ownership for data lake operations through features like auto-scaling clusters and workload-aware spot instance management. It's a good alternative for enterprises that want the benefits of open-source engines without the full burden of self-management and are highly focused on optimizing their cloud spend.
+
+**Best for:** Enterprises looking for a managed service to optimize cost and performance of big data analytics on cloud data lakes.
+
+### 13. Tinybird: Real-Time Data Analytics for Developers
+
+Tinybird is a real-time data platform designed for developers. It allows you to ingest streaming data at scale and use SQL to build low-latency APIs that power data-intensive applications, dashboards, and real-time personalization.
+
+Built on ClickHouse, Tinybird is optimized for speed and efficiency. It abstracts away the complexity of managing a real-time data infrastructure, providing a simple, API-first workflow. While not a direct competitor to Databricks for batch processing or ML, it's a powerful alternative for use cases that require immediate insights and data-driven APIs.
+
+**Best for:** Developers building real-time data products, dashboards, and APIs that require immediate insights from streaming data.
+
+## Comparison of Databricks Alternatives
+
+| Tool             | License                       | Deployment                | Best for                                            | Primary Focus                         |
+|------------------|-------------------------------|---------------------------|-----------------------------------------------------|---------------------------------------|
+| Kestra           | Open-Source (Apache 2.0) + EE | Cloud, On-prem, Hybrid, K8s | Orchestration across data, AI, infra, business        | Unified, declarative workflow orchestration |
+| Snowflake        | Commercial                    | Cloud (AWS, Azure, GCP)   | Cloud Data Warehousing & Analytics                  | Managed Data Warehouse, Lakehouse     |
+| Microsoft Fabric | Commercial (SaaS)             | Azure                     | Unified Azure Data & AI Platform                    | End-to-End Analytics Platform         |
+| Amazon EMR       | Commercial (AWS Service)      | AWS                       | Managed Big Data Frameworks on AWS                  | Distributed Processing (Spark, Hadoop)  |
+| Google BigQuery  | Commercial (GCP Service)      | GCP                       | Serverless Data Warehousing & ML                    | Serverless Data Warehouse & Analytics |
+| Apache Spark     | Open-Source                   | Self-managed              | Flexible Big Data Processing                        | Distributed Data Processing Engine    |
+| Dremio           | Open-Source + Commercial      | Cloud, On-prem            | Open Data Lakehouse with SQL Query                  | Data Lake Query Engine                |
+| MotherDuck       | Commercial (Serverless)       | Cloud (DuckDB)            | Local-First Serverless SQL Analytics                | Interactive SQL Analytics             |
+| Dataiku          | Commercial                    | Cloud, On-prem            | End-to-End Data Science & ML                        | Collaborative AI Platform             |
+| Apache Flink     | Open-Source                   | Self-managed              | Real-Time Stream Processing                         | High-Performance Stream Processing    |
+| IOMETE           | Open-Source + Commercial      | K8s, Cloud, On-prem       | Kubernetes-Native Data Lakehouse                    | Managed K8s Lakehouse                 |
+| Qubole           | Commercial                    | Cloud                     | Cost-Optimized Data Lake Analytics                  | Managed Big Data Platform             |
+| Tinybird         | Commercial                    | Cloud                     | Real-Time Data Products & APIs                      | API-First Real-Time Analytics         |
+
+## Choosing the Right Databricks Alternative for Your Needs
+
+Selecting the right platform requires a careful assessment of your team's skills, existing infrastructure, and long-term goals. Here’s a framework to guide your decision.
+
+### For Data Engineering Teams Prioritizing Flexibility
+
+If your priority is building a flexible, best-of-breed data stack, you need tools that are interoperable and not tied to a single vendor.
+*   **Kestra** is ideal for orchestrating diverse tools and technologies with a language-agnostic, declarative approach.
+*   **Apache Spark** provides ultimate control for teams willing to manage their own infrastructure.
+*   **Dremio** offers an open lakehouse foundation that allows you to query data in place.
+For a deeper dive into building modern data platforms, explore our resources on [declarative orchestration for modern data engineers](/data).
+
+### For Organizations Deeply Invested in a Single Cloud Ecosystem
+
+If your organization has standardized on a single cloud provider, leveraging their native services can offer significant advantages in integration and billing.
+*   **Microsoft Fabric** is the clear choice for Azure-centric organizations.
+*   **Amazon EMR** is the go-to for teams building on AWS.
+*   **Google BigQuery** offers a powerful serverless option for those on GCP.
+*   **Snowflake**, while cloud-agnostic, has deep integrations with all major cloud providers and is a strong choice for a managed data warehouse.
+
+### For AI/ML Platform Teams Seeking Specific Capabilities
+
+When AI and machine learning are the primary drivers, specialized platforms can provide a more tailored and productive experience.
+*   **Dataiku** offers a collaborative, end-to-end environment for building and deploying AI models.
+*   **Kestra** provides robust capabilities for AI agent orchestration, allowing you to build complex, auditable AI workflows. Discover more about [Kestra's AI plugin ecosystem](/blogs/kestra-plugins-ai-ecosystem).
+
+### For Teams Seeking Open-Source Control and Cost Efficiency
+
+For those looking to avoid vendor lock-in and manage costs, open-source solutions provide a powerful path forward.
+*   **Apache Spark** is the foundational engine for building a custom data platform.
+*   **Dremio** and **IOMETE** offer open-source lakehouse platforms with commercial support options.
+*   **Kestra's** open-source core provides a production-ready orchestration engine that can be deployed anywhere without licensing fees.
+
+## Conclusion: Beyond the Platform, Orchestrate Your Entire Stack
+
+The data platform landscape in 2026 offers a wealth of powerful Databricks alternatives, each with unique strengths. The best choice is not a one-size-fits-all answer but depends on your specific needs—whether they are driven by cost, flexibility, cloud strategy, or a focus on open-source.
+
+Ultimately, the data platform is just one piece of a larger puzzle. Modern data ecosystems are composed of dozens of specialized tools, and the real challenge lies in making them work together reliably and efficiently. This is where a universal orchestration control plane becomes critical.
+
+Platforms like Kestra provide the unifying layer that connects your entire stack, whether you choose Databricks, Snowflake, an open-source solution, or a combination of tools. By separating orchestration from execution, you gain the flexibility to evolve your data platform without having to rewrite your core business logic.
+
+Explore our [comparison of Kestra vs. alternatives](/vs) and browse our full library of [data, AI, and infrastructure resources](/resources) to learn more about building a resilient and scalable data architecture.

--- a/src/contents/resources/debezium-alternatives/index.md
+++ b/src/contents/resources/debezium-alternatives/index.md
@@ -1,0 +1,203 @@
+---
+title: "Top Debezium Alternatives for Change Data Capture (CDC)"
+description: "Explore the leading Debezium alternatives for real-time change data capture. Compare open-source, managed, and Kafka-less solutions to find the best fit for your data pipelines."
+metaTitle: "Debezium Alternatives: Top CDC Tools for Data Pipelines"
+metaDescription: "Explore the best Debezium alternatives: top open-source, managed, and Kafka-less CDC tools like Kestra, Airbyte, and Maxwell for your data streaming needs."
+tag: "data"
+date: 2026-07-08
+slug: "debezium-alternatives"
+faq:
+  - question: "What is the difference between Maxwell and Debezium?"
+    answer: "Maxwell's Daemon is a lightweight, single-process CDC tool specifically for MySQL, offering simplicity for MySQL-only environments. Debezium, in contrast, is a robust, distributed framework for multiple databases (PostgreSQL, MongoDB, SQL Server, MySQL) designed for integration with Kafka, offering broader database support and a more complex, fault-tolerant architecture."
+  - question: "What is the difference between Debezium and NiFi?"
+    answer: "Debezium is a change data capture tool focused on extracting database changes and publishing them, typically to Kafka. Apache NiFi is a dataflow management system that excels at consuming, processing, and distributing data from various sources (including Kafka) to downstream systems. They are complementary: Debezium captures, and NiFi can then process the captured changes."
+  - question: "How does Debezium compare to other CDC tools?"
+    answer: "Debezium stands out as a powerful open-source CDC engine with extensive database compatibility and deep Kafka integration. While it provides robust change capture, other tools offer different trade-offs: some are simpler for specific databases (like Maxwell), some provide broader ETL/ELT capabilities (like Airbyte), and others are fully managed services that abstract away operational complexity."
+  - question: "What is the difference between Debezium and Airbyte?"
+    answer: "Debezium is a real-time CDC engine primarily designed to stream database changes to Kafka, focusing on the capture mechanism. Airbyte is a broader ELT platform that offers a wide array of connectors, including CDC as an ingestion method, to move data from sources to destinations like data warehouses. Airbyte simplifies the end-to-end data movement, while Debezium specializes in the raw change capture."
+  - question: "What is the best alternative to Debezium?"
+    answer: "The 'best' alternative to Debezium depends on your specific needs. For a managed, Kafka-less experience, services like Integrate.io or Estuary Flow are strong contenders. For open-source, broad ELT capabilities, Airbyte is excellent. If you need lightweight MySQL-only CDC, Maxwell's Daemon is simpler. Kestra offers a flexible orchestration layer that can integrate with or replace Debezium for managing CDC pipelines declaratively."
+  - question: "Is Debezium still worth using in 2026?"
+    answer: "Yes, Debezium remains a highly capable and widely adopted open-source CDC tool in 2026, especially for teams committed to a Kafka-centric streaming architecture. Its active community and broad database support ensure its continued relevance. However, its operational complexity and Kafka dependency drive many teams to explore alternatives for simpler, managed, or Kafka-less solutions."
+---
+
+Debezium has long been a cornerstone for real-time change data capture (CDC), enabling data teams to stream database changes to Kafka for various downstream applications. However, as data architectures evolve, many organizations find themselves re-evaluating their CDC strategy. The operational overhead of managing Kafka, the desire for simpler deployment models, or the need for broader data integration capabilities often prompt a search for alternatives.
+
+This article explores the top Debezium alternatives in 2026, from open-source tools to fully managed platforms, each offering a distinct approach to CDC. We'll delve into their strengths, limitations, and ideal use cases, providing a framework to help you choose the right solution to power your modern data pipelines.
+
+## Why Teams Seek Alternatives to Debezium for CDC
+
+Debezium is a powerful open-source project, but its design philosophy, centered around Kafka, introduces trade-offs that don't fit every organization. The reasons teams look for alternatives often boil down to complexity, scope, and operational model.
+
+**Operational Complexity of Kafka:** The most significant driver is Debezium's tight coupling with Apache Kafka. While Kafka is a robust streaming platform, it is not a trivial piece of infrastructure to manage. Teams without existing Kafka expertise face a steep learning curve and significant operational burden related to setup, tuning, monitoring, and scaling a Kafka cluster, Zookeeper, and Kafka Connect. This complexity can overshadow the benefits of CDC for smaller teams or projects where a full-blown streaming architecture is overkill.
+
+**Maintenance and Expertise:** Running Debezium effectively requires a deep understanding of its connectors, configuration options, and failure modes. Debugging issues with offsets, schema evolution, or connector lifecycle management demands specialized knowledge. As teams grow, this can create a knowledge silo and a dependency on a few key individuals.
+
+**Limited Scope Beyond Capture:** Debezium excels at one thing: capturing database changes and publishing them. It is not a complete data pipeline solution. Teams still need to build, manage, and monitor the downstream consumers that process these change events. This often results in a collection of disparate scripts and services, each with its own logic and potential points of failure. An orchestration layer is needed to manage the end-to-end process, and many teams prefer a single tool that can handle both the capture and the subsequent workflow.
+
+**Desire for Kafka-less or Managed Solutions:** The operational overhead of a self-hosted Debezium and Kafka stack leads many to seek simpler architectures. [Kafka-less CDC solutions](/blogs/2022-04-05-debezium-without-kafka-connect) that stream changes directly to a destination or via a lighter-weight message queue are increasingly popular. Similarly, managed SaaS platforms that handle the entire CDC process—from capture to delivery—offer a compelling trade-off, abstracting away all infrastructure concerns in exchange for a subscription fee.
+
+## Key Considerations for Choosing a Debezium Alternative
+
+Selecting the right CDC tool involves more than just swapping out a connector. It requires a clear understanding of your technical requirements, operational capacity, and long-term data strategy.
+
+### Understanding Your CDC Needs: Real-time, Batch, or Both?
+
+First, define your latency requirements. Does your use case demand sub-second, real-time data replication for applications like cache invalidation or fraud detection? Or is your goal to support near-real-time analytics, where updates every few minutes or hours are sufficient? Debezium is built for low-latency streaming. Some alternatives, particularly ELT platforms, may operate on micro-batch schedules. Be clear about what "real-time" means for your business to narrow down the field.
+
+### Kafka-less CDC: Simplifying Your Streaming Architecture
+
+The decision to use Kafka is a major architectural choice. A Kafka-less approach can drastically reduce infrastructure complexity, cost, and maintenance. This is ideal for use cases where you need to move data from a source database directly to a data warehouse, a cloud storage bucket, or an API without the intermediate step of a durable log. However, you lose Kafka's benefits, such as a persistent, replayable buffer and the ability to serve multiple independent consumers. Evaluate if the simplicity of a point-to-point CDC pipeline outweighs the flexibility of a central streaming backbone.
+
+### Open-Source vs. Managed Solutions: Control vs. Convenience
+
+Open-source tools like Debezium, Maxwell, or Airbyte offer maximum control, flexibility, and no licensing costs. You can customize them to your exact needs and deploy them in any environment, including on-premises or in a VPC. The trade-off is that you are responsible for all setup, maintenance, scaling, and troubleshooting.
+
+Managed CDC services offer the opposite proposition. They provide a turnkey solution with predictable costs, expert support, and zero operational overhead. This allows your team to focus on using the data rather than managing the pipeline. The downside is less control, potential vendor lock-in, and a consumption-based pricing model that may become expensive at scale. For a broader view of this trade-off, explore various [ETL orchestration tools](/resources/data/etl-orchestration-tool-alternatives).
+
+## The Top Debezium Alternatives for Modern Data Pipelines
+
+The landscape of CDC tools is diverse, ranging from lightweight open-source projects to comprehensive enterprise platforms. Here are eight leading alternatives to Debezium.
+
+### 1. Kestra: Declarative Orchestration for Any CDC Strategy
+
+Kestra is not a like-for-like CDC capture tool but an orchestration platform that provides a flexible and powerful way to manage CDC workflows, either with Debezium or as a Kafka-less alternative. It acts as a unified control plane for your entire data pipeline.
+
+Kestra integrates directly with Debezium through a suite of plugins for [PostgreSQL](/plugins/plugin-debezium-postgres), [MySQL](/plugins/plugin-debezium-mysql), MongoDB, SQL Server, Oracle, and DB2. You can use a Kestra trigger to launch a workflow in real-time for every change event (e.g., INSERT, UPDATE, DELETE) captured by Debezium. This event-driven model allows you to process changes declaratively without writing and managing custom consumers.
+
+For teams looking to avoid Kafka, Kestra can directly manage CDC processes. A workflow can periodically poll for changes or be triggered by a database mechanism, then execute downstream tasks in any language—Python, SQL, Shell, Node.js—to process and deliver the data. This provides a simpler, auditable, and more integrated approach.
+
+All workflows are defined as simple YAML files, making them easy to version control, review, and manage with GitOps practices. This declarative approach, combined with a visual UI, simplifies the development and maintenance of complex data pipelines. For example, you can implement a full CDC pipeline by following a simple [blueprint for listening to Postgres changes with Debezium](/blueprints/listen-debezium).
+
+```yaml
+id: debezium-postgres-cdc
+namespace: company.team.production
+
+tasks:
+  - id: process-changes
+    type: io.kestra.plugin.scripts.python.Script
+    script: |
+      import json
+      
+      # '{{ trigger.data }}' contains the CDC event from Debezium
+      event = json.loads('{{ trigger.data }}')
+      
+      # Your processing logic here
+      print(f"Processing change for table {event['source']['table']} with ID: {event['after']['id']}")
+
+triggers:
+  - id: watch-for-changes
+    type: io.kestra.plugin.debezium.postgres.Trigger
+    host: "{{ secrets.PG_HOST }}"
+    username: "{{ secrets.PG_USER }}"
+    password: "{{ secrets.PG_PASSWORD }}"
+    # Other Debezium connector properties here
+```
+
+Companies like [Leroy Merlin France](/customers/leroy-merlin-france) have used Kestra to build a Data Mesh at scale, increasing data production by 900%, while [JPMorgan Chase](/customers/jpmorgan-chase) orchestrates complex cybersecurity analytics workflows processing billions of rows. Kestra's strength lies in its ability to provide a single, unified platform for all your [data orchestration](/data) needs.
+
+**Best for:** Teams seeking a flexible, event-driven orchestrator to manage CDC alongside other data, infra, and AI workflows, simplifying operations and enabling a Kafka-less approach when desired.
+
+### 2. Airbyte: Open-Source ELT with CDC Capabilities
+
+Airbyte is a popular open-source data integration platform focused on ELT (Extract, Load, Transform). It offers a vast library of connectors for both sources and destinations. For many of its database sources, Airbyte supports CDC as a replication method, allowing it to incrementally sync changes to a destination like Snowflake, BigQuery, or Redshift.
+
+Unlike Debezium, which is a specialized CDC engine, Airbyte is a complete ELT tool. It manages the schema mapping, data loading, and basic transformation scheduling. This makes it an excellent choice for teams whose primary goal is to replicate data from an operational database to an analytical warehouse. Both self-hosted open-source and managed cloud versions are available.
+
+**Best for:** Data teams needing a comprehensive ELT platform with CDC as an ingestion method, especially those leveraging its extensive connector library.
+
+### 3. Maxwell's Daemon: Lightweight MySQL CDC
+
+Maxwell's Daemon is an open-source CDC application specifically for MySQL and its variants (MariaDB, Aurora). It reads MySQL binlogs, transforms row changes into JSON, and pushes them to various targets, including Kafka, Kinesis, Google Cloud Pub/Sub, or standard output.
+
+Its key advantage over Debezium is its simplicity and lightweight nature. It runs as a single process and is significantly easier to configure and operate for MySQL-only environments. If your entire data ecosystem is built on MySQL and you need a straightforward, no-frills CDC tool, Maxwell is a strong contender.
+
+**Best for:** Teams with MySQL-only environments looking for a straightforward, lightweight CDC solution.
+
+### 4. BladePipe: Kafka-less CDC for Direct Data Streams
+
+BladePipe is a more recent entrant focused on providing a modern, Kafka-less CDC pipeline. It aims to simplify the architecture by streaming database changes directly to destinations like cloud object storage or data warehouses without an intermediate message broker.
+
+This direct approach reduces latency and operational complexity. It's designed for data engineers who need to build reliable, low-maintenance pipelines for analytics and data replication. BladePipe handles schema evolution and provides tooling for monitoring and managing the data flow, offering a more complete solution than a raw capture tool.
+
+**Best for:** Organizations prioritizing a direct, Kafka-free path for specific database changes to destinations like object storage or data warehouses.
+
+### 5. Integrate.io: Managed CDC and Data Integration
+
+Integrate.io is a cloud-based, low-code data integration platform that offers ETL, ELT, and CDC capabilities. It provides a visual, drag-and-drop interface for building data pipelines, making it accessible to a wider range of users, including data analysts and business users.
+
+As a fully managed service, Integrate.io handles all the underlying infrastructure, from connector maintenance to pipeline execution and monitoring. Its CDC feature allows for efficient replication of data from sources like Salesforce, MySQL, and PostgreSQL to cloud data warehouses. It's a strong alternative for businesses that want to implement CDC without dedicating engineering resources to infrastructure management.
+
+**Best for:** Businesses needing a fully managed, low-code data integration solution with robust CDC without managing underlying infrastructure.
+
+### 6. Enterprise Solutions: Qlik, Talend, Oracle GoldenGate
+
+For large enterprises with complex, heterogeneous environments and strict requirements for security, governance, and support, established commercial platforms are often the preferred choice.
+
+*   **Qlik Replicate (formerly Attunity):** A leader in enterprise data replication, Qlik provides high-performance, real-time CDC across a wide range of databases, mainframes, and SaaS applications.
+*   **Talend:** A comprehensive data integration suite that includes CDC as part of its broader capabilities, which also cover data quality, master data management, and an enterprise service bus.
+*   **Oracle GoldenGate:** A premium, high-performance solution for real-time data integration and replication, especially powerful within Oracle ecosystems but also supporting heterogeneous environments.
+
+These tools come with a significant price tag but offer proven reliability, extensive features, and dedicated enterprise support.
+
+**Best for:** Large enterprises with complex, mission-critical data environments requiring robust, proven, and often proprietary CDC and data integration capabilities.
+
+### 7. Estuary Flow (formerly OLake): Real-time Data Integration Platform
+
+Estuary Flow is a fully managed, real-time data integration platform built around CDC. It aims to provide a unified solution for capturing, transforming, and delivering data with strong guarantees of correctness and consistency.
+
+Flow connects to various databases and SaaS applications, captures changes in real-time, and allows for in-stream transformations using SQL or TypeScript. It manages schema evolution automatically and ensures that data arrives at its destination (like a data warehouse or another database) in a consistent state. It competes directly with managed Debezium offerings but aims to solve the end-to-end pipeline problem.
+
+**Best for:** Teams looking for a managed service that handles the full real-time data pipeline, from capture to delivery, with strong consistency guarantees.
+
+### 8. Apache NiFi: Flow-Based Dataflow Management
+
+Apache NiFi is not a CDC capture tool itself, but it is often used as an alternative for processing and routing data streams generated by CDC tools. NiFi provides a visual, flow-based programming model where users can build complex dataflows by connecting processors on a canvas.
+
+A common pattern is to have Debezium publish changes to Kafka, and then have NiFi consume from Kafka to perform transformations, enrichment, filtering, and routing to multiple destinations. For teams that need granular control over the dataflow and value strong data provenance and visual pipeline management, NiFi is a powerful complement or downstream alternative to custom consumers. You can find more details on [Apache NiFi alternatives](/resources/data/apache-nifi-alternatives) for different use cases.
+
+**Best for:** Organizations with complex data routing, transformation, and governance needs for their CDC-derived data streams.
+
+## Comparison Table: Debezium Alternatives at a Glance
+
+| Tool | License | Deployment | Primary Use Case | Kafka Dependency | Best For |
+|---|---|---|---|---|---|
+| **Kestra** | Apache 2.0 (OSS & Enterprise) | Self-hosted, Cloud | Workflow Orchestration | Optional | Flexible, event-driven orchestration of CDC and other workflows. |
+| **Airbyte** | MIT (OSS & Cloud) | Self-hosted, Cloud | ELT & Data Integration | No | Comprehensive ELT with CDC as a source for warehouse replication. |
+| **Maxwell's Daemon** | Apache 2.0 | Self-hosted | CDC for MySQL | Optional | Lightweight, simple CDC for MySQL-only environments. |
+| **BladePipe** | Commercial | Cloud | Kafka-less CDC | No | Direct, simplified CDC pipelines without a message broker. |
+| **Integrate.io** | Commercial | Cloud | Managed ETL/ELT/CDC | No | Low-code, fully managed data integration for businesses. |
+| **Qlik/Talend/GoldenGate** | Commercial | Self-hosted, Cloud | Enterprise Data Integration | Varies | Large enterprises with complex, mission-critical requirements. |
+| **Estuary Flow** | Commercial | Cloud | Managed Real-time Pipelines | No | End-to-end managed CDC with strong consistency guarantees. |
+| **Apache NiFi** | Apache 2.0 | Self-hosted | Dataflow Management | No (but often used with it) | Complex data routing and processing of CDC streams. |
+
+## How to Choose the Right Debezium Alternative for Your Stack
+
+The best choice depends entirely on your team's skills, infrastructure, and goals.
+
+### For Data Engineering Teams Prioritizing Flexibility and Control
+
+If your team values control, customization, and open-source tooling, **Kestra**, **Airbyte**, and **Maxwell** are excellent choices.
+*   **Kestra** offers the most flexibility, allowing you to build any kind of CDC workflow—event-driven with Debezium, scheduled polling, or Kafka-less—all defined as code in a unified platform.
+*   **Airbyte** is the go-to if your main objective is moving data from many sources into a data warehouse.
+*   **Maxwell** is perfect for simple, dedicated MySQL CDC.
+Explore how to build modern [data platforms](/data) to see where these tools fit.
+
+### For Teams Seeking Managed Services and Reduced Operational Overhead
+
+If your priority is to minimize infrastructure management and accelerate time-to-value, managed services are the way to go.
+*   **Integrate.io** is ideal for teams that prefer a low-code, visual interface.
+*   **Estuary Flow** provides a robust, real-time solution for engineers who want a managed platform with strong data guarantees.
+*   Don't forget managed Kafka providers like **Confluent Cloud**, which can simplify the Kafka part of a Debezium deployment, though you still manage the Debezium connectors.
+
+### For Enterprises with Complex Integration and Governance Needs
+
+Large organizations often have requirements that go beyond simple data movement, including advanced governance, security, and lineage.
+*   **Qlik**, **Talend**, and **Oracle GoldenGate** are the established leaders in this space, offering mature, feature-rich platforms with enterprise-grade support.
+These solutions are designed to integrate deeply into complex IT landscapes. For more resources on building enterprise-grade pipelines, check out our [data engineering resources](/resources/data).
+
+## Conclusion: Optimizing Your Change Data Capture Strategy
+
+While Debezium remains a powerful and relevant tool for Kafka-centric architectures, the growing ecosystem of alternatives offers compelling options for nearly every use case. Whether you need a lightweight open-source tool, a comprehensive ELT platform, or a fully managed service, there is a solution that can fit your technical and operational needs.
+
+The key is to look beyond the capture mechanism and consider the entire data lifecycle. Tools that provide a unified control plane, declarative definitions, and visibility across the entire pipeline are essential for building scalable and maintainable data systems. [Kestra](/), as an orchestration platform, provides this unifying layer, allowing you to integrate the best CDC tool for the job while managing the end-to-end workflow with confidence and clarity.

--- a/src/contents/resources/matillion-alternatives/index.md
+++ b/src/contents/resources/matillion-alternatives/index.md
@@ -1,0 +1,180 @@
+---
+title: "Top Matillion Alternatives for Data Integration and Orchestration"
+description: "Explore leading Matillion alternatives, from specialized ELT tools to universal orchestrators like Kestra, to find the best fit for your data stack and workflow needs."
+metaTitle: "Top Matillion Alternatives for Data Integration"
+metaDescription: "Find the best Matillion alternatives for cloud data integration. Compare features, pricing, and see how Kestra unifies your ELT and data workflows."
+tag: "data"
+date: 2026-07-01
+slug: "matillion-alternatives"
+faq:
+  - question: "What are the main types of data integration tools?"
+    answer: "Data integration tools generally fall into categories like ETL (Extract, Transform, Load), ELT (Extract, Load, Transform), and workflow orchestrators. ETL tools transform data before loading, while ELT loads raw data into a data warehouse for in-database transformation. Workflow orchestrators, like Kestra, coordinate these tools and other data processes."
+  - question: "How do ETL and ELT tools differ?"
+    answer: "ETL tools perform transformations on source data before loading it into a destination, often requiring a staging area. ELT tools first load raw data directly into a data warehouse or lake, then perform transformations using the destination's compute power. ELT is often favored in cloud data warehouse environments for its flexibility and scalability."
+  - question: "Can open-source alternatives replace Matillion?"
+    answer: "Yes, open-source alternatives like Airbyte and dbt offer powerful capabilities for data integration and transformation, respectively. Kestra, as an open-source orchestrator, can then unify and manage these tools within a broader data pipeline, providing flexibility and cost-effectiveness compared to proprietary solutions."
+  - question: "What should I look for in a Matillion alternative's support?"
+    answer: "When evaluating support, consider factors like responsiveness, documentation quality, community forums, and the availability of enterprise-level SLAs. For open-source tools, a strong community is often a key aspect of support, complemented by commercial offerings for managed services or dedicated assistance."
+  - question: "Is Matillion still a viable choice for data integration?"
+    answer: "Matillion remains a viable choice, particularly for teams deeply embedded in cloud data warehouses like Snowflake, Redshift, or BigQuery, valuing its visual, SQL-centric approach to ELT. However, teams seek alternatives due to evolving needs around pricing, operational complexity for custom logic, or the desire for more unified, cross-domain orchestration."
+  - question: "How does Kestra enhance data integration workflows?"
+    answer: "Kestra enhances data integration by providing a declarative, event-driven orchestration layer that can trigger, monitor, and manage various ETL/ELT tools like Matillion, Fivetran, or Airbyte. It allows for complex dependencies, error handling, and integration with infrastructure, AI, and business processes, offering a unified control plane for your entire data stack."
+---
+
+Matillion has long been a go-to for cloud-native ELT, celebrated for its visual interface and deep integrations with leading data warehouses. However, as data stacks grow more complex and teams demand greater flexibility, many organizations are seeking alternatives that offer different pricing models, broader integration capabilities, or a more developer-centric approach. The market for data integration tools is rapidly evolving, with new platforms emerging to address real-time needs, hybrid cloud environments, and the increasing demand for end-to-end workflow orchestration.
+
+This guide explores the top Matillion alternatives in 2026, including specialized ELT solutions, open-source powerhouses, and universal orchestrators like Kestra. We'll analyze their strengths, ideal use cases, and how they stack up against Matillion to help you choose the best fit for your evolving data integration strategy.
+
+## The Evolving Landscape of Data Integration: Why Seek Matillion Alternatives?
+
+Matillion carved out a significant niche by providing a powerful, low-code interface for building ELT pipelines directly on top of cloud data warehouses like Snowflake, BigQuery, and Redshift. Its visual workflow builder and push-down transformation model empower data analysts and engineers to transform massive datasets efficiently, leveraging the compute power of the underlying warehouse. For teams focused on SQL-based transformations within a specific cloud ecosystem, Matillion offers a streamlined and accessible solution.
+
+However, the modern data stack is rarely homogenous. Teams often find themselves looking for alternatives for several common reasons:
+*   **Pricing Complexity:** Matillion's credit-based pricing can become costly and unpredictable as data volumes and compute usage scale. Teams often seek more transparent or consumption-based models.
+*   **Limited Customization:** While the visual interface is a strength, it can become a constraint for complex logic, non-SQL transformations, or integrating custom Python scripts, which can feel less integrated into the core workflow.
+*   **Narrow Orchestration Scope:** Matillion excels at ELT but is not designed to be a general-purpose orchestrator. As pipelines grow, teams need to manage dependencies that extend beyond the [data warehouse ETL](/resources/data/data-warehouse-etl) process, involving infrastructure tasks, API calls, or AI model training.
+*   **Vendor Lock-in:** Being tightly coupled to a specific cloud data warehouse can be a concern for organizations adopting a multi-cloud strategy or wishing to avoid deep dependencies on a single vendor's ecosystem.
+
+## Our Evaluation Criteria for Data Integration Alternatives
+
+To provide a fair comparison, we evaluated each Matillion alternative based on a consistent set of criteria that reflect the needs of modern data teams. These factors include:
+
+*   **Deployment Model:** Can the tool be used as a managed cloud service, self-hosted on-premises or in a private cloud, or in a hybrid model?
+*   **License:** Is the tool a commercial, proprietary product, or is it open-source, offering greater flexibility and community support?
+*   **Primary Use Case:** Does the tool focus on ELT, ETL, data ingestion, in-warehouse transformation, or universal workflow orchestration?
+*   **Pricing Transparency:** Is the pricing model straightforward and predictable (e.g., per-seat, usage-based) or complex and opaque?
+*   **Integration Ecosystem:** How extensive is the library of pre-built connectors and integrations with other data tools?
+*   **Developer Experience:** Does the platform cater to developers with features like code-based definitions, Git integration, and robust APIs?
+
+## 1. Kestra: The Unified Orchestration Control Plane for Your Data Stack
+
+Kestra is not a direct, like-for-like replacement for Matillion's visual ELT interface. Instead, it operates at a higher level as a universal, declarative orchestration platform. It acts as the control plane that can manage and coordinate Matillion, any of its alternatives, and the hundreds of other tools and processes that make up a modern data platform.
+
+Workflows in Kestra are defined in simple, declarative YAML, making them easy to version, review, and manage with GitOps practices. Its language-agnostic architecture allows you to run tasks in Python, SQL, R, Bash, or any Docker container, providing ultimate flexibility. With an event-driven design and over 1,400 plugins, Kestra can trigger complex workflows from sources like Kafka, S3, or webhooks, connecting your entire data ecosystem.
+
+For example, a Kestra workflow could first trigger a Fivetran sync, then run a dbt transformation, validate the data with a Python script, and finally notify a Slack channel—all within a single, auditable YAML file. This provides a level of end-to-end [data orchestration](/resources/data/data-orchestration) that specialized [ETL orchestration tools](/resources/data/etl-orchestration-tool-alternatives) cannot match. Companies like Leroy Merlin have used Kestra to manage their Data Mesh at scale, increasing data production by 900%.
+
+```yaml
+id: elt-orchestration-with-dbt
+namespace: io.kestra.dbt
+
+tasks:
+  - id: extract-load
+    type: io.kestra.plugin.airbyte.connections.Sync
+    connectionId: "your-airbyte-connection-id"
+
+  - id: transform
+    type: io.kestra.plugin.dbt.cli.Run
+    dependsOn:
+      - extract-load
+    runner: DOCKER
+    docker:
+      image: ghcr.io/dbt-labs/dbt-snowflake:1.5.0
+    commands:
+      - dbt run
+```
+
+While Kestra provides the orchestration and scheduling engine, it does not offer a visual interface for building SQL transformations in the way Matillion does.
+
+**Best for:** Data engineering managers and platform engineers seeking a unified, scalable, and vendor-neutral orchestration layer to manage diverse data integration tools and broader enterprise workflows. Kestra provides the backbone for your entire [data platform](/data).
+
+## 2. Fivetran: Automated Data Movement for Every Source
+
+Fivetran is a market leader in the managed ELT space, focusing almost exclusively on the "Extract" and "Load" parts of the process. Its primary strength is a massive library of over 500 pre-built, fully managed connectors that automate data ingestion from SaaS applications, databases, and APIs into your cloud data warehouse.
+
+Fivetran's "set it and forget it" model is a major draw. It handles schema evolution automatically, adapting to source changes without manual intervention. This frees up data teams from the brittle and time-consuming task of building and maintaining data ingestion pipelines.
+
+The main limitation is its focus. Fivetran is not a transformation tool. While it has integrations with tools like dbt for post-load transformations, the core product is about data movement. Its consumption-based pricing model, based on Monthly Active Rows (MAR), can also become expensive for high-volume use cases.
+
+**Best for:** Teams prioritizing fast, reliable, and automated data ingestion from a wide array of sources into cloud data warehouses, who are willing to pay for a fully managed, maintenance-free solution.
+
+## 3. Airbyte: Open-Source ELT with Extensive Connector Flexibility
+
+Airbyte has rapidly gained popularity as the leading open-source alternative for data integration. It offers a vast and growing library of connectors, many of which are contributed by its active community. Its open-source nature provides maximum flexibility, allowing teams to self-host the platform, modify existing connectors, or build new ones using its Connector Development Kit (CDK).
+
+Airbyte can be deployed as a self-hosted solution or used via Airbyte Cloud, offering a managed service for those who prefer it. While it provides basic in-pipeline transformations, complex data modeling typically requires pairing it with a tool like dbt.
+
+The primary trade-off is the operational overhead. Self-hosting Airbyte requires managing the infrastructure, updates, and scaling, which can be a significant undertaking compared to a fully managed tool like Fivetran.
+
+**Best for:** Data teams needing granular control over data connectors, the flexibility of an open-source platform, and the ability to self-host or integrate custom data sources. It's a strong choice for those looking for a cost-effective, developer-friendly alternative to proprietary tools.
+
+## 4. dbt: Analytics Engineering for In-Warehouse Transformation
+
+dbt (Data Build Tool) is not an ELT tool itself, but rather the T-layer that has become the industry standard for in-warehouse transformations. It allows analytics engineers to transform, test, and document data models using just SQL. By bringing software engineering best practices like version control, testing, and CI/CD to data transformation, dbt empowers teams to build reliable and maintainable data models.
+
+Many teams use dbt in conjunction with an ingestion tool like Fivetran or Airbyte. The ingestion tool handles the EL, and dbt handles the T. This modular approach, known as the modern data stack, provides a powerful and flexible alternative to all-in-one platforms. [dbt integrations](/resources/data/dbt-integrations) are a core part of many data workflows.
+
+The limitation is clear: dbt does not handle data extraction or loading. It is purely focused on what happens after data is already in your warehouse.
+
+**Best for:** Analytics engineers and data teams who need to perform complex, version-controlled transformations within their cloud data warehouse and want to adopt a software engineering mindset for their data modeling.
+
+## 5. Informatica PowerCenter & IDMC: Enterprise-Grade Data Management
+
+Informatica is a long-standing leader in the enterprise data management space. Its offerings, including the traditional PowerCenter and the modern Intelligent Data Management Cloud (IDMC), provide a comprehensive suite of tools that go far beyond simple ELT. Informatica covers data integration, data quality, master data management (MDM), and data governance.
+
+Its strengths lie in its ability to handle complex, large-scale enterprise environments, including hybrid and on-premises data sources. It offers robust features for data governance and regulatory compliance, making it a staple in industries like finance and healthcare.
+
+However, Informatica comes with significant drawbacks for many modern teams. It is known for its high cost, steep learning curve, and a user experience that can feel less agile and cloud-native compared to newer tools.
+
+**Best for:** Large enterprises with diverse and complex data landscapes, strict governance and compliance requirements, and existing investments in the Informatica ecosystem.
+
+## 6. AWS Glue: Serverless ETL in the Amazon Ecosystem
+
+AWS Glue is a fully managed, serverless ETL service provided by Amazon Web Services. It is designed to discover, prepare, and integrate data for analytics. Glue can automatically crawl your data sources (like S3 and RDS) to build a centralized Glue Data Catalog, and then generate and run ETL jobs using Apache Spark.
+
+As a native AWS service, it integrates deeply with the entire AWS ecosystem, including S3, Redshift, and Athena. Its serverless nature means you only pay for the resources consumed while your jobs are running, which can be cost-effective for spiky workloads.
+
+The primary limitation is its tight coupling to the AWS ecosystem, creating vendor lock-in. Managing Glue jobs, particularly the underlying Spark configurations, can also be complex for users who are not experienced with Spark or AWS. Transformations are typically written in Python or Scala, which may be a barrier for SQL-centric teams.
+
+**Best for:** AWS-centric organizations seeking a powerful, scalable, and serverless ETL solution that integrates natively with their existing AWS data services.
+
+## 7. Azure Data Factory: Cloud ETL/ELT for Microsoft Ecosystems
+
+Similar to AWS Glue, Azure Data Factory (ADF) is Microsoft's managed cloud ETL and data integration service. It provides a visual, drag-and-drop interface for building data pipelines, along with a rich set of over 90 built-in connectors to various data sources.
+
+ADF integrates seamlessly with the entire Azure data ecosystem, including Azure Synapse Analytics, Azure Data Lake Storage, and Azure SQL Database. It supports both code-free and code-first approaches, allowing teams to design visually or write their own code.
+
+Like Glue, its biggest drawback is vendor lock-in to the Azure platform. While powerful, its pricing can become complex and expensive at scale, and managing complex dependencies and orchestration logic can be challenging compared to a dedicated orchestration tool.
+
+**Best for:** Organizations committed to the Azure cloud who need a managed, visual ETL/ELT solution that integrates deeply with their Microsoft data ecosystem.
+
+## 8. Talend: Data Integration and Governance for Hybrid Environments
+
+Talend offers a broad data integration platform with both an open-source version (Talend Open Studio) and a commercial cloud offering (Talend Cloud). It supports a wide range of integration scenarios, including ETL, ELT, and Enterprise Application Integration (EAI).
+
+One of Talend's key strengths is its ability to operate in complex hybrid and multi-cloud environments, connecting on-premises systems with cloud services. The platform also includes strong features for data quality, data profiling, and master data management, making it a good fit for organizations with mature data governance programs.
+
+The trade-offs include a potentially steep learning curve and high resource requirements for the self-hosted version. The commercial enterprise version can be expensive, and the free open-source version has limitations in terms of features and collaborative capabilities.
+
+**Best for:** Organizations with complex hybrid data environments that require a versatile data integration platform with strong data governance features.
+
+## Comparison Table: Matillion Alternatives at a Glance
+
+| Tool | License | Deployment | Primary Focus | Transformation Approach | Best For | Pricing Model |
+|---|---|---|---|---|---|---|
+| **Matillion** | Commercial | Cloud | Cloud ELT | Visual, Push-down SQL | Teams using Snowflake, BigQuery, Redshift | Credit-based |
+| **Kestra** | Open-Source Core | Self-hosted, Cloud | Universal Orchestration | Language-Agnostic (SQL, Python, etc.) | Unifying the entire data stack | Open-Source, Per-instance (EE) |
+| **Fivetran** | Commercial | Cloud | Managed Data Ingestion | Post-load (dbt) | Automated, reliable ingestion | Consumption-based (MAR) |
+| **Airbyte** | Open-Source | Self-hosted, Cloud | Data Ingestion | Basic, Post-load (dbt) | Open-source flexibility, custom connectors | Open-Source, Consumption-based (Cloud) |
+| **dbt** | Open-Source Core | Self-hosted, Cloud | In-Warehouse Transformation | Code-based (SQL) | Analytics engineering, data modeling | Open-Source, Per-seat (Cloud) |
+| **Informatica** | Commercial | Cloud, On-prem | Enterprise Data Management | Visual, ETL/ELT | Large enterprises with governance needs | Subscription, custom |
+| **AWS Glue** | Commercial | Cloud (AWS) | Serverless ETL | Code-based (Python/Scala) | AWS-centric organizations | Pay-per-use |
+| **Azure Data Factory** | Commercial | Cloud (Azure) | Cloud ETL/ELT | Visual, Code-based | Azure-centric organizations | Pay-per-use |
+| **Talend** | Open-Source Core | Self-hosted, Cloud | Hybrid Data Integration | Visual, ETL/ELT | Hybrid environments, data governance | Open-Source, Subscription |
+
+## Choosing Your Ideal Matillion Alternative: A Decision Framework
+
+Selecting the right tool depends entirely on your team's specific needs, skills, and strategic goals. Here’s a framework to guide your decision:
+
+*   **For Data Engineering Teams:** If your priority is developer experience, custom code support, and seamless integration with tools like dbt and Airbyte, a modular stack orchestrated by a platform like Kestra is ideal. This approach provides maximum flexibility and control over your [data pipelines](/resources/data/data-pipeline).
+*   **For Platform Engineering Teams:** If you are building an internal data platform, focus on tools that support GitOps, declarative configurations (YAML), and can unify data and infrastructure workflows. Kestra excels here, providing a single control plane for both [infrastructure automation](/infra-automation) and data processes.
+*   **For Small Teams or Startups:** If your goal is quick time-to-value and low operational overhead, a managed ingestion tool like Fivetran or Airbyte Cloud can be highly effective. Pair it with dbt Cloud for transformations to get a powerful, scalable stack without managing infrastructure.
+*   **For Business and Analytics Teams:** If your users are less technical and prefer a visual, low-code interface, a direct competitor like Talend or a cloud-native service like Azure Data Factory might be a better fit than more code-centric options.
+
+When future-proofing your data stack, prioritize platforms that are open, extensible, and vendor-neutral. A flexible orchestrator at the core allows you to swap individual tools in and out as your needs evolve, without having to rebuild your entire workflow logic.
+
+## Unifying Your Data Integration Strategy with the Right Orchestrator
+
+The search for a Matillion alternative often reveals a deeper need: the need for a cohesive strategy to manage an increasingly diverse set of data tools. While specialized ELT platforms solve one part of the puzzle, the real challenge lies in coordinating them with the rest of your data, infrastructure, and [AI automation](/ai-automation) workflows.
+
+This is where a universal orchestration platform like [Kestra](/) provides critical value. By separating the orchestration logic from the individual tools, Kestra allows you to build resilient, observable, and scalable data pipelines that span your entire technology stack. Whether you choose Fivetran for ingestion, dbt for transformation, or continue to use Matillion for specific workloads, Kestra can serve as the unifying control plane to ensure everything runs smoothly together.

--- a/src/contents/resources/orchestra-alternatives/index.md
+++ b/src/contents/resources/orchestra-alternatives/index.md
@@ -1,0 +1,161 @@
+---
+title: "Top Orchestra Alternatives for Data & System Integration"
+description: "Explore the leading alternatives to Orchestra for robust data orchestration, enterprise integration, and workflow automation. Discover platforms like Kestra, Airflow, and Prefect to power your operations."
+metaTitle: "Top Orchestra Alternatives for Data Orchestration"
+metaDescription: "Looking for Orchestra alternatives? Compare Kestra, Airflow, Prefect, and other top platforms for enterprise workflow automation and robust data orchestration."
+tag: "data"
+date: 2026-07-01
+slug: "orchestra-alternatives"
+faq:
+  - question: "What is Orchestra.io and why do companies seek alternatives?"
+    answer: "Orchestra.io is an integration platform designed for enterprise integration, API connectivity, and automation. Companies often seek alternatives due to specific needs around deployment models, operational complexity, integration ecosystems, or to find platforms that offer broader capabilities beyond simple data movement, such as cross-domain workflow orchestration or more flexible language support."
+  - question: "Is Kestra a good alternative to Orchestra.io for data orchestration?"
+    answer: "Yes, Kestra is a strong alternative to Orchestra.io, especially for teams seeking a declarative, language-agnostic, and event-driven orchestration platform. It excels at unifying data, AI, and infrastructure workflows, offering robust features for complex data pipelines, API integrations, and automation with a focus on operational efficiency and scalability."
+  - question: "What are key features to look for in Orchestra.io alternatives?"
+    answer: "When evaluating alternatives, prioritize features like broad integration capabilities (databases, APIs, clouds), flexible workflow definition (declarative vs. code-based), scalability, robust error handling, monitoring, and deployment options (cloud, on-prem, hybrid). Consider ease of use for your team's technical skill set and the overall cost of ownership."
+  - question: "What are some open-source alternatives to Orchestra.io?"
+    answer: "Several open-source platforms serve as powerful alternatives. Kestra, with its Apache 2.0 license, provides a declarative, event-driven engine. Apache Airflow offers a mature Python-based ecosystem. Prefect is another Python-centric option, while n8n provides a visual, low-code approach, often self-hosted for SaaS automation."
+  - question: "How do cloud-native options compare to Orchestra.io?"
+    answer: "Cloud-native options like AWS Step Functions or Azure Data Factory provide deep integration with their respective cloud ecosystems, offering managed services that reduce operational overhead. While excellent for cloud-specific workloads, they can introduce vendor lock-in. Kestra, in contrast, offers multi-cloud and hybrid deployment flexibility."
+  - question: "Which alternative is best for enterprise-grade automation?"
+    answer: "For enterprise-grade automation, Kestra offers a unified control plane for data, AI, and infrastructure workflows, with features like RBAC, audit logs, and hybrid deployment. Platforms like Workato also target enterprises with extensive SaaS integration capabilities, though often with a different persona and operational model."
+---
+
+The landscape of data and system integration is constantly evolving, with organizations increasingly seeking robust platforms to automate complex workflows across diverse environments. As tools like Orchestra.io gain traction for their enterprise integration and API connectivity, many teams find themselves evaluating alternatives to better align with specific architectural preferences, operational needs, or scaling requirements. Whether driven by a desire for more declarative control, broader language support, or a unified orchestration plane spanning data, AI, and infrastructure, the search for the right fit is critical.
+
+Orchestra.io provides solutions for connecting various systems and automating data flows, but its approach may not suit every team's unique challenges. This article cuts through the noise to focus on alternatives tailored for serious data and system orchestration, rather than musical libraries. The leading alternatives to Orchestra for enterprise integration and data orchestration in 2026 include Kestra, Apache Airflow, Prefect, Dagster, n8n, AWS Step Functions, and Workato—each offering distinct advantages for various workloads. We’ll explore why teams look beyond Orchestra, what key features to prioritize, and how to choose the platform that best empowers your engineering and data teams.
+
+## Why look for an alternative to Orchestra.io?
+
+While Orchestra.io carves out a niche in enterprise integration, teams often look for alternatives when their needs evolve beyond its core focus. The reasons for exploring other platforms typically fall into a few key categories:
+
+*   **Architectural Philosophy:** Teams may prefer a different model for defining workflows. While some platforms favor a code-first, imperative approach, others champion a declarative, configuration-as-code model. This choice impacts maintainability, auditability, and collaboration between technical and non-technical teams.
+*   **Operational Overhead:** The complexity of deploying, scaling, and maintaining an orchestration tool can become a significant factor. A solution that requires extensive infrastructure management or has a steep learning curve might not be sustainable for all teams.
+*   **Deployment Flexibility:** The need to deploy on-premises, in a specific cloud, in an air-gapped environment, or across a hybrid infrastructure can limit the viability of SaaS-only or cloud-specific platforms.
+*   **Cross-Domain Orchestration:** Many organizations need a single control plane that can manage more than just data integration. A platform that can seamlessly orchestrate data pipelines, infrastructure automation (IaC), AI/ML workflows, and business processes offers a more holistic solution.
+*   **Total Cost of Ownership (TCO):** Beyond licensing fees, the true cost includes infrastructure, maintenance hours, and the potential for vendor lock-in. Opaque or usage-based pricing models can lead to unpredictable costs as workloads scale. Evaluating different [data orchestration platforms](/blogs/top-data-orchestration-platforms) is crucial for long-term financial planning.
+
+## How we evaluated these alternatives
+
+To provide a clear comparison, we evaluated each alternative based on a consistent set of criteria relevant to modern engineering and data teams:
+
+*   **Deployment Model:** Can the platform run on-premises, in the cloud, in a hybrid setup, or is it SaaS-only?
+*   **License:** Is it open-source (e.g., Apache 2.0), open-core, or fully commercial?
+*   **Primary Use Case:** What is the tool's sweet spot? Data engineering, application integration, infrastructure automation, or AI workflows?
+*   **Workflow Definition:** How are workflows defined? Declarative YAML, Python code, a visual drag-and-drop builder, or JSON?
+*   **Scalability & Performance:** How does the architecture handle a growing number of complex workflows and high-throughput tasks?
+*   **Ecosystem:** How extensive is the library of plugins and integrations? How active is the community?
+*   **Governance & Operations:** What features are available for security (RBAC, SSO), auditability, and reducing operational burden?
+
+## The alternatives to Orchestra.io
+
+### 1. Kestra: The declarative control plane for all workflows
+
+[Kestra](/) is an open-source, event-driven orchestration platform designed to unify data, AI, and infrastructure workflows under a single, declarative control plane. Its core philosophy is that workflow logic should be treated as configuration, defined in simple, auditable YAML files. This approach decouples the orchestration logic from the execution code, enabling teams to manage complex processes with clarity and confidence.
+
+Kestra is language-agnostic, capable of running tasks written in Python, SQL, Bash, R, and many other languages, often without requiring custom Docker images. It can be deployed anywhere—from a single laptop with Docker to a large-scale Kubernetes cluster in a hybrid cloud or air-gapped environment. This flexibility makes it a powerful choice for organizations seeking to standardize automation across different teams and use cases. For example, Leroy Merlin France transformed its DataMesh architecture with Kestra, increasing data production by 900%, while Displayce achieved unified monitoring and orchestration for its expanding data operations.
+
+```yaml
+id: process-customer-data
+namespace: production.data_team
+
+tasks:
+  - id: fetch_new_users
+    type: io.kestra.plugin.jdbc.postgresql.Query
+    sql: "SELECT * FROM users WHERE created_at > '{{ trigger.date }}';"
+    store: true
+
+  - id: process_in_python
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      users.csv: "{{ outputs.fetch_new_users.uri }}"
+    script: |
+      import pandas as pd
+      df = pd.read_csv("users.csv")
+      df['processed'] = True
+      df.to_csv("processed_users.csv", index=False)
+
+  - id: notify_on_slack
+    type: io.kestra.plugin.notifications.slack.SlackExecution
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    message: "Processed {{ outputs.process_in_python.metrics.rows }} new users."
+```
+
+**Best for:** Teams seeking a unified, auditable, and scalable orchestration platform to manage workflows across all technical domains, from [data engineering](/data) to [infrastructure automation](/infra-automation) and [AI pipelines](/ai-automation).
+
+### 2. Apache Airflow: The mature data orchestrator
+
+Apache Airflow is the most established open-source data orchestrator, known for its vast ecosystem of community-contributed operators and its "workflows-as-code" paradigm using Python. For years, it has been the default choice for scheduling and running complex batch [data pipelines](/docs/use-cases/data-pipelines).
+
+Airflow's strength lies in its maturity and the deep familiarity many data engineers have with its concepts, such as DAGs (Directed Acyclic Graphs). However, its Python-centric nature can be a limitation for polyglot teams, as even simple shell or SQL tasks must be wrapped in Python operators. Furthermore, managing an Airflow deployment at scale can be operationally complex, requiring careful configuration of schedulers, workers, and a metadata database. Is Airflow a good alternative? Yes, for teams deeply invested in the Python data ecosystem who are prepared for the operational responsibilities.
+
+**Best for:** Python-heavy data teams with existing investment in the Airflow ecosystem and a need for its extensive library of operators.
+
+### 3. Prefect: Pythonic and developer-friendly
+
+Prefect is a modern data orchestrator that also uses a Python-based, code-first approach but places a strong emphasis on developer experience and dynamic workflows. It allows for more flexible and dynamic pipeline generation at runtime, which can be a significant advantage for complex ML and data science use cases.
+
+Prefect offers a hybrid execution model, where a managed cloud control plane can orchestrate tasks running on customer-managed infrastructure. While its developer-friendly features are a major draw, its Python-only authoring model makes it less suitable for teams with diverse language needs. Its cloud-first business model means the open-source, self-hosted path is less prominent than the commercial offering.
+
+**Best for:** Python-centric data and ML teams prioritizing developer experience and dynamic workflow generation.
+
+### 4. Dagster: Asset-centric data orchestration
+
+Dagster takes a unique, asset-centric approach to orchestration. Instead of focusing on tasks, it models workflows as a graph of data assets (like tables, files, or ML models). This provides excellent data lineage and observability out of the box, making it easier to understand data dependencies and debug issues.
+
+This opinionated approach, rooted in software engineering principles, is highly beneficial for teams focused on data quality and governance. However, the asset paradigm represents a steeper learning curve compared to traditional task orchestrators and is less naturally suited to workflows that don't produce persistent data assets, such as infrastructure automation or simple API-driven processes.
+
+**Best for:** Analytics engineering teams focused on data quality, lineage, and applying a software engineering discipline to their data assets.
+
+### 5. n8n: Visual workflow automation and SaaS integration
+
+[n8n](/resources/infrastructure/n8n-alternatives) is an open-source workflow automation tool that uses a visual, node-based editor. It's often described as a self-hostable alternative to Zapier, with a large library of pre-built nodes for integrating with hundreds of SaaS applications and APIs.
+
+n8n excels at rapid prototyping and empowering less technical users to build powerful automations. Its visual approach makes it highly accessible for connecting different web services. However, it is not designed for high-throughput data engineering, complex batch processing, or infrastructure orchestration. While it can be a powerful tool for its target use case, it's not a direct replacement for a full-featured data orchestrator.
+
+**Best for:** Ops teams and developers seeking quick, visual automation for SaaS-to-SaaS integrations and internal tools.
+
+### 6. AWS Step Functions: Serverless orchestration on AWS
+
+AWS Step Functions is a fully managed, serverless orchestrator for coordinating tasks across various AWS services. It uses a visual workflow designer to create state machines defined in JSON, providing built-in error handling, retries, and parallelism.
+
+Its primary strength is its deep, native integration with the AWS ecosystem, making it an excellent choice for building resilient, serverless applications and microservices that are entirely hosted on [AWS](/orchestration/aws). The main trade-off is vendor lock-in; workflows are tightly coupled to AWS services and are not portable to other clouds or on-premises environments. For teams committed to the AWS ecosystem, it's a powerful and low-overhead option.
+
+**Best for:** Teams building serverless applications and microservices primarily within the AWS ecosystem.
+
+### 7. Workato: Enterprise iPaaS for business automation
+
+Workato is a leading enterprise Integration Platform as a Service (iPaaS) designed for business process automation. It provides a low-code/no-code environment with an extensive library of connectors for thousands of business applications, from Salesforce and SAP to Slack and ServiceNow.
+
+Workato is exceptionally strong at orchestrating workflows that span multiple departments and SaaS tools, often involving human-in-the-loop approvals. Its focus is on the business user and IT teams managing application integration. While it's a powerful platform for its domain, it's not designed for engineering-led, code-heavy workloads like data transformation, ML model training, or infrastructure provisioning.
+
+**Best for:** Business and IT teams needing extensive integration with SaaS applications and formal business process automation.
+
+## Comparison table
+
+| Tool | License | Deployment | Best for | Workflow Definition | Key Differentiator |
+|---|---|---|---|---|---|
+| **Kestra** | Open-Source (Apache 2.0) | Cloud, On-Prem, Hybrid | Unified cross-domain orchestration | Declarative YAML | Language-agnostic, event-driven control plane |
+| **Apache Airflow** | Open-Source (Apache 2.0) | On-Prem, Cloud | Python-centric data pipelines | Python Code (DAGs) | Mature, massive operator ecosystem |
+| **Prefect** | Open-Source (Apache 2.0) | Cloud, On-Prem, Hybrid | Dynamic Python workflows | Python Code | Developer experience, dynamic task generation |
+| **Dagster** | Open-Source (Apache 2.0) | Cloud, On-Prem, Hybrid | Asset-aware data platforms | Python Code | Asset-centric graph and data lineage |
+| **n8n** | Open-Source (Fair-code) | Cloud, On-Prem | SaaS & API integration | Visual Node Editor | Visual builder with extensive SaaS connectors |
+| **AWS Step Functions** | Commercial | AWS Cloud | AWS-native serverless apps | JSON (State Language) | Deep integration with all AWS services |
+| **Workato** | Commercial | SaaS | Enterprise business automation | Visual Recipe Builder | iPaaS with thousands of business app connectors |
+
+## How to choose the right data orchestration alternative
+
+Selecting the right platform depends entirely on your team's specific needs, skills, and strategic goals.
+
+*   **For data engineering teams:** If your primary need is building, scheduling, and monitoring complex data pipelines, platforms like **Kestra**, **Airflow**, **Prefect**, and **Dagster** are your top contenders. Choose **Kestra** for declarative, language-agnostic control and scalability. Opt for **Airflow**, **Prefect**, or **Dagster** if your team and workflows are exclusively Python-based.
+*   **For infrastructure & DevOps teams:** When the goal is automating IaC, CI/CD, and IT operations, a platform with strong GitOps principles and infrastructure-level integrations is key. **Kestra** excels here with its declarative YAML model, making it a natural fit for [infrastructure automation](/infra-automation). For teams fully invested in AWS, **AWS Step Functions** provides a native solution.
+*   **For AI & ML platform teams:** Orchestrating AI workflows requires support for heterogeneous tasks, reproducibility, and integration with the ML ecosystem. **Kestra**'s language-agnostic nature and agentic capabilities make it a strong choice for coordinating everything from data prep to model training and deployment. **Prefect** and **Dagster** are also well-suited for Python-based ML pipelines.
+*   **For small teams & rapid prototyping:** If the goal is to quickly connect SaaS tools or build internal automations without deep engineering, a visual tool is often the best fit. **n8n** provides a powerful, self-hostable open-source option for this purpose, making it accessible even for [non-technical teams](/resources/ai/ai-orchestration-for-non-technical-teams).
+
+## Conclusion: Powering your operations with the right orchestrator
+
+Choosing an alternative to Orchestra.io is about more than finding a replacement; it's an opportunity to select a platform that aligns with your organization's future. The right tool should not only solve today's integration challenges but also provide a scalable foundation for tomorrow's automation needs.
+
+While code-centric tools like Airflow and Prefect serve the Python data community well, and iPaaS platforms like Workato handle business application integration, Kestra offers a unique value proposition: a single, unified platform that speaks the language of every engineering team. By treating workflows as declarative YAML, Kestra provides a common ground for data, platform, and AI engineers to collaborate, govern, and scale automation across the entire organization.
+
+Ready to see how a declarative, event-driven approach can simplify your complex workflows? Explore our [blueprints](/blueprints) to see real-world examples or browse our extensive library of [plugins](/plugins).

--- a/src/contents/resources/uipath-alternatives/index.md
+++ b/src/contents/resources/uipath-alternatives/index.md
@@ -1,0 +1,179 @@
+---
+title: "Top UiPath Alternatives: Modernizing RPA and Workflow Automation"
+description: "UiPath has long dominated RPA, but new platforms offer greater flexibility, AI integration, and broader workflow capabilities. Explore the leading alternatives for modern enterprise automation."
+metaTitle: "Top UiPath Alternatives for Workflow Automation"
+metaDescription: "Compare the best UiPath alternatives — Kestra, Power Automate, Automation Anywhere and more — for modern RPA, orchestration, and AI-driven automation."
+tag: "infrastructure"
+date: 2026-07-08
+slug: "uipath-alternatives"
+faq:
+  - question: "Who is UiPath's biggest competitor?"
+    answer: "UiPath faces strong competition from platforms like Microsoft Power Automate, Automation Anywhere, and Blue Prism, especially in traditional RPA. Emerging agentic AI platforms are also becoming significant alternatives for broader workflow automation."
+  - question: "What is the alternative to UiPath?"
+    answer: "Alternatives to UiPath vary based on need, ranging from comprehensive RPA suites like Automation Anywhere, low-code platforms such as Microsoft Power Automate, to declarative orchestration tools like Kestra that unify diverse automation tasks."
+  - question: "Why are organizations seeking UiPath alternatives?"
+    answer: "Organizations often seek UiPath alternatives due to its RPA-centric focus, which may not fully address broader data, AI, or infrastructure orchestration needs. Considerations also include licensing costs, complexity for code-driven workflows, and a desire for more vendor-neutral or open-source solutions."
+  - question: "What are the leading RPA software platforms?"
+    answer: "The leading RPA software platforms include UiPath, Automation Anywhere, and Blue Prism. These tools specialize in automating repetitive, rule-based tasks, often through UI interaction, and offer enterprise-grade capabilities for process discovery and bot management."
+  - question: "What are the benefits of open-source RPA alternatives?"
+    answer: "Open-source RPA alternatives offer benefits like cost savings, greater flexibility for customization, and community-driven development. They can also provide more control over the automation environment and reduce vendor lock-in compared to proprietary solutions."
+  - question: "How does Kestra compare to traditional RPA tools like UiPath?"
+    answer: "Kestra offers a declarative, language-agnostic orchestration platform that can unify data, AI, and infrastructure workflows. While not a direct RPA tool for UI automation, Kestra can orchestrate RPA bots as part of larger, end-to-end enterprise workflows, providing a broader control plane for diverse automation needs."
+---
+
+The landscape of enterprise automation is rapidly evolving, moving beyond simple Robotic Process Automation (RPA) to encompass complex, AI-driven, and cross-domain workflows. For years, UiPath has been a dominant force in RPA, excelling at automating repetitive, rule-based tasks through user interface interactions. However, as organizations seek to unify their automation efforts across data pipelines, infrastructure operations, and burgeoning AI initiatives, the limitations of an RPA-centric approach become more apparent. Teams are now looking for platforms that offer greater flexibility, deeper integration with diverse tech stacks, and a more robust foundation for orchestrating the entire enterprise.
+
+This shift isn't just about finding another tool for screen scraping; it's about adopting a control plane that can manage human-in-the-loop processes, API integrations, code execution, and AI agents alongside traditional RPA bots. The leading alternatives to UiPath in 2026 for AI workflow automation and broader enterprise orchestration include Kestra, Microsoft Power Automate, Automation Anywhere, Blue Prism, Make.com, and Appian. This article will delve into the strengths and trade-offs of each, offering a clear framework to help you choose the ideal platform for your evolving automation strategy.
+
+## Why Seek Alternatives to UiPath for Enterprise Automation?
+
+UiPath became a market leader by making UI-level automation accessible and scalable. Yet, the very focus that fueled its rise now presents challenges for organizations with maturing automation strategies. The search for alternatives is often driven by a need to move beyond RPA's traditional boundaries.
+
+Here are the key reasons enterprises are exploring other options:
+
+*   **RPA-Centric Worldview:** UiPath is fundamentally an RPA platform. While it has expanded into process mining and AI, its core architecture is designed for automating tasks via user interfaces. This can be cumbersome for API-first, event-driven, or data-intensive workflows where a UI doesn't exist. Modern automation requires a platform that treats APIs, code, and data as first-class citizens, not just as extensions to an RPA bot.
+*   **Licensing and Scaling Costs:** UiPath's licensing model, often based on the number of bots, orchestrator instances, and developer seats, can become prohibitively expensive as automation scales across an enterprise. Unattended bots, in particular, can lead to significant costs, prompting a search for platforms with more predictable or consumption-based pricing.
+*   **Operational Complexity for Technical Workflows:** For DevOps and data engineering teams, defining complex, conditional logic or managing dependencies in a graphical interface can be less efficient than using code. The process of versioning, testing, and deploying UiPath workflows can feel disconnected from standard software development lifecycles, which increasingly rely on GitOps and declarative configurations. This can lead to [orchestration problems rooted in complexity](/resources/infrastructure/orchestration-problems-complexity).
+*   **Vendor Lock-in and Ecosystem Dependency:** Committing to UiPath means investing heavily in its specific ecosystem, from its proprietary workflow designer to its training and certification paths. Organizations seeking more flexibility and a vendor-neutral approach may prefer open-source or standards-based tools that integrate more easily with a diverse set of technologies without locking them into a single vendor's stack. An [IT automation platform](/resources/infrastructure/it-automation-platform) should enable, not constrain, the use of best-of-breed tools.
+*   **The Rise of AI-Native and Declarative Orchestration:** The new generation of automation demands platforms built for orchestrating AI agents, managing complex data pipelines for RAG applications, and defining infrastructure as code. Declarative platforms, where workflows are defined as auditable text files (like YAML), offer greater transparency, governance, and easier integration with AI-powered code generation tools.
+
+## Evaluating Modern Automation Platforms: Key Criteria
+
+Choosing a UiPath alternative requires looking beyond a simple feature-for-feature comparison. The right platform depends on your primary use cases, team skills, and long-term strategy. Here are the essential criteria to consider:
+
+*   **Deployment Flexibility:** Can the platform run where you need it to? Options range from fully managed SaaS to [self-hosted workflow orchestration](/resources/infrastructure/self-hosted-workflow-orchestration) on-premises, in a private cloud, or in air-gapped environments. Hybrid capabilities are critical for enterprises with diverse infrastructure.
+*   **Core Automation Paradigm:** Is the tool primarily RPA-centric, low-code/no-code, declarative (configuration-as-code), or code-first? This determines who can build workflows (citizen developers vs. engineers) and how those workflows are managed, versioned, and audited.
+*   **Scope of Automation:** Does the platform excel at UI automation, API integration, data processing, infrastructure management, AI agent orchestration, or long-running business processes? A truly universal platform should handle multiple types of workloads effectively.
+*   **Scalability and Enterprise Readiness:** Look for features that support large-scale deployment, such as high availability, robust security models (RBAC, SSO), comprehensive audit logs, and observability. Strong [workflow governance](/resources/infrastructure/workflow-governance) is non-negotiable for mission-critical processes.
+*   **Pricing Model Transparency:** Evaluate the total cost of ownership (TCO). Is pricing based on users, tasks, bots, or resources? A transparent and predictable pricing model is crucial for avoiding unexpected costs as your usage grows.
+*   **Open-Source Availability and Community:** An open-source core can offer significant advantages, including cost savings, customization flexibility, and a vibrant community for support and innovation.
+
+## 1. Kestra: The Unified Declarative Control Plane
+
+Kestra is an open-source, declarative orchestration platform designed to unify all types of workflows—from data and AI to infrastructure and business processes—under a single control plane. Instead of focusing on UI automation, Kestra orchestrates the underlying tools and systems, including RPA bots, through a language-agnostic YAML interface.
+
+This approach positions Kestra not as a direct RPA replacement, but as a higher-level orchestrator that can coordinate RPA tasks as part of a broader, end-to-end enterprise workflow. With a thriving community of over 26,000 GitHub stars and a track record of executing over 2 billion workflows in 2025, Kestra is built for reliability at scale.
+
+**Key Differentiators:**
+*   **Declarative & Language-Agnostic:** Workflows are defined in simple YAML files, making them easy to read, version in Git, and audit. This [GitOps](/resources/infrastructure/gitops) approach aligns with modern DevOps practices. Kestra can run scripts in any language (Python, Node.js, Shell, PowerShell) and execute Docker containers, providing ultimate flexibility. It has first-class support for [Windows workflow orchestration tools](/resources/infrastructure/windows-workflow-orchestration-tools).
+*   **Unified Orchestration:** Kestra’s strength lies in its ability to connect disparate domains. A single workflow can ingest data, trigger a dbt transformation, call a machine learning model, provision infrastructure via Terraform, and then initiate an RPA bot to update a legacy system. This is the core of modern [infra automation](/infra-automation).
+*   **Event-Driven by Default:** Kestra is built for [event-driven orchestration](/resources/infrastructure/event-driven-orchestration), able to trigger workflows from webhooks, message queues (Kafka, SQS), file detections, and more. This enables reactive, real-time automation that traditional RPA schedulers struggle with.
+*   **Extensible Plugin Ecosystem:** With over 1,400 plugins, Kestra integrates with a vast array of technologies across databases, cloud services, data tools, and enterprise applications. This allows it to serve as a central hub for your entire tech stack, from [Kubernetes workflow orchestration](/resources/infrastructure/kubernetes-workflow-orchestration) to cybersecurity automation, as demonstrated by customers like JPMorgan Chase.
+
+Kestra is best for platform engineers, data engineers, and technical teams seeking a central, code-adjacent orchestrator for complex, cross-domain workflows. Its [open-source orchestration model offers significant cost savings](/resources/infrastructure/open-source-orchestration-cost-savings) and flexibility compared to proprietary RPA suites.
+
+## 2. Microsoft Power Automate: Integrated Automation for the Microsoft Ecosystem
+
+Microsoft Power Automate is a comprehensive automation platform that combines RPA (Power Automate for desktop), API-based automation (cloud flows), and business process management. Its primary strength is its seamless integration into the wider Microsoft ecosystem, including Microsoft 365, Dynamics 365, Power BI, and Azure.
+
+As a UiPath alternative, Power Automate is compelling for organizations already heavily invested in Microsoft's technology stack. It empowers both citizen developers and professional developers to build automations through a low-code, drag-and-drop interface.
+
+**Key Differentiators:**
+*   **Deep Microsoft Integration:** Power Automate offers thousands of connectors, with unparalleled integration for Microsoft services. Automating tasks in SharePoint, Teams, Outlook, or Dynamics 365 is incredibly straightforward.
+*   **Accessibility for Citizen Developers:** Its user-friendly interface lowers the barrier to entry for automation, allowing business users to create their own flows without extensive coding knowledge.
+*   **AI Builder:** The platform includes pre-built AI models for tasks like form processing, object detection, and text classification, which can be easily incorporated into workflows.
+
+However, its tight coupling to the Microsoft ecosystem can be a limitation for organizations with multi-cloud strategies or a diverse set of non-Microsoft applications. While it can connect to other systems, its core power and ease of use diminish outside the Microsoft world. For those looking at [Azure alternatives](/resources/infrastructure/azure-alternatives), this dependency is a key consideration.
+
+Power Automate is best for organizations deeply embedded in the Microsoft ecosystem that want to empower business users and citizen developers to automate their own tasks and processes.
+
+## 3. Automation Anywhere: Enterprise RPA with Intelligent Automation
+
+Automation Anywhere is one of UiPath's most direct competitors in the enterprise RPA space. Its cloud-native platform, Automation 360, provides a comprehensive suite of tools for discovering, automating, and governing processes at scale.
+
+The platform strongly emphasizes "intelligent automation," integrating AI and machine learning capabilities directly into its RPA core. This includes tools for process discovery to identify automation opportunities, IQ Bot for intelligent document processing, and analytics to measure bot performance and ROI.
+
+**Key Differentiators:**
+*   **Cloud-Native Platform:** Automation 360 is a modern, web-based platform designed for scalability and accessibility, which can reduce the infrastructure overhead compared to some on-premises RPA solutions.
+*   **AI-Driven Process Intelligence:** The platform's Discovery Bot uses AI to analyze user actions and recommend processes that are prime candidates for automation, helping organizations build a robust pipeline of opportunities.
+*   **Bot Lifecycle Management:** It provides strong tools for managing the entire lifecycle of a bot, from development and testing to deployment and maintenance, which is critical for large-scale [automation](/resources/infrastructure/automation) initiatives.
+
+While a powerful RPA tool, its primary focus remains on process automation. Orchestrating complex data pipelines or infrastructure-as-code workflows may require integrating it with other specialized tools, potentially leading to a fragmented automation landscape.
+
+Automation Anywhere is best for large enterprises committed to a top-down RPA strategy, particularly those focused on back-office process optimization and leveraging AI for process discovery and document understanding.
+
+## 4. Blue Prism: Secure and Scalable Digital Workforce
+
+Blue Prism has long been a key player in the RPA market, with a reputation for providing a secure, scalable, and governed "digital workforce." It is often favored by large enterprises in highly regulated industries like banking, insurance, and healthcare, where compliance and auditability are paramount.
+
+The platform's architecture emphasizes centralized control and reusability. It maintains a clear separation between the process definition studio, the control room for managing bots, and the runtime bots themselves. This structured approach supports robust governance and makes it easier to manage large fleets of software robots.
+
+**Key Differentiators:**
+*   **Enterprise-Grade Security and Governance:** Blue Prism offers features like granular role-based access control, detailed audit logs, and secure credential management, making it a strong choice for security-conscious organizations.
+*   **Scalability and Resilience:** The platform is designed for high-availability and large-scale deployments, with features for load balancing and centralized management of thousands of bots.
+*   **Object-Oriented Design:** Its design studio uses a concept of reusable "business objects" that encapsulate interactions with specific applications. This promotes modularity and can accelerate the development of new automations.
+
+The trade-off for this level of control and security can be a steeper learning curve and a more complex implementation compared to other tools. Its focus is squarely on enterprise RPA, and it may feel overly rigid for teams that prefer more agile, code-driven, or API-first automation approaches.
+
+Blue Prism is best for large, highly regulated enterprises that require a robust, secure, and centrally governed platform for deploying a large-scale digital workforce.
+
+## 5. Make.com: Visual Automation for SaaS Integrations
+
+Make.com (formerly Integromat) represents a different category of automation tool that has significant overlap with certain RPA use cases. It is a visual workflow builder designed primarily for connecting SaaS applications and APIs. For businesses whose processes are largely driven by modern web-based apps, it can be a powerful and cost-effective alternative to traditional RPA.
+
+Instead of mimicking human clicks on a screen, Make automates workflows by directly interacting with the APIs of thousands of applications. Its visual interface, where users connect "modules" to create a scenario, is highly intuitive and makes it easy to visualize the flow of data.
+
+**Key Differentiators:**
+*   **Visual, API-First Workflow Building:** The drag-and-drop interface is powerful and intuitive, allowing users to build complex, multi-step workflows without writing code.
+*   **Extensive App Ecosystem:** Make offers a huge library of pre-built connectors for popular SaaS tools, from CRMs and marketing automation platforms to project management software and communication tools.
+*   **Cost-Effectiveness:** For API-driven tasks, Make's pricing model, based on the number of operations, can be significantly more affordable than licensing RPA bots for the same outcome.
+
+Make's primary limitation is that it is not an RPA tool. It cannot interact with desktop applications or legacy systems that lack APIs. For a full comparison with similar tools, see our list of [Make alternatives](/resources/infrastructure/make-alternatives).
+
+Make.com is best for business users and operations teams needing to automate processes that span multiple SaaS applications, especially when a visual, API-first approach is more efficient than UI automation.
+
+## 6. Appian: Low-Code Automation with RPA and BPM
+
+Appian is a low-code platform that provides a unified suite for enterprise automation, combining Business Process Management (BPM), RPA, AI, and case management capabilities. Appian's philosophy is that RPA is just one piece of a much larger automation puzzle.
+
+The platform allows you to build end-to-end business processes that can orchestrate human tasks, system integrations, and RPA bots within a single workflow. This is particularly powerful for complex, long-running processes that require human decision-making and exception handling.
+
+**Key Differentiators:**
+*   **Unified Low-Code Platform:** Appian provides a single environment for building custom applications and automating processes, reducing the need to stitch together multiple point solutions.
+*   **Strong BPM and Case Management:** It excels at managing structured and unstructured processes that involve human-in-the-loop workflows, making it ideal for use cases like loan origination, claims processing, and customer onboarding.
+*   **Full-Stack Automation:** By combining RPA with API integration and human task management, Appian can automate a process from start to finish, regardless of the underlying systems.
+
+The platform's comprehensive nature means it can have a steeper learning curve and higher resource requirements than more specialized tools. It is less focused on the granular needs of data or infrastructure orchestration and is better suited for business-process-centric automation.
+
+Appian is best for organizations looking for a unified low-code platform to manage and automate complex, end-to-end business processes that combine human tasks, system integrations, and RPA.
+
+## Comparison Table: UiPath Alternatives at a Glance
+
+| Tool | License | Deployment | Core Automation Paradigm | Primary Use Case | Scalability | Pricing Model |
+|---|---|---|---|---|---|---|
+| **Kestra** | Open-Source (Apache 2.0) & Enterprise | Cloud, On-Prem, Hybrid, Air-Gapped | Declarative (YAML), Polyglot | Unified orchestration across data, AI, infra & business | High (proven at billions of executions) | Open-Source (Free), Enterprise (Per-instance), Cloud (Usage-based) |
+| **Microsoft Power Automate** | Commercial | Cloud (Azure) & On-Prem Gateway | Low-Code / No-Code | Business process & desktop automation in Microsoft ecosystems | High (within Azure) | Per-user, Per-flow, Per-bot |
+| **Automation Anywhere** | Commercial | Cloud & On-Prem | RPA-centric, AI-driven | Enterprise-scale RPA and intelligent document processing | High | Custom (based on bots and platform components) |
+| **Blue Prism** | Commercial | Cloud & On-Prem | RPA-centric, Governed | Secure, compliant RPA for regulated industries | High | Custom (based on number of bots) |
+| **Make.com** | Commercial | Cloud (SaaS) | Visual, API-First | SaaS application integration and API workflow automation | Medium | Tiered (based on operations/month) |
+| **Appian** | Commercial | Cloud & On-Prem | Low-Code, BPM-centric | End-to-end business process and case management | High | Per-user |
+
+## Choosing the Right UiPath Alternative for Your Enterprise
+
+The best alternative depends entirely on your goals, your team's skills, and your existing technology landscape. Use this framework to guide your decision.
+
+### For Data-Driven Automation and AI Orchestration
+
+If your primary need is to automate data pipelines, ML workflows, or RAG applications, a traditional RPA tool is a poor fit. You need a platform that understands data dependencies and can execute code efficiently.
+*   **Top Recommendation: Kestra.** Its declarative, language-agnostic nature makes it ideal for orchestrating complex data and AI workflows. It provides the version control, observability, and scalability required for production-grade [data](/data) and [AI automation](/ai-automation).
+
+### For Infrastructure and DevOps Teams
+
+These teams require tools that align with Infrastructure as Code (IaC) and GitOps principles. Automation must be auditable, version-controlled, and API-driven.
+*   **Top Recommendation: Kestra.** Its YAML-based workflows and API-first design are a natural fit for platform and DevOps engineers. Kestra can orchestrate Terraform, Ansible, Kubernetes, and custom scripts as part of a unified [infra automation](/infra-automation) strategy, enabling true [GitOps for operations](/resources/infrastructure/gitops-for-operations).
+
+### For Business and Citizen Developers
+
+If your goal is to empower non-technical users to automate their own tasks within a defined ecosystem, a low-code/no-code platform is the best choice.
+*   **Top Recommendations: Microsoft Power Automate and Make.com.** Power Automate is the clear winner for Microsoft-centric organizations. Make.com is an excellent choice for automating processes across a diverse set of best-of-breed SaaS applications.
+
+### For Regulated Industries and Large Enterprises
+
+When security, governance, and compliance are the top priorities, you need a platform with a proven track record in enterprise environments.
+*   **Top Recommendations: Blue Prism and Kestra.** Blue Prism offers best-in-class governance for large-scale RPA deployments. For organizations needing to govern a mix of RPA, code, and infrastructure workflows, Kestra Enterprise provides robust [workflow orchestration security](/resources/infrastructure/workflow-orchestration-security), including RBAC, SSO, and detailed audit logs, as demonstrated by customers like Crédit Agricole.
+
+## Conclusion: Modernizing Your Automation Strategy
+
+Moving beyond UiPath is about more than just switching RPA vendors; it's an opportunity to adopt a more modern, holistic approach to enterprise automation. While RPA excels at automating UI-based tasks, the future of automation lies in platforms that can unify workflows across your entire technology stack.
+
+Declarative, language-agnostic orchestration platforms like [Kestra](/) provide a flexible and scalable foundation for this new era. By treating automation as code, they offer the governance that enterprises demand while providing the flexibility that technical teams need. As you evaluate your options, consider not only what you need to automate today, but also the complex, AI-driven, and event-based workflows you will need to orchestrate tomorrow.

--- a/src/contents/resources/what-is-uipath/index.md
+++ b/src/contents/resources/what-is-uipath/index.md
@@ -1,0 +1,196 @@
+---
+title: "What Is UiPath? RPA & Business Automation Explained"
+description: "UiPath is a leader in Robotic Process Automation (RPA). Understand its platform, market trends, and how Kestra provides a powerful, declarative alternative for unified enterprise orchestration."
+metaTitle: "What Is UiPath? RPA Platform Explained"
+metaDescription: "UiPath is the leading RPA platform. Learn what it does, how its Orchestrator and robots work, and when a declarative alternative like Kestra fits better."
+tag: "infrastructure"
+date: 2026-07-08
+slug: "what-is-uipath"
+faq:
+  - question: "What exactly does UiPath do?"
+    answer: "UiPath primarily provides a platform for Robotic Process Automation (RPA), which involves using software robots to automate repetitive, rule-based tasks traditionally performed by humans. This extends to business process orchestration, leveraging AI to handle more complex scenarios, integrate systems, and manage workflows across an enterprise."
+  - question: "What are the market trends affecting UiPath's position?"
+    answer: "UiPath's market position is influenced by the broader trends in AI, automation, and enterprise software. While still a leader in RPA, the rise of agentic AI and unified orchestration platforms is shifting the landscape. Companies are looking for more integrated solutions that can handle diverse workloads beyond just UI-based automation."
+  - question: "Does UiPath have a future in the evolving automation landscape?"
+    answer: "Yes, UiPath continues to evolve its platform by integrating more AI capabilities, including AI agents and document understanding, to stay relevant in the changing automation landscape. Its future depends on successfully adapting to demands for deeper system integrations, broader orchestration capabilities, and more flexible deployment models beyond traditional RPA."
+  - question: "Who are UiPath's biggest competitors?"
+    answer: "UiPath's biggest competitors in the RPA space include Automation Anywhere, Blue Prism, and Microsoft Power Automate. In the broader automation and orchestration market, it competes with platforms like Kestra, which offer declarative, language-agnostic solutions for data, infrastructure, and AI workflows."
+  - question: "How does Kestra compare to UiPath for enterprise automation?"
+    answer: "While UiPath focuses on RPA and business process automation, Kestra offers a declarative, language-agnostic orchestration platform that unifies data, AI, infrastructure, and business workflows. Kestra excels at orchestrating code-driven tasks, APIs, and event-driven processes, providing a centralized control plane for complex, hybrid environments, often complementing or offering an alternative to RPA for technical automation."
+  - question: "What is Robotic Process Automation (RPA)?"
+    answer: "Robotic Process Automation (RPA) is a technology that uses software robots, or 'bots,' to mimic human actions and automate repetitive, rule-based tasks in business processes. These bots can interact with applications, websites, and data just like a human, executing tasks faster and with fewer errors, freeing up human workers for more complex activities."
+  - question: "Can UiPath integrate with other orchestration platforms?"
+    answer: "Yes, UiPath can integrate with other orchestration platforms through APIs and various connectors. This allows enterprises to combine UiPath's RPA capabilities with broader workflow management systems like Kestra, enabling the orchestration of RPA bots as part of larger, end-to-end data, infrastructure, or business workflows."
+---
+
+UiPath has become synonymous with Robotic Process Automation (RPA), empowering organizations to automate repetitive, rule-based tasks across their business operations. Its platform, leveraging software robots and increasingly AI, has transformed how enterprises approach efficiency and digital transformation.
+
+However, as the automation landscape evolves, the demand for a unified control plane that orchestrates more than just UI-driven tasks is growing. This article will delve into UiPath's core offerings, its market standing, and how it compares to broader orchestration platforms like Kestra, which provides a declarative, language-agnostic approach to managing complex workflows across data, AI, and infrastructure.
+
+## Understanding UiPath: The Foundation of Robotic Process Automation (RPA)
+
+UiPath's identity is rooted in RPA, a technology designed to automate human-centric processes. Understanding this foundation is key to grasping its value proposition and its place in the broader automation market.
+
+### Defining RPA: Automating Repetitive Tasks with Software Robots
+
+Robotic Process Automation (RPA) uses software "robots" or "bots" to replicate the actions a human would take while interacting with a digital system. Think of it as a digital workforce that can log into applications, enter data, copy and paste files, fill out forms, and extract information from documents.
+
+The core principle of RPA is to automate high-volume, repetitive, and rule-based tasks. Instead of building complex API integrations, which can be time-consuming or impossible with legacy systems, RPA bots operate at the user interface (UI) level—the same way a person does. This makes it a powerful tool for streamlining processes without altering the underlying IT infrastructure.
+
+### UiPath's Evolution: From RPA to AI-Powered Business Orchestration
+
+While UiPath began as a pure-play RPA vendor, it has significantly expanded its capabilities to address more complex business challenges. The platform now incorporates Artificial Intelligence (AI) and machine learning to create a more comprehensive business orchestration solution.
+
+This evolution includes features like:
+- **Document Understanding:** AI models that can extract and interpret data from structured and unstructured documents, such as invoices, contracts, and emails.
+- **Process Mining:** Tools that analyze business processes to identify bottlenecks and opportunities for automation.
+- **AI Agents:** More sophisticated bots that can handle exceptions, make simple decisions, and learn from new data.
+
+By integrating these technologies, UiPath aims to move beyond simple task automation to orchestrate end-to-end business processes, positioning itself as a key component of an enterprise's [IT automation platform](resources/infrastructure/it-automation-platform).
+
+## Key Components of the UiPath Platform
+
+The UiPath platform is a suite of integrated tools designed to discover, build, manage, and run automations at scale. Its architecture is built around several core components that work in concert.
+
+### The Orchestrator: Centralized Management and Control
+
+The UiPath Orchestrator is the web-based central hub for managing the entire digital workforce. It acts as the command center, allowing administrators to:
+- Deploy, schedule, and monitor robots and processes.
+- Manage queues and transactions for unattended robots.
+- Enforce governance policies and security controls.
+- View logs and analytics on automation performance.
+
+The Orchestrator provides the visibility and control necessary to scale automation from a few bots to thousands, ensuring reliability and compliance across the enterprise.
+
+### Robots and AI Agents: The Workforce of Automation
+
+UiPath's robots are the execution agents that carry out the automated tasks. They come in two primary forms:
+- **Attended Robots:** These bots work alongside human employees, typically on the same machine. They are triggered by user actions and are best suited for front-office tasks that require human intervention or supervision.
+- **Unattended Robots:** These bots operate autonomously in the background on servers or virtual machines. They are ideal for high-volume, back-office processes that can run without human involvement, scheduled and managed by the Orchestrator.
+
+AI agents represent the next generation of these robots, enhanced with machine learning capabilities to handle more variable and complex tasks.
+
+### Building and Deploying Automations: Studio, Apps, and Test Suite
+
+To create and deploy these automations, UiPath offers a development environment and supporting tools:
+- **UiPath Studio:** A visual, drag-and-drop development environment where users design automation workflows. It offers different profiles for citizen developers and experienced programmers.
+- **UiPath Apps:** A low-code tool for building custom applications and user interfaces that can interact with automated processes, enabling human-in-the-loop workflows.
+- **UiPath Test Suite:** A set of tools for testing both applications and automations to ensure they are robust and error-free before deployment.
+
+These components provide a comprehensive lifecycle for automation, from initial design in Studio to management and execution via the Orchestrator, with a user-friendly experience documented in their [UI guides](/docs/ui).
+
+## UiPath in the Evolving Automation Market
+
+As a publicly traded company and a leader in its category, UiPath's performance is closely watched. Its position is shaped by both its internal strategy and the external forces of the rapidly changing technology landscape.
+
+### Market Position and Trajectory: Analyzing UiPath's Strengths and Challenges
+
+UiPath established itself as a dominant force in the RPA market, earning a strong reputation for its powerful and scalable platform. Its strengths lie in its comprehensive feature set, extensive partner ecosystem, and large enterprise customer base.
+
+However, the company faces challenges as the market matures. The rise of cloud-native automation, API-first integration, and all-in-one platforms from major cloud providers creates a more competitive environment. Additionally, the inherent fragility of UI-based automation can lead to high maintenance costs, causing some organizations to seek more robust, code-based solutions.
+
+### The Future of RPA and UiPath's Role
+
+The future of automation is less about isolated task bots and more about integrated, intelligent workflows that span the entire enterprise. RPA is not disappearing, but its role is evolving. It is becoming one of many tools in a broader automation toolkit.
+
+UiPath is actively adapting to this shift by investing heavily in AI, expanding its cloud offerings, and positioning its platform as a central hub for "hyperautomation." Its future success will depend on its ability to integrate seamlessly with other enterprise systems and prove its value beyond traditional RPA use cases, competing with a wide range of [data orchestration platforms](/blogs/top-data-orchestration-platforms).
+
+## When UiPath is the Right Choice for Automation
+
+Despite the changing landscape, RPA and the UiPath platform remain the ideal solution for specific scenarios. A symmetrical analysis shows where it excels:
+
+- **Integrating with Legacy Systems:** When dealing with older applications that lack modern APIs, RPA is often the fastest and most cost-effective way to automate processes.
+- **High-Volume, Rule-Based Tasks:** For processes like data entry, invoice processing, or employee onboarding that are highly repetitive and follow clear rules, UiPath bots can deliver significant efficiency gains.
+- **Front-Office and Attended Automation:** In call centers or customer service departments, attended bots can assist employees by automating parts of their workflow, reducing handling times and improving consistency.
+- **Citizen Development Programs:** UiPath's low-code Studio and user-friendly interface make it suitable for empowering business users to build their own simple automations, freeing up IT resources.
+
+In these contexts, UiPath provides a direct and effective path to automation with a clear return on investment.
+
+## Exploring Alternatives: Where UiPath's Approach May Diverge
+
+While powerful, the RPA model has limitations, especially as automation needs become more complex and integrated with core engineering practices.
+
+### The Limitations of UI-Based Automation at Scale
+
+Automations built on a user interface are inherently brittle. A minor change to a website's layout, an application update, or a shift in screen resolution can break a bot. This fragility leads to several challenges at scale:
+- **High Maintenance Overhead:** Teams can spend a significant amount of time updating and fixing broken bots.
+- **Debugging Complexity:** Pinpointing the source of an error in a long, screen-based workflow can be difficult and time-consuming.
+- **Performance Bottlenecks:** UI-based interactions are slower and less efficient than direct API calls or database operations.
+
+### The Need for Code-Native and Declarative Orchestration
+
+For technical workflows—such as data pipelines, infrastructure provisioning, and CI/CD processes—a different approach is often required. Code-native and declarative orchestration platforms offer several advantages:
+- **Robustness:** API-first and event-driven workflows are less susceptible to superficial changes and provide more reliable integrations.
+- **Governance and Version Control:** Defining workflows as code (e.g., in YAML) allows for versioning, peer reviews, and auditable changes through Git.
+- **Scalability and Performance:** Direct system-to-system communication is faster and more scalable than mimicking human clicks.
+
+This is where the concept of a universal control plane for [workflow management](/resources/infrastructure/workflow-management) emerges, one that can handle diverse workloads beyond the scope of traditional RPA.
+
+## Kestra's Approach to Unified Enterprise Orchestration
+
+Kestra provides a declarative, language-agnostic platform designed to be the central control plane for all enterprise workflows, from [data pipelines](/data) and [AI models](/ai-automation) to [infrastructure operations](/infra-automation).
+
+### Declarative YAML: Orchestration as Code
+
+In Kestra, all workflows are defined as simple YAML files. This declarative approach separates the "what" from the "how." You define the sequence of tasks, triggers, and dependencies, and the Kestra engine handles the execution. This makes workflows easy to read, write, and manage like any other piece of code, enabling GitOps practices for your automation.
+
+### Polyglot Execution and Event-Driven Workflows
+
+Kestra is language-agnostic. A single workflow can seamlessly orchestrate tasks written in Python, SQL, Shell, Node.js, and more, all running in isolated environments. It is built to be event-driven, with native triggers for webhooks, schedules, file detections, and message queues, allowing you to build reactive, real-time automation.
+
+### Orchestrating RPA with Broader Workflows: A Complementary Role
+
+Kestra doesn't have to be a pure alternative to UiPath; it can also be a powerful complement. You can use Kestra as a higher-level orchestrator that triggers UiPath bots as part of a larger, end-to-end process. For example, a Kestra workflow could first ingest data from a database, then trigger a UiPath bot via an API call to enter that data into a legacy system, and finally send a notification to a Slack channel.
+
+This allows you to leverage your existing RPA investments while integrating them into a more robust, auditable, and scalable orchestration framework.
+
+```yaml
+id: trigger-uipath-process
+namespace: company.automation
+
+description: "Example Kestra flow to trigger a UiPath Orchestrator process via API."
+
+inputs:
+  - id: tenant_name
+    type: STRING
+    description: "Your UiPath Cloud Orchestrator tenant name."
+  - id: release_key
+    type: STRING
+    description: "The Release Key of the process to start in UiPath."
+  - id: input_arguments
+    type: JSON
+    description: "JSON string of input arguments for the UiPath process."
+    defaults: "{}"
+
+tasks:
+  - id: start_uipath_process
+    type: io.kestra.plugin.core.http.Request
+    uri: "https://cloud.uipath.com/{{inputs.tenant_name}}/orchestrator_/odata/Jobs/UiPath.Server.Configuration.OData.StartJobs"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ secrets.UIPATH_ACCESS_TOKEN }}"
+      Content-Type: "application/json"
+    body: |
+      {
+        "startInfo": {
+          "ReleaseKey": "{{ inputs.release_key }}",
+          "Strategy": "Specific",
+          "RobotIds": [],
+          "JobsCount": 1,
+          "InputArguments": "{{ inputs.input_arguments | json }}"
+        }
+      }
+  - id: log_job_id
+    type: io.kestra.plugin.scripts.shell.Commands
+    commands:
+      - "echo 'UiPath Job started with ID: {{ outputs.start_uipath_process.body.value[0].Id }}'"
+```
+
+## Choosing the Right Orchestration Platform for Your Enterprise
+
+The choice between UiPath and a platform like Kestra is not always an either/or decision. It's about selecting the right tool for the right job and building a cohesive automation strategy.
+
+- **Lean on UiPath and RPA** for automating UI-driven processes, integrating with legacy systems, and empowering citizen developers to tackle front-office tasks.
+- **Choose Kestra** when you need a robust, scalable, and auditable control plane for your technical workflows, including data engineering, infrastructure as code, and complex, multi-system processes.
+
+Ultimately, a modern enterprise needs both. By combining the strengths of RPA for user-centric tasks and a declarative platform for backend orchestration, organizations can build a comprehensive and resilient automation fabric. Kestra provides the [open-source orchestration platform](/) to serve as that central, unified control plane, ensuring that all automated processes, from UI bots to complex data pipelines, are governed, observable, and aligned with your engineering best practices, including robust [audit logs orchestration](/resources/infrastructure/audit-logs-orchestration).


### PR DESCRIPTION
## Summary

Imports the ready W27 SEO drafts from [`vfanucci/kestra-seo`](https://github.com/vfanucci/kestra-seo) into the resources hub, one `src/contents/resources/{slug}/index.md` per page, following the resource page template (front-matter + `/resources/{tag}/{slug}` URLs). These are the drafts finalized on 2026-06-30 / 2026-07-01 that were not yet on the docs site.

| Page | Tag | URL | Source PR |
|------|-----|-----|-----------|
| UiPath Alternatives | infrastructure | `/resources/infrastructure/uipath-alternatives` | kestra-seo#199 |
| Atlan Alternatives | data | `/resources/data/atlan-alternatives` | kestra-seo#201 |
| Automation Anywhere Alternatives | infrastructure | `/resources/infrastructure/automation-anywhere-alternatives` | kestra-seo#202 |
| Databricks Alternatives | data | `/resources/data/databricks-alternatives` | kestra-seo#203 |
| Debezium Alternatives | data | `/resources/data/debezium-alternatives` | kestra-seo#204 |
| Matillion Alternatives | data | `/resources/data/matillion-alternatives` | kestra-seo#205 |
| Orchestra Alternatives | data | `/resources/data/orchestra-alternatives` | kestra-seo#206 |
| What Is UiPath? (definition) | infrastructure | `/resources/infrastructure/what-is-uipath` | kestra-seo#198 |

No slug collisions with existing resources. Each page only adds an `index.md` (pages are auto-discovered — no nav/registry changes needed).

## Template-compliance fixes applied on import

- **automation-anywhere-alternatives** & **debezium-alternatives**: source drafts were wrapped in a ```` ```yaml ````/```` ```markdown ```` fence (Gemini output artifact) — fence stripped so the file starts with clean front-matter.
- **automation-anywhere-alternatives**: `metaDescription` trimmed 167 → 144 chars (≤160).
- **debezium-alternatives**: `metaDescription` trimmed 163 → 155 chars (140–160).
- **what-is-uipath**: re-slugged from `uipath-alternatives` (collided with #199, which is the dedicated alternatives listicle). This page is definitional ("what is UiPath / RPA explained"), so it now targets `what-is-uipath`; `title`/`metaTitle` reframed to match intent and the stray `| Kestra` suffix removed (the docs template already appends it).
- All other pages passed front-matter checks unchanged (metaTitle ≤60, metaDescription 140–160).

## Not included (deliberately)

- **kestra-seo#185 (infrastructure-as-code)** — clean draft, but overlaps the existing `what-is-infrastructure-as-code` page; held back pending a cannibalization/canonical decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
