### PR TITLE
seo(resources): add 3 new + rewrite 2 W27 concept pages (delta-lake, ai-agent, idempotency, data-mesh, rag-pipeline)

### DIFF
--- a/src/contents/resources/data-mesh-architecture/index.md
+++ b/src/contents/resources/data-mesh-architecture/index.md
@@ -1,296 +1,201 @@
 ---
-title: "What Is Data Mesh Architecture? Principles, Pillars, and Real-World Implementation"
-description: "Data mesh architecture decentralizes data ownership across domains. The 4 principles, a real implementation (Leroy Merlin: +900% data production), and the tool stack."
-metaTitle: "Data Mesh Architecture: 4 Principles & Examples | Kestra"
-metaDescription: "Data mesh decentralizes data ownership to domain teams. Learn the 4 principles, a real implementation (Leroy Merlin: +900% data production), and compare tools."
-tag: data
-date: 2026-07-01
+title: "Data Mesh Architecture: Principles, Benefits, and Orchestration"
+description: "Explore data mesh architecture, a decentralized approach to data management. Learn its four core principles, how it differs from data lakes, and how Kestra helps orchestrate domain-oriented data products."
+metaTitle: "Data Mesh Architecture: Principles & Orchestration"
+metaDescription: "Understand data mesh architecture and its four principles for decentralized data. Learn the benefits, challenges, and how Kestra orchestrates data products."
+tag: "data"
+date: 2026-07-07
+slug: "data-mesh-architecture"
 faq:
-  - question: "What is a data mesh architecture?"
-    answer: "Data mesh architecture is a decentralized approach to data management where domain teams own their data as products, supported by a self-serve platform and federated governance. It addresses the scaling limits of centralized data lakes and warehouses by distributing ownership, while enforcing consistent governance policies across domains."
   - question: "What are the 4 pillars of data mesh?"
-    answer: "The 4 pillars of data mesh are: (1) domain-oriented decentralized data ownership, (2) data as a product, (3) self-serve data infrastructure as a platform, and (4) federated computational governance. The first three principles were introduced by Zhamak Dehghani in her May 2019 article; the complete four-principle framework was published in December 2020."
+    answer: "The four core principles of data mesh architecture are domain-oriented decentralized ownership, data as a product, self-serve data platform, and federated computational governance. These principles guide the shift from a centralized data lake or data warehouse to a distributed model where data domains own and serve their data."
   - question: "Is data mesh obsolete?"
-    answer: "No. Data mesh isn't obsolete, but it has matured. Early 2020s hype framed it as a replacement for data lakes — in practice, most successful implementations combine data mesh principles (domain ownership, governance) with existing warehouses and lakes, rather than replacing them outright."
-  - question: "What is federated computational governance in data mesh?"
-    answer: "Federated computational governance means a cross-domain committee defines policy primitives — access control standards, data quality requirements, lineage standards, and compliance constraints — that apply everywhere. These policies are encoded into the self-serve platform where possible, so compliance is automatic. Domain teams have autonomy to build their own data products within these guardrails, rather than being free-form or under central control."
-  - question: "How is data mesh different from a data lake?"
-    answer: "A data lake is a centralized storage pattern — all raw data in one place, typically owned by a central team. A data mesh is a decentralized ownership pattern — domain teams own their data products. The two aren't mutually exclusive: many organizations run data mesh on top of existing lakes."
-  - question: "Do I need to replace my data warehouse to adopt data mesh?"
-    answer: "No. Most data mesh implementations run on top of existing warehouses and lakes. What changes is ownership: instead of a central team owning all pipelines into the warehouse, domain teams own the pipelines that produce their own schemas. The physical infrastructure stays; the organizational model shifts."
+    answer: "In the 2022 Data Management Hype Cycle, Gartner moved data mesh to 'Obsolete before plateau,' but this is a prediction. While the pure vision may evolve, data mesh concepts like domain ownership and data as a product are being subsumed by other emerging data tools and architectures, making it a continuously relevant influence."
+  - question: "What is a data mesh vs data lake?"
+    answer: "A data mesh is a decentralized architectural paradigm focusing on domain-owned, product-oriented data, while a data lake is a centralized storage repository for raw data. A data mesh emphasizes data ownership and governance at the domain level, whereas a data lake centralizes storage, often leading to a monolithic structure."
+  - question: "Who owns data mesh?"
+    answer: "In a data mesh model, ownership is decentralized and shifts to domain teams—those closest to the data and most familiar with how it's used. These data owners are responsible for producing data products tailored to specific uses, ensuring higher quality and relevance than a centralized team."
+  - question: "What are the main advantages of a data mesh?"
+    answer: "The primary advantages of a data mesh include enhanced data ownership and quality, increased agility and scalability for data teams, and improved data discoverability and usability across the organization. It fosters a culture where data is treated as a first-class product, leading to more reliable and accessible insights."
+  - question: "How does data mesh impact data governance?"
+    answer: "Data mesh transforms governance from a centralized, top-down approach to a federated model. Each domain team is responsible for governing its data products, adhering to global policies set by a federated governance body. This ensures consistency while allowing domain-specific flexibility."
 ---
 
-A marketing analyst files a ticket for a new attribution dataset. It joins a queue behind 40 other requests, all routed through one central data team that owns every pipeline in the company. Three weeks later the dataset arrives, modeled by engineers who have never run a campaign and who guessed at half the business logic. By then the question that prompted the request has changed. This pattern repeats across sales, finance, and logistics, and it is the structural failure that data mesh sets out to fix: a single central team becomes the bottleneck for an entire organization's analytics.
+> **TL;DR** — Data mesh is a decentralized data architecture that organizes data by business domain, treating data as a product with domain-oriented ownership, self-serve capabilities, and federated governance.
 
-Data mesh architecture offers a decentralized answer to this problem. By treating data as a product owned by the domain teams that understand it best, it gives organizations a way to manage data with more autonomy, better quality, and the scalability that a central team alone cannot provide. This article explains the core principles of data mesh, where it fits, the challenges it brings, and how Kestra can serve as the orchestration layer in a successful implementation.
+For many organizations, the promise of a centralized data lake has given way to a monolithic bottleneck. Data teams struggle with slow delivery, poor data quality, and a lack of clear ownership, leading to frustration and underutilized data assets. This challenge spurred the concept of data mesh, an architectural paradigm designed to decentralize data ownership and foster a product mindset.
 
-## Demystifying Data Mesh: A Paradigm Shift for Data Management
+This article explores data mesh architecture, detailing its four foundational principles and contrasting it with traditional data platforms. We'll discuss its benefits, common implementation hurdles, and demonstrate how Kestra provides a powerful orchestration layer to build and manage domain-oriented data products.
 
-Data mesh is a sociotechnical approach to building a decentralized data architecture. Coined by Zhamak Dehghani, it shifts the responsibility for data from a central team to the business domains that produce and understand the data best. Instead of a single, monolithic data platform, a data mesh consists of a distributed network of data products, each owned and managed by a specific domain.
+## How Data Mesh Architecture Decentralizes Data Management
 
-### Why Decentralization is Key in Modern Data
+Data mesh represents a significant shift in thinking about data architecture. It moves away from centralized, monolithic platforms toward a distributed model that mirrors the structure of the business itself.
 
-As organizations scale, centralized data teams become overwhelmed with requests from various business units. This creates a backlog, slows down innovation, and distances data consumers from data producers. The central team often lacks the specific business context to effectively manage and model data for every domain, leading to misunderstandings, poor [data quality](/resources/data/data-quality), and underused data assets.
+### From Centralized Lakes to Distributed Domains
 
-Decentralization addresses this by embedding data ownership within the business domains. The teams closest to the data—the experts in marketing, sales, logistics, or finance—take responsibility for their own data pipelines and products. This model creates greater accountability, improves data quality, and accelerates the delivery of data-driven insights. It mirrors the success of microservices in software engineering, applying similar principles of domain-driven design and distributed ownership to the data landscape. Effective [data orchestration](/resources/data/data-orchestration) becomes the connective tissue that allows these decentralized domains to function as a cohesive whole.
+Traditional data architectures, such as the data warehouse and the [data lakehouse](/resources/data/lakehouse-architecture), centralize data storage and management. A single team of specialized data engineers is typically responsible for ingesting, transforming, and serving data to the rest of the organization. While this approach offers centralized control, it often creates bottlenecks as the central team becomes overwhelmed with requests from various business units. This can lead to slow delivery times, a poor understanding of domain-specific data context, and a lack of clear ownership for data quality.
 
-### Core Characteristics of a Data Mesh
+Data mesh architecture challenges this paradigm by distributing data ownership to the business domains that produce and understand the data. Instead of a single data lake, a data mesh consists of an ecosystem of interconnected "data products" owned and managed by different domain teams (e.g., sales, marketing, logistics). This decentralization aims to increase agility, improve data quality, and make data more accessible and useful for a wider range of consumers. Effective [data orchestration](/resources/data/data-orchestration) becomes the critical layer that connects these distributed domains, ensuring that data products can be discovered, accessed, and combined reliably.
 
-A data mesh architecture is defined by several key characteristics that distinguish it from traditional, centralized models:
+## The Four Principles Driving Data Mesh Adoption
 
-*   **Distributed Ownership:** Data is owned by the domain teams that produce it, not by a central data team.
-*   **Data as a Product:** Data is treated as a first-class product, with clear owners, quality standards, and consumers.
-*   **Self-Serve Infrastructure:** A common platform provides domain teams with the tools and services they need to build, deploy, and manage their data products independently.
-*   **Federated Governance:** A central governance body sets global standards and policies, but enforcement is distributed and automated within each domain.
-*   **Interoperability:** Data products are designed to be discoverable, addressable, and interoperable, forming a connected network of data.
-
-These characteristics work together to create a more agile, scalable, and resilient data ecosystem that can adapt to the evolving needs of the business.
-
-## The Four Pillars of a Data Mesh: Foundations for Decentralized Data
-
-The data mesh concept is built upon four foundational principles. Understanding these pillars is essential for any organization considering a move toward this decentralized architecture.
+The data mesh concept is built on four core principles that work together to enable a decentralized, scalable, and product-oriented approach to data management.
 
 ### Domain-Oriented Decentralized Ownership
 
-This is the cornerstone of data mesh. It dictates that analytical data ownership should be aligned with the business domains that have the most context. A domain is a logical grouping of business capabilities, such as "customer management," "order processing," or "inventory."
-
-Under this principle, the domain team is responsible for the entire lifecycle of their data, from ingestion and transformation to serving it to consumers. They own their data pipelines, their data models, and the quality of the data they produce. This tight coupling of data and domain expertise ensures that data is managed by the people who understand it best, leading to higher quality and greater relevance.
+This is the foundational principle of data mesh. It dictates that analytical data should be owned by the business domains that are closest to it. For example, the marketing team owns marketing data, and the logistics team owns supply chain data. These domain teams are responsible for the entire lifecycle of their data, from ingestion to transformation and serving it to consumers. This approach aligns data ownership with business expertise, leading to higher-quality, more contextually relevant data. A well-defined [data management organization structure](/resources/data/data-management-organization-structure) is essential for this principle to succeed.
 
 ### Data as a Product
 
-In a data mesh, data is not just a byproduct of operational systems; it is a product in its own right. Each domain produces and serves one or more "data products" to the rest of the organization. A data product is a logical unit of data that is:
+In a data mesh, data is not just a byproduct of operational systems; it is treated as a first-class product. Each domain is responsible for creating and maintaining "data products" that are designed to be valuable and usable for their consumers. A data product includes not only the data itself but also the code, metadata, and infrastructure necessary to access and use it. These products must be discoverable, addressable, trustworthy, and interoperable. This product-thinking mindset shifts the focus from building pipelines to delivering value to data consumers. For a real-world example, see [how Leroy Merlin France enabled Data Mesh at scale](/blogs/2023-08-16-datamesh).
 
-*   **Discoverable:** It has clear metadata and is registered in a central catalog.
-*   **Addressable:** It can be accessed through a well-defined interface, like an API or a SQL view.
-*   **Trustworthy:** It meets defined quality standards and has clear service-level objectives (SLOs).
-*   **Self-Describing:** Its schema, semantics, and lineage are well-documented.
-*   **Secure:** Access is controlled through globally defined policies.
-*   **Interoperable:** It adheres to standards that allow it to be easily combined with other data products.
+### Self-Serve Data Platform Capabilities
 
-Thinking of data as a product forces domain teams to consider the needs of their consumers and to take responsibility for the quality and usability of the data they provide. Tracking [data lineage](/resources/data/data-lineage) across these products is what lets consumers trust where a dataset came from and how it was transformed. This product-oriented mindset is what makes a data mesh reliable and valuable rather than a loose collection of disconnected datasets.
-
-### Self-Serve Data Platform
-
-To let domain teams build and manage their own data products, they need access to a self-serve data platform. This platform provides the underlying infrastructure and tools that abstract away technical complexity, allowing teams to focus on data, not infrastructure.
-
-A self-serve platform in a data mesh context should provide capabilities for:
-
-*   Data storage and processing.
-*   Pipeline orchestration and scheduling.
-*   Data quality monitoring and testing.
-*   Schema management and versioning.
-*   Access control and security.
-*   Data cataloging and discovery.
-
-The goal is to provide a "paved road" for data product development, offering standardized, easy-to-use tools that let domains operate with a high degree of autonomy. This is a key element in achieving true [data choreography](/blogs/2023-09-13-choreography), where domains can independently develop and evolve their data products.
+To empower domain teams to build and manage their own data products, a data mesh requires a central, self-serve data platform. This platform provides the tools and infrastructure that domain teams need, such as data storage, processing engines, pipeline orchestration, and data cataloging. The goal is to abstract away the complexity of the underlying technology, allowing domain teams to focus on creating high-quality data products without needing to be deep infrastructure experts. This platform should be designed to be domain-agnostic and easy to use.
 
 ### Federated Computational Governance
 
-Decentralization can lead to chaos without a framework for global coordination. Federated computational governance provides this framework. It establishes a set of global rules, standards, and policies that all data products must adhere to, ensuring interoperability, security, and compliance across the mesh.
+While data ownership is decentralized, governance in a data mesh is a shared responsibility. A federated governance model establishes global standards, policies, and best practices that all data products must adhere to. This includes standards for data quality, security, privacy, and interoperability. A central governance body, composed of representatives from different domains and the central platform team, is responsible for defining these global policies. The enforcement of these policies is automated and embedded into the self-serve platform, ensuring that all data products are compliant without creating a centralized bottleneck.
 
-The "federated" aspect means that representatives from each domain, along with central platform and data governance teams, collaboratively define these global policies. The "computational" aspect means that these policies are embedded and enforced automatically by the self-serve platform. This automated approach to governance scales more effectively than manual review processes and lets domain teams move quickly while remaining compliant.
+## Why Data Mesh Requires Robust Orchestration
 
-## Why Data Mesh Solves Modern Data Challenges
+Implementing a successful data mesh architecture is impossible without a powerful orchestration layer. As data ownership becomes distributed across numerous domains, the need for a system to coordinate, govern, and ensure the reliability of these independent data products becomes paramount.
 
-The adoption of data mesh is driven by the limitations of traditional, centralized data architectures in large, complex organizations.
+Robust orchestration provides the necessary framework to:
+- **Coordinate independent data products:** Orchestration tools manage the dependencies and trigger the execution of workflows that span multiple domains, ensuring that data flows correctly between different data products.
+- **Ensure data quality and validation:** Automated workflows can enforce [data quality](/resources/data/data-quality) checks and validation rules as part of the data product lifecycle, ensuring that data meets the standards defined by the federated governance model.
+- **Implement federated governance policies:** Orchestration allows for the consistent application of access control, audit trails, and other governance policies across all data products, making federated governance a practical reality.
+- **Automate data product lifecycle:** The entire [data engineering lifecycle](/resources/data/data-engineering-life-cycle) of a data product—from ingestion and transformation to publishing and versioning—can be defined and automated as a workflow.
+- **Handle cross-domain dependencies and error recovery:** When a data product in one domain fails, an orchestration platform can manage the impact on downstream consumers, handle retries, and trigger alerts, maintaining the overall health of the mesh.
 
-### Overcoming Traditional Data Architecture Bottlenecks
+## Orchestrate Data Mesh with Kestra: Building a Domain-Oriented Data Product
 
-For years, the standard approach to analytics has been to centralize data in a data warehouse or data lake. A central team of data engineers is responsible for ingesting data from various sources, cleaning and transforming it, and making it available for analysis. While this model works for smaller organizations, it breaks down at scale.
+Kestra serves as the ideal orchestration plane for a data mesh. Its declarative, language-agnostic nature allows domain teams to define their data products as code, manage them through [GitOps practices](/blogs/2024-02-06-gitops), and integrate any tool or language they need.
 
-*   **The Central Team Bottleneck:** As the number of data sources and consumers grows, the central data team becomes a bottleneck. They cannot keep up with the volume of requests, and their lack of domain-specific context leads to slow delivery and suboptimal data models.
-*   **Lack of Ownership:** When data pipelines are managed by a central team, source system owners have little incentive to ensure the quality of the data they produce. This leads to data quality issues that are difficult to resolve downstream.
-*   **Technical and Organizational Coupling:** Monolithic data platforms create tight coupling between different parts of the organization. A change in one area can have unforeseen consequences in another, making the system brittle and difficult to evolve. The concepts behind a [lakehouse architecture](/resources/data/lakehouse-architecture) attempt to solve some of these issues, but data mesh takes the separation of concerns a step further.
-
-### Driving Agility, Scalability, and Data Quality
-
-Data mesh directly addresses these challenges by decentralizing ownership and giving domain teams the means to act on their own data.
-
-*   **Increased Agility:** Domain teams can develop and deploy their data products independently, without waiting for a central team. This allows them to respond more quickly to changing business needs.
-*   **Improved Scalability:** The architecture scales organizationally. As new domains are added, they can be onboarded to the self-serve platform and start producing data products without overloading a central team.
-*   **Higher Data Quality:** By making domain teams responsible for the quality of their data products, data mesh creates a strong incentive to produce clean, reliable, and well-documented data.
-*   **Clearer Ownership and Accountability:** The model establishes clear lines of ownership for data, reducing ambiguity and making it easier to manage the data lifecycle.
-
-## Data Mesh vs. Legacy Architectures: A Strategic Choice
-
-Data mesh represents a fundamental departure from centralized data architectures like data warehouses and data lakes.
-
-### Distinguishing Data Mesh from Data Warehouses and Data Lakes
-
-| Feature | Data Warehouse | Data Lake | Data Mesh |
-| :--- | :--- | :--- | :--- |
-| **Ownership** | Centralized (Data Team) | Centralized (Data Team) | Decentralized (Domain Teams) |
-| **Architecture** | Monolithic, schema-on-write | Monolithic, schema-on-read | Distributed, network of nodes |
-| **Data Model** | Highly structured, relational | Raw, unstructured/semi-structured | Polyglot, treated as a product |
-| **Team Structure** | Functional (ETL, BI) | Functional (Platform, Data Science) | Cross-functional (Domain Teams) |
-| **Governance** | Centralized, top-down | Centralized, often ad-hoc | Federated, computational |
-| **Technology** | Specialized SQL databases | Commodity storage (e.g., S3) | Self-serve platform with various tools |
-
-It is worth noting that a data mesh can coexist with existing data warehouses and data lakes and build on top of them. A domain might use a data warehouse to serve its structured data products, or it might consume data from a central data lake. The key difference is the ownership model and the product-oriented approach.
-
-### Data Mesh vs. Data Fabric
-
-Data mesh is often confused with data fabric, but the two solve different parts of the problem. Data mesh is primarily an **organizational and architectural** pattern: it changes *who owns data* and *how data is treated*, decentralizing ownership to domains and packaging data as products. Data fabric is primarily a **technology** pattern: it uses metadata, knowledge graphs, and automation to create a unified layer that integrates and accesses data across distributed sources, regardless of where it lives.
-
-Because they operate at different levels, the two are complementary rather than competing. A data fabric can supply the connective technology—automated metadata, discovery, and access—that a data mesh's self-serve platform exposes to domain teams. An organization can adopt the domain-ownership philosophy of a mesh while using fabric-style tooling to make data discoverable and accessible across that mesh.
-
-### When Data Mesh is the Right Strategic Choice
-
-Data mesh is not a one-size-fits-all solution. It introduces significant organizational and technical complexity and is best suited for specific scenarios.
-
-**Data mesh is a strong fit for:**
-
-*   **Large, complex organizations:** Companies with multiple business units, diverse data sources, and a high degree of organizational complexity.
-*   **Organizations with a culture of autonomy:** Companies that already embrace decentralized decision-making and have a strong engineering culture.
-*   **Data-driven businesses:** Companies where data is a core strategic asset and where agility in data delivery is a competitive advantage.
-
-**Data mesh may be overkill for:**
-
-*   **Small to medium-sized businesses:** Organizations with a relatively simple data landscape and a small data team can often be served well by a centralized architecture.
-*   **Companies with highly centralized operations:** If the business itself is not organized into clear, autonomous domains, implementing a data mesh can be difficult.
-
-### Is Data Mesh Obsolete?
-
-The question of whether data mesh is "obsolete" is misguided. It is a strategic architectural pattern, not a fleeting trend. Some of the backlash comes from organizations that adopted the label without the organizational change behind it—standing up "domains" while keeping a single team responsible for every pipeline, which reproduces the original bottleneck under a new name. That is a failure of implementation, not of the idea.
-
-For the right type of organization facing scaling challenges, the core principles remain highly relevant: decentralized ownership, data as a product, self-service, and federated governance all hold up regardless of which tools are in fashion. The choice depends on organizational maturity, scale, and strategic goals, not on the age of the concept.
-
-## Challenges and Considerations Before Adopting Data Mesh
-
-Data mesh is demanding, and a clear-eyed view of its costs prevents expensive missteps. The hardest problems are rarely technical.
-
-### Organizational Challenges
-
-The biggest obstacle is people, not technology. Data mesh requires teams that have never owned data to suddenly take responsibility for it, which means new skills, new hiring, and a cultural shift toward product thinking. Domains that lack engineering maturity will struggle, and without executive sponsorship the model tends to stall halfway, leaving the organization with the costs of decentralization and few of its benefits.
-
-### Technical Challenges
-
-Decentralized ownership multiplies the surface area for failure. Maintaining interoperability across independently built data products, keeping schemas consistent, and tracking [data observability](/resources/data/data-observability) signals across domains all become harder as the number of products grows. Each domain can make locally sensible choices that are globally incompatible, so the platform must enforce standards without becoming a bottleneck itself.
-
-### Tooling Challenges
-
-A self-serve platform is a prerequisite, not an optional extra, and assembling one is significant work. Teams need orchestration, cataloging, quality testing, and access control that domain engineers can use without deep platform expertise. Many organizations underestimate this and try to retrofit a centralized stack, which undermines the autonomy the mesh depends on. Choosing the right orchestration layer matters here; comparing options such as [Airflow alternatives](/resources/data/airflow-alternatives) is a reasonable starting point when the existing scheduler cannot support per-domain ownership.
-
-### Cost Considerations
-
-Decentralization can increase total cost before it reduces it. Duplicated infrastructure across domains, the headcount required to staff domain data teams, and the platform investment all add up early in the journey. The payoff—faster delivery and reduced central-team load—arrives later, so leadership needs realistic expectations about the timeline and the up-front spend.
-
-## Implementing Data Mesh: A Practical Roadmap
-
-Transitioning to a data mesh is a journey, not a big-bang project. It requires a thoughtful, iterative approach that combines organizational change with technical implementation.
-
-### Defining Data Domains and Crafting Data Products
-
-The first step is to identify and define the business domains. This process often involves mapping out the organization's business capabilities and grouping them into logical domains. Once domains are defined, you can begin to identify potential data products within each domain.
-
-Start small with one or two pilot domains. Work with these teams to define their first data products, focusing on high-value use cases. This involves:
-
-*   Identifying the key data assets within the domain.
-*   Understanding the needs of potential consumers.
-*   Defining the schema, SLOs, and access policies for the data product.
-*   Developing the [data ingestion](/blogs/2024-03-06-guide-integration-ingestion) and transformation pipelines to create the product.
-
-### Building Self-Serve Data Platform Capabilities
-
-In parallel, a platform team should begin building the initial version of the self-serve data platform. The focus should be on providing the core capabilities needed by the pilot domains. This might include:
-
-*   A standardized way to provision storage (e.g., S3 buckets, Snowflake schemas).
-*   A shared orchestration tool for building and managing pipelines.
-*   Templates and best practices for data quality testing.
-*   A basic data catalog for discovering data products.
-
-The platform should evolve based on the needs of the domain teams, with the platform team acting as a product team for the internal platform.
-
-### Establishing Effective Federated Governance
-
-As the mesh grows, it becomes important to establish a federated governance model. This involves creating a governance council with representatives from the domains, the platform team, and central functions like security and legal.
-
-This group is responsible for defining and evolving the global policies for the mesh, such as:
-
-*   Data classification and security standards.
-*   Interoperability standards for data product interfaces.
-*   Metadata standards for the data catalog.
-*   Global compliance policies (e.g., GDPR, CCPA).
-
-The key is to automate the enforcement of these policies through the self-serve platform, making compliance the path of least resistance for domain teams.
-
-## Kestra: Your Orchestration Control Plane for Data Mesh
-
-A powerful orchestration tool is a critical component of the self-serve data platform in a data mesh. Kestra's architecture and features make it a strong control plane for implementing and managing a data mesh.
-
-*   **Declarative Workflows for Data Products:** Kestra uses declarative YAML files to define workflows. This aligns with the "data as a product" principle, as the YAML definition can be version-controlled, reviewed, and managed alongside the data product's code and documentation. It serves as a clear, executable contract for how the data product is created.
-*   **Domain-Oriented Ownership with Namespaces:** Kestra's hierarchical namespaces let you map your organizational structure directly onto the platform. Each domain can have its own namespace, providing a clear boundary for their workflows, secrets, and permissions. This enables true domain-oriented ownership and autonomy.
-*   **Self-Serve Capabilities via a Rich Plugin Ecosystem:** With over 1,400 plugins, Kestra provides a vast library of pre-built integrations for databases, storage systems, and data tools. This lets the platform team offer a rich set of self-serve capabilities to domain teams, enabling them to build complex pipelines without writing extensive custom code.
-*   **Federated Governance through Code:** Kestra's declarative nature enables "governance as code." Global policies can be implemented as reusable subflows or templates that domain teams can incorporate into their workflows. Features like audit logs and role-based access control (RBAC) in the Enterprise Edition provide the visibility and control needed for federated governance.
-
-Here is an example of a simple Kestra flow that represents a data product. A "marketing" domain team could use this workflow to process raw lead data, enrich it, and publish it as a clean, reliable "enriched_leads" data product.
+The following example shows how a sales domain team could create a data product using Kestra. This workflow fetches daily sales data from an API, processes it with a Python script, and publishes it as a versioned Parquet file to an S3 bucket, making it available for consumers.
 
 ```yaml
-id: enriched-leads-data-product
-namespace: marketing.leads
+id: sales-data-product
+namespace: retail.sales
 
-description: Processes raw lead data from S3, enriches it, and loads it to Snowflake as a data product.
+description: Fetches daily sales data, processes it, and publishes it as a data product to S3.
 
 tasks:
-  - id: get-raw-leads
-    type: io.kestra.plugin.aws.s3.Download
-    bucket: raw-data-bucket
-    key: leads/{{ trigger.date }}.csv
+  - id: get-daily-sales
+    type: io.kestra.plugin.core.http.Request
+    uri: https://api.sales.example.com/daily-report
+    method: GET
+    headers:
+      Authorization: "Bearer {{ secret('SALES_API_TOKEN') }}"
+    retry:
+      maxAttempt: 3
+      delay: PT1M
 
-  - id: enrich-leads
+  - id: process-sales-data
     type: io.kestra.plugin.scripts.python.Script
     docker:
       image: python:3.11-slim
     script: |
       import pandas as pd
-      df = pd.read_csv('{{ outputs['get-raw-leads'].uri }}')
-      # ... enrichment logic using external APIs or internal data ...
-      df['enriched_at'] = pd.Timestamp.now()
-      df.to_csv('enriched_leads.csv', index=False)
+      import json
+      from kestra import Kestra
 
-  - id: load-to-snowflake
-    type: io.kestra.plugin.jdbc.snowflake.Write
-    url: "{{ secret('SNOWFLAKE_URL') }}"
-    username: "{{ secret('SNOWFLAKE_USER') }}"
-    password: "{{ secret('SNOWFLAKE_PASSWORD') }}"
-    warehouse: MARKETING_WH
-    database: MARKETING_DB
-    schema: LEADS
-    tableName: ENRICHED_LEADS
-    from: "{{ outputs['enrich-leads'].outputFiles['enriched_leads.csv'] }}"
+      # Load data from the previous task
+      with open("{{ outputs['get-daily-sales'].body }}") as f:
+          data = json.load(f)
+
+      df = pd.json_normalize(data, 'sales')
+
+      # Data quality checks
+      df.dropna(subset=['order_id', 'customer_id'], inplace=True)
+      df['order_date'] = pd.to_datetime(df['order_date'])
+
+      # Save processed data as Parquet
+      output_file = "processed_sales.parquet"
+      df.to_parquet(output_file)
+
+      # Make the file available to the next task
+      Kestra.outputs({'processed_file': output_file})
+    outputFiles:
+      - "{{ outputs.processed_file }}"
+
+  - id: publish-to-s3
+    type: io.kestra.plugin.aws.s3.Upload
+    accessKeyId: "{{ secret('AWS_ACCESS_KEY_ID') }}"
+    secretKeyId: "{{ secret('AWS_SECRET_ACCESS_KEY') }}"
+    region: "us-east-1"
+    bucket: "sales-data-products"
+    key: "daily_sales/v1/{{ flow.startDate | date('yyyy-MM-dd') }}.parquet"
+    from: "{{ outputs['process-sales-data'].outputFiles['processed_file'] }}"
 
 triggers:
-  - id: daily-run
+  - id: daily-schedule
     type: io.kestra.plugin.core.trigger.Schedule
-    cron: "0 5 * * *"
+    cron: "0 5 * * *" # Run daily at 5 AM UTC
+
+errors:
+  - id: notify-on-failure
+    type: io.kestra.plugin.notifications.slack.SlackExecution
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    channel: "#sales-data-alerts"
 ```
 
-This workflow is self-contained within the `marketing.leads` namespace, uses secrets for secure credential management, and declaratively defines the steps to create the data product, making it a fitting asset in a data mesh.
+A few things are worth noticing in this workflow:
+- **Declarative & Version-Controlled:** The entire data product logic is defined in a single YAML file, which can be stored in Git, reviewed, and versioned alongside other code.
+- **Polyglot Execution:** The workflow seamlessly combines an HTTP request with a Python script, demonstrating Kestra's ability to orchestrate tasks written in different languages and technologies.
+- **Built-in Resilience:** The `retry` mechanism on the HTTP request task ensures the workflow can handle transient API failures without manual intervention.
+- **Clear Ownership:** The `namespace: retail.sales` clearly assigns ownership of this data product to the sales domain, making it discoverable and manageable within the mesh.
 
-## Real-World Impact: Data Mesh in Action
+### Orchestrating Data Product Lifecycle: Automation and Governance
 
-The principles of data mesh are not just theoretical; they are delivering tangible results for organizations willing to embrace the change.
+Kestra provides the tools to manage the full lifecycle of a data product. Using features like [Assets](/docs/enterprise/governance/assets), teams can track data lineage and metadata automatically. Sensitive information, such as API keys and database credentials, can be securely managed using Kestra's built-in [Secrets manager](/docs/enterprise/governance/secrets). This combination of automation and governance tooling is essential for scaling a data mesh effectively. As one Kestra user, [Gorgias, noted](/blogs/2024-01-16-gorgias), applying Infrastructure as Code best practices to data engineering is a key benefit.
 
-One of the clearest examples is **[Leroy Merlin France](/blogs/2023-08-16-datamesh)**. By adopting a data mesh architecture powered by Kestra, the company transformed its data landscape. It gave its data products and teams the autonomy to manage their own data domains independently, which led to a **900% increase in data production**. This shows how decentralization, combined with the right orchestration platform, can unlock major productivity gains and support a truly data-driven culture.
+## Where Data Mesh Pays Off: Real-World Use Cases
 
-Beyond retail, data mesh principles are being applied across various industries:
+The principles of data mesh deliver tangible benefits in various scenarios. Organizations like **Leroy Merlin France** have transformed their data architecture with Kestra, increasing data production by 900%.
 
-*   **Financial Services:** Banks are using data mesh to give different lines of business (e.g., retail banking, investment banking, wealth management) control over their own data, enabling faster development of new financial products and more accurate risk modeling.
-*   **Healthcare:** Hospitals and research institutions are implementing data mesh to manage sensitive patient data across different departments (e.g., clinical, research, administrative), improving data sharing for research while maintaining strict compliance.
-*   **Manufacturing:** Companies are using data mesh to connect data from IoT sensors, supply chain systems, and factory floors, giving plant managers and operations teams direct access to the data they need to optimize production.
+Common use cases where data mesh excels include:
+- **Accelerating Data Delivery:** By empowering domain teams, businesses can develop and deploy analytics and machine learning models faster.
+- **Improving Data Ownership and Accountability:** Clear ownership leads to higher data quality and more reliable insights.
+- **Enabling Self-Service Analytics:** Data consumers can easily discover and access high-quality data products without relying on a central team.
+- **Scaling Data Operations:** Data mesh provides a scalable model for large organizations with complex data landscapes and numerous business domains.
+- **Fostering Innovation:** Accessible, trustworthy data encourages experimentation and the development of new data-driven products and services.
+Explore more [customer stories](/customers) and practical [data engineering blueprints](/blueprints/data-engineering-pipeline) to see how these principles are applied in practice.
 
-## The Evolving Landscape of Data Mesh
+## Data Mesh vs. Data Lake: Understanding the Architectural Shift
 
-Data mesh is a continuously evolving paradigm. As organizations gain more experience with its implementation, best practices are emerging, and the supporting technology ecosystem is maturing.
+While both architectures aim to make data available for analytics, their approaches are fundamentally different.
 
-### Integration with Emerging Technologies
+| Aspect | Data Lake / Lakehouse | Data Mesh |
+|---|---|---|
+| **Architecture** | Centralized, monolithic repository. | Decentralized, distributed ecosystem of data products. |
+| **Ownership** | Owned by a central data engineering team. | Owned by decentralized business domain teams. |
+| **Data Focus** | Raw, unprocessed data stored in a central location. | Curated, high-quality data served as a product. |
+| **Team Structure** | Specialized, central team of data engineers. | Cross-functional domain teams with data skills. |
+| **Governance** | Centralized, top-down governance model. | Federated governance with global standards. |
+| **Agility** | Can become a bottleneck as the organization scales. | Designed for agility and scalability. |
 
-The principles of data mesh are proving to be highly compatible with other modern data trends. For example, platforms like Databricks can be a core component of a data mesh implementation. A Databricks workspace can be aligned with a specific business domain, providing the computational engine for that domain's data products. The key is to use the platform in a way that supports decentralized ownership and self-service, rather than creating another centralized monolith.
+Choosing between a data mesh and a [data lakehouse architecture](/resources/data/lakehouse-architecture) depends on organizational scale and complexity. For smaller companies or those with a single primary data domain, a centralized model may be sufficient. For larger, more complex organizations, a data mesh can provide the scalability and agility needed to succeed.
 
-Similarly, the rise of AI and machine learning fits the data mesh model well. An ML model can be treated as a type of data product, owned and managed by the domain team that has the expertise to build and maintain it. The decentralized nature of the mesh allows different domains to experiment with and deploy their own models, encouraging innovation in AI.
+## Addressing Data Mesh Challenges with a Unified Orchestration Platform
 
-As organizations explore the best [ETL orchestration tools](/resources/data/etl-orchestration-tool-alternatives), they are increasingly looking for solutions that fit naturally into this distributed, domain-driven world.
+Despite its benefits, implementing a data mesh is not without challenges. It requires significant organizational change, a cultural shift toward data product thinking, and investment in the right technology.
 
-The journey to a data mesh is a significant undertaking, but for large organizations struggling with the limitations of centralized data platforms, it offers a clear path toward greater agility, scalability, and data-driven innovation. By embracing the principles of domain ownership, data as a product, a self-serve platform, and federated governance, companies can unlock the full potential of their data assets.
+Common hurdles include:
+- **Organizational and Cultural Shift:** Moving from a centralized to a decentralized model requires a change in mindset and a commitment from leadership.
+- **Technical Complexity:** Building a self-serve data platform and managing a distributed ecosystem of data products can be technically challenging.
+- **Tooling:** Finding the right tools to support a data mesh—from data cataloging and discovery to orchestration and governance—is crucial.
 
-Platforms like Kestra provide the essential orchestration layer that ties the mesh together, enabling domains to operate autonomously while maintaining global consistency and control. As you explore your data strategy, consider whether the decentralized, product-oriented approach of data mesh is the right choice to move your organization forward. To see how Kestra can help you build your modern data platform, explore our [declarative data orchestration](/data) solutions.
+The question "is data mesh obsolete?" often arises from these complexities. While Gartner's prediction in 2022 suggested this, the reality is more nuanced. The core principles of data mesh—domain ownership, data as a product—are becoming increasingly influential, even if pure implementations are rare. These concepts are being integrated into modern data platforms and strategies.
+
+A unified orchestration platform like Kestra can mitigate many of these challenges. By providing a declarative framework for defining data products, built-in [workflow governance](/resources/infrastructure/workflow-governance), and comprehensive [data observability](/resources/data/data-observability), Kestra simplifies the technical implementation and helps enforce the principles of the mesh across the organization.
+
+## Related Concepts
+- [What Is Data Orchestration?](/resources/data/data-orchestration)
+- [Best ETL Pipeline Tools for Data Engineering](/resources/data/etl-pipeline-tools)
+- [dbt Integrations for Data Orchestration](/resources/data/dbt-integrations)
+- [ETL Workflow: Design, Orchestrate, and Scale](/resources/data/etl-workflow)
+- [How Leroy Merlin France Enabled Data Mesh at Scale](/blogs/2023-08-16-datamesh)
+- [Data Lineage: Track, Visualize & Govern with Kestra](/resources/data/data-lineage)
+
+Ready to implement your data mesh strategy? Explore Kestra's capabilities for [data orchestration](/data).

--- a/src/contents/resources/delta-lake/index.md
+++ b/src/contents/resources/delta-lake/index.md
@@ -1,0 +1,205 @@
+---
+title: "Delta Lake: ACID Transactions, Lakehouse Architecture, and Orchestration"
+description: "Explore Delta Lake, an open-source storage layer that brings ACID transactions and reliability to data lakes, forming the foundation of modern lakehouse architectures. Learn how Kestra orchestrates Delta Lake workflows for robust data management."
+metaTitle: "Delta Lake: ACID, Lakehouse, Orchestration"
+metaDescription: "Delta Lake provides ACID transactions, schema enforcement, and time travel for lakehouses. Understand its architecture and how Kestra orchestrates it."
+tag: "data"
+date: 2026-07-07
+slug: "delta-lake"
+faq:
+  - question: "What is Delta Lake and why is it important?"
+    answer: "Delta Lake is an open-source storage layer that runs on top of an existing data lake (like S3 or ADLS) to bring ACID transactions, schema enforcement, and data versioning. It's crucial for building a reliable data lakehouse, enabling data teams to combine the flexibility of data lakes with the reliability of data warehouses for analytics and AI workloads."
+  - question: "What are the core benefits of Delta Lake?"
+    answer: "Key benefits include ACID transactions (Atomicity, Consistency, Isolation, Durability) for data reliability, schema enforcement to prevent bad data, time travel for data versioning and rollbacks, and scalable metadata handling. These features ensure data quality and simplify complex data operations in a lakehouse environment."
+  - question: "How does Delta Lake support ACID transactions?"
+    answer: "Delta Lake implements ACID properties through a transaction log that records every change to the table. This log ensures that multiple operations can occur concurrently without corrupting data, and that data remains consistent even during failures. It allows for reliable upserts, deletes, and complex data manipulations."
+  - question: "How does Delta Lake compare to Apache Iceberg?"
+    answer: "Both Delta Lake and Apache Iceberg are open-source table formats for data lakes, providing ACID properties and schema evolution. Delta Lake originated from Databricks and is tightly integrated with Spark, while Iceberg is cloud-agnostic and supports a broader range of query engines. The choice often depends on existing ecosystem investments and specific workload requirements."
+  - question: "Can Kestra orchestrate Delta Lake workflows?"
+    answer: "Yes, Kestra can orchestrate all aspects of Delta Lake workflows by integrating with compute engines like Databricks, Spark, or Dremio. It can trigger data ingestion, run transformations (e.g., using dbt or Python), manage schema evolution, handle error recovery, and automate data quality checks, providing end-to-end governance and visibility."
+  - question: "What is a Delta Lake Lakehouse architecture?"
+    answer: "A Delta Lake Lakehouse architecture combines the best features of data lakes (scalability, flexibility, low cost) and data warehouses (ACID transactions, schema governance, performance). Delta Lake serves as the transaction layer on top of object storage, allowing data teams to perform SQL analytics, machine learning, and data science directly on their data lake with strong reliability guarantees."
+---
+
+> **TL;DR** — Delta Lake is an open-source storage layer that brings ACID transactions, schema enforcement, and time travel to data lakes, forming the foundation of modern lakehouse architectures for reliable data management.
+
+Traditional data lakes promised flexibility but often struggled with data reliability, consistency, and governance, leading to "data swamps." As data volumes and complexity grew, teams faced challenges ensuring data quality and managing concurrent operations without corruption.
+
+Delta Lake emerged to solve these problems by bringing data warehousing features like ACID transactions directly to data lakes. This open-source storage layer transforms a simple collection of files into a robust, transactional data platform, forming the foundation of the modern lakehouse architecture. This article explores Delta Lake's core capabilities and demonstrates how Kestra orchestrates its workflows for resilient data management.
+
+## How Delta Lake works: ACID transactions and unified data management
+
+Delta Lake is an open-source storage layer that operates on top of existing data lakes, such as Amazon S3, Azure Data Lake Storage, or Google Cloud Storage. It doesn't replace your object storage; instead, it enhances it with reliability and performance features. At its core, Delta Lake organizes data into versioned Parquet files and maintains a transaction log that records every operation performed on a table.
+
+### The transaction log: Enabling ACID properties
+
+The key to Delta Lake's reliability is its transaction log, stored as ordered JSON files in a `_delta_log` directory alongside the data files. This log is the single source of truth, providing a complete history of every change made to a table. It enables the ACID properties that are standard in traditional databases:
+
+*   **Atomicity:** Operations are all-or-nothing. A transaction that writes five files either succeeds completely or fails, leaving the table in its previous state.
+*   **Consistency:** Data is always in a valid state. Schema enforcement ensures that all data written to a table conforms to its defined structure.
+*   **Isolation:** Concurrent reads and writes do not interfere with each other. Readers see a consistent snapshot of the data, even while new data is being written.
+*   **Durability:** Once a transaction is committed, it is permanent, even in the event of system failures.
+
+### Schema enforcement and evolution
+
+Delta Lake enforces the table's schema on write, preventing the ingestion of corrupt or mismatched data that could break downstream processes. If an incoming record doesn't match the expected data types or column names, the transaction fails. This proactive data quality check is a significant improvement over schema-on-read systems.
+
+At the same time, Delta Lake supports explicit schema evolution. You can add new columns, change data types, or modify column comments without rewriting the entire table, allowing your data structures to evolve with business needs.
+
+### Time travel and versioning
+
+Because the transaction log records every version of the table, Delta Lake allows you to query historical data. This "time travel" capability is invaluable for:
+
+*   **Auditing:** Examining data at a specific point in time for compliance or analysis.
+*   **Rollbacks:** Quickly reverting a table to a previous version to recover from accidental bad writes or deletions.
+*   **Reproducibility:** Running machine learning models or reports on the exact same version of the data for consistent results.
+
+These features collectively build a reliable foundation for a modern [Lakehouse Architecture](/resources/data/lakehouse-architecture).
+
+## Why Delta Lake needs orchestration beyond basic operations
+
+While Delta Lake provides a robust foundation, managing data pipelines in a production environment requires more than just its core features. This is where orchestration becomes critical. Production workflows involve complex dependencies, error handling, and operational governance that extend beyond the capabilities of a storage layer.
+
+An orchestration platform is needed to:
+
+*   **Manage complex dependencies:** A typical ETL/ELT pipeline involves multiple steps, from ingesting raw data and running transformations to loading it into Delta tables and performing quality checks. Orchestration ensures these steps run in the correct order.
+*   **Handle error recovery:** If a write to a Delta table fails, an orchestrator can trigger automated recovery logic, retry the operation, or send an alert to the data team.
+*   **Automate data quality checks:** Orchestration platforms can integrate with tools like dbt or Great Expectations to run validation tests before and after data is written to Delta Lake.
+*   **Integrate diverse systems:** Data rarely originates in one place. Orchestration connects various sources (databases, APIs, streaming platforms) and sinks, with Delta Lake as a central component.
+*   **Provide end-to-end visibility:** A centralized control plane gives you a complete view of your data lifecycle, making it easier to monitor performance, debug issues, and manage compliance across all your [data pipelines](/docs/use-cases/data-pipelines).
+
+Without a dedicated orchestrator, teams are left to build and maintain brittle, custom scripts, losing the reliability that Delta Lake was adopted to provide. For more insight, you can explore various [ETL orchestration tools](/resources/data/etl-orchestration-tool-alternatives).
+
+## Orchestrate Delta Lake with Kestra: An ETL example
+
+Kestra can manage the entire lifecycle of a Delta Lake workflow, from data ingestion and processing to loading and validation. The following example demonstrates a common ETL pattern: downloading raw data from S3, processing it with Python, and loading it into a Delta Lake table hosted on Databricks.
+
+```yaml
+id: delta_lake_etl_workflow
+namespace: company.team.data
+description: "Ingests data from S3, processes it with Python, and loads into a Delta Lake table on Databricks."
+
+inputs:
+  - id: s3_bucket
+    type: STRING
+    defaults: "my-data-bucket"
+  - id: s3_key
+    type: STRING
+    defaults: "raw_data/sales_data.csv"
+  - id: databricks_table
+    type: STRING
+    defaults: "sales_data.processed_sales"
+
+tasks:
+  - id: download_from_s3
+    type: io.kestra.plugin.aws.s3.Download
+    bucket: "{{ inputs.s3_bucket }}"
+    key: "{{ inputs.s3_key }}"
+
+  - id: process_data_with_python
+    type: io.kestra.plugin.scripts.python.Script
+    warningOnStdErr: false
+    script: |
+      import pandas as pd
+      import io
+      from kestra.io import KestraIO
+
+      # Read raw data from Kestra's internal storage
+      with open("{{ outputs.download_from_s3.uri }}", "r") as f:
+          raw_csv_data = f.read()
+
+      df = pd.read_csv(io.StringIO(raw_csv_data))
+      df['processed_at'] = pd.to_datetime('now')
+      df['total_amount'] = df['quantity'] * df['price']
+
+      # Write processed data to a temporary file
+      processed_file_path = "processed_sales.csv"
+      df.to_csv(processed_file_path, index=False)
+
+      # Make the processed file available as an output
+      KestraIO.outputs({"uri": processed_file_path})
+    outputs:
+      - processed_sales.csv
+
+  - id: load_to_delta_lake_databricks
+    type: io.kestra.plugin.jdbc.databricks.Query
+    url: "jdbc:databricks://{{ secret('DATABRICKS_HOST') }}:443/default;AuthMech=3;UID=token;PWD={{ secret('DATABRICKS_TOKEN') }};"
+    sql: |
+      CREATE TABLE IF NOT EXISTS {{ inputs.databricks_table }} (
+        id INT,
+        product_name STRING,
+        quantity INT,
+        price DOUBLE,
+        processed_at TIMESTAMP,
+        total_amount DOUBLE
+      ) USING DELTA;
+
+      COPY INTO {{ inputs.databricks_table }}
+      FROM '{{ outputs.process_data_with_python.uri }}'
+      FILEFORMAT = CSV
+      FORMAT_OPTIONS ('header' = 'true', 'inferSchema' = 'false')
+      COPY_OPTIONS ('mergeSchema' = 'true');
+    beforeCommands:
+      - "SET spark.databricks.delta.schema.autoMerge.enabled = true;"
+
+errors:
+  - id: send_alert_on_failure
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    payload: |
+      {
+        "text": ":x: Delta Lake ETL workflow failed! \n Flow: `{{ flow.id }}` \n Execution: `{{ execution.id }}` \n Details: {{ execution.status }}"
+      }
+```
+
+A few things are worth noticing in this workflow:
+
+*   **Declarative & Version Controlled:** The entire ETL process is defined in a single YAML file, making it easy to version, review, and audit.
+*   **Polyglot Execution:** The flow seamlessly combines different tools—an S3 integration, a Python script for transformation, and a Databricks SQL query—without requiring complex glue code.
+*   **Seamless Data Handoff:** Kestra's internal storage automatically passes the output of one task as an input to the next, simplifying data flow between steps.
+*   **Built-in Error Handling:** The `errors` block provides a robust mechanism for sending alerts or triggering remediation workflows when any task fails.
+
+This declarative approach to orchestration complements Delta Lake's reliability, creating a truly robust and manageable data platform. For more details on our partnership, see how [Databricks and Kestra are joining forces](/blogs/2024-03-07-databricks-partnership).
+
+## Delta Lake in action: Common use cases and integrations
+
+Delta Lake's features make it suitable for a wide range of data workloads, from traditional analytics to real-time applications.
+
+### Building a Lakehouse architecture
+
+This is the primary use case. Delta Lake provides the transactional layer needed to perform both BI and AI workloads directly on the data lake, eliminating the need for separate, siloed data warehouses and data lakes.
+
+### Handling real-time data ingestion
+
+With its support for streaming reads and writes, Delta Lake is well-suited for building real-time data pipelines. It can serve as a unified sink for both batch and streaming data, simplifying the architecture for applications that require fresh data.
+
+### Data versioning and audit trails
+
+For regulated industries, the ability to reconstruct the state of data at any point in time is critical for compliance and auditing. Time travel provides an immutable history of all data changes.
+
+### Integrations across the data ecosystem
+
+Delta Lake is an open-source project with a growing ecosystem. It integrates natively with compute engines like Apache Spark, Trino, and Flink. It is also a core component of platforms like Databricks and is supported by Dremio, and can be managed with tools like dbt. You can learn more about [data lakehouse orchestration with Kestra and Dremio](/blogs/2023-12-07-dremio-kestra-integration) or explore [dbt integrations for data orchestration](/resources/data/dbt-integrations). The format is also a key part of modern data platforms, including as an alternative to [Microsoft Fabric](/resources/data/microsoft-fabric-alternatives).
+
+## Delta Lake vs. other table formats: Iceberg and Hudi
+
+Delta Lake is one of three major open table formats for the data lakehouse. Its main counterparts are Apache Iceberg and Apache Hudi.
+
+*   **Apache Iceberg:** Originally developed at Netflix, Iceberg is known for its strong focus on correctness and performance, especially for huge tables. It is compute-engine agnostic and has broad support across the ecosystem.
+*   **Apache Hudi:** Created at Uber, Hudi (Hadoop Upserts Deletes and Incrementals) focuses on providing fast upserts and incremental data processing, making it a strong choice for change data capture and streaming use cases.
+
+The choice between them often depends on your primary compute engine and specific needs. Delta Lake has the tightest integration with Spark and the Databricks ecosystem, while Iceberg is often favored for its interoperability. Many platforms are now offering support for all three, as seen in various [Databricks alternatives](/resources/data/databricks-alternatives).
+
+## Kestra's role in modern Delta Lake environments
+
+As organizations adopt Delta Lake to build reliable data platforms, Kestra provides the essential orchestration layer to operationalize these environments at scale. By offering a unified, declarative control plane, Kestra helps teams manage the entire data lifecycle around Delta Lake. This includes centralizing data ingestion, automating transformations, enforcing data quality, and providing end-to-end visibility and governance.
+
+By combining the reliability of Delta Lake with the robust orchestration capabilities of Kestra, data teams can build modern, scalable, and resilient data platforms to power their analytics and AI initiatives. Explore how Kestra can help you build your modern [data platform](/data) or browse our full set of [data engineering resources](/resources/data).
+
+## Related concepts
+- [Lakehouse Architecture: Principles & Benefits](/resources/data/lakehouse-architecture)
+- [Data Orchestration: The Engine of Modern Data Pipelines](/resources/data/data-orchestration)
+- [Databricks Alternatives: Top Data & AI Platforms (2026)](/resources/data/databricks-alternatives)
+- [dbt Integrations for Data Orchestration](/resources/data/dbt-integrations)
+- [Top ETL Orchestration Tools for Modern Data Pipelines](/resources/data/etl-orchestration-tool-alternatives)
+- [Orchestrate Data Pipelines in Kestra](/docs/use-cases/data-pipelines)

--- a/src/contents/resources/how-to-build-an-ai-agent/index.md
+++ b/src/contents/resources/how-to-build-an-ai-agent/index.md
@@ -1,0 +1,169 @@
+---
+title: "How to Build an AI Agent with Declarative Orchestration"
+description: "Learn to build production-ready AI agents using Kestra's declarative YAML orchestration. Discover how to integrate LLMs, define tools, and manage complex agentic workflows for robust, auditable automation."
+metaTitle: "Build AI Agents: Step-by-Step with Kestra Orchestration"
+metaDescription: "Build AI agents with declarative orchestration, LLM integration, tool definition, and governance. Master robust AI workflows from concept to production."
+tag: "ai"
+date: 2026-07-07
+slug: "how-to-build-an-ai-agent"
+faq:
+  - question: "Is it free to build an AI agent?"
+    answer: "Building an AI agent can range from free to costly. Open-source frameworks and models allow free development, but commercial LLM APIs, cloud compute, and advanced orchestration platforms like Kestra's Enterprise Edition typically involve costs for production-grade reliability, governance, and scale. Basic experimentation can often be done for free or at minimal cost."
+  - question: "Can you build an AI agent with ChatGPT?"
+    answer: "While ChatGPT is a powerful LLM, it's not a standalone 'AI agent' in the true sense, as it lacks persistent memory, autonomous planning, and direct tool integration without external wrappers. You can use ChatGPT (or its underlying models via API) as the core LLM within an agent, but you'll need an orchestration layer like Kestra to provide the memory, tools, and decision-making framework to create a fully functional agent."
+  - question: "Can I build AI agents without coding?"
+    answer: "Yes, it's increasingly possible to build AI agents with low-code or no-code platforms, especially for simpler use cases. Tools like Kestra's declarative YAML allow for agent definition without traditional programming, focusing on configuration over custom code. However, more complex agents requiring custom logic or deep integrations may still benefit from some coding expertise."
+  - question: "What are the 5 types of AI agents?"
+    answer: "Common classifications of AI agents include Simple Reflex Agents (reacts to current state), Model-Based Reflex Agents (maintains internal state), Goal-Based Agents (plans to achieve goals), Utility-Based Agents (chooses actions with highest expected utility), and Learning Agents (improves performance over time). Kestra's orchestration enables building complex agents that combine elements of these types."
+  - question: "Is ChatGPT an AI agent?"
+    answer: "ChatGPT itself is primarily a large language model designed for conversational interaction. It does not inherently possess the full characteristics of an autonomous AI agent, such as persistent memory, the ability to use external tools, or long-term planning. However, its underlying models can be integrated into an agentic architecture to power the reasoning and generation capabilities of a true AI agent."
+  - question: "What is the 30% rule for AI?"
+    answer: "The '30% rule for AI' is a general guideline suggesting that if an AI system can automate approximately 30% of a task or process, it's often a good candidate for implementation. This threshold indicates sufficient value to justify development, even if full automation isn't immediately achievable. It emphasizes focusing on practical, impactful automation rather than striving for 100% in all cases."
+---
+
+> **TL;DR** — Building an AI agent involves combining a Large Language Model (LLM) with memory, tools, and a planning module. This allows the agent to reason, interact with external systems, and execute tasks autonomously. Success requires a robust orchestration layer to manage these components and ensure reliable, auditable performance.
+
+Building effective AI agents goes beyond simply prompting a Large Language Model (LLM). It involves orchestrating a complex interplay of reasoning, memory, tool use, and external systems to achieve autonomous goals. The challenge lies in managing this complexity, ensuring reliability, and providing governance across diverse tasks.
+
+This guide provides a practical, step-by-step approach to constructing robust AI agents. We will explore the core components of agentic design, discuss various development approaches, and demonstrate how Kestra's declarative orchestration simplifies the creation, deployment, and management of production-ready [AI agent workflows](/resources/ai/agentic-workflows).
+
+## Understanding AI Agents and Their Core Components
+
+An AI agent is a system that can perceive its environment, make decisions, and take actions to achieve specific goals. Unlike a simple chatbot, a true agent possesses a more sophisticated architecture.
+
+### Beyond Simple Prompts: Defining True AI Agents
+
+A true [AI agent](/resources/ai/ai-agent) is more than a one-shot prompt-and-response interaction. It operates within a continuous loop, often referred to as a ReAct (Reason + Act) loop, where it assesses a situation, plans its next step, executes an action, and observes the outcome to inform its subsequent decisions. The key components include:
+*   **LLM Core**: The reasoning engine, typically a powerful model like GPT-5 or Claude Opus 4, that processes information and makes decisions.
+*   **Memory**: A mechanism for the agent to retain information across multiple interactions, providing context and enabling more complex, stateful operations.
+*   **Tools**: A defined set of functions or external systems the agent can use to interact with the world, such as searching the web, querying a database, or calling an API.
+*   **Planning**: The ability to break down a high-level goal into a sequence of smaller, executable steps.
+*   **Execution**: The capacity to carry out the planned steps using its available tools.
+
+### Is ChatGPT a True AI Agent?
+
+While ChatGPT can exhibit agent-like behaviors, it is fundamentally an LLM. It lacks the built-in, persistent memory and autonomous tool-use capabilities of a true agent. To build a functional agent, you must wrap the LLM in an external framework or orchestration platform that provides these missing components.
+
+## Why AI Agents Require Robust Orchestration
+
+As agents move from prototypes to production systems, managing their behavior becomes critical. This is where a dedicated orchestration layer is essential for several reasons:
+
+*   **State Management and Context Preservation**: Agents need persistent memory across interactions. An orchestrator manages this state, ensuring the agent has the right context for each decision without requiring complex custom code.
+*   **Tool Integration and Management**: Securely connecting agents to external systems like APIs, databases, or other Kestra flows is paramount. Orchestration provides a secure, governed way to define and manage these tools.
+*   **Error Handling and Resilience**: What happens when a tool fails or an LLM gives an unexpected response? Orchestration platforms provide automatic retries, fallback mechanisms, and human-in-the-loop approval gates to ensure resilience.
+*   **Observability and Auditability**: For debugging and compliance, you need a clear record of an agent's decisions, tool calls, and outcomes. A central control plane offers detailed logs and audit trails for every execution.
+*   **Scalability and Resource Management**: An orchestration engine can handle concurrent agent executions, manage compute resources efficiently, and scale your agentic workflows as demand grows.
+
+## Building AI Agents with Declarative Kestra: A Practical Example
+
+Kestra provides a declarative approach to building agents, defining their entire logic—LLM, memory, and tools—in simple YAML. This makes agents easier to build, version, and govern.
+
+Let's build an agent that receives a user query, uses a Kestra subflow as a tool to read a document, and then summarizes it.
+
+```yaml
+id: document_summarizer_agent
+namespace: dev.ai.agents
+
+description: An AI agent that summarizes a document based on a user query.
+
+inputs:
+  - id: query
+    type: STRING
+    description: The user's request for summarization.
+  - id: document_uri
+    type: STRING
+    description: URI to the document to be summarized.
+
+tasks:
+  - id: ai_agent_task
+    type: io.kestra.plugin.ai.agent.AIagent
+    model: openai/gpt-5
+    temperature: 0.7
+    system: "You are a helpful assistant that can summarize documents. Use the 'read_document' tool to access the document content."
+    prompt: "{{ inputs.query }}"
+    memory:
+      type: io.kestra.plugin.ai.agent.memory.ChatMemory
+      id: chat_memory
+    tools:
+      - name: read_document
+        description: "Reads the content of a document from a given URI and returns its text."
+        parameters:
+          type: object
+          properties:
+            uri:
+              type: string
+              description: "The URI of the document to read (e.g., kestra://../my_document.txt)."
+          required:
+            - uri
+        task:
+          id: read_file_tool
+          type: io.kestra.plugin.core.flow.Subflow
+          flowId: read_document_flow
+          namespace: dev.ai.tools
+          inputs:
+            documentUri: "{{ tool.uri }}"
+```
+
+**What this example demonstrates:**
+*   **Declarative YAML**: The entire agent logic, including LLM configuration, memory, and tools, is defined in a human-readable YAML file. This is a core principle of [agentic orchestration](/resources/ai/agentic-orchestration).
+*   **Tool Integration**: Kestra allows any flow to be exposed as a tool. Here, the agent can call a separate flow (`read_document_flow`) to handle file access securely. This separates the agent's reasoning from the tool's implementation.
+*   **Memory Management**: `ChatMemory` is automatically managed by Kestra, providing persistent context across agent interactions without any manual state handling.
+*   **Version Control**: Because the agent is defined as code, it can be versioned in Git, enabling GitOps practices for managing your AI systems.
+
+## Choosing the Right Approach for Your AI Agent
+
+When building an agent, you can choose between code-first frameworks and declarative platforms.
+
+### Code-First vs. Low-Code/Declarative Platforms
+
+Python frameworks like LangChain and LlamaIndex offer immense flexibility for developers comfortable with writing custom code. They provide libraries to chain LLM calls, manage memory, and integrate tools programmatically.
+
+In contrast, a declarative platform like Kestra abstracts away the boilerplate code. Instead of writing Python scripts to wire components together, you define the relationships in YAML. This approach accelerates development, improves readability for non-programmers, and enforces standardized, auditable agent designs.
+
+### Cost Considerations for AI Agent Development
+
+Is it free to build an AI agent? Not entirely. While open-source frameworks are free, you will incur costs for:
+*   **LLM API Calls**: Production agents using commercial models like GPT-5 or Claude Opus 4 are billed per token.
+*   **Compute Resources**: Running the agent and its tools requires processing power.
+*   **Platform Licenses**: Enterprise-grade orchestration platforms may have licensing fees for advanced features like RBAC, audit logs, and high availability.
+
+## Orchestrating Advanced AI Agent Capabilities
+
+As your needs mature, you'll want to build more sophisticated agents. Kestra's orchestration capabilities support these advanced patterns.
+
+### Implementing Reasoning, Planning, and Multi-Agent Systems
+
+You can chain multiple agents together in a single Kestra flow, creating a [multi-agent system](/resources/ai/multi-agent-system) where each agent has a specialized role. For example, a "researcher" agent could gather information, passing its findings to a "writer" agent to synthesize a report.
+
+### Cloud-Based vs. Local LLMs for Agents
+
+While cloud-based LLMs offer state-of-the-art performance, you may need to use local models for cost, privacy, or customization reasons. Kestra's Docker Task Runner allows you to run any model in a containerized environment, giving you the flexibility to orchestrate both cloud and local LLMs within the same workflow.
+
+### The Five Types of AI Agents
+
+AI agents are often categorized by their complexity and capabilities:
+1.  **Simple Reflex Agents**: Act only based on the current situation.
+2.  **Model-Based Reflex Agents**: Maintain an internal model of the world.
+3.  **Goal-Based Agents**: Formulate goals and plan actions to achieve them.
+4.  **Utility-Based Agents**: Choose actions that maximize a utility function.
+5.  **Learning Agents**: Improve their performance over time through experience.
+
+Kestra can orchestrate all five types, from simple event-driven reflex agents to complex learning agents that trigger retraining pipelines based on performance metrics.
+
+## Real-World Impact: Use Cases for AI Agents
+
+With a robust orchestration platform, AI agents can be deployed to solve real business problems:
+*   **Automated Data Processing**: Agents that identify, extract, and transform data from unstructured sources like PDFs or emails, then load it into a structured database.
+*   **IT Operations and Remediation**: Agents that monitor system alerts, diagnose issues by querying logs, and trigger automated runbooks to resolve them.
+*   **Customer Support Automation**: Agents that handle complex user queries by looking up information in internal knowledge bases and escalating to a human agent with full context when needed.
+*   **Code Generation and Refactoring**: Agents that assist developers by generating boilerplate code, writing unit tests, or refactoring legacy applications, all within a governed [AI code generation workflow](/resources/ai/ai-code-generation-workflow).
+
+## Related concepts
+-   [What Are AI Agents? Definition & Examples](/resources/ai/ai-agent)
+-   [What is Agentic AI? Explained Simply](/resources/ai/agentic-ai)
+-   [What is Agentic Orchestration? Definition & Components](/resources/ai/agentic-orchestration)
+-   [MCP Orchestration: Unifying AI Agents & Tools](/resources/ai/mcp-orchestration)
+-   [AI Code Generation Workflow: Orchestration & Governance](/resources/ai/ai-code-generation-workflow)
+-   [Building Production-Ready AI Agents: Orchestrating Agentic Workflows with Kestra](/blogs/orchestrate-ai-agents-kestra)
+
+Kestra provides the declarative control plane to build, deploy, and govern your production-ready AI agents. Explore our [AI automation resources](/ai-automation) to learn more.

--- a/src/contents/resources/idempotency/index.md
+++ b/src/contents/resources/idempotency/index.md
@@ -1,0 +1,117 @@
+---
+title: "Idempotency: Ensuring Reliable Operations in Distributed Workflows"
+description: "Idempotency is the property of an operation that produces the same result regardless of how many times it's executed. Learn why it's crucial for building fault-tolerant APIs, data pipelines, and event-driven systems, and how to implement it effectively with Kestra."
+metaTitle: "Idempotency for Reliable Distributed Workflows"
+metaDescription: "Idempotency keeps APIs, data pipelines, and event-driven systems reliable. Learn its principles, patterns, and how Kestra ensures repeatable operations."
+tag: "infrastructure"
+date: 2026-07-07
+slug: "idempotency"
+faq:
+  - question: "What is idempotency in API?"
+    answer: "In APIs, an idempotent operation guarantees that sending the same request multiple times will have the exact same effect on the server as sending it just once. This is crucial for reliability in distributed systems, preventing unintended side effects from retries."
+  - question: "What do you mean by idempotent?"
+    answer: "Idempotent refers to a property where an operation, when applied multiple times, yields the same result as applying it once. In computer science, this is vital for designing fault-tolerant systems that can safely retry operations without creating duplicate data or side effects."
+  - question: "What are some real-world examples of idempotency?"
+    answer: "Everyday examples include pressing an elevator call button or a pedestrian traffic light button; multiple presses don't change the outcome. In software, setting a value in a database, deleting a resource, or sending a unique payment request are common idempotent operations."
+  - question: "Is ChatGPT idempotent?"
+    answer: "No, large language models like ChatGPT are generally not idempotent. Providing the same prompt multiple times will typically generate different responses, as their nature involves a degree of randomness and contextual variation, making the output non-repeatable."
+  - question: "What are the 5 API methods?"
+    answer: "The five primary HTTP API methods are GET, POST, PUT, PATCH, and DELETE. Of these, GET, PUT, and DELETE are inherently idempotent. POST is generally not idempotent, as repeated requests can create duplicate resources, while PATCH has conditional idempotency."
+---
+
+> **TL;DR** — Idempotency is the property of an operation that produces the same result regardless of how many times it's executed. It is crucial for building fault-tolerant APIs, data pipelines, and event-driven systems, ensuring that retries or duplicate messages do not lead to unintended side effects or inconsistent state.
+
+In distributed systems, failures are a given. Network glitches, timeouts, or transient errors can lead to operations being retried, sometimes multiple times. Without careful design, these retries can result in unintended side effects like duplicate data, incorrect state changes, or even financial discrepancies.
+
+This is where idempotency becomes a critical property. It's the assurance that performing an operation once or a hundred times yields the exact same outcome. Understanding and implementing idempotency is fundamental for building reliable, resilient systems that can gracefully handle the chaos of distributed computing.
+
+## How idempotency works
+
+The term "idempotent" originates from mathematics, where it describes an element of a set that remains unchanged when multiplied by itself. In computer science, the concept is adapted to describe operations. An operation is idempotent if executing it multiple times has the same effect on the system's state as executing it just once.
+
+For example, setting a variable `x` to the value `10` is an idempotent operation. No matter how many times you run `x = 10`, the final value of `x` will be `10`. Conversely, incrementing `x` (`x = x + 1`) is not idempotent, as each execution changes the final state. This principle of repeatable, predictable outcomes is the foundation of fault-tolerant system design.
+
+## Why reliable systems demand idempotency
+
+In any distributed architecture, from microservices to data pipelines, components communicate over a network, which is inherently unreliable. Messages can be lost, delayed, or duplicated. Idempotency provides a safety mechanism to handle these uncertainties gracefully.
+
+Without it, a simple network hiccup could cause a client to retry an API request, leading to a customer being charged twice or a duplicate record being inserted into a database. With idempotency, the system recognizes the repeated request and ensures the operation is processed only once, maintaining data integrity.
+
+This is particularly important for APIs. HTTP methods like `GET`, `PUT`, and `DELETE` are designed to be idempotent. A `GET` request retrieves data without changing state. A `PUT` request updates a resource to a specific state; multiple `PUT` requests with the same payload result in the same final state. A `DELETE` request removes a resource; subsequent `DELETE` requests for the same resource will find it already gone, but the system state remains consistently "resource absent." The `POST` method, used for creating new resources, is typically not idempotent. You can [extend Kestra with the API](/docs/how-to-guides/api) to build robust integrations that leverage these principles.
+
+## Orchestrating idempotent operations with Kestra: Preventing duplicate webhook processing
+
+Kestra provides built-in primitives to make workflow execution idempotent. A common use case is processing incoming webhooks, where a client might retry a request and send the same event multiple times. By using a unique identifier from the incoming request, we can prevent duplicate processing.
+
+Many systems provide an idempotency key in their webhook headers (e.g., `Idempotency-Key` or `X-Request-ID`). Kestra can map this header to a special `system.correlationId` label, which can then be used to build a duplicate-processing guard with the [KV Store](/docs/concepts/kv-store).
+
+The following workflow demonstrates this pattern. It's triggered by a [webhook](/docs/how-to-guides/webhooks), checks if the event's correlation ID has been processed before, and only proceeds if it's a new event.
+
+```yaml
+id: idempotent-webhook-processor
+namespace: company.team.production
+
+triggers:
+  - id: inbound-event
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: my-secret-webhook-key
+
+tasks:
+  - id: check-duplicate
+    type: io.kestra.plugin.core.tasks.kv.Get
+    namespace: "{{ flow.namespace }}"
+    key: "processed-{{ trigger.headers['Idempotency-Key'] }}"
+    errorOnMissing: false
+
+  - id: is-new-event
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ outputs['check-duplicate'].value == null }}"
+    then:
+      - id: process-event
+        type: io.kestra.plugin.core.task.Log
+        message: "Processing new event with ID {{ trigger.headers['Idempotency-Key'] }}"
+      - id: mark-as-processed
+        type: io.kestra.plugin.core.tasks.kv.Set
+        namespace: "{{ flow.namespace }}"
+        key: "processed-{{ trigger.headers['Idempotency-Key'] }}"
+        value: "{{ execution.id }}"
+    else:
+      - id: log-duplicate
+        type: io.kestra.plugin.core.task.Log
+        message: "Duplicate event received with ID {{ trigger.headers['Idempotency-Key'] }}. Skipping."
+```
+
+A few things are worth noticing in this flow:
+*   **Correlation ID**: The flow relies on the client sending a unique `Idempotency-Key` header. This key is used to create a unique identifier in the KV store.
+*   **State Management**: Kestra's KV Store acts as a durable log of processed events. The `Get` task checks for the existence of the key, and `errorOnMissing: false` prevents the flow from failing if the key isn't found (which is the case for a new event).
+*   **Conditional Logic**: The `If` task cleanly separates the logic for new and duplicate events, making the workflow's behavior explicit and easy to audit.
+*   **Declarative Guard**: This entire idempotency check is defined declaratively in YAML, not buried in imperative code, making it transparent and maintainable. You can learn more about how Kestra uses [system and hidden labels](/docs/concepts/system-labels) for administrative metadata.
+
+### Designing for idempotency in workflows
+
+Beyond webhook processing, several principles guide the design of idempotent workflows:
+*   **Unique Business Keys**: Identify a natural key in your data (like an order ID, user ID, or transaction ID) that uniquely identifies an operation. Use this key to check if the operation has already been completed.
+*   **State Checking**: Before performing an action, check the current state of the system. For example, before creating a user, check if a user with that email already exists.
+*   **Atomic Operations**: Whenever possible, design operations to be atomic (all-or-nothing). Databases transactions are a classic example. If an operation is atomic and idempotent, it can be safely retried upon failure.
+
+Kestra's architecture encourages these patterns by separating state management from task logic, allowing you to build complex, resilient systems from simple, declarative blocks.
+
+## Practical applications of idempotency
+
+Idempotency is not an abstract concept; it's a practical requirement for many real-world systems:
+*   **Payment Processing**: Ensuring a customer is charged exactly once, even if they click the "submit" button multiple times or the network connection fails.
+*   **Resource Provisioning**: In [infrastructure automation](/resources/infrastructure/automation), creating a virtual machine or a database should be idempotent. Running the same script multiple times shouldn't create multiple instances.
+*   **Data Ingestion**: An [ETL workflow](/resources/data/etl-workflow) should be able to re-run for a specific time period without creating duplicate records in the destination data warehouse.
+*   **Messaging Systems**: Consumers in a message queue should process each message exactly once, even if the message is redelivered due to an acknowledgment failure.
+
+A common question is whether modern AI systems are idempotent. For example, is ChatGPT idempotent? The answer is generally no. Submitting the same prompt to a large language model multiple times will likely produce different responses due to the probabilistic nature of the model. This non-determinism is a key design consideration when building AI-driven workflows.
+
+## Related concepts
+
+Building robust systems involves understanding several related concepts. Explore these resources to deepen your knowledge:
+*   [Prevent Duplicate Executions with Correlation IDs](/docs/how-to-guides/idempotency)
+*   [Declarative Orchestration for Modern Data Engineers](/data)
+*   [Orchestrate Your Entire Infrastructure from One Control Plane](/infra-automation)
+*   [Kestra, Open Source Declarative Orchestration Platform](/)
+
+Building idempotent workflows from scratch adds complexity. Kestra provides the primitives to handle retries, state, and duplicate prevention declaratively. If you are ready to build more resilient systems, get started with Kestra.

--- a/src/contents/resources/rag-pipeline/index.md
+++ b/src/contents/resources/rag-pipeline/index.md
@@ -1,198 +1,189 @@
 ---
-title: "RAG Pipeline Orchestration — A Practical Guide to Production-Grade Retrieval-Augmented Generation"
-description: "RAG pipeline orchestration coordinates retrievers, re-rankers, LLMs, and post-processors from query to response. Components, production concerns, and tools."
-metaTitle: "RAG Pipeline Orchestration: Production Guide | Kestra"
-metaDescription: "Learn how RAG pipeline orchestration coordinates retrievers, re-rankers, LLMs, and post-processors from query to response. Covers components, RAGOps, and tools."
-tag: ai
-date: 2026-04-21
+title: "RAG Pipeline: Build Reliable LLM Applications"
+description: "Explore Retrieval-Augmented Generation (RAG) pipelines, their essential components, and how they enhance LLM accuracy. Learn to orchestrate robust RAG workflows with Kestra's declarative approach."
+metaTitle: "RAG Pipeline: Build Reliable LLM Apps"
+metaDescription: "Understand the RAG pipeline, its key components, and how it improves LLM accuracy. Learn to build and orchestrate production-grade RAG workflows with Kestra."
+tag: "ai"
+date: 2026-07-07
+slug: "rag-pipeline"
 faq:
-  - question: "What is orchestration in RAG?"
-    answer: "RAG orchestration coordinates the components of a retrieval-augmented generation system — retrievers, re-rankers, context builders, LLMs, and post-processors. It manages the flow from user query to final response, handling state, errors, retries, and optimization across the pipeline."
-  - question: "What is a RAG pipeline?"
-    answer: "A RAG pipeline is an end-to-end system that retrieves relevant context from a knowledge base and uses it to augment an LLM's response. Retrieval-Augmented Generation pipelines combine a retrieval component (typically vector search) with a generation component (an LLM) to deliver accurate, contextually grounded responses using data outside the model's training set."
-  - question: "What is a RAG data pipeline?"
-    answer: "A RAG data pipeline handles the offline ingestion side of RAG — transforming unstructured source data (documents, databases, web pages) into a vector search index. It chunks documents, generates embeddings, and loads them into a vector database so the query-time retrieval pipeline can return relevant context to the LLM. Orchestrating this pipeline reliably — with scheduling, error handling, and freshness monitoring — is what separates a prototype from a production RAG system."
-  - question: "What are the 4 levels of RAG?"
-    answer: "The four stages of a RAG pipeline are: (1) Indexing — preparing and embedding source documents into a vector store; (2) Retrieval — finding relevant documents for a given query; (3) Augmentation — injecting retrieved context into the prompt; (4) Generation — the LLM producing the final response grounded in retrieved context."
-  - question: "What are the 7 types of RAG?"
-    answer: "Seven commonly cited RAG architectures are: Naïve (simple retrieval + generation), Advanced (with pre/post-processing), GraphRAG (knowledge-graph-based retrieval), Hybrid (combining vector + keyword search), Agentic (agent-directed retrieval), Multi-Hop (chained queries for complex questions), and Adaptive/Iterative RAG (self-correcting through feedback loops)."
-  - question: "What is orchestration used for?"
-    answer: "Orchestration coordinates the execution of multiple automated tasks or processes across systems and applications. In RAG specifically, orchestration manages document ingestion, embedding generation, vector indexing, retrieval calls, LLM generation, and output validation — ensuring each step runs in the right sequence with proper error handling."
+  - question: "What does RAG mean in LLM?"
+    answer: "RAG (Retrieval-Augmented Generation) is an LLM technique that enhances model responses by retrieving relevant information from an external knowledge base before generating an answer. This grounds the LLM in up-to-date, factual data, reducing hallucinations and improving the accuracy and trustworthiness of its output. It ensures the LLM doesn't solely rely on its pre-trained knowledge."
+  - question: "What are the five key components of a RAG pipeline?"
+    answer: "A RAG pipeline typically consists of five core components: Document Ingestion (collecting and processing data), Document Chunking (breaking data into manageable pieces), Vector Embedding (converting chunks into numerical representations), Vector Store (storing embeddings for efficient retrieval), and Retrieval & Prompt Augmentation (fetching relevant chunks and adding them to the LLM's prompt to generate a grounded response."
+  - question: "Why use RAG instead of a bare LLM?"
+    answer: "RAG enhances LLMs by providing external, up-to-date, and domain-specific information, which a bare LLM lacks beyond its training data. This reduces hallucinations, improves factual accuracy, allows for source attribution, and enables the LLM to answer questions about proprietary or real-time data that wasn't part of its original training set. It makes LLM applications more reliable and trustworthy."
+  - question: "Is ChatGPT a RAG LLM?"
+    answer: "While early versions of ChatGPT relied solely on their pre-trained knowledge, current versions (like those with ChatGPT Search) incorporate retrieval mechanisms to access and synthesize information from the web. This means they leverage RAG-like capabilities to ground responses in external data. However, the exact architecture isn't fully disclosed, and custom RAG pipelines offer more control over data sources."
+  - question: "What is the best RAG pipeline?"
+    answer: "The 'best' RAG pipeline depends on specific needs, but key characteristics include efficient data ingestion, effective chunking strategies, high-quality embeddings, a performant vector store, and robust orchestration for reliability and observability. A declarative, event-driven orchestration platform like Kestra, combined with robust data sources and LLM providers, allows teams to build, monitor, and scale highly effective RAG pipelines tailored to their use cases."
+  - question: "How does Kestra support RAG pipeline development?"
+    answer: "Kestra provides a declarative, language-agnostic platform to orchestrate every stage of a RAG pipeline. This includes plugins for data ingestion, Python tasks for chunking and preprocessing, integrations with LLM providers for embedding generation, and database plugins for vector store interaction. Its event-driven capabilities, error handling, and monitoring features ensure reliable and auditable RAG deployments."
 ---
 
-Most Retrieval-Augmented Generation pipelines start the same way. An engineer writes a prototype in a Jupyter notebook using LangChain or LlamaIndex: load some documents, embed them, store them in a vector database, write a retrieval function, wire it to an LLM. The demo works. It's impressive. It gets shown to leadership, and leadership asks the obvious next question: can we put this in production?
+> **TL;DR** — Retrieval-Augmented Generation (RAG) pipelines enhance Large Language Model (LLM) responses by fetching external, relevant context from a knowledge base. This process grounds the LLM in up-to-date and proprietary data, significantly reducing hallucinations and improving the factual accuracy and trustworthiness of AI applications.
 
-The gap between "the demo works" and "it serves production traffic" is RAG pipeline orchestration. Not the retrieval logic, not the prompt engineering, not the model choice — those are typically solved at the prototype stage. (For a deeper look at how components connect structurally, see the companion [RAG architecture guide](/resources/ai/rag-architecture).) The hard part is what comes after: coordinating document ingestion at scale, keeping the vector index fresh as source data changes, managing latency budgets across retrieval and generation, handling LLM timeouts with fallback models, monitoring retrieval quality over time, and doing all of this with the same reliability expectations as any other production system.
+Large Language Models (LLMs) are powerful, but their knowledge is limited to their training data, leading to factual inaccuracies or "hallucinations." For enterprises and developers building AI applications, relying solely on an LLM's pre-trained knowledge is often insufficient and risky. The solution lies in grounding LLMs with real-time, accurate, and proprietary information.
 
-This guide covers what RAG pipeline orchestration is, the key components of an orchestration layer, how to build production-grade workflows with practical examples, the emerging discipline of RAGOps, and how orchestration fits alongside frameworks like LangChain and managed services like Azure AI Search.
+This is where Retrieval-Augmented Generation (RAG) pipelines become essential. A RAG pipeline allows LLMs to retrieve relevant context from external data sources before generating a response, drastically improving accuracy, relevancy, and trustworthiness. This article explores the mechanics of RAG and demonstrates how Kestra provides the declarative orchestration layer to build, manage, and scale robust RAG systems.
 
-## What Is RAG Pipeline Orchestration?
+## How Retrieval-Augmented Generation Works
 
-RAG pipeline orchestration coordinates the components of a retrieval-augmented generation system — retrievers, re-rankers, context builders, LLMs, and post-processors. It manages the flow from user query to final response, handling state, errors, retries, and optimization across the pipeline.
+Retrieval-Augmented Generation (RAG) is an architectural pattern that combines a retrieval system with a generative LLM. Instead of asking an LLM to answer a question from its internal memory, the RAG process first searches a private knowledge base for relevant documents, then provides those documents to the LLM as context along with the original question. This allows the model to synthesize an answer based on specific, verifiable information.
 
-Orchestration is a distinct layer from the frameworks that implement RAG logic. LangChain, LlamaIndex, LangChain4j, and Haystack are *frameworks*: they provide the primitives for retrieval, embedding, prompt construction, and LLM calling. Orchestration is what runs those primitives reliably in production — triggering workflows on events, retrying failed calls, observing what happened, coordinating multiple frameworks if needed, and tying RAG into the rest of the enterprise data stack.
+This approach directly addresses the primary weaknesses of standalone LLMs:
+*   **Knowledge Cutoff:** LLMs are unaware of events that occurred after their training date. RAG provides up-to-the-minute information.
+*   **Hallucinations:** By grounding the model in factual documents, RAG significantly reduces the chance of the LLM inventing incorrect information.
+*   **Domain Specificity:** RAG enables an LLM to answer questions about proprietary or niche topics (e.g., internal company policies, technical documentation) that were not part of its public training data.
+*   **Source Attribution:** Because the pipeline retrieves specific documents, applications can cite sources, allowing users to verify information and build trust.
 
-A RAG pipeline without orchestration is a demo. A RAG pipeline with orchestration is a production system.
+### The Core Components of a RAG Pipeline
 
-## RAG Data Pipeline vs RAG Query Pipeline
+A complete RAG system consists of two main processes: an offline indexing pipeline that prepares the knowledge base, and an online retrieval-and-generation pipeline that answers user queries. The indexing pipeline typically includes the following components:
 
-Before going deeper, an important distinction: a full RAG system has two pipelines with very different orchestration concerns.
+1.  **Document Ingestion and Preparation:** This stage involves collecting raw data from various sources (APIs, databases, files) and cleaning it by removing irrelevant content like HTML tags, ads, or navigation bars.
+2.  **Document Chunking:** The cleaned documents are broken down into smaller, semantically coherent segments or "chunks." This is crucial because LLMs have context window limits, and smaller chunks provide more targeted context for the retrieval system.
+3.  **Vector Embedding:** Each chunk is passed to an embedding model (like those from OpenAI, Cohere, or open-source alternatives) which converts the text into a numerical vector. This vector represents the semantic meaning of the text.
+4.  **Vector Store:** These embeddings are loaded into a specialized database called a vector store (e.g., Pinecone, Weaviate, or PostgreSQL with the `pgvector` extension). This database is optimized for efficient similarity search on high-dimensional vectors.
+5.  **Retrieval and Prompt Augmentation:** When a user submits a query, it is also converted into an embedding. The vector store is then searched to find the document chunks with embeddings most similar to the query's embedding.
+6.  **LLM Generation:** The retrieved chunks are formatted and inserted into a prompt template along with the original user query. This augmented prompt is then sent to the LLM, which generates a final, context-aware answer.
 
-| Dimension | RAG data pipeline (offline) | RAG query pipeline (online) |
-| --- | --- | --- |
-| **When it runs** | On schedule, on event, or batch | On user query, synchronously |
-| **Latency requirement** | Minutes to hours acceptable | Milliseconds to seconds |
-| **Typical steps** | Ingest → chunk → embed → index | Query → retrieve → re-rank → augment → generate |
-| **Failure tolerance** | Retries acceptable; workflow can reschedule | Low tolerance; need fast fallbacks |
-| **Orchestration fit** | Workflow orchestrator (Kestra, Airflow) | Framework runtime (LangChain, LangChain4j) wrapped by orchestrator |
+The entire system forms the foundation of a reliable [RAG architecture](/resources/ai/rag-architecture), ensuring that the final output is both relevant and factually grounded.
 
-The two pipelines have different orchestration profiles. The data pipeline is a classic batch/event-driven workflow — exactly what orchestrators were built for. The query pipeline is a low-latency request/response flow, which sits partly in framework code and partly in orchestration (for logging, monitoring, and fallback logic).
+## Why RAG Pipelines Are Essential for LLM Reliability
 
-A RAG data pipeline uses unstructured source data — documents, web pages, database records — that lives in databases and data lakes. The pipeline's job is to build a trustworthy vector search index filled with accurate, pertinent context. The query pipeline then uses that index to answer user questions. Confusing the two leads to architecture mistakes (treating low-latency concerns in the batch layer, or vice versa).
+Building a proof-of-concept RAG application in a notebook is one thing; deploying a reliable, production-grade system is another. Production RAG pipelines need to be robust, scalable, and observable. This is where orchestration becomes critical.
 
-## The 4 Stages of a RAG Pipeline
+A RAG pipeline, like any other [AI pipeline](/resources/ai/ai-pipeline), involves multiple dependent steps that must be executed in a specific order. Failures can occur at any stage—an API might be down during ingestion, an embedding model could fail, or the vector database might be temporarily unavailable.
 
-A RAG pipeline has four sequential stages that both the data and query sides touch in different ways:
+Effective orchestration provides:
+*   **Reliability:** Automatic retries, error handling, and alerting ensure that the pipeline can recover from transient failures.
+*   **Observability:** Centralized logging and monitoring provide visibility into each stage, making it easier to debug issues and track performance.
+*   **Scalability:** An orchestration platform can manage the distribution of tasks, allowing the pipeline to process large volumes of documents efficiently.
+*   **Maintainability:** Defining the entire workflow as declarative code makes it version-controlled, auditable, and easier for teams to collaborate on.
 
-- **Indexing.** Source documents are chunked, embedded into vectors, and stored in a vector database. This is offline and typically handled by the data pipeline. Quality issues at this stage (bad chunking, stale documents, embedding model mismatch) propagate downstream invisibly.
-- **Retrieval.** A user query is embedded and compared against the indexed vectors to find the most relevant documents. This is online, fast, and the place where hybrid search (vector + keyword) often matters.
-- **Augmentation.** Retrieved documents are inserted into the LLM prompt as context, along with the user query. Context window management and token budgeting happen here.
-- **Generation.** The LLM produces a response grounded in the augmented prompt. Model choice, temperature, and output validation all apply at this stage.
+Ultimately, robust orchestration transforms a fragile script into a resilient, production-ready system, which is essential for any application that relies on [LLM evaluation](/resources/ai/llm-evaluation) and consistent performance.
 
-These four stages are the standard mental model for RAG. What differs across implementations is what happens inside each stage — which is where the seven RAG architectures come in.
+## Orchestrate Your RAG Pipeline with Kestra: A Document Indexing Example
 
-## The 7 Types of RAG Architectures
-
-Seven commonly cited RAG architectures cover the spectrum from simple to advanced:
-
-- **Naïve RAG.** Simple retrieve-then-generate, single query, flat document store. Fast to build, limited accuracy on complex questions.
-- **Advanced RAG.** Adds pre-retrieval (query rewriting, expansion) and post-retrieval (re-ranking, context compression) steps. Production baseline.
-- **GraphRAG.** Uses a knowledge graph alongside or instead of vector search for retrieval. Better for questions requiring multi-hop reasoning over structured relationships.
-- **Hybrid RAG.** Combines vector search with keyword/BM25 search, often with a re-ranker to fuse results. Addresses vector search's weakness on exact-match terms.
-- **Agentic RAG.** An agent decides when to retrieve, what to retrieve, and whether the retrieved context is sufficient, making multi-round retrieval decisions. Powerful but latency-heavy.
-- **Multi-Hop RAG.** Chains multiple retrieval steps for complex questions that require synthesizing information from multiple documents.
-- **Adaptive / Iterative RAG.** Self-correcting through feedback loops — the pipeline evaluates its own output and re-retrieves or re-generates if quality is low.
-
-Orchestration concerns vary by type. Naïve RAG needs basic workflow scaffolding. Agentic and Iterative RAG need complex control flow (loops, conditionals, state management) that pushes the orchestration layer harder.
-
-## Key Components of a RAG Orchestration Layer
-
-Five components define what a production RAG orchestration layer must handle:
-
-- **Data preparation and chunking.** Scheduled or event-driven ingestion of source documents. Chunking strategy choices (fixed-size, semantic, recursive). Quality tests on chunks (length distribution, overlap, deduplication). Source freshness monitoring.
-- **Vector indexing and retrieval.** Embedding generation (batched for efficiency), upsert to the [vector database](/resources/ai/vector-database), index freshness tracking, retrieval quality monitoring (are relevant documents being returned?).
-- **Prompt augmentation and context building.** Token budget management, context-window packing, deduplication of similar retrieved chunks, metadata injection (timestamps, source attribution). This is where "how much context" is decided dynamically.
-- **LLM generation.** Model routing (fast cheap model for simple queries, better model for complex ones), retry-on-timeout, fallback model chains, structured output validation.
-- **Post-processing and evaluation.** Groundedness checks (is the answer supported by retrieved context?), output validation against schemas, toxicity filters, citation generation.
-
-Each of these is an orchestration concern as much as a framework concern. Frameworks provide the primitives; orchestration decides when they run, how they recover from failure, and how they're observed.
-
-## A Production RAG Orchestration Example
-
-Here's what a real RAG data pipeline looks like in Kestra — ingestion, embedding, and vector database upsert, with event-driven triggering when new documents land in S3 and a nightly quality check on retrieval behavior:
+The document indexing process is the backbone of any RAG system. It needs to run reliably and on a schedule to keep the knowledge base fresh. The following Kestra workflow demonstrates how to build a declarative, automated ingestion pipeline that fetches web content, chunks it, generates embeddings, and stores them in a PostgreSQL vector database.
 
 ```yaml
-id: rag_data_pipeline
-namespace: company.ai
-
-description: |
-  Event-driven RAG indexing: new documents in S3 trigger chunking,
-  embedding, and upsert to the vector database. Nightly quality check
-  evaluates retrieval drift.
-
-triggers:
-  - id: on_new_document
-    type: io.kestra.plugin.aws.s3.Trigger
-    bucket: rag-source-corpus
-    action: NONE
-    interval: PT1M
-
-  - id: nightly_quality_check
-    type: io.kestra.plugin.core.trigger.Schedule
-    cron: "0 2 * * *"
-    disabled: false
+id: web-to-pgvector-ingestion
+namespace: company.team.rag
 
 tasks:
-  - id: download_document
-    type: io.kestra.plugin.aws.s3.Download
-    bucket: rag-source-corpus
-    key: "{{ trigger.objects[0].key }}"
+  - id: fetch_documentation
+    type: io.kestra.plugin.core.http.Request
+    uri: /docs/getting-started
 
-  - id: chunk_and_embed
+  - id: chunk_and_prepare
     type: io.kestra.plugin.scripts.python.Script
+    docker:
+      image: python:3.11-slim
     beforeCommands:
-      - pip install langchain-text-splitters openai
+      - pip install beautifulsoup4 langchain
     script: |
-      from langchain_text_splitters import RecursiveCharacterTextSplitter
-      from openai import OpenAI
+      from bs4 import BeautifulSoup
+      from langchain.text_splitter import RecursiveCharacterTextSplitter
+      import json
 
-      with open("{{ outputs.download_document.outputFiles['document'] }}") as f:
-          text = f.read()
+      # Load HTML content from Kestra's internal storage
+      with open("{{ outputs.fetch_documentation.uri }}", "r") as f:
+          html_content = f.read()
+      
+      soup = BeautifulSoup(html_content, 'html.parser')
+      # Extract text from the main content area
+      main_content = soup.find('main')
+      text = main_content.get_text() if main_content else ""
 
-      splitter = RecursiveCharacterTextSplitter(
-          chunk_size=1000, chunk_overlap=200
+      text_splitter = RecursiveCharacterTextSplitter(
+          chunk_size=1000,
+          chunk_overlap=100,
+          length_function=len
       )
-      chunks = splitter.split_text(text)
+      
+      chunks = text_splitter.split_text(text)
+      
+      # Prepare chunks for embedding and output as a JSON file
+      output_data = [{"text": chunk} for chunk in chunks]
+      with open("chunks.json", "w") as f:
+          json.dump(output_data, f)
 
-      client = OpenAI()
-      embeddings = [
-          client.embeddings.create(
-              input=chunk, model="text-embedding-3-small"
-          ).data[0].embedding
-          for chunk in chunks
-      ]
-      # persist chunks + embeddings as artifact
+    outputFiles:
+      - chunks.json
 
-  - id: upsert_to_vector_db
-    type: io.kestra.plugin.scripts.python.Script
-    script: |
-      # upsert embeddings + chunks to Pinecone, pgvector, or Weaviate
-      # with source metadata (document ID, timestamp, version)
+  - id: generate_embeddings
+    type: io.kestra.plugin.llm.openai.Embeddings
+    apiKey: "{{ secret('OPENAI_API_KEY') }}"
+    model: text-embedding-3-small
+    input: "{{ outputs.chunk_and_prepare.outputFiles['chunks.json'] }}"
 
-  - id: notify_indexed
-    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
-    url: "{{ secret('SLACK_WEBHOOK') }}"
-    payload: '{"text": "✅ New document indexed: {{ trigger.objects[0].key }}"}'
+  - id: upsert_to_pgvector
+    type: io.kestra.plugin.jdbc.postgresql.Query
+    url: "{{ secret('POSTGRES_URL') }}"
+    username: "{{ secret('POSTGRES_USER') }}"
+    password: "{{ secret('POSTGRES_PASSWORD') }}"
+    sql: |
+      CREATE TABLE IF NOT EXISTS kestra_docs (
+        id SERIAL PRIMARY KEY,
+        content TEXT,
+        embedding VECTOR(1536)
+      );
 
-errors:
-  - id: alert_on_indexing_failure
-    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
-    url: "{{ secret('SLACK_WEBHOOK') }}"
-    payload: '{"text": "❌ RAG indexing failed — execution {{ execution.id }}"}'
+      -- Use a subflow to iterate over each embedding and insert it
+    each: "{{ outputs.generate_embeddings.embeddings }}"
+    query: |
+      INSERT INTO kestra_docs (content, embedding)
+      VALUES (
+        '{{ value.text | sqlsafe }}',
+        '{{ value.embedding }}'
+      );
+
+triggers:
+  - id: daily_refresh
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 4 * * *"
+
 ```
 
-That's the data pipeline side. The query pipeline (retrieval + LLM generation) is typically wrapped inside a framework like LangChain4j and called from either a synchronous API or from another Kestra workflow for batch scenarios. Kestra's AI plugin namespace (`io.kestra.plugin.ai.*`) provides native tasks for the most common RAG operations.
+A few things are worth noticing in this workflow:
+*   **Declarative & Version-Controlled:** The entire pipeline is defined in a single YAML file, which can be stored in Git, reviewed by peers, and deployed through CI/CD, aligning with GitOps best practices for [AI code generation pipelines](/resources/ai/ai-code-generation-pipelines).
+*   **Polyglot by Design:** The flow seamlessly combines a generic HTTP request plugin, a Python script for custom logic using popular libraries, an OpenAI plugin for embeddings, and a standard PostgreSQL plugin. No glue code is needed.
+*   **Robust & Scheduled:** The `trigger` block ensures this pipeline runs automatically every day at 4 AM, keeping the knowledge base current. Kestra's engine handles retries and error logging automatically.
+*   **Separation of Concerns:** Secrets like API keys and database credentials are managed securely through Kestra's secret management, not hardcoded in the workflow.
 
-## RAGOps — Operating RAG Pipelines in Production
+### Orchestrating the Retrieval and Generation Flow
 
-MLOps gave teams a discipline for operating ML models in production. RAGOps is the same discipline applied to RAG systems — an emerging term for the operational concerns specific to retrieval-augmented generation:
+The query-time part of the RAG pipeline can also be orchestrated as a separate Kestra workflow. This flow would typically be triggered by a webhook from an application, take a user query as input, generate an embedding for the query, retrieve relevant chunks from the vector store, and finally call the LLM with the augmented prompt to generate the answer. You can see a complete example in the [RAG ingest and query blueprint](/blueprints/ai-rag-ingest-and-query).
 
-- **Retrieval quality drift.** The vector index gets stale as source data changes. Relevant documents stop being returned, hallucinations creep in. Monitoring retrieval quality (Precision@K, Recall@K against a labeled eval set) is the RAGOps equivalent of model drift monitoring.
-- **Cost per query.** RAG queries consume tokens (LLM context + generation) and vector database reads. At scale, a few cents per query becomes significant budget. Per-query cost tracking, tied to specific users or use cases, is a RAGOps primitive.
-- **Latency SLAs.** RAG query pipelines have end-to-end latency budgets — typically 500ms to 5s depending on use case. P50, P95, and P99 latency tracking, broken out by pipeline stage (retrieval, re-rank, generation), surfaces bottlenecks.
-- **Groundedness and hallucination monitoring.** Are LLM outputs actually grounded in the retrieved context? Automated groundedness scoring (either via a separate LLM judge or rule-based validation) catches the failure mode most damaging to user trust.
-- **Corpus freshness.** How old is the most stale document in the index? How quickly do changes propagate? Corpus freshness SLAs are rarely explicit but often expected.
+## Common RAG Pipeline Use Cases
 
-These concerns sit in the orchestration layer because they require workflow coordination: scheduled evaluations, alert thresholds, automated re-indexing when drift is detected, cost aggregation across runs. Framework code doesn't do this naturally; orchestration does.
+RAG pipelines are versatile and can be applied to a wide range of applications that require grounded, context-aware AI.
 
-## Multi-Agent RAG — Beyond Linear Pipelines
+*   **Customer Support Chatbots:** Provide answers based on the latest product documentation and knowledge base articles, reducing support tickets.
+*   **Internal Knowledge Bases:** Allow employees to ask questions about company policies, technical documentation, or project histories in natural language.
+*   **Research Assistants:** Help analysts and researchers quickly synthesize information from vast archives of documents, reports, and scientific papers.
+*   **Legal Document Analysis:** Enable lawyers to query large volumes of case law or contracts to find relevant precedents and clauses.
+*   **Real-time Data Analytics:** Combine RAG with streaming data sources to answer questions about live operational data.
 
-Linear RAG (one query, one retrieval, one generation) handles straightforward Q&A well. For complex tasks — research assistants, customer support with policy lookups, code assistants with codebase awareness — a single retrieval pass often isn't enough. Multi-agent systems have emerged as the pattern: multiple agents coordinate, each with specialized retrieval and reasoning roles. See the [agentic workflows guide](/resources/ai/agentic-workflows) for how these patterns are structured in practice.
+## Optimizing and Managing RAG Pipelines (RAGOps)
 
-The challenge, as practitioners have noted, is that multi-agent systems compound RAG's existing latency and reliability problems. Running retrieval, re-ranking, and generation sequentially across multiple agents creates latency bottlenecks and error accumulation. Structured orchestration — explicit state management, parallelization where possible, fast fallbacks when an agent fails — becomes the load-bearing component.
+The "best" RAG pipeline is one that is continuously monitored, evaluated, and improved. This practice, often called RAGOps, involves several key activities:
 
-## Choosing a RAG Orchestration Tool
+*   **Monitoring Performance:** Track metrics like retrieval latency, generation speed, and cost per query.
+*   **Evaluating Relevance:** Use evaluation frameworks to measure the quality of both the retrieval and generation steps. Are the retrieved chunks relevant to the query? Is the final answer accurate and helpful?
+*   **Scaling Infrastructure:** As the volume of data grows, the vector store and ingestion pipeline must scale accordingly.
+*   **A/B Testing:** Experiment with different chunking strategies, embedding models, and prompt templates to find the optimal configuration.
 
-The RAG tool landscape in 2026 has three distinct layers, and most teams need one from each:
+A robust orchestration platform is the foundation of RAGOps, providing the necessary tools for scheduling evaluations, logging results, and deploying changes in a controlled manner.
 
-- **Frameworks** (LangChain, LlamaIndex, LangChain4j, Haystack). These provide the RAG primitives — retrievers, chains, prompt templates, agent abstractions. Choice depends on language preference (Python dominant; LangChain4j for JVM stacks) and ecosystem maturity.
-- **Vector databases** (Pinecone, Weaviate, Qdrant, pgvector, Milvus). Storage and retrieval at scale. Choice depends on deployment model, scale, and integration requirements.
-- **Orchestrators** (Kestra, Airflow, Prefect, Dagster). Production workflow execution — triggering, retrying, observing, alerting across the full RAG system.
+## Related Concepts
 
-The framework and orchestrator choices are separate. A LangChain-based RAG pipeline still benefits from Kestra orchestration for data ingestion, indexing workflows, and RAGOps monitoring. Managed services (Azure AI Search with Microsoft Foundry, Databricks' RAG features) combine some layers but constrain deployment flexibility.
+*   [RAG Architecture: Build Reliable LLM Applications](/resources/ai/rag-architecture)
+*   [AI Pipeline Explained: Stages, Architecture, and Automation](/resources/ai/ai-pipeline)
+*   [LLM Evaluation: Frameworks, Metrics & Practices](/resources/ai/llm-evaluation)
+*   [How to Orchestrate a RAG Pipeline with Kestra](/blogs/orchestrate-rag-pipeline-kestra)
+*   [AI Orchestration Resources](/resources/ai)
 
-## Getting Started
-
-RAG pipelines are moving from prototype to production faster than any previous AI pattern. The teams that close the gap successfully treat RAG as a production system, not a model demo — which means taking orchestration, RAGOps, and operational observability seriously from the start, not after the first outage.
-
-For teams building or operating RAG at scale, [Kestra](/) provides the orchestration layer — event-driven triggers for re-indexing, scheduled quality checks, native AI plugin integrations, and observability across the full pipeline. Start with the [AI automation hub](/ai-automation), or explore the broader [data orchestration guide](/resources/data/data-orchestration) for the adjacent category.
+Ready to build your own reliable LLM applications? Explore Kestra's [AI orchestration capabilities](/ai-automation) and get started with a [RAG pipeline blueprint](/blueprints/ai-rag-ingest-and-query) today.


### PR DESCRIPTION
## Summary

Imports 5 W27 concept/standard SEO drafts from [`vfanucci/kestra-seo`](https://github.com/vfanucci/kestra-seo) into the resources hub.

| Page | Tag | URL | Source PR | Type |
|------|-----|-----|-----------|------|
| Delta Lake | data | `/resources/data/delta-lake` | kestra-seo#224 | **new** |
| How to Build an AI Agent | ai | `/resources/ai/how-to-build-an-ai-agent` | kestra-seo#225 | **new** |
| Idempotency | infrastructure | `/resources/infrastructure/idempotency` | kestra-seo#226 | **new** |
| Data Mesh Architecture | data | `/resources/data/data-mesh-architecture` | kestra-seo#220 | ⚠️ **rewrite of existing page** |
| RAG Pipeline | ai | `/resources/ai/rag-pipeline` | kestra-seo#233 | ⚠️ **rewrite of existing page** |

## ⚠️ Two of these overwrite live pages

`data-mesh-architecture` and `rag-pipeline` already exist on the site — these commits **replace** them with the new pipeline versions. Review the diff before merging; if the existing versions should be kept, drop those two files from this PR.

## Import fixes applied (front-matter hygiene)

Per the recurring pipeline artifacts:
- **Stray code fence** after front-matter (```` ```yaml ```` wrapper) removed where present; fence counts balanced so bodies render as markdown, not code blocks.
- **Future `date:`** normalized to `2026-07-07` (drafts carried scheduled future dates).
- **metaDescription** trimmed to 140–160 (`data-mesh-architecture` 163→156, `idempotency` 164→152).
- Stray `image:` / `author:` fields stripped; metaTitle ` | Kestra` suffix stripped where present.
- No unresolved reviewer markers; no duplicated headings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
