### PR TITLE
fix(analytics): fire GTM page-views on client-side navigations

### DIFF
--- a/src/scripts/cookieconsent.ts
+++ b/src/scripts/cookieconsent.ts
@@ -7,77 +7,107 @@ import { GTM_ID } from "astro:env/client"
 const isEurope =
     Intl.DateTimeFormat().resolvedOptions().timeZone.indexOf("Europe") === 0
 
-window.addEventListener("DOMContentLoaded", () => {
-    const enabledAnalytics = async () => {
-        window.dataLayer = window.dataLayer || []
-        window.dataLayer.push({
-            "gtm.start": new Date().getTime(),
-            event: "gtm.js",
-        })
+// The site uses Astro's <ClientRouter /> in production, so navigating between
+// pages is a client-side transition, not a full reload. These guards make sure
+// the one-time bootstrap (consent modal, GTM/PostHog init) runs only once,
+// while the page-view event is pushed on *every* navigation so GTM triggers
+// (and conversion tags) fire on soft navigations too — not just the first load.
+let analyticsEnabled = false
+let marketingEnabled = false
+let consentInitialized = false
 
-        const s = document.createElement("script")
-        s.async = true
-        s.src = `https://www.googletagmanager.com/gtm.js?id=${GTM_ID}`
-        document.head.appendChild(s)
+const pushPageView = () => {
+    window.dataLayer = window.dataLayer || []
+    window.dataLayer.push({
+        event: "content-view",
+        "content-name": window.location.pathname + window.location.search,
+        "content-view-name": window.astroClientConfig?.slug,
+    })
+}
 
-        const response = await $fetchApi<{
-            posthog: { token: string }
-            id: string
-        }>("/config", {
-            credentials: "include",
-        })
+const enabledAnalytics = async () => {
+    // Push a page-view on every navigation (including client-side transitions).
+    if (analyticsEnabled) {
+        pushPageView()
+        return
+    }
+    analyticsEnabled = true
 
-        posthog.init(response.posthog.token, {
-            api_host: window.location.origin + "/t/",
-            ui_host: "https://eu.posthog.com",
-            capture_pageview: false,
-            capture_pageleave: true,
-            autocapture: false,
-            disable_session_recording: false,
-        })
+    window.dataLayer = window.dataLayer || []
+    window.dataLayer.push({
+        "gtm.start": new Date().getTime(),
+        event: "gtm.js",
+    })
 
-        posthog.register_for_session({
-            from: "SITE",
-        })
+    const s = document.createElement("script")
+    s.async = true
+    s.src = `https://www.googletagmanager.com/gtm.js?id=${GTM_ID}`
+    document.head.appendChild(s)
 
-        if (!posthog.get_property("__alias")) {
-            posthog.alias(response.id)
-        }
+    const response = await $fetchApi<{
+        posthog: { token: string }
+        id: string
+    }>("/config", {
+        credentials: "include",
+    })
 
-        posthog.capture("$pageview")
+    posthog.init(response.posthog.token, {
+        api_host: window.location.origin + "/t/",
+        ui_host: "https://eu.posthog.com",
+        capture_pageview: false,
+        capture_pageleave: true,
+        autocapture: false,
+        disable_session_recording: false,
+    })
 
-        window.dataLayer.push({
-            event: "identify",
-            category: "sys",
-            noninteraction: true,
-            kuid: response.id,
-        })
+    posthog.register_for_session({
+        from: "SITE",
+    })
 
-        window.dataLayer.push({
-            event: "content-view",
-            "content-name": window.location.pathname + window.location.search,
-            "content-view-name": window.astroClientConfig.slug,
-        })
-
-        localStorage.setItem("KUID", response.id)
-
-        if (window?.location?.search) {
-            const urlParams = new URLSearchParams(window.location.search)
-            const ke = urlParams.get("ke")
-            if (ke) {
-                identify(ke)
-            }
-        }
+    if (!posthog.get_property("__alias")) {
+        posthog.alias(response.id)
     }
 
-    const enabledMarketing = () => {
-        window.dataLayer.push({
-            event: "enable_marketing",
-            category: "sys",
-            noninteraction: true,
-        })
-    }
+    posthog.capture("$pageview")
 
+    window.dataLayer.push({
+        event: "identify",
+        category: "sys",
+        noninteraction: true,
+        kuid: response.id,
+    })
+
+    pushPageView()
+
+    localStorage.setItem("KUID", response.id)
+
+    if (window?.location?.search) {
+        const urlParams = new URLSearchParams(window.location.search)
+        const ke = urlParams.get("ke")
+        if (ke) {
+            identify(ke)
+        }
+    }
+}
+
+const enabledMarketing = () => {
+    if (marketingEnabled) {
+        return
+    }
+    marketingEnabled = true
+
+    window.dataLayer = window.dataLayer || []
+    window.dataLayer.push({
+        event: "enable_marketing",
+        category: "sys",
+        noninteraction: true,
+    })
+}
+
+// astro:page-load fires on the initial load *and* after every client-side
+// navigation, so GTM/PostHog bootstrap on whichever page the visitor lands on
+// first, and every subsequent page reports a page-view.
+document.addEventListener("astro:page-load", () => {
     if (!isEurope) {
         enabledAnalytics()
         enabledMarketing()
@@ -85,6 +115,16 @@ window.addEventListener("DOMContentLoaded", () => {
         return
     }
 
+    // Consent already handled on an earlier page — just report the page-view.
+    if (consentInitialized) {
+        if (analyticsEnabled) {
+            enabledAnalytics()
+        }
+
+        return
+    }
+
+    consentInitialized = true
     document.documentElement.classList.add("cc--darkmode")
 
     runCookieConsent({


### PR DESCRIPTION
## Context

Follow-up to the Google Ads conversion-tracking support session (Case 0-1698000040693). Two of the issues Google raised have the **same root cause**:

1. *"GTM appears only on the homepage, not on /get-started, /demo, /enterprise, /pricing."*
2. *"Conversion tags only fire on a full page reload, not when the URL changes."*

## Root cause

`layout.astro` enables Astro's `<ClientRouter />` in production, so navigation between pages is a **client-side transition**, not a full reload.

GTM bootstrap **and** the `content-view` page-view push lived inside a `DOMContentLoaded` handler in `cookieconsent.ts`. `DOMContentLoaded` fires **only once**, on the first full load — so GTM only initialised (and only pushed a page-view) on whichever page the visitor landed on first (usually the homepage). Every subsequent soft navigation pushed nothing, so Google's page-view triggers never fired.

`analytics.js` already uses the correct `astro:page-load` event (fires on initial load **and** every client-side navigation); this brings `cookieconsent.ts` in line with it.

## Change

- Bootstrap GTM + PostHog **once** (guarded), then push the `content-view` page-view on **every** `astro:page-load`.
- Consent modal and PostHog init still run only once; consent gating for EU visitors is unchanged.
- No change to what data is collected — only *when* the page-view event fires.

## Verification for reviewers

In production preview, open GTM Preview / Tag Assistant, then navigate homepage → /get-started → /pricing → /enterprise **without reloading**. Each navigation should now push a `content-view` event and fire the corresponding page-view conversion tag.

> Note for the Google side: the conversion tags currently trigger on **Window Loaded**, which does not re-fire on client-side navigations. To benefit fully from this change, the GTM triggers should be switched to fire on the `content-view` custom event (or History Change) rather than Window Loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)