### PR TITLE
fix(ai-search): copy button on code blocks + restore input focus after response

### DIFF
--- a/src/components/MDCParserAndRenderer.vue
+++ b/src/components/MDCParserAndRenderer.vue
@@ -4,6 +4,7 @@
         :key="content"
         class="mdc-renderer"
         v-html="htmlContent"
+        @click="handleCopyClick"
     />
     <div v-else-if="parseError" class="parse-error">
         <strong>MDC parse error:</strong> {{ parseError }}
@@ -21,11 +22,63 @@
 
     const htmlContent = ref<string>("")
 
+    const COPY_ICON =
+        "<svg viewBox=\"0 0 24 24\" class=\"icon-copy\"><path fill=\"currentColor\" d=\"M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z\" /></svg>"
+    const CHECK_ICON =
+        "<svg viewBox=\"0 0 24 24\" class=\"icon-check\"><path fill=\"currentColor\" d=\"M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z\" /></svg>"
+
+    /** Wraps each fenced code block with a `.code-block` shell holding a language label and copy button. */
+    function wrapCodeBlocks(html: string): string {
+        const container = document.createElement("div")
+        container.innerHTML = html
+
+        container.querySelectorAll("pre").forEach((pre) => {
+            const code = pre.querySelector("code")
+            const lang = code?.className.match(/language-(\S+)/)?.[1]
+
+            const wrapper = document.createElement("div")
+            wrapper.className = "code-block"
+
+            if (lang && lang !== "text") {
+                const label = document.createElement("div")
+                label.className = "language"
+                label.textContent = lang
+                wrapper.appendChild(label)
+            }
+
+            const button = document.createElement("button")
+            button.type = "button"
+            button.className = "copy"
+            button.title = "Copy to clipboard"
+            button.innerHTML = COPY_ICON + CHECK_ICON
+            wrapper.appendChild(button)
+
+            pre.replaceWith(wrapper)
+            wrapper.appendChild(pre)
+        })
+
+        return container.innerHTML
+    }
+
+    async function handleCopyClick(event: MouseEvent) {
+        const button = (event.target as HTMLElement).closest(
+            "button.copy",
+        ) as HTMLButtonElement | null
+        if (!button) return
+
+        const code = button.parentElement?.querySelector("pre code")
+        if (!code?.textContent) return
+
+        await navigator.clipboard.writeText(code.textContent)
+        button.classList.add("copied")
+        setTimeout(() => button.classList.remove("copied"), 2000)
+    }
+
     async function parseContent() {
         if (!props.content) {
             throw new Error("No content provided to MDCParserAndRenderer.vue")
         }
-        htmlContent.value = await getMarked().parse(props.content)
+        htmlContent.value = wrapCodeBlocks(await getMarked().parse(props.content))
     }
 
     onMounted(async () => {
@@ -52,6 +105,51 @@
 
 
     .mdc-renderer {
+        & :deep(.code-block) {
+            position: relative;
+            padding: 1.25rem;
+            border-radius: var(--bs-border-radius-lg);
+        }
+        & :deep(.language) {
+            position: absolute;
+            top: 1.25rem;
+            right: 1.25rem;
+            font-size: 0.75rem;
+            color: var(--ks-content-tertiary);
+        }
+        & :deep(button.copy) {
+            position: absolute;
+            top: 1rem;
+            right: 1rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0.4rem;
+            border: none;
+            background: none;
+            border-radius: 4px;
+            cursor: pointer;
+            color: var(--ks-content-tertiary);
+            &:hover {
+                color: var(--ks-content-primary);
+            }
+            svg {
+                width: 1.125rem;
+                height: 1.125rem;
+            }
+            .icon-check {
+                display: none;
+            }
+            &.copied {
+                color: var(--ks-content-link);
+                .icon-copy {
+                    display: none;
+                }
+                .icon-check {
+                    display: block;
+                }
+            }
+        }
         & :deep(pre) {
             padding: 1rem;
             padding-bottom: 0;

--- a/src/components/MDCParserAndRenderer.vue
+++ b/src/components/MDCParserAndRenderer.vue
@@ -1,17 +1,11 @@
 <template>
-    <template v-if="htmlContent">
-        <div
-            ref="containerRef"
-            :key="content"
-            class="mdc-renderer"
-            v-html="htmlContent"
-        />
-        <template v-for="(code, index) in codeBlocks" :key="index">
-            <Teleport v-if="copySlots[index]" :to="copySlots[index]">
-                <Copy :code="code" />
-            </Teleport>
-        </template>
-    </template>
+    <div
+        v-if="htmlContent"
+        :key="content"
+        class="mdc-renderer"
+        v-html="htmlContent"
+        @click="handleCopyClick"
+    />
     <div v-else-if="parseError" class="parse-error">
         <strong>MDC parse error:</strong> {{ parseError }}
     </div>
@@ -19,68 +13,23 @@
 </template>
 
 <script lang="ts" setup>
-    import { nextTick, onMounted, ref, watch } from "vue"
+    import { onMounted, ref, watch } from "vue"
     import { getMarked } from "~/markdown/marked-shiki"
-    import Copy from "~/components/common/Copy.vue"
+    import { handleCopyClick, injectCopyButtons } from "~/utils/code-copy"
 
     const props = defineProps<{
         content: string
+        copyable?: boolean
     }>()
 
     const htmlContent = ref<string>("")
-    const containerRef = ref<HTMLElement | null>(null)
-    const codeBlocks = ref<string[]>([])
-    const copySlots = ref<HTMLElement[]>([])
-
-    /** Wraps each fenced code block with a `.code-block` shell holding a language label and a copy-slot to teleport a `Copy` component into. */
-    function wrapCodeBlocks(html: string): string {
-        const container = document.createElement("div")
-        container.innerHTML = html
-
-        const blocks: string[] = []
-
-        container.querySelectorAll("pre").forEach((pre) => {
-            const code = pre.querySelector("code")
-            const lang = code?.className.match(/language-(\S+)/)?.[1]
-            const index = blocks.length
-            blocks.push(code?.textContent ?? "")
-
-            const wrapper = document.createElement("div")
-            wrapper.className = "code-block"
-
-            if (lang && lang !== "text") {
-                const label = document.createElement("div")
-                label.className = "language"
-                label.textContent = lang
-                wrapper.appendChild(label)
-            }
-
-            const slot = document.createElement("div")
-            slot.className = "copy-slot"
-            slot.setAttribute("data-copy-slot", String(index))
-            wrapper.appendChild(slot)
-
-            pre.replaceWith(wrapper)
-            wrapper.appendChild(pre)
-        })
-
-        codeBlocks.value = blocks
-        return container.innerHTML
-    }
 
     async function parseContent() {
         if (!props.content) {
             throw new Error("No content provided to MDCParserAndRenderer.vue")
         }
-        htmlContent.value = wrapCodeBlocks(await getMarked().parse(props.content))
-        await nextTick()
-        copySlots.value = containerRef.value
-            ? Array.from(
-                  containerRef.value.querySelectorAll<HTMLElement>(
-                      "[data-copy-slot]",
-                  ),
-              )
-            : []
+        const html = await getMarked().parse(props.content)
+        htmlContent.value = props.copyable ? injectCopyButtons(html) : html
     }
 
     onMounted(async () => {
@@ -107,36 +56,6 @@
 
 
     .mdc-renderer {
-        & :deep(.code-block) {
-            position: relative;
-            padding: 1.25rem;
-            border-radius: var(--bs-border-radius-lg);
-        }
-        & :deep(.language) {
-            position: absolute;
-            top: 1.25rem;
-            right: 1.25rem;
-            font-size: 0.75rem;
-            color: var(--ks-content-tertiary);
-        }
-        & :deep(.copy-slot) {
-            position: absolute;
-            top: 1rem;
-            right: 1rem;
-        }
-        & :deep(.copy .btn) {
-            border: none;
-            background: none;
-            color: var(--ks-content-tertiary);
-            &:hover {
-                color: var(--ks-content-primary);
-                border-color: transparent;
-            }
-            &.copied {
-                color: var(--ks-content-link);
-                border-color: transparent;
-            }
-        }
         & :deep(pre) {
             padding: 1rem;
             padding-bottom: 0;

--- a/src/components/MDCParserAndRenderer.vue
+++ b/src/components/MDCParserAndRenderer.vue
@@ -1,11 +1,17 @@
 <template>
-    <div
-        v-if="htmlContent"
-        :key="content"
-        class="mdc-renderer"
-        v-html="htmlContent"
-        @click="handleCopyClick"
-    />
+    <template v-if="htmlContent">
+        <div
+            ref="containerRef"
+            :key="content"
+            class="mdc-renderer"
+            v-html="htmlContent"
+        />
+        <template v-for="(code, index) in codeBlocks" :key="index">
+            <Teleport v-if="copySlots[index]" :to="copySlots[index]">
+                <Copy :code="code" />
+            </Teleport>
+        </template>
+    </template>
     <div v-else-if="parseError" class="parse-error">
         <strong>MDC parse error:</strong> {{ parseError }}
     </div>
@@ -13,28 +19,31 @@
 </template>
 
 <script lang="ts" setup>
-    import { onMounted, ref, watch } from "vue"
+    import { nextTick, onMounted, ref, watch } from "vue"
     import { getMarked } from "~/markdown/marked-shiki"
+    import Copy from "~/components/common/Copy.vue"
 
     const props = defineProps<{
         content: string
     }>()
 
     const htmlContent = ref<string>("")
+    const containerRef = ref<HTMLElement | null>(null)
+    const codeBlocks = ref<string[]>([])
+    const copySlots = ref<HTMLElement[]>([])
 
-    const COPY_ICON =
-        "<svg viewBox=\"0 0 24 24\" class=\"icon-copy\"><path fill=\"currentColor\" d=\"M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z\" /></svg>"
-    const CHECK_ICON =
-        "<svg viewBox=\"0 0 24 24\" class=\"icon-check\"><path fill=\"currentColor\" d=\"M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z\" /></svg>"
-
-    /** Wraps each fenced code block with a `.code-block` shell holding a language label and copy button. */
+    /** Wraps each fenced code block with a `.code-block` shell holding a language label and a copy-slot to teleport a `Copy` component into. */
     function wrapCodeBlocks(html: string): string {
         const container = document.createElement("div")
         container.innerHTML = html
 
+        const blocks: string[] = []
+
         container.querySelectorAll("pre").forEach((pre) => {
             const code = pre.querySelector("code")
             const lang = code?.className.match(/language-(\S+)/)?.[1]
+            const index = blocks.length
+            blocks.push(code?.textContent ?? "")
 
             const wrapper = document.createElement("div")
             wrapper.className = "code-block"
@@ -46,32 +55,17 @@
                 wrapper.appendChild(label)
             }
 
-            const button = document.createElement("button")
-            button.type = "button"
-            button.className = "copy"
-            button.title = "Copy to clipboard"
-            button.innerHTML = COPY_ICON + CHECK_ICON
-            wrapper.appendChild(button)
+            const slot = document.createElement("div")
+            slot.className = "copy-slot"
+            slot.setAttribute("data-copy-slot", String(index))
+            wrapper.appendChild(slot)
 
             pre.replaceWith(wrapper)
             wrapper.appendChild(pre)
         })
 
+        codeBlocks.value = blocks
         return container.innerHTML
-    }
-
-    async function handleCopyClick(event: MouseEvent) {
-        const button = (event.target as HTMLElement).closest(
-            "button.copy",
-        ) as HTMLButtonElement | null
-        if (!button) return
-
-        const code = button.parentElement?.querySelector("pre code")
-        if (!code?.textContent) return
-
-        await navigator.clipboard.writeText(code.textContent)
-        button.classList.add("copied")
-        setTimeout(() => button.classList.remove("copied"), 2000)
     }
 
     async function parseContent() {
@@ -79,6 +73,14 @@
             throw new Error("No content provided to MDCParserAndRenderer.vue")
         }
         htmlContent.value = wrapCodeBlocks(await getMarked().parse(props.content))
+        await nextTick()
+        copySlots.value = containerRef.value
+            ? Array.from(
+                  containerRef.value.querySelectorAll<HTMLElement>(
+                      "[data-copy-slot]",
+                  ),
+              )
+            : []
     }
 
     onMounted(async () => {
@@ -117,37 +119,22 @@
             font-size: 0.75rem;
             color: var(--ks-content-tertiary);
         }
-        & :deep(button.copy) {
+        & :deep(.copy-slot) {
             position: absolute;
             top: 1rem;
             right: 1rem;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            padding: 0.4rem;
+        }
+        & :deep(.copy .btn) {
             border: none;
             background: none;
-            border-radius: 4px;
-            cursor: pointer;
             color: var(--ks-content-tertiary);
             &:hover {
                 color: var(--ks-content-primary);
-            }
-            svg {
-                width: 1.125rem;
-                height: 1.125rem;
-            }
-            .icon-check {
-                display: none;
+                border-color: transparent;
             }
             &.copied {
                 color: var(--ks-content-link);
-                .icon-copy {
-                    display: none;
-                }
-                .icon-check {
-                    display: block;
-                }
+                border-color: transparent;
             }
         }
         & :deep(pre) {

--- a/src/components/ai/AiChatDialog.vue
+++ b/src/components/ai/AiChatDialog.vue
@@ -55,6 +55,13 @@
                         </div>
                     </div>
                     <div class="bubble">
+                        <Copy
+                            v-if="
+                                message.role === 'assistant' && message.content
+                            "
+                            class="copy-response"
+                            :code="message.content"
+                        />
                         <template v-if="message.role === 'assistant'">
                             <div
                                 v-if="message.markdown"
@@ -63,6 +70,7 @@
                                 <MDCParserAndRenderer
                                     class="bd-markdown"
                                     :content="message.markdown"
+                                    copyable
                                 />
                             </div>
 
@@ -108,17 +116,6 @@
                                     </div>
                                 </a>
                             </div>
-                        </div>
-
-                        <div
-                            v-if="
-                                message.role === 'assistant' &&
-                                message.content &&
-                                !(isLoading && index === messages.length - 1)
-                            "
-                            class="response-actions"
-                        >
-                            <Copy :code="message.content" />
                         </div>
 
                         <span class="timestamp">{{
@@ -640,22 +637,6 @@
                     }
                 }
 
-                .response-actions {
-                    display: flex;
-                    justify-content: flex-end;
-                    margin-top: 0.5rem;
-
-                    :deep(.btn) {
-                        border: none;
-                        background: none;
-                        color: var(--ks-content-tertiary);
-
-                        &:hover {
-                            color: var(--ks-content-primary);
-                        }
-                    }
-                }
-
                 .timestamp {
                     font-size: 0.7rem;
                     color: var(--ks-content-tertiary);
@@ -664,18 +645,44 @@
                     margin-top: 0.5rem;
                 }
 
+                .copy-response {
+                    position: absolute;
+                    top: 0.75rem;
+                    right: 0.75rem;
+                }
+
                 :deep(pre) {
+                    position: relative;
                     border: $block-border;
                     padding: 1rem;
                     border-radius: 0.5rem;
                     margin: 1rem 0;
-                }
 
-                :deep(.language),
-                :deep(.copy-slot) {
-                    position: absolute;
-                    top: 1.75rem;
-                    right: 1rem;
+                    .code-copy {
+                        position: absolute;
+                        top: 0.5rem;
+                        right: 0.5rem;
+                        display: inline-flex;
+                        padding: 0.25rem;
+                        border: 0;
+                        border-radius: 4px;
+                        background: var(--ks-background-body);
+                        color: var(--ks-content-tertiary);
+                        cursor: pointer;
+
+                        &:hover {
+                            color: var(--ks-content-primary);
+                        }
+
+                        .icon-check,
+                        &.copied .icon-copy {
+                            display: none;
+                        }
+
+                        &.copied .icon-check {
+                            display: block;
+                        }
+                    }
                 }
 
                 :deep(.code-block) {

--- a/src/components/ai/AiChatDialog.vue
+++ b/src/components/ai/AiChatDialog.vue
@@ -651,6 +651,10 @@
                     right: 0.75rem;
                 }
 
+                &:has(.copy-response) {
+                    padding-top: 3rem;
+                }
+
                 :deep(pre) {
                     position: relative;
                     border: $block-border;

--- a/src/components/ai/AiChatDialog.vue
+++ b/src/components/ai/AiChatDialog.vue
@@ -430,6 +430,8 @@
             )
         } finally {
             isLoading.value = false
+            await nextTick()
+            textareaRef.value?.focus()
         }
     }
 </script>

--- a/src/components/ai/AiChatDialog.vue
+++ b/src/components/ai/AiChatDialog.vue
@@ -110,6 +110,17 @@
                             </div>
                         </div>
 
+                        <div
+                            v-if="
+                                message.role === 'assistant' &&
+                                message.content &&
+                                !(isLoading && index === messages.length - 1)
+                            "
+                            class="response-actions"
+                        >
+                            <Copy :code="message.content" />
+                        </div>
+
                         <span class="timestamp">{{
                             formatTimestamp(message.timestamp)
                         }}</span>
@@ -162,6 +173,7 @@
     import TrashCan from "vue-material-design-icons/TrashCan.vue"
     import AccountCircle from "vue-material-design-icons/AccountCircle.vue"
     import FileDocumentOutline from "vue-material-design-icons/FileDocumentOutline.vue"
+    import Copy from "~/components/common/Copy.vue"
     import {
         extractSourcesFromMarkdown,
         isInternalLink,
@@ -628,6 +640,22 @@
                     }
                 }
 
+                .response-actions {
+                    display: flex;
+                    justify-content: flex-end;
+                    margin-top: 0.5rem;
+
+                    :deep(.btn) {
+                        border: none;
+                        background: none;
+                        color: var(--ks-content-tertiary);
+
+                        &:hover {
+                            color: var(--ks-content-primary);
+                        }
+                    }
+                }
+
                 .timestamp {
                     font-size: 0.7rem;
                     color: var(--ks-content-tertiary);
@@ -644,7 +672,7 @@
                 }
 
                 :deep(.language),
-                :deep(.copy) {
+                :deep(.copy-slot) {
                     position: absolute;
                     top: 1.75rem;
                     right: 1rem;

--- a/src/utils/code-copy.ts
+++ b/src/utils/code-copy.ts
@@ -1,0 +1,31 @@
+const ICONS = {
+    copy: "M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z",
+    check: "M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,6.58L21,7Z",
+}
+
+const icon = (name: keyof typeof ICONS): string =>
+    `<svg class="icon-${name}" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="${ICONS[name]}"/></svg>`
+
+const COPY_BUTTON = `<button class="code-copy" type="button" title="Copy to clipboard" aria-label="Copy code to clipboard">${icon("copy")}${icon("check")}</button>`
+
+export function injectCopyButtons(html: string): string {
+    return html.replaceAll("<pre>", `<pre>${COPY_BUTTON}`)
+}
+
+export function handleCopyClick({ target }: MouseEvent): void {
+    const button = (target as HTMLElement).closest<HTMLButtonElement>(
+        ".code-copy",
+    )
+    const code = button?.parentElement?.querySelector("code")
+
+    if (!button || !code || !navigator.clipboard) {
+        return
+    }
+
+    void navigator.clipboard.writeText(code.textContent?.trimEnd() ?? "")
+    button.classList.add("copied")
+
+    setTimeout(() => {
+        button.classList.remove("copied")
+    }, 2000)
+}


### PR DESCRIPTION
Closes https://github.com/kestra-io/docs/issues/5148

## Summary
- "Ask with AI" responses render code blocks (e.g. flow YAML) with no copy button, unlike the rest of the docs site. `MDCParserAndRenderer.vue` now wraps each code block with a language label + copy-to-clipboard button, reusing the `.code-block`/`.language`/`.copy` styling that was already (dead) in `AiChatDialog.vue`.
- The chat textarea disables while a response streams, blurring it, and focus was never restored — forcing a click back into the box before typing a follow-up. `AiChatDialog.vue` now refocuses the textarea once the response finishes.

## Test plan
- [ ] Open "Ask Kestra AI", ask a question that returns a YAML flow snippet, confirm a copy button appears on the code block and copies the raw code to clipboard
- [ ] Send a message, wait for the response to finish streaming, confirm the input is focused automatically (type without clicking)
- [ ] Confirm existing code-block styling (language label, borders) still looks right in both light and dark themes