### PR TITLE
seo(resources): rewrite change-data-capture (concept-glossary template pilot)

### DIFF
--- a/src/contents/resources/change-data-capture/index.md
+++ b/src/contents/resources/change-data-capture/index.md
@@ -1,234 +1,151 @@
 ---
-title: "What is Change Data Capture (CDC)?"
-description: "Change Data Capture (CDC) is a crucial technique for modern data architectures. This guide explores what CDC is, its operational mechanisms, and how it ensures real-time data synchronization across systems."
-metaTitle: "What is Change Data Capture (CDC)? | Kestra"
-metaDescription: "Learn what change data capture (CDC) is, how it works, and how to implement it with Kestra. Compare log-based, trigger-based, and timestamp-based CDC methods."
+title: "What Is Change Data Capture (CDC) — and How to Orchestrate It"
+description: "Change data capture (CDC) detects and streams row-level database changes — inserts, updates, and deletes — in real time, powering real-time analytics, warehouse synchronization, and event-driven architectures."
+metaTitle: "What Is Change Data Capture (CDC)? Definition & Orchestration Guide"
+metaDescription: "Change Data Capture (CDC) streams row-level database changes in real time. Learn how CDC works — and orchestrate a full Postgres → Snowflake CDC pipeline in YAML."
 tag: data
-date: 2026-05-02
+date: 2026-07-03
 faq:
-  - question: "What is change data capture (CDC)?"
-    answer: "Change Data Capture (CDC) is a set of software design patterns that identifies and tracks row-level changes—inserts, updates, and deletes—in a source database and makes those changes available to downstream systems in real time or near-real time, without requiring a full table scan."
-  - question: "What is the difference between ETL and CDC?"
-    answer: "Traditional ETL is batch-oriented: it extracts large volumes of data at scheduled intervals, transforms it, and loads it into a target system. CDC is event-driven: it captures only the incremental changes (inserts, updates, deletes) as they happen, providing a continuous, low-latency stream instead of bulk snapshots. The two techniques are complementary—CDC can serve as the extract phase of a modern real-time ETL or ELT pipeline."
-  - question: "What are the main methods of change data capture?"
-    answer: "The three most common CDC methods are: (1) Log-based CDC, which reads the database transaction log (e.g., PostgreSQL WAL, MySQL binlog) with minimal source-system impact; (2) Trigger-based CDC, which fires database triggers on every change to write events to a changelog table; and (3) Timestamp-based CDC, which polls tables for rows whose last-modified timestamp is newer than the previous extraction—simple to implement but unable to capture deletes."
-  - question: "What is an example of change data capture?"
-    answer: "A common example is an e-commerce platform. When a customer places an order, a log-based CDC tool like Debezium reads the INSERT event from the database transaction log, publishes it to a message broker like Kafka, and multiple services consume it in real time: the inventory service decrements stock, the shipping service starts fulfillment, and an analytics dashboard updates—all without tightly coupling those services to the orders database."
-  - question: "Does change data capture affect database performance?"
-    answer: "It depends on the method. Log-based CDC reads the transaction log asynchronously and has minimal impact on source database performance. Trigger-based CDC runs synchronously on every data modification and can add measurable overhead. Timestamp-based CDC requires periodic table scans, which add query load. For production workloads, log-based CDC is generally recommended."
-  - question: "What is IBM change data capture?"
-    answer: "IBM InfoSphere Data Replication (also referred to as IBM CDC) is IBM's enterprise suite for real-time data replication and change data capture. It supports sources including Db2, Oracle, and SQL Server, and targets such as Kafka, Snowflake, and Google BigQuery. It integrates with IBM DataStage for ETL and is available on-premises and within IBM Cloud Pak for Data."
+  - question: "Is change data capture real-time?"
+    answer: "Log-based CDC is near-real-time: changes appear in the transaction log within milliseconds of commit. End-to-end latency depends on the pipeline — sub-second with a real-time trigger, or the polling interval with batch capture."
+  - question: "What's the difference between CDC and ETL?"
+    answer: "ETL moves data in scheduled bulk loads, while CDC streams individual row-level changes continuously. They are complementary: CDC feeds increments and an orchestrator coordinates both."
+  - question: "Does CDC impact the performance of the source database?"
+    answer: "Log-based CDC has minimal impact because it reads the transaction log the database already writes. Query-based CDC is heavier since every poll scans tables."
+  - question: "Do I need Kafka to run Debezium?"
+    answer: "No. Debezium is often deployed via Kafka Connect, but Kestra's Debezium plugins embed the engine directly, providing capture, state management and downstream processing in one declarative flow without a Kafka cluster."
 ---
 
-In the dynamic landscape of modern data architectures, keeping disparate systems synchronized and data consistently up-to-date is a perpetual challenge. Traditional batch processing often introduces latency, making real-time insights a distant goal. This is where Change Data Capture (CDC) emerges as a critical technique, fundamentally altering how organizations manage and react to data modifications.
+> **TL;DR** — Change data capture (CDC) is a data integration pattern that detects and streams row-level changes — inserts, updates, and deletes — from a database as they happen, instead of re-copying entire tables on a schedule. CDC powers real-time analytics, data warehouse synchronization, and event-driven architectures while keeping the load on source systems minimal.
 
-This comprehensive guide will demystify Change Data Capture, exploring its core mechanisms, diverse methods, and profound benefits. We'll delve into how CDC empowers real-time analytics, streamlines migrations, and enhances operational efficiency, alongside a deep dive into how Kestra, a declarative orchestration platform, can seamlessly integrate and manage your CDC pipelines, turning raw data changes into actionable insights.
+Most data teams meet CDC the day a nightly full-table copy stops scaling: the sync window grows, the warehouse bill climbs, and the business asks why yesterday's orders aren't in this morning's dashboard. CDC fixes all three at once — you move only what changed, seconds after it changed.
 
-## What is Change Data Capture (CDC)?
+This guide covers how CDC works, and then does what most CDC articles don't: it shows a **complete, runnable pipeline** that captures changes from PostgreSQL and merges them into Snowflake.
 
-Change Data Capture (CDC) is a set of software design patterns used to identify and track changes to data in a source database. Instead of extracting an entire dataset, CDC captures only the incremental changes—inserts, updates, and deletes—and makes them available in real time. This process allows other systems to respond to these changes as they happen, ensuring data consistency and enabling a wide range of real-time applications.
+## How CDC works
 
-The primary purpose of CDC is to maintain synchronization between different data stores with minimal impact on the source system. By capturing only the deltas, CDC avoids the resource-intensive overhead of full table scans and large batch transfers. This makes it a cornerstone of modern [data orchestration](/resources/data/data-orchestration), supporting everything from real-time analytics to zero-downtime database migrations. In an era where business decisions depend on the freshest possible data, CDC provides the mechanism to move from periodic batch updates to a continuous, event-driven flow of information.
+There are three ways to detect changes in a database, and they are not equal:
 
-## How change data capture works
+| Method | How it detects changes | Load on source | Captures deletes? | Latency |
+| :-- | :-- | :-- | :-- | :-- |
+| **Log-based** (the standard) | Reads the database's transaction log (the [WAL](/resources/data/postgres-wal) in Postgres) | Minimal — no queries against tables | ✅ Yes | Seconds |
+| **Query-based** | Polls tables on a timestamp/version column | A full scan per poll | ❌ No (a deleted row simply disappears) | Poll interval |
+| **Trigger-based** | Database triggers write changes to an audit table | Adds write overhead to every transaction | ✅ Yes | Seconds |
 
-At its core, CDC operates by monitoring a source database for modifications and then streaming those changes to consumers. The implementation details can vary, but the goal remains the same: to provide a reliable, low-latency stream of change events.
+Log-based CDC won this comparison years ago, and **[Debezium](https://debezium.io/)** is its de-facto open-source implementation: it reads the transaction log of Postgres, MySQL, SQL Server, MongoDB, Oracle, or DB2 and emits one structured change event per row.
 
-### CDC mechanisms and techniques
+## Why CDC needs orchestration
 
-Several techniques exist for implementing CDC, each with its own trade-offs in terms of performance, reliability, and complexity. The most common methods include:
-- **Log-based CDC:** Reads the database's native transaction log (e.g., PostgreSQL's WAL, MySQL's binlog) to capture changes. This is often the most efficient and reliable method.
-- **Trigger-based CDC:** Uses database triggers on source tables to record changes into a separate changelog table. This method is database-agnostic but can add overhead to the source system.
-- **Timestamp-based CDC:** Relies on a `last_updated` column in each table to identify recently modified rows. This approach is simpler to implement but has limitations, such as being unable to capture `DELETE` operations reliably.
+Capturing changes is the easy half. A production CDC pipeline also needs to:
 
-### Batch processing vs. real-time CDC
+- **transform** raw change events (handle deletes, deduplicate, enrich);
+- **load** them into a destination with correct upsert semantics ([MERGE](/resources/data/snowflake-merge), not blind inserts);
+- **recover** from failures without losing or double-processing events;
+- **alert** someone when the pipeline breaks — not when the business notices.
 
-The distinction between batch and real-time processing is crucial in understanding the value of CDC. For a deeper comparison, see our guide on [batch vs. streaming processing](/resources/data/batch-vs-streaming-processing).
-- **Batch Processing:** Traditionally, data is extracted in large chunks at scheduled intervals (e.g., nightly). This creates data latency, meaning the target system is always out of sync with the source.
-- **Real-time CDC:** CDC systems capture changes as they occur and stream them immediately. This approach minimizes latency, allowing target systems to reflect the source's state within seconds or milliseconds. While batch processing is suitable for historical analysis, real-time CDC is essential for operational analytics, fraud detection, and other time-sensitive applications.
+That layer is orchestration. Here is what it looks like as one declarative flow.
 
-### Does change data capture affect performance?
+## Orchestrate CDC with Kestra: Postgres → Snowflake
 
-A common concern with CDC is its potential impact on the performance of the source database. The effect varies significantly based on the chosen method.
-- **Trigger-based CDC** can have a noticeable performance impact. Because triggers are executed synchronously with every `INSERT`, `UPDATE`, or `DELETE` operation, they add overhead to each transaction, potentially slowing down the application.
-- **Timestamp-based CDC** requires queries to scan tables for new or updated records, which can be resource-intensive, especially on large tables without proper indexing.
-- **Log-based CDC** generally has the lowest performance impact. It reads the transaction log asynchronously, meaning it doesn't interfere with the database's primary workload. The process of reading the log is offloaded from the main database engine, making it a non-intrusive and highly efficient method for capturing changes.
-
-This event-driven topology is what makes CDC so powerful: a single row change in the source can fan out to every system that needs it, without coupling those systems to the source database. The next sections explore the concrete benefits this architecture unlocks.
-
-## Benefits of implementing change data capture
-
-Implementing CDC offers significant advantages for data management and analytics, moving organizations toward a more agile, data-driven operational model.
-
-### Data synchronization and consistency
-
-CDC ensures that data across multiple systems remains consistent and up-to-date. By propagating changes in real time, it eliminates the data silos and inconsistencies that arise from delayed batch updates. This is critical for microservices architectures, where different services might own their data but need a consistent view of related data from other services.
-
-### Improved operational efficiency
-
-By capturing only incremental changes, CDC dramatically reduces the volume of data that needs to be transferred and processed. This minimizes network bandwidth usage, reduces the load on both source and target systems, and lowers overall compute costs. The efficiency gains are particularly pronounced in large-scale environments with high transaction volumes.
-
-### Enabling real-time analytics and reporting
-
-The most transformative benefit of CDC is its ability to power real-time analytics. When change events are streamed as they happen, they can be fed directly into analytics platforms, data warehouses, or business intelligence dashboards. This allows businesses to monitor operations, detect anomalies, and make informed decisions based on the most current data available, rather than relying on outdated snapshots from the previous day.
-
-## Use cases for change data capture
-
-CDC is a versatile technique applicable to a wide range of data integration challenges. Its ability to provide low-latency, reliable data streams makes it invaluable in many modern architectures — see the dedicated [Change Data Capture use cases](/use-cases/change-data-capture) page for the patterns Kestra teams run in production.
-
-### Data warehousing and ETL processes
-
-CDC is a key enabler for efficient data warehousing. Instead of performing full extracts in a traditional [ETL workflow](/resources/data/etl-workflow), CDC allows for incremental updates to the data warehouse. This reduces the time and resources required for the ETL process, shortens the data refresh cycle, and provides analysts with more current data. This approach is foundational to building a modern, responsive [data pipeline](/resources/data/create-data-pipeline).
-
-### Database replication and migration
-
-When migrating from one database system to another, minimizing downtime is critical. CDC facilitates zero-downtime migrations by allowing the new database to be synchronized with the old one in real time. Once the initial data load is complete, CDC keeps the target database up-to-date with any changes occurring on the source. The cutover can then be performed with minimal disruption to applications — a common scenario in broader [database management workflows](/use-cases/databases-management).
-
-### Auditing and compliance
-
-For industries with strict regulatory requirements, maintaining a detailed audit trail of all data changes is essential. CDC provides a complete, ordered history of every modification made to the data, including what changed, who changed it, and when. This immutable log of events can be used for auditing, compliance reporting, and historical analysis.
-
-### What is an example of change data capture?
-
-A classic example of CDC is in an e-commerce platform — a pattern that sits at the core of modern [retail data workflows](/use-cases/retail). When a customer places an order, a new record is inserted into the `orders` table in the transactional database.
-1.  A log-based CDC tool like Debezium reads this `INSERT` event from the database's transaction log.
-2.  The change event is published to a message broker like Kafka.
-3.  Multiple downstream services can consume this event in real time:
-    - The inventory service decrements the stock count.
-    - The shipping service initiates the fulfillment process.
-    - The analytics platform updates a real-time sales dashboard.
-    - A marketing automation tool sends an order confirmation email.
-
-This event-driven architecture, powered by CDC, ensures that all parts of the system are synchronized instantly without tightly coupling them to the orders database.
-
-## Change data capture methods and tools
-
-Choosing the right CDC method and tool is critical for a successful implementation. Each approach has distinct characteristics that make it suitable for different scenarios.
-
-### Log-based CDC
-
-Log-based CDC is widely considered the gold standard. It works by reading the database's transaction log, which is an ordered, append-only record of all changes.
-- **How it works:** A CDC agent tails the transaction log, parses the binary log entries, and converts them into structured change events.
-- **Pros:** Minimal performance impact on the source database, captures all changes (including deletes and schema changes), and guarantees data consistency.
-- **Cons:** Can be complex to set up, as it requires deep integration with the specific database's log format.
-- **Tools:** [Debezium](https://kestra.io/docs/how-to-guides/debezium) is the leading open-source platform for log-based CDC, with connectors for databases like [MySQL](/plugins/plugin-debezium-mysql), [PostgreSQL](https://kestra.io/blogs/2022-04-05-debezium-without-kafka-connect), [SQL Server](/plugins/plugin-debezium-sqlserver), [Oracle](/plugins/plugin-debezium-oracle), and [DB2](/plugins/plugin-debezium-db2).
-
-### Trigger-based CDC
-
-This method uses standard database triggers to capture changes.
-- **How it works:** For each table being tracked, `INSERT`, `UPDATE`, and `DELETE` triggers are created. When a change occurs, the trigger fires and writes a record of the change to a separate "shadow" or "changelog" table.
-- **Pros:** It's database-agnostic and relatively straightforward to implement.
-- **Cons:** It adds transactional overhead to the source database, which can impact application performance. Triggers can also be complex to manage and maintain at scale.
-
-### Timestamp-based CDC
-
-Also known as query-based CDC, this method relies on columns in the source tables to identify changes.
-- **How it works:** It requires tables to have a column like `last_modified_timestamp`. The CDC process periodically queries the tables to find rows with a timestamp later than the last extraction time.
-- **Pros:** Simple to implement and doesn't require special database permissions or features.
-- **Cons:** It cannot reliably capture `DELETE` operations (since the row is gone), can miss changes that occur between queries, and puts additional query load on the source database.
-
-### Comparison of CDC strategies
-
-| Strategy | Performance Impact | Reliability | Complexity | Captures Deletes? |
-| --- | --- | --- | --- | --- |
-| **Log-based** | Low | High | High | Yes |
-| **Trigger-based** | Medium-High | High | Medium | Yes |
-| **Timestamp-based**| Medium | Low | Low | No |
-
-## CDC vs. ETL: understanding the differences
-
-While CDC and ETL are both data integration techniques, they serve different purposes and operate on different principles.
-
-### What is the difference between ETL and CDC?
-
-- **ETL (Extract, Transform, Load):** Typically a batch-oriented process that extracts large volumes of data (often entire tables), transforms it into a specific format, and loads it into a target system like a data warehouse. It operates on data in bulk at scheduled intervals.
-- **CDC (Change Data Capture):** A process that identifies and captures individual data changes (row-level inserts, updates, deletes) as they happen. It operates on a continuous stream of events, not on bulk data.
-
-### When to use CDC instead of ETL
-
-CDC is preferable when:
-- **Real-time data is required:** For applications that need up-to-the-second data.
-- **Source system impact must be minimized:** Log-based CDC is less intrusive than large batch extracts.
-- **Network bandwidth is a concern:** Sending only changes is far more efficient than sending full datasets.
-
-### How CDC complements ETL
-
-CDC and ETL are not mutually exclusive; they often work together. CDC can serve as the "Extract" phase in a modern, real-time [ETL or ELT pipeline](/resources/data/etl-vs-elt). Instead of a batch extract job, a CDC process continuously streams changes from the source, which are then transformed and loaded into the target system. This creates a more efficient, low-latency [data pipeline](/resources/data/data-pipeline).
-
-## Exploring IBM and Microsoft's CDC solutions
-
-Major database vendors often provide native or integrated CDC solutions to support data integration within their ecosystems.
-
-### What is IBM change data capture?
-
-IBM offers a suite of data replication and integration products under its InfoSphere brand, often referred to as IBM Change Data Capture. These tools are designed for enterprise environments and support a wide range of sources, including Db2, Oracle, and SQL Server. They provide log-based capture capabilities and are tightly integrated with other IBM products like DataStage for ETL and Cognos for analytics.
-
-### Microsoft SQL Server change data capture
-
-Microsoft SQL Server includes a built-in CDC feature. When enabled on a database and specific tables, it automatically creates changelog tables and capture jobs that populate them with row-level changes. This native functionality provides a reliable way to track modifications without relying on custom triggers. The change data is then accessible via table-valued functions, which can be queried by downstream applications and integration tools.
-
-For both IBM and Microsoft solutions, an orchestration platform like Kestra can be used to manage the end-to-end workflow, triggering downstream processes based on the captured changes and integrating them with the broader data ecosystem.
-
-## Orchestrating Change Data Capture with Kestra
-
-While CDC tools like Debezium are excellent at capturing change events, they are just one piece of the puzzle. A robust orchestration platform is needed to manage the entire workflow that follows. This is where Kestra excels, providing a declarative, language-agnostic control plane for your CDC pipelines.
-
-With Kestra, you can define your entire data flow in a simple YAML file. This includes configuring the CDC process, reacting to change events with real-time triggers, and orchestrating the downstream tasks that process the data. Kestra's extensive library of [plugins](/plugins) allows you to connect to any source or destination, from message queues like Kafka to data warehouses like Snowflake.
-
-For example, you can create a Kestra workflow that is triggered in real time by a change in a PostgreSQL database, captured via the Debezium plugin. The workflow could then transform the data using a Python script, load it into a data warehouse, and send a Slack notification upon completion.
-
-Here is an example of a Kestra flow that listens for changes in a PostgreSQL database using Debezium and processes each change event:
+This flow uses the [Debezium PostgreSQL trigger](https://kestra.io/plugins/plugin-debezium-postgres) to poll for change events (one execution per batch), cleans them in Python, stages the result in Snowflake, and merges it into the target table. Deleted rows are flagged by Debezium (`deleted` field) and handled explicitly.
 
 ```yaml
-id: debezium-postgres-listener
-namespace: company.team.production
-
-tasks:
-  - id: process-event
-    type: io.kestra.plugin.scripts.python.Script
-    script: |
-      from kestra import Kestra
-      import json
-
-      event = json.loads('{{ trigger.data }}')
-      change_type = event['payload']['op']
-      customer_id = event['payload']['after']['id']
-
-      print(f"Detected change '{change_type}' for customer ID: {customer_id}")
-      Kestra.outputs({'customerId': customer_id, 'changeType': change_type})
+id: postgres-cdc-to-snowflake
+namespace: company.data
 
 triggers:
-  - id: postgres-changes
+  - id: postgres_cdc
     type: io.kestra.plugin.debezium.postgres.Trigger
-    hostname: "{{ secret('POSTGRES_HOST') }}"
-    port: "{{ secret('POSTGRES_PORT') }}"
-    username: "{{ secret('POSTGRES_USER') }}"
-    password: "{{ secret('POSTGRES_PASSWORD') }}"
-    database: "sales"
+    hostname: "{{ secret('PG_HOST') }}"
+    port: "5432"
+    database: production
+    username: "{{ secret('PG_USERNAME') }}"
+    password: "{{ secret('PG_PASSWORD') }}"
     includedTables:
-      - "public.customers"
+      - public.orders
+    format: INLINE
+    splitTable: "OFF"
+    snapshotMode: INITIAL
+    interval: PT1M
+
+tasks:
+  - id: to_json
+    type: io.kestra.plugin.serdes.json.IonToJson
+    from: "{{ trigger.uris.data }}"
+
+  - id: transform
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      changes.jsonl: "{{ outputs.to_json.uri }}"
+    outputFiles:
+      - orders_clean.csv
+    script: |
+      import csv, json
+
+      with open("changes.jsonl") as src, open("orders_clean.csv", "w", newline="") as out:
+          writer = None
+          for line in src:
+              row = json.loads(line)
+              row["is_deleted"] = bool(row.pop("deleted", False))
+              if writer is None:
+                  writer = csv.DictWriter(out, fieldnames=row.keys())
+                  writer.writeheader()
+              writer.writerow(row)
+
+  - id: stage
+    type: io.kestra.plugin.jdbc.snowflake.Upload
+    url: "jdbc:snowflake://{{ secret('SNOWFLAKE_ACCOUNT') }}.snowflakecomputing.com"
+    username: "{{ secret('SNOWFLAKE_USERNAME') }}"
+    password: "{{ secret('SNOWFLAKE_PASSWORD') }}"
+    from: "{{ outputs.transform.outputFiles['orders_clean.csv'] }}"
+    fileName: orders_changes.csv
+    prefix: cdc
+    stageName: "@analytics.public.%orders_staging"
+
+  - id: merge
+    type: io.kestra.plugin.jdbc.snowflake.Queries
+    url: "jdbc:snowflake://{{ secret('SNOWFLAKE_ACCOUNT') }}.snowflakecomputing.com"
+    username: "{{ secret('SNOWFLAKE_USERNAME') }}"
+    password: "{{ secret('SNOWFLAKE_PASSWORD') }}"
+    sql: |
+      COPY INTO analytics.public.orders_staging;
+      MERGE INTO analytics.public.orders t
+      USING analytics.public.orders_staging s ON t.order_id = s.order_id
+      WHEN MATCHED AND s.is_deleted THEN DELETE
+      WHEN MATCHED THEN UPDATE SET t.status = s.status, t.updated_at = s.updated_at
+      WHEN NOT MATCHED AND NOT s.is_deleted THEN
+        INSERT (order_id, status, updated_at) VALUES (s.order_id, s.status, s.updated_at);
+
+errors:
+  - id: alert
+    type: io.kestra.plugin.notifications.slack.SlackExecution
+    url: "{{ secret('SLACK_WEBHOOK') }}"
+    channel: "#data-alerts"
 ```
 
-This declarative approach makes CDC pipelines easier to build, manage, and scale. You can find more examples in our [Blueprints library](/blueprints/listen-debezium).
+A few things worth noticing — because they are exactly the parts a raw Debezium deployment leaves you to build yourself:
 
-## Best practices for change data capture
+- **State is managed for you.** The trigger stores Debezium offsets in Kestra's KV Store, so a restart resumes from the last committed position instead of re-snapshotting the table.
+- **Deletes are first-class.** `deleted: ADD_FIELD` (the default) flags removed rows, and the MERGE handles them — the failure mode of query-based CDC simply doesn't exist here.
+- **Failure has a path.** The `errors` block alerts Slack on any failed execution; add [retries with exponential backoff](/resources/data/exponential-backoff) per task if the destination is flaky.
 
-To ensure your CDC implementation is robust, scalable, and secure, consider the following best practices.
+### Batch or real-time? Two triggers, one decision
 
-### Monitoring and error handling
+The flow above uses `Trigger` — it polls every minute (`interval: PT1M`) and creates **one execution per batch** of changes. Its sibling [`RealtimeTrigger`](https://kestra.io/plugins/plugin-debezium-postgres) creates **one execution per row**, within milliseconds.
 
-A CDC pipeline is a critical piece of infrastructure. Implement comprehensive [monitoring](/docs/administrator-guide/monitoring) to track latency, throughput, and error rates. Kestra provides built-in observability features, allowing you to set up alerts for failed tasks and configure automatic retries to handle transient issues, ensuring the reliability of your data flows.
+Rule of thumb: warehouse sync and analytics want the batch trigger (fewer, larger MERGEs are cheaper in Snowflake); operational reactions — fraud checks, cache invalidation, notifications — want the real-time trigger. It's a one-line change, which is the point of keeping CDC logic in declarative YAML rather than in connector configuration files.
 
-### Scalability considerations
+## Where CDC pays off
 
-As data volumes grow, your CDC pipeline must be able to scale. Choose tools and architectures that support distributed processing. For log-based CDC, this might involve deploying multiple connectors in parallel. In Kestra, you can use worker groups to distribute the processing load across multiple nodes, ensuring your pipeline can handle high-throughput data streams without bottlenecks.
+- **Warehouse synchronization** — replace nightly full loads with minute-level freshness (this page's flow; see also [blueprint #194](https://kestra.io/blueprints/194-use-debezium-to-trigger-a-flow-whenever-new-entries-hit-a-postgres-database-then-send-notification-to-slack-and-process-data-in-python): Debezium → Slack notification → Python processing).
+- **Event-driven architectures** — turn database changes into triggers for downstream [workflows](/resources/data/event-driven-orchestration) without touching application code.
+- **Audit trails & compliance** — an immutable stream of every change, with metadata, for free.
+- **Cache and search-index invalidation** — update Redis or Elasticsearch the moment a row changes, via the same pattern with a different final task.
 
-### Security implications
+Kestra ships Debezium plugins for **PostgreSQL, MySQL, SQL Server, MongoDB, Oracle, and DB2** — the flow above ports to any of them by swapping the trigger type.
 
-CDC pipelines often handle sensitive data. It's crucial to secure the data both in transit and at rest. Use encryption for connections to databases and message brokers. Manage credentials and other sensitive information using a secure secrets management system. Kestra offers built-in [secrets management](/docs/best-practices/secrets-management) and integrates with external vaults to ensure that your data remains protected throughout the pipeline.
+---
 
-## Conclusion
+**Related concepts:** [Postgres logical replication](/resources/data/postgres-logical-replication) · [Postgres WAL](/resources/data/postgres-wal) · [Snowflake streams](/resources/data/snowflake-streams) · [ETL vs ELT](/resources/data/etl-vs-elt) · [Dead letter queue](/resources/data/dead-letter-queue) · [Data orchestration](/resources/data/data-orchestration)
 
-Change Data Capture is no longer a niche technique but a fundamental component of modern data engineering. By moving from inefficient batch processing to real-time event streams, CDC enables organizations to build more responsive, efficient, and data-driven systems. Whether you are synchronizing microservices, migrating databases, or powering real-time analytics, CDC provides the foundation for a truly agile data architecture.
-
-By combining powerful CDC tools like Debezium with a declarative orchestration platform like Kestra, [data engineers](/use-cases/data-engineers) can build, manage, and scale complex data pipelines with unprecedented ease and reliability. To see how Kestra can transform your [data orchestration](/data), explore our platform and get started today.
+**▶ Run this flow in minutes** — [try Kestra Cloud](https://kestra.io/cloud) or `docker run kestra/kestra` and paste the YAML above.


### PR DESCRIPTION
## Summary

**Rewrite** of the existing live page [`/resources/data/change-data-capture`](https://kestra.io/resources/data/change-data-capture) — pilot of the **v1 concept-glossary template**.

The new version replaces the long generic explainer with a tighter definition-first page that then does what most CDC articles don't: it ships a **complete, runnable Postgres → Snowflake CDC flow** in YAML (Debezium trigger → Python transform → Snowflake stage + MERGE → Slack alert).

| Field | Value |
|-------|-------|
| URL | `/resources/data/change-data-capture` (unchanged) |
| tag | `data` |
| Primary keyword | change data capture (1,900 US/mo) |
| Schema | Article + FAQPage (FAQ auto-generated from front-matter) |

## Notes for review

- This **overwrites a live page** (was last dated 2026-05-02). Diff is a full-content replacement.
- FAQ moved into front-matter `faq:` (4 entries) so the template renders the FAQPage schema — the manual JSON-LD block from the draft was dropped to avoid duplication.
- Body H1 dropped (title comes from front-matter, per resource convention).
- ⚠️ Editorial gate from the template: the embedded flow should be validated via the Kestra validation API + a live test before publishing.
- Some inline concept links point to glossary pages that may not exist yet (`postgres-wal`, `snowflake-merge`, `exponential-backoff`, `postgres-logical-replication`, `snowflake-streams`, `dead-letter-queue`) — left in as forward-links for the concept-glossary rollout; to be pruned/created on polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
