### PR TITLE
fix(ci): consolidate and fix Lighthouse benchmark workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,6 @@ concurrency:
 
 permissions:
   pull-requests: write
-  actions: read # download baseline artifact from lighthouse.yml
 
 jobs:
   truncate-url-slug:
@@ -97,94 +96,3 @@ jobs:
           template: |
             🔗 [${{ format('https://{0}-docs.kestra-io.workers.dev', needs.truncate-url-slug.outputs.slug) }}](${{ format('https://{0}-docs.kestra-io.workers.dev', needs.truncate-url-slug.outputs.slug) }})
             🔗 [${{ steps.preview-deploy.outputs.deployment-url }}](${{ steps.preview-deploy.outputs.deployment-url }})
-
-  lighthouse:
-    name: Lighthouse Benchmark
-    if: ${{ startsWith(github.repository, 'kestra-io/') && github.event_name == 'pull_request' }}
-    needs: truncate-url-slug
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Node
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Build site
-        run: npm run build
-        env:
-          NO_IMAGE_OPTIM: "true"
-
-      - name: Install Lighthouse
-        # Installed ad-hoc to keep package.json lean; ~100 MB only needed in CI.
-        run: npm install --no-save lighthouse chrome-launcher
-
-      - name: Start local dev server
-        # wrangler dev serves the built Workers bundle locally via Miniflare —
-        # no Cloudflare credentials required, no network access needed.
-        run: npx wrangler dev --local &
-
-      - name: Wait for dev server to be ready
-        run: |
-          echo "Waiting for http://localhost:8787…"
-          for i in $(seq 1 24); do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8787 || true)
-            if [ "$STATUS" = "200" ]; then
-              echo "Server is ready (HTTP 200)."
-              exit 0
-            fi
-            echo "  Attempt $i/24: HTTP $STATUS — retrying in 5 s…"
-            sleep 5
-          done
-          echo "Warning: server did not return 200 after 2 min; running Lighthouse anyway."
-
-      # Try to download the latest baseline artifact saved after a main-branch deploy.
-      # If none exists yet (first run after setup), this step is skipped silently.
-      - name: Download main branch baseline
-        id: baseline
-        uses: dawidd6/action-download-artifact@v6
-        continue-on-error: true
-        with:
-          workflow: lighthouse.yml
-          branch: main
-          name: lighthouse-baseline
-          path: baseline/
-
-      - name: Run Lighthouse benchmark
-        run: node scripts/lighthouse-benchmark.mjs
-        env:
-          BASE_URL: http://localhost:8787
-          BASE_URL_OUTPUT: ${{ github.ref == 'refs/heads/main' && 'https://kestra.io' || format('https://{0}-docs.kestra-io.workers.dev', needs.truncate-url-slug.outputs.slug) }}
-          OUTPUT_FILE: lighthouse-results.json
-          BASELINE_FILE: ${{ steps.baseline.outcome == 'success' && 'baseline/lighthouse-results.json' || '' }}
-          MARKDOWN_FILE: lighthouse-report.md
-
-      - name: Read Lighthouse report
-        id: report
-        run: |
-          {
-            echo "content<<LIGHTHOUSE_REPORT_DELIMITER"
-            cat lighthouse-report.md
-            printf '\n'
-            echo "LIGHTHOUSE_REPORT_DELIMITER"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Comment on PR
-        uses: kestra-io/actions/actions/comment-update@main
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          title: "## 🔦 Lighthouse Benchmark"
-          template: ${{ steps.report.outputs.content }}
-
-      - name: Upload results as artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: lighthouse-results
-          path: lighthouse-results.json
-          retention-days: 30

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -11,14 +11,11 @@ on:
 jobs:
   lighthouse-baseline:
     name: Lighthouse – Save Baseline (main)
-    if: |
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.repository, 'kestra-io/')
+    if: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.conclusion == 'success' && startsWith(github.repository, 'kestra-io/') }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+
     steps:
       - name: Checkout main
         uses: actions/checkout@v6
@@ -28,28 +25,53 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build site
+        run: npm run build
+        env:
+          NO_IMAGE_OPTIM: "true"
+
       - name: Install Lighthouse
         # Installed ad-hoc to keep package.json lean; ~100 MB only needed in CI.
         run: npm install --no-save lighthouse chrome-launcher
 
-      - name: Run Lighthouse against production
+      - name: Start local dev server
+        # wrangler dev serves the built Workers bundle locally via Miniflare —
+        # no Cloudflare credentials required, no network access needed.
+        run: npx wrangler dev --local &
+
+      - name: Wait for dev server to be ready
+        run: |
+          echo "Waiting for http://localhost:8787…"
+          for i in $(seq 1 24); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8787 || true)
+            if [ "$STATUS" = "200" ]; then
+              echo "Server is ready (HTTP 200)."
+              exit 0
+            fi
+            echo "  Attempt $i/24: HTTP $STATUS — retrying in 5 s…"
+            sleep 5
+          done
+          echo "Warning: server did not return 200 after 2 min; running Lighthouse anyway."
+
+      - name: Run Lighthouse against local build
         run: node scripts/lighthouse-benchmark.mjs
         env:
-          BASE_URL: https://kestra.io
-          OUTPUT_FILE: lighthouse-results-prod.json
-          MARKDOWN_FILE: lighthouse-report-prod.md
+          BASE_URL: http://localhost:8787
+          OUTPUT_FILE: lighthouse-results.json
+          MARKDOWN_FILE: lighthouse-report.md
 
-      # Fixed artifact name so dawidd6/action-download-artifact can always
-      # fetch "the latest baseline from main" in deploy.yml's lighthouse job.
       - name: Upload as baseline artifact
         uses: actions/upload-artifact@v7
         with:
-          name: lighthouse-baseline-prod
-          path: lighthouse-results-prod.json
+          name: lighthouse-baseline
+          path: lighthouse-results.json
           retention-days: 30
 
-      - name: Update commit comment
+      - name: Comment on commit
         uses: peter-evans/commit-comment@v4
         with:
-          body-path: lighthouse-report-prod.md
+          body-path: lighthouse-report.md
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,23 +1,26 @@
 name: Lighthouse Benchmark
 
-# Saves a Lighthouse baseline artifact after every successful deploy to main.
-# The baseline is later downloaded by the lighthouse job in deploy.yml so PRs
-# can show ▲/▼ deltas against the production scores.
 on:
-  workflow_run:
-    workflows: ["Deploy"]
-    types: [completed]
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: lighthouse-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  lighthouse-baseline:
-    name: Lighthouse – Save Baseline (main)
-    if: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.conclusion == 'success' && startsWith(github.repository, 'kestra-io/') }}
+  lighthouse:
+    name: Lighthouse Benchmark
+    if: startsWith(github.repository, 'kestra-io/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
-      - name: Checkout main
+      - name: Checkout
         uses: actions/checkout@v6
 
       - name: Set up Node
@@ -56,14 +59,40 @@ jobs:
           done
           echo "Warning: server did not return 200 after 2 min; running Lighthouse anyway."
 
-      - name: Run Lighthouse against local build
+      # Only on PRs: fetch the latest baseline saved from main so the report
+      # can show ▲/▼ deltas. Silently skipped if no baseline exists yet.
+      - name: Download main branch baseline
+        id: baseline
+        if: github.event_name == 'pull_request'
+        uses: dawidd6/action-download-artifact@v6
+        continue-on-error: true
+        with:
+          workflow: lighthouse.yml
+          branch: main
+          name: lighthouse-baseline
+          path: baseline/
+
+      - name: Run Lighthouse benchmark
         run: node scripts/lighthouse-benchmark.mjs
         env:
           BASE_URL: http://localhost:8787
           OUTPUT_FILE: lighthouse-results.json
+          BASELINE_FILE: ${{ steps.baseline.outcome == 'success' && 'baseline/lighthouse-results.json' || '' }}
           MARKDOWN_FILE: lighthouse-report.md
 
-      - name: Upload as baseline artifact
+      - name: Read Lighthouse report
+        id: report
+        run: |
+          {
+            echo "content<<LIGHTHOUSE_REPORT_DELIMITER"
+            cat lighthouse-report.md
+            printf '\n'
+            echo "LIGHTHOUSE_REPORT_DELIMITER"
+          } >> "$GITHUB_OUTPUT"
+
+      # main: save scores as the new baseline for future PR comparisons.
+      - name: Upload baseline artifact
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v7
         with:
           name: lighthouse-baseline
@@ -71,7 +100,25 @@ jobs:
           retention-days: 30
 
       - name: Comment on commit
+        if: github.event_name == 'push'
         uses: peter-evans/commit-comment@v4
         with:
           body-path: lighthouse-report.md
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      # PRs: post scores as a PR comment and keep results for inspection.
+      - name: Upload PR results artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: lighthouse-results
+          path: lighthouse-results.json
+          retention-days: 30
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        uses: kestra-io/actions/actions/comment-update@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          title: "## 🔦 Lighthouse Benchmark"
+          template: ${{ steps.report.outputs.content }}


### PR DESCRIPTION
## Summary

- **Fix: workflow never triggered** — the job `if` condition used a YAML `|` literal block scalar, embedding newlines that GitHub Actions' expression evaluator doesn't handle reliably. Replaced with `${{ }}` syntax.
- **Fix: 403 on commit comment** — `permissions: contents: read` prevented `peter-evans/commit-comment` from writing. Changed to `contents: write`.
- **Fix: artifact name mismatch** — `lighthouse.yml` uploaded `lighthouse-baseline-prod` but `deploy.yml` downloaded `lighthouse-baseline`. Aligned to `lighthouse-baseline`.
- **Switch to localhost baseline** — baseline now runs against a local `wrangler dev` build (same as PR tests) instead of `https://kestra.io`, so scores are comparable without Cloudflare CDN effects.
- **Consolidate into one workflow** — removed the duplicate `lighthouse` job from `deploy.yml` and rewrote `lighthouse.yml` as a single workflow triggered directly on `push`/`pull_request`. Conditional steps replace the two separate code paths; shared steps (build, serve, run) are written once.

## Test plan

- [ ] Merge to `main` → "Lighthouse Benchmark" workflow fires, uploads `lighthouse-baseline` artifact, posts a commit comment
- [ ] Open a PR → same workflow downloads the baseline, runs benchmark, posts `## 🔦 Lighthouse Benchmark` PR comment with ▲/▼ deltas

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCccWT5qKrUF1s425LLW4A)_