### PR TITLE
chore(docs): add missing pageUrl prop to NavToc component.

### DIFF
--- a/src/components/docs/NavToc.vue
+++ b/src/components/docs/NavToc.vue
@@ -111,6 +111,7 @@
             markdownBody?: string,
             pagePath?: string,
             pageTitle?: string,
+            pageUrl?: string,
         }>(),
         {
             links: () => [],


### PR DESCRIPTION
fixes: https://github.com/kestra-io/docs/issues/5064

---

Img ref: 
<img width="528" height="921" alt="image" src="https://github.com/user-attachments/assets/6614f981-4dea-4413-a1c1-d5627c4933af" />
