### PR TITLE
fix(plugins): hide the `longDescription` on subgroups

### DIFF
--- a/src/components/plugins/PluginIndex.vue
+++ b/src/components/plugins/PluginIndex.vue
@@ -52,7 +52,7 @@
                 </div>
             </div>
         </template>
-        <template v-if="description !== undefined && plugin?.longDescription">
+        <template v-if="showLongDescription && description !== undefined && plugin?.longDescription">
             <div id="how-to-use-this-plugin" class="description">
                 <div ref="contentWrap" class="markdown-container" :class="{expanded: isExpanded}">
                     <div ref="contentInner" class="markdown-inner">
@@ -92,7 +92,8 @@
         activeId?: string | undefined
         subgroupBlueprintCounts?: Record<string, number>,
         metadataMap?: Record<string, PluginMetadata>,
-        schemas?: Record<string, { title?: string }>
+        schemas?: Record<string, { title?: string }>,
+        showLongDescription?: boolean
     }>();
 
     const getSubgroupMetadata = (subGroupWrapper: Plugin) => {

--- a/src/components/plugins/PluginsIndexWrapper.vue
+++ b/src/components/plugins/PluginsIndexWrapper.vue
@@ -49,6 +49,7 @@
         subgroupBlueprintCounts?: Record<string, number>
         metadataMap?: Record<string, PluginMetadata>
         schemas?: Record<string, { title?: string }>
+        showLongDescription?: boolean
     }>()
 </script>
 
@@ -63,6 +64,7 @@
         :subgroup-blueprint-counts
         :metadata-map
         :schemas
+        :show-long-description
         :active-id="activeId"
         @navigate="navigate"
     >

--- a/src/components/plugins/SubgroupView.astro
+++ b/src/components/plugins/SubgroupView.astro
@@ -25,6 +25,7 @@ interface Props {
     pluginType: string | undefined
     blueprintsSectionHeading: { id: string } | undefined
     relatedBlogs: any[]
+    showLongDescription: boolean
 }
 
 const {
@@ -42,6 +43,7 @@ const {
     pluginType,
     blueprintsSectionHeading,
     relatedBlogs,
+    showLongDescription,
 } = Astro.props
 ---
 
@@ -55,6 +57,7 @@ const {
         {subgroupBlueprintCounts}
         {metadataMap}
         schemas={elementTitle}
+        {showLongDescription}
         client:idle
     />
 </PluginDocsFrame>

--- a/src/pages/plugins/[...slug].astro
+++ b/src/pages/plugins/[...slug].astro
@@ -387,6 +387,7 @@ const pluginSchema = pluginType
                         {pluginType}
                         {blueprintsSectionHeading}
                         {relatedBlogs}
+                        showLongDescription={subGroup === undefined}
                     />
                 )
             }

--- a/src/utils/plugins/buildPluginPageProps.ts
+++ b/src/utils/plugins/buildPluginPageProps.ts
@@ -265,10 +265,11 @@ export function buildPluginPageProps(input: BuildPluginPagePropsInput) {
               : blueprintCounts?.[rootPlugin?.group ?? pluginName] > 0
 
         const isRootView = pluginType === undefined
+        const isRootPluginPage = isRootView && subGroup === undefined
 
         return [
             ...baseTocLinks,
-            ...(isRootView && rootPlugin?.longDescription
+            ...(isRootPluginPage && rootPlugin?.longDescription
                 ? [tocEntry("how-to-use-this-plugin", extractFirstHeading(rootPlugin.longDescription) ?? "How to use this plugin")]
                 : []),
             ...(isRootView && currentPluginVideos?.length > 0


### PR DESCRIPTION
closes https://github.com/kestra-io/docs/issues/5113