### PR TITLE
feat(demo): redirect to /thank-you after a successful demo booking

### DIFF
--- a/src/components/demo/Meeting.vue
+++ b/src/components/demo/Meeting.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-    import { onMounted, ref, useTemplateRef } from "vue"
+    import { onMounted, onUnmounted, ref, useTemplateRef } from "vue"
     import posthog from "posthog-js"
     import { useGtm } from "@gtm-support/vue-gtm"
     import identify from "~/utils/identify"
@@ -183,7 +183,28 @@
         }
     }
 
+    // HubSpot's Meetings embed lives in a cross-origin iframe and posts a
+    // message to the parent window once a booking is confirmed. The confirmation
+    // happens entirely inside the iframe, so there is no parent-page navigation
+    // to hang a conversion on. We listen for that message and redirect to a
+    // dedicated /thank-you page, giving Google Ads a distinct URL to track the
+    // "Book a Demo" conversion against.
+    const onHubSpotMessage = (event: MessageEvent) => {
+        if (event.data?.meetingBookSucceeded) {
+            posthog.capture("bookdemo_confirmed")
+            gtm?.trackEvent({
+                event: "bookdemo_confirmed",
+                noninteraction: false,
+            })
+            // Full navigation (not the client-side router) so the /thank-you
+            // page fires a real page load for the conversion tag.
+            window.location.assign("/thank-you")
+        }
+    }
+
     onMounted(() => {
+        window.addEventListener("message", onHubSpotMessage)
+
         if (getHubspotTracking() === null) {
             const base = getGeoMeetingUrl()
             const current = new URLSearchParams(window.location.search)
@@ -194,6 +215,10 @@
             })
             valid.value = true
         }
+    })
+
+    onUnmounted(() => {
+        window.removeEventListener("message", onHubSpotMessage)
     })
 </script>
 

--- a/src/pages/thank-you.astro
+++ b/src/pages/thank-you.astro
@@ -1,0 +1,98 @@
+---
+import Layout from "~/components/layout.astro"
+
+const title = "Thank you"
+const description = "Your demo request has been received."
+---
+
+<Layout
+    title={title}
+    description={description}
+    headerTheme="darkText"
+    noindex={true}
+>
+    <section class="thank-you">
+        <div class="thank-you-card">
+            <div class="check" aria-hidden="true">
+                <svg
+                    width="40"
+                    height="40"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
+                    <path
+                        d="M5 13l4 4L19 7"
+                        stroke="currentColor"
+                        stroke-width="2.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"></path>
+                </svg>
+            </div>
+            <h1>Thank you — your demo is booked</h1>
+            <p>
+                We’ve received your request and a calendar invitation is on its
+                way to your inbox. One of our orchestration experts will meet you
+                at the scheduled time to walk through how Kestra fits your stack.
+            </p>
+            <div class="actions">
+                <a class="btn btn-primary" href="/">Back to homepage</a>
+                <a class="btn btn-secondary" href="/docs/getting-started">
+                    Explore the docs
+                </a>
+            </div>
+        </div>
+    </section>
+</Layout>
+
+<style lang="scss">
+    .thank-you {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 70vh;
+        padding: 4rem 1.5rem;
+    }
+
+    .thank-you-card {
+        max-width: 640px;
+        text-align: center;
+    }
+
+    .check {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 72px;
+        height: 72px;
+        margin-bottom: 2rem;
+        border-radius: 50%;
+        color: #fff;
+        background: var(--ks-content-color-highlight, #8405ff);
+    }
+
+    h1 {
+        font-size: 2.5rem;
+        margin-bottom: 1.5rem;
+    }
+
+    p {
+        font-size: 1.15rem;
+        color: var(--ks-content-secondary);
+        margin-bottom: 2.5rem;
+    }
+
+    .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        justify-content: center;
+    }
+
+    .btn {
+        padding: 0.75rem 1.75rem;
+        border-radius: 0.5rem;
+        font-weight: 600;
+        text-decoration: none;
+    }
+</style>


### PR DESCRIPTION
## Context

Follow-up to the Google Ads conversion-tracking support session (Case 0-1698000040693). Google asked for a **dedicated Thank You page** that loads on a successful "Book a Demo" submission so the conversion can be tracked.

## Why it's needed

The demo flow submits the HubSpot form, then swaps in a **cross-origin HubSpot Meetings iframe**. The booking is confirmed *inside* that iframe — the parent page never navigates, so there was no distinct URL or page load for Google Ads to attach the "Book a Demo" conversion to. This is exactly the gap the Google engineer hit while trying to verify the tag.

## Change

- **New `/thank-you` page** (`noindex`) with a booking-confirmation message and CTAs back to the homepage / docs.
- **`Meeting.vue`** now listens for HubSpot's `meetingBookSucceeded` `postMessage` from the Meetings iframe. On success it:
  - emits `bookdemo_confirmed` to PostHog and the GTM `dataLayer`, and
  - redirects to `/thank-you` with a **full page load** (`window.location.assign`) so the conversion tag fires on a real, trackable URL.
- The listener is registered in `onMounted` and cleaned up in `onUnmounted`.

## Follow-up on the Google side

Once merged, the Google Ads / GTM "Book a Demo" conversion should trigger on a page view of `/thank-you` (or on the `bookdemo_confirmed` custom event). Pairs with #5101, which makes page-views fire on client-side navigations.

## Verification for reviewers

On `/demo`: fill the form, book a slot in the HubSpot calendar. On booking confirmation the page should redirect to `/thank-you` and a `bookdemo_confirmed` event should appear in the GTM Preview dataLayer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)