### PR TITLE
fix(get-started): stop serving stale plugin count

### DIFF
--- a/src/pages/get-started.astro
+++ b/src/pages/get-started.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = false
 import Layout from "~/components/layout.astro"
 import Hero from "~/components/get-started/Hero.astro"
 import SetupSteps from "~/components/get-started/SetupSteps.astro"


### PR DESCRIPTION
## Summary
- `/get-started` shows an "N+ integrations" count baked in at build time because the page is static-prerendered by default. `/plugins` already opts into `prerender = false`, so it fetches `/plugins/subgroups` live on every request.
- The api.kestra.io fix for transient plugin-download failures (kestra-io/api.kestra.io#464) bumped the live count across a `/100` rounding boundary (1499 → 1696), so `/plugins` jumped to "1600+" while `/get-started` stayed frozen at "1400+" from the last docs deploy.
- Marking `get-started.astro` `prerender = false` makes it fetch live like `/plugins`, so the two pages can't drift again between deploys.

## Test plan
- [ ] `npm run build` succeeds
- [ ] `/get-started` renders with the same plugin count as `/plugins` after deploy