### PR TITLE
fix(cloud): link SOC 2 / GDPR tiles directly to Drata Trust Center

### DIFF
--- a/src/components/cloud/Header.astro
+++ b/src/components/cloud/Header.astro
@@ -73,11 +73,11 @@ const FEATURES = [
             </div>
 
             <div class="bottom-tiles" data-usal="fade-u">
-                <a href="/trust" target="_blank" class="tile">
+                <a href="https://app.drata.com/trust/0a8e867d-7c4c-4fc5-bdc7-217f9c839604" target="_blank" class="tile">
                     <Image src={soc2Img} alt="SOC 2" />
                     <small>SOC 2 Type 1 / Type 2</small>
                 </a>
-                <a href="/trust" target="_blank" class="tile">
+                <a href="https://app.drata.com/trust/0a8e867d-7c4c-4fc5-bdc7-217f9c839604" target="_blank" class="tile">
                     <Image src={gdprImg} alt="GDPR" />
                     <small>GDPR</small>
                 </a>


### PR DESCRIPTION
## What

On the [/cloud](https://kestra.io/cloud) page, the two compliance tiles (SOC 2 and GDPR) linked to `/trust`, which is a redirect to the Drata Trust Center. This points them directly at the Drata URL, removing the redirect hop.

**Before:** `<a href="/trust" target="_blank">`
**After:** `<a href="https://app.drata.com/trust/0a8e867d-7c4c-4fc5-bdc7-217f9c839604" target="_blank">`

## File
- `src/components/cloud/Header.astro` (2 links)

## Note
This matches the existing pattern in `src/components/layout/Certifications.astro`, which already links directly to the Drata URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)