### PR TITLE
fix(docs): promote latest-slim image with plugin auto-install across get-started and installation docs

### DIFF
--- a/src/components/get-started/Hero.astro
+++ b/src/components/get-started/Hero.astro
@@ -20,6 +20,7 @@ const dockerCommand = `<span class="t-cmd">docker</span> <span class="t-sub">run
   <span class="t-flag">-v</span> <span class="t-val">kestra_db:/app/data</span> <span class="t-bs">\\</span>
   <span class="t-flag">-v</span> <span class="t-val">/var/run/docker.sock:/var/run/docker.sock</span> <span class="t-bs">\\</span>
   <span class="t-flag">-v</span> <span class="t-val">/tmp:/tmp</span> <span class="t-bs">\\</span>
+  <span class="t-flag">-e</span> <span class="t-val">KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true</span> <span class="t-bs">\\</span>
   <span class="t-val">kestra/kestra:latest-no-plugins</span> <span class="t-sub">server standalone</span>`
 ---
 
@@ -55,7 +56,7 @@ const dockerCommand = `<span class="t-cmd">docker</span> <span class="t-sub">run
                 <div class="command-label">
                     <img src="/icon-simple.svg" alt="Kestra" width="20" height="20" style="width:20px;height:20px;flex-shrink:0" />
                     <span class="command-hint">Run this. That's it.</span>
-                    <button class="copy-btn" title="Copy command" onclick={`navigator.clipboard.writeText(${JSON.stringify(`docker run --pull=always --rm -it -p 8080:8080 --user=root \\\n  --name kestra \\\n  -v kestra_data:/app/storage \\\n  -v kestra_db:/app/data \\\n  -v /var/run/docker.sock:/var/run/docker.sock \\\n  -v /tmp:/tmp \\\n  kestra/kestra:latest-no-plugins server standalone`)})`}>
+                    <button class="copy-btn" title="Copy command" onclick={`navigator.clipboard.writeText(${JSON.stringify(`docker run --pull=always --rm -it -p 8080:8080 --user=root \\\n  --name kestra \\\n  -v kestra_data:/app/storage \\\n  -v kestra_db:/app/data \\\n  -v /var/run/docker.sock:/var/run/docker.sock \\\n  -v /tmp:/tmp \\\n  -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true \\\n  kestra/kestra:latest-no-plugins server standalone`)})`}>
                         <Icon name="mdi:content-copy" />
                     </button>
                 </div>

--- a/src/components/get-started/Hero.astro
+++ b/src/components/get-started/Hero.astro
@@ -20,7 +20,7 @@ const dockerCommand = `<span class="t-cmd">docker</span> <span class="t-sub">run
   <span class="t-flag">-v</span> <span class="t-val">kestra_db:/app/data</span> <span class="t-bs">\\</span>
   <span class="t-flag">-v</span> <span class="t-val">/var/run/docker.sock:/var/run/docker.sock</span> <span class="t-bs">\\</span>
   <span class="t-flag">-v</span> <span class="t-val">/tmp:/tmp</span> <span class="t-bs">\\</span>
-  <span class="t-val">kestra/kestra:latest</span> <span class="t-sub">server local</span>`
+  <span class="t-val">kestra/kestra:latest-no-plugins</span> <span class="t-sub">server standalone</span>`
 ---
 
 <section class="hero-section">
@@ -55,7 +55,7 @@ const dockerCommand = `<span class="t-cmd">docker</span> <span class="t-sub">run
                 <div class="command-label">
                     <img src="/icon-simple.svg" alt="Kestra" width="20" height="20" style="width:20px;height:20px;flex-shrink:0" />
                     <span class="command-hint">Run this. That's it.</span>
-                    <button class="copy-btn" title="Copy command" onclick={`navigator.clipboard.writeText(${JSON.stringify(`docker run --pull=always --rm -it -p 8080:8080 --user=root \\\n  --name kestra \\\n  -v kestra_data:/app/storage \\\n  -v kestra_db:/app/data \\\n  -v /var/run/docker.sock:/var/run/docker.sock \\\n  -v /tmp:/tmp \\\n  kestra/kestra:latest server local`)})`}>
+                    <button class="copy-btn" title="Copy command" onclick={`navigator.clipboard.writeText(${JSON.stringify(`docker run --pull=always --rm -it -p 8080:8080 --user=root \\\n  --name kestra \\\n  -v kestra_data:/app/storage \\\n  -v kestra_db:/app/data \\\n  -v /var/run/docker.sock:/var/run/docker.sock \\\n  -v /tmp:/tmp \\\n  kestra/kestra:latest-no-plugins server standalone`)})`}>
                         <Icon name="mdi:content-copy" />
                     </button>
                 </div>

--- a/src/components/get-started/Hero.astro
+++ b/src/components/get-started/Hero.astro
@@ -21,7 +21,7 @@ const dockerCommand = `<span class="t-cmd">docker</span> <span class="t-sub">run
   <span class="t-flag">-v</span> <span class="t-val">/var/run/docker.sock:/var/run/docker.sock</span> <span class="t-bs">\\</span>
   <span class="t-flag">-v</span> <span class="t-val">/tmp:/tmp</span> <span class="t-bs">\\</span>
   <span class="t-flag">-e</span> <span class="t-val">KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true</span> <span class="t-bs">\\</span>
-  <span class="t-val">kestra/kestra:latest-no-plugins</span> <span class="t-sub">server standalone</span>`
+  <span class="t-val">kestra/kestra:latest-slim</span> <span class="t-sub">server standalone</span>`
 ---
 
 <section class="hero-section">
@@ -56,7 +56,7 @@ const dockerCommand = `<span class="t-cmd">docker</span> <span class="t-sub">run
                 <div class="command-label">
                     <img src="/icon-simple.svg" alt="Kestra" width="20" height="20" style="width:20px;height:20px;flex-shrink:0" />
                     <span class="command-hint">Run this. That's it.</span>
-                    <button class="copy-btn" title="Copy command" onclick={`navigator.clipboard.writeText(${JSON.stringify(`docker run --pull=always --rm -it -p 8080:8080 --user=root \\\n  --name kestra \\\n  -v kestra_data:/app/storage \\\n  -v kestra_db:/app/data \\\n  -v /var/run/docker.sock:/var/run/docker.sock \\\n  -v /tmp:/tmp \\\n  -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true \\\n  kestra/kestra:latest-no-plugins server standalone`)})`}>
+                    <button class="copy-btn" title="Copy command" onclick={`navigator.clipboard.writeText(${JSON.stringify(`docker run --pull=always --rm -it -p 8080:8080 --user=root \\\n  --name kestra \\\n  -v kestra_data:/app/storage \\\n  -v kestra_db:/app/data \\\n  -v /var/run/docker.sock:/var/run/docker.sock \\\n  -v /tmp:/tmp \\\n  -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true \\\n  kestra/kestra:latest-slim server standalone`)})`}>
                         <Icon name="mdi:content-copy" />
                     </button>
                 </div>

--- a/src/components/get-started/Hero.astro
+++ b/src/components/get-started/Hero.astro
@@ -21,7 +21,7 @@ const dockerCommand = `<span class="t-cmd">docker</span> <span class="t-sub">run
   <span class="t-flag">-v</span> <span class="t-val">/var/run/docker.sock:/var/run/docker.sock</span> <span class="t-bs">\\</span>
   <span class="t-flag">-v</span> <span class="t-val">/tmp:/tmp</span> <span class="t-bs">\\</span>
   <span class="t-flag">-e</span> <span class="t-val">KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true</span> <span class="t-bs">\\</span>
-  <span class="t-val">kestra/kestra:latest-slim</span> <span class="t-sub">server standalone</span>`
+  <span class="t-val">kestra/kestra:latest-slim</span> <span class="t-sub">server local</span>`
 ---
 
 <section class="hero-section">
@@ -56,7 +56,7 @@ const dockerCommand = `<span class="t-cmd">docker</span> <span class="t-sub">run
                 <div class="command-label">
                     <img src="/icon-simple.svg" alt="Kestra" width="20" height="20" style="width:20px;height:20px;flex-shrink:0" />
                     <span class="command-hint">Run this. That's it.</span>
-                    <button class="copy-btn" title="Copy command" onclick={`navigator.clipboard.writeText(${JSON.stringify(`docker run --pull=always --rm -it -p 8080:8080 --user=root \\\n  --name kestra \\\n  -v kestra_data:/app/storage \\\n  -v kestra_db:/app/data \\\n  -v /var/run/docker.sock:/var/run/docker.sock \\\n  -v /tmp:/tmp \\\n  -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true \\\n  kestra/kestra:latest-slim server standalone`)})`}>
+                    <button class="copy-btn" title="Copy command" onclick={`navigator.clipboard.writeText(${JSON.stringify(`docker run --pull=always --rm -it -p 8080:8080 --user=root \\\n  --name kestra \\\n  -v kestra_data:/app/storage \\\n  -v kestra_db:/app/data \\\n  -v /var/run/docker.sock:/var/run/docker.sock \\\n  -v /tmp:/tmp \\\n  -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true \\\n  kestra/kestra:latest-slim server local`)})`}>
                         <Icon name="mdi:content-copy" />
                     </button>
                 </div>

--- a/src/components/get-started/SetupSteps.astro
+++ b/src/components/get-started/SetupSteps.astro
@@ -12,7 +12,7 @@ const dockerCommandUnix = `docker run --pull=always --rm -it -p 8080:8080 --user
   -v kestra_db:/app/data \\
   -v /var/run/docker.sock:/var/run/docker.sock \\
   -v /tmp:/tmp \\
-  kestra/kestra:latest server local`
+  kestra/kestra:latest-no-plugins server standalone`
 
 const dockerCommandWindows = `docker run --pull=always --rm -it -p 8080:8080 --user=root ^
   --name kestra ^
@@ -20,7 +20,7 @@ const dockerCommandWindows = `docker run --pull=always --rm -it -p 8080:8080 --u
   -v kestra_db:/app/data ^
   -v /var/run/docker.sock:/var/run/docker.sock ^
   -v /tmp:/tmp ^
-  kestra/kestra:latest server local`
+  kestra/kestra:latest-no-plugins server standalone`
 ---
 
 <section class="setup-steps">

--- a/src/components/get-started/SetupSteps.astro
+++ b/src/components/get-started/SetupSteps.astro
@@ -12,6 +12,7 @@ const dockerCommandUnix = `docker run --pull=always --rm -it -p 8080:8080 --user
   -v kestra_db:/app/data \\
   -v /var/run/docker.sock:/var/run/docker.sock \\
   -v /tmp:/tmp \\
+  -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true \\
   kestra/kestra:latest-no-plugins server standalone`
 
 const dockerCommandWindows = `docker run --pull=always --rm -it -p 8080:8080 --user=root ^
@@ -20,6 +21,7 @@ const dockerCommandWindows = `docker run --pull=always --rm -it -p 8080:8080 --u
   -v kestra_db:/app/data ^
   -v /var/run/docker.sock:/var/run/docker.sock ^
   -v /tmp:/tmp ^
+  -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true ^
   kestra/kestra:latest-no-plugins server standalone`
 ---
 

--- a/src/components/get-started/SetupSteps.astro
+++ b/src/components/get-started/SetupSteps.astro
@@ -13,7 +13,7 @@ const dockerCommandUnix = `docker run --pull=always --rm -it -p 8080:8080 --user
   -v /var/run/docker.sock:/var/run/docker.sock \\
   -v /tmp:/tmp \\
   -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true \\
-  kestra/kestra:latest-slim server standalone`
+  kestra/kestra:latest-slim server local`
 
 const dockerCommandWindows = `docker run --pull=always --rm -it -p 8080:8080 --user=root ^
   --name kestra ^
@@ -22,7 +22,7 @@ const dockerCommandWindows = `docker run --pull=always --rm -it -p 8080:8080 --u
   -v /var/run/docker.sock:/var/run/docker.sock ^
   -v /tmp:/tmp ^
   -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true ^
-  kestra/kestra:latest-slim server standalone`
+  kestra/kestra:latest-slim server local`
 ---
 
 <section class="setup-steps">

--- a/src/components/get-started/SetupSteps.astro
+++ b/src/components/get-started/SetupSteps.astro
@@ -13,7 +13,7 @@ const dockerCommandUnix = `docker run --pull=always --rm -it -p 8080:8080 --user
   -v /var/run/docker.sock:/var/run/docker.sock \\
   -v /tmp:/tmp \\
   -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true \\
-  kestra/kestra:latest-no-plugins server standalone`
+  kestra/kestra:latest-slim server standalone`
 
 const dockerCommandWindows = `docker run --pull=always --rm -it -p 8080:8080 --user=root ^
   --name kestra ^
@@ -22,7 +22,7 @@ const dockerCommandWindows = `docker run --pull=always --rm -it -p 8080:8080 --u
   -v /var/run/docker.sock:/var/run/docker.sock ^
   -v /tmp:/tmp ^
   -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true ^
-  kestra/kestra:latest-no-plugins server standalone`
+  kestra/kestra:latest-slim server standalone`
 ---
 
 <section class="setup-steps">

--- a/src/contents/docs/01.quickstart/index.md
+++ b/src/contents/docs/01.quickstart/index.md
@@ -44,6 +44,10 @@ If you re-run the command and Docker reports `You have to remove (or rename) tha
 - uses the lightweight `no-plugins` image and installs plugins automatically on demand
 :::
 
+:::alert{type="info"}
+The `kestra/kestra:latest-no-plugins` image ships without any plugins to keep the download small. The `KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true` environment variable makes Kestra install any plugin automatically the first time a flow needs it, so you don't need to pre-install anything. If you prefer an image with all plugins bundled, use `kestra/kestra:latest` instead.
+:::
+
 The container is ready when the logs show `Main server is running at http://...:8080`.
 
 ## Step 2: Open the Kestra UI

--- a/src/contents/docs/01.quickstart/index.md
+++ b/src/contents/docs/01.quickstart/index.md
@@ -30,7 +30,8 @@ docker run --pull=always --rm -it -p 8080:8080 --user=root \
   -v kestra_db:/app/data \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /tmp:/tmp \
-  kestra/kestra:latest server local
+  -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true \
+  kestra/kestra:latest-no-plugins server standalone
 ```
 
 If you re-run the command and Docker reports `You have to remove (or rename) that container to be able to reuse that name.`, remove the old container with `docker rm -f kestra` or pick a different `--name`.
@@ -40,6 +41,7 @@ If you re-run the command and Docker reports `You have to remove (or rename) tha
 - stores local files in the `kestra_data` Docker volume
 - persists the H2 database in the `kestra_db` Docker volume
 - mounts `/tmp` and the Docker socket so script and container tasks can run locally
+- uses the lightweight `no-plugins` image and installs plugins automatically on demand
 :::
 
 The container is ready when the logs show `Main server is running at http://...:8080`.

--- a/src/contents/docs/01.quickstart/index.md
+++ b/src/contents/docs/01.quickstart/index.md
@@ -31,7 +31,7 @@ docker run --pull=always --rm -it -p 8080:8080 --user=root \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /tmp:/tmp \
   -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true \
-  kestra/kestra:latest-slim server standalone
+  kestra/kestra:latest-slim server local
 ```
 
 If you re-run the command and Docker reports `You have to remove (or rename) that container to be able to reuse that name.`, remove the old container with `docker rm -f kestra` or pick a different `--name`.

--- a/src/contents/docs/01.quickstart/index.md
+++ b/src/contents/docs/01.quickstart/index.md
@@ -31,7 +31,7 @@ docker run --pull=always --rm -it -p 8080:8080 --user=root \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /tmp:/tmp \
   -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true \
-  kestra/kestra:latest-no-plugins server standalone
+  kestra/kestra:latest-slim server standalone
 ```
 
 If you re-run the command and Docker reports `You have to remove (or rename) that container to be able to reuse that name.`, remove the old container with `docker rm -f kestra` or pick a different `--name`.
@@ -41,11 +41,11 @@ If you re-run the command and Docker reports `You have to remove (or rename) tha
 - stores local files in the `kestra_data` Docker volume
 - persists the H2 database in the `kestra_db` Docker volume
 - mounts `/tmp` and the Docker socket so script and container tasks can run locally
-- uses the lightweight `no-plugins` image and installs plugins automatically on demand
+- uses the lightweight `slim` image and installs plugins automatically on demand
 :::
 
 :::alert{type="info"}
-The `kestra/kestra:latest-no-plugins` image ships without any plugins to keep the download small. The `KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true` environment variable makes Kestra install any plugin automatically the first time a flow needs it, so you don't need to pre-install anything. If you prefer an image with all plugins bundled, use `kestra/kestra:latest` instead.
+The `kestra/kestra:latest-slim` image ships without any plugins to keep the download small. The `KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true` environment variable makes Kestra install any plugin automatically the first time a flow needs it, so you don't need to pre-install anything. If you prefer an image with all plugins bundled, use `kestra/kestra:latest` instead.
 :::
 
 The container is ready when the logs show `Main server is running at http://...:8080`.

--- a/src/contents/docs/02.installation/02.docker/index.md
+++ b/src/contents/docs/02.installation/02.docker/index.md
@@ -23,10 +23,15 @@ docker run --pull=always --rm -it -p 8080:8080 --user=root \
   -v kestra_db:/app/data \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /tmp:/tmp \
-  kestra/kestra:latest server local
+  -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true \
+  kestra/kestra:latest-no-plugins server standalone
 ```
 
 Open http://localhost:8080 in your browser to launch the UI and start building your first flows.
+
+:::alert{type="info"}
+The `kestra/kestra:latest-no-plugins` image ships without any plugins to keep the download small. With `KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true`, Kestra installs any plugin automatically the first time a flow needs it, so you don't need to pre-install anything. If you prefer an image with all plugins bundled, use `kestra/kestra:latest` instead.
+:::
 
 :::alert{type="info"}
 The above command starts Kestra with an embedded H2 database. Storage files are stored on the `kestra_data` Docker volume, and the H2 database is persisted on the `kestra_db` Docker volume. For production-ready persistence with a PostgreSQL database and more configurability, follow the [Docker Compose installation](../03.docker-compose/index.md).
@@ -152,7 +157,7 @@ Two image variants are available:
 
 Both variants are based on the [`eclipse-temurin:21-jre`](https://hub.docker.com/_/eclipse-temurin) Docker image.
 
-The `kestra/kestra:*` images include all Kestra [plugins](/plugins) in their **latest versions**. The `kestra/kestra:*-no-plugins` images do not contain any plugins. Use the `kestra/kestra:*` version to access all available plugins.
+The `kestra/kestra:*` images include all Kestra [plugins](/plugins) in their **latest versions**. The `kestra/kestra:*-no-plugins` images do not bundle any plugins, which keeps them much smaller to download. When running the standalone server with plugin auto-install enabled (`KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true`), Kestra downloads and installs any missing plugin automatically the first time a flow uses it — so the `-no-plugins` image stays fully usable.
 
 ## Docker image tags
 
@@ -164,7 +169,7 @@ The following tags are available for each Docker image (append `-no-plugins` to 
 - `v<X.X.X>`: Immutable tag for an exact version (e.g., `v1.0.1`). Never changes; **best for locked-down production.**
 - `develop`: Nightly/continuous build from the `develop` branch. Unstable and not recommended for production, only for testing.
 
-The **default Kestra image** `kestra/kestra:latest` already includes **all plugins**. To use a lightweight version of Kestra without plugins, add the suffix `*-no-plugins`.
+The **default Kestra image** `kestra/kestra:latest` already includes **all plugins**. To use a lightweight version of Kestra without bundled plugins, add the suffix `-no-plugins`. These images ship without plugins on purpose — they are a fraction of the size of the full image, and combined with plugin auto-install (`KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true` on a standalone server), missing plugins are fetched on demand when a flow needs them.
 
 ### Recommended images for production
 

--- a/src/contents/docs/02.installation/02.docker/index.md
+++ b/src/contents/docs/02.installation/02.docker/index.md
@@ -24,7 +24,7 @@ docker run --pull=always --rm -it -p 8080:8080 --user=root \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /tmp:/tmp \
   -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true \
-  kestra/kestra:latest-slim server standalone
+  kestra/kestra:latest-slim server local
 ```
 
 Open http://localhost:8080 in your browser to launch the UI and start building your first flows.
@@ -157,7 +157,7 @@ Two image variants are available:
 
 Both variants are based on the [`eclipse-temurin:21-jre`](https://hub.docker.com/_/eclipse-temurin) Docker image.
 
-The `kestra/kestra:*` images include all Kestra [plugins](/plugins) in their **latest versions**. The `kestra/kestra:*-slim` images do not bundle any plugins, which keeps them much smaller to download. When running the standalone server with plugin auto-install enabled (`KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true`), Kestra downloads and installs any missing plugin automatically the first time a flow uses it — so the `-slim` image stays fully usable.
+The `kestra/kestra:*` images include all Kestra [plugins](/plugins) in their **latest versions**. The `kestra/kestra:*-slim` images do not bundle any plugins, which keeps them much smaller to download. When plugin auto-install is enabled (`KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true`), Kestra downloads and installs any missing plugin automatically the first time a flow uses it — so the `-slim` image stays fully usable.
 
 :::alert{type="info"}
 The `*-slim` images were previously published under the `*-no-plugins` suffix. The `-no-plugins` tags are deprecated aliases of `-slim` and will be removed in a future release.
@@ -173,7 +173,7 @@ The following tags are available for each Docker image (append `-slim` to any im
 - `v<X.X.X>`: Immutable tag for an exact version (e.g., `v1.0.1`). Never changes; **best for locked-down production.**
 - `develop`: Nightly/continuous build from the `develop` branch. Unstable and not recommended for production, only for testing.
 
-The **default Kestra image** `kestra/kestra:latest` already includes **all plugins**. To use a lightweight version of Kestra without bundled plugins, add the suffix `-slim`. These images ship without plugins on purpose — they are a fraction of the size of the full image, and combined with plugin auto-install (`KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true` on a standalone server), missing plugins are fetched on demand when a flow needs them.
+The **default Kestra image** `kestra/kestra:latest` already includes **all plugins**. To use a lightweight version of Kestra without bundled plugins, add the suffix `-slim`. These images ship without plugins on purpose — they are a fraction of the size of the full image, and combined with plugin auto-install (`KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true`), missing plugins are fetched on demand when a flow needs them.
 
 ### Recommended images for production
 

--- a/src/contents/docs/02.installation/02.docker/index.md
+++ b/src/contents/docs/02.installation/02.docker/index.md
@@ -24,13 +24,13 @@ docker run --pull=always --rm -it -p 8080:8080 --user=root \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /tmp:/tmp \
   -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true \
-  kestra/kestra:latest-no-plugins server standalone
+  kestra/kestra:latest-slim server standalone
 ```
 
 Open http://localhost:8080 in your browser to launch the UI and start building your first flows.
 
 :::alert{type="info"}
-The `kestra/kestra:latest-no-plugins` image ships without any plugins to keep the download small. With `KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true`, Kestra installs any plugin automatically the first time a flow needs it, so you don't need to pre-install anything. If you prefer an image with all plugins bundled, use `kestra/kestra:latest` instead.
+The `kestra/kestra:latest-slim` image ships without any plugins to keep the download small. With `KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true`, Kestra installs any plugin automatically the first time a flow needs it, so you don't need to pre-install anything. If you prefer an image with all plugins bundled, use `kestra/kestra:latest` instead.
 :::
 
 :::alert{type="info"}
@@ -153,15 +153,19 @@ The official Kestra Docker images are available on [DockerHub](https://hub.docke
 
 Two image variants are available:
 - `kestra/kestra:*`
-- `kestra/kestra:*-no-plugins`
+- `kestra/kestra:*-slim`
 
 Both variants are based on the [`eclipse-temurin:21-jre`](https://hub.docker.com/_/eclipse-temurin) Docker image.
 
-The `kestra/kestra:*` images include all Kestra [plugins](/plugins) in their **latest versions**. The `kestra/kestra:*-no-plugins` images do not bundle any plugins, which keeps them much smaller to download. When running the standalone server with plugin auto-install enabled (`KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true`), Kestra downloads and installs any missing plugin automatically the first time a flow uses it — so the `-no-plugins` image stays fully usable.
+The `kestra/kestra:*` images include all Kestra [plugins](/plugins) in their **latest versions**. The `kestra/kestra:*-slim` images do not bundle any plugins, which keeps them much smaller to download. When running the standalone server with plugin auto-install enabled (`KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true`), Kestra downloads and installs any missing plugin automatically the first time a flow uses it — so the `-slim` image stays fully usable.
+
+:::alert{type="info"}
+The `*-slim` images were previously published under the `*-no-plugins` suffix. The `-no-plugins` tags are deprecated aliases of `-slim` and will be removed in a future release.
+:::
 
 ## Docker image tags
 
-The following tags are available for each Docker image (append `-no-plugins` to any image to exclude all but Kestra core plugins):
+The following tags are available for each Docker image (append `-slim` to any image to exclude all but Kestra core plugins):
 
 - `latest`: The most recent stable release (rolling tag). Intended for trying new features; not an LTS. Support ends when the next stable release (~ 2 months) becomes available.
 - `latest-lts`: The current Long-Term Support (rolling tag). Tracks the active LTS line (updates roughly every 6 months to the new LTS) and receives fixes for ~1 year.
@@ -169,7 +173,7 @@ The following tags are available for each Docker image (append `-no-plugins` to 
 - `v<X.X.X>`: Immutable tag for an exact version (e.g., `v1.0.1`). Never changes; **best for locked-down production.**
 - `develop`: Nightly/continuous build from the `develop` branch. Unstable and not recommended for production, only for testing.
 
-The **default Kestra image** `kestra/kestra:latest` already includes **all plugins**. To use a lightweight version of Kestra without bundled plugins, add the suffix `-no-plugins`. These images ship without plugins on purpose — they are a fraction of the size of the full image, and combined with plugin auto-install (`KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true` on a standalone server), missing plugins are fetched on demand when a flow needs them.
+The **default Kestra image** `kestra/kestra:latest` already includes **all plugins**. To use a lightweight version of Kestra without bundled plugins, add the suffix `-slim`. These images ship without plugins on purpose — they are a fraction of the size of the full image, and combined with plugin auto-install (`KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true` on a standalone server), missing plugins are fetched on demand when a flow needs them.
 
 ### Recommended images for production
 
@@ -178,25 +182,25 @@ For production deployments, choose one of the following:
 **Latest stable version** for staying most up to date while also stable (make note that this is a rolling tag that changes quite frequently):
 
 - `kestra/kestra:latest` — latest stable with all plugins
-- `kestra/kestra:latest-no-plugins` — latest stable without plugins
+- `kestra/kestra:latest-slim` — latest stable without plugins
 
 **Pinned versions** for maximum stability:
 
 - `kestra/kestra:v<X.X.X>` — all plugins included
-- `kestra/kestra:v<X.X.X>-no-plugins` — no bundled plugins, only core to Kestra
+- `kestra/kestra:v<X.X.X>-slim` — no bundled plugins, only core to Kestra
 
 **LTS rolling tag** if you want automatic updates within the LTS line:
 
 - `kestra/kestra:latest-lts`
-- `kestra/kestra:latest-lts-no-plugins`
+- `kestra/kestra:latest-lts-slim`
 
 ### Recommended images for development
 
 For development or testing new features:
 
 - `kestra/kestra:latest` — latest stable with all plugins
-- `kestra/kestra:latest-no-plugins` — latest stable without plugins
-- `kestra/kestra:develop` / `kestra/kestra:develop-no-plugins` — daily builds with unreleased features, unstable
+- `kestra/kestra:latest-slim` — latest stable without plugins
+- `kestra/kestra:develop` / `kestra/kestra:develop-slim` — daily builds with unreleased features, unstable
 
 ## Build a custom Docker image
 
@@ -220,12 +224,12 @@ RUN mkdir -p /app/plugins && \
 
 ### Add plugins to a Docker image
 
-By default, the base Docker image `kestra/kestra:latest` contains all plugins (unless you use the `kestra/kestra:latest-no-plugins` version). You can add specific plugins to the base image and build a custom image.
+By default, the base Docker image `kestra/kestra:latest` contains all plugins (unless you use the `kestra/kestra:latest-slim` version). You can add specific plugins to the base image and build a custom image.
 
 The following `Dockerfile` creates an image from the base image and adds the `plugin-aws`, `storage-gcs` and `plugin-gcp` binaries using the command `kestra plugins install`:
 
 ```dockerfile
-ARG IMAGE_TAG=latest-no-plugins
+ARG IMAGE_TAG=latest-slim
 FROM kestra/kestra:$IMAGE_TAG
 
 RUN /app/kestra plugins install \

--- a/src/contents/docs/02.installation/12.standalone-server/index.md
+++ b/src/contents/docs/02.installation/12.standalone-server/index.md
@@ -25,7 +25,7 @@ For example, to launch Kestra:
 For more information on database configuration, check out the [Runtime and Storage configuration guide](../../configuration/02.runtime-and-storage/index.md)
 
 :::alert{type="warning"}
-Running the jar version comes without any [plugins](/plugins). You need to install them manually with the `kestra plugins install directory_with_plugins/` command. Alternatively, point to a directory with the plugins in the configuration file or an environment variable `KESTRA_PLUGINS_PATH` (e.g., `KESTRA_PLUGINS_PATH=/Users/anna/dev/plugins`).
+Running the jar version comes without any [plugins](/plugins) — the JAR is kept small on purpose. When running `server standalone`, Kestra can install missing plugins automatically the first time a flow needs them (plugin auto-install, enabled with the `KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true` environment variable or `kestra.plugins.auto-install.enabled: true` in the configuration). Alternatively, install plugins manually with the `kestra plugins install directory_with_plugins/` command, or point to a directory with the plugins in the configuration file or an environment variable `KESTRA_PLUGINS_PATH` (e.g., `KESTRA_PLUGINS_PATH=/Users/anna/dev/plugins`).
 :::
 
 ## Configuration

--- a/src/contents/docs/10.administrator-guide/upgrades/index.md
+++ b/src/contents/docs/10.administrator-guide/upgrades/index.md
@@ -66,10 +66,11 @@ The webserver hosts the API, so stop and then start it immediately to avoid down
 
 If you want to stick to a specific Kestra version, you can pin the [Docker image tag](https://hub.docker.com/r/kestra/kestra/tags) to a specific release. Here are some examples:
 
-- `kestra/kestra:v0.21.4-no-plugins` includes the 0.21.4 release with the fourth patch version
-- `kestra/kestra:v0.21.4` includes the 0.21.4 release with all plugins
-- `kestra/kestra:v0.19.0-no-plugins` includes the 0.19 release without any plugins
-- `kestra/kestra:v0.19.0` includes the 0.19 release with all plugins.
+- `kestra/kestra:v0.24.0-slim` includes the 0.24 release without any plugins
+- `kestra/kestra:v0.24.0` includes the 0.24 release with all plugins
+- `kestra/kestra:v0.21.4` includes the 0.21.4 release with all plugins.
+
+The `-slim` suffix replaces the former `-no-plugins` suffix; releases older than the rename only exist under `-no-plugins` (e.g. `kestra/kestra:v0.21.4-no-plugins`).
 
 You can also create a custom image with your own plugins and dependencies, as explained in the [Docker installation](../../02.installation/02.docker/index.md).
 

--- a/src/contents/docs/15.how-to-guides/selected-plugin-installation/index.md
+++ b/src/contents/docs/15.how-to-guides/selected-plugin-installation/index.md
@@ -5,14 +5,14 @@ icon: /src/contents/docs/icons/tutorial.svg
 stage: Getting Started
 topics:
   - Kestra Concepts
-description: Learn how to install specific Kestra plugins in the open-source version for a lightweight build and faster startup using the -no-plugins Docker image.
+description: Learn how to install specific Kestra plugins in the open-source version for a lightweight build and faster startup using the -slim Docker image.
 ---
 
 Install a selection of Kestra plugins in the open-source version.
 
 Pick and choose Kestra plugins to create lightweight builds and achieve a faster startup. This guide explains how to:
 
-- Install specific plugins when using the `-no-plugins` Docker image
+- Install specific plugins when using the `-slim` Docker image (formerly `-no-plugins`)
 - Understand plugin versioning across Open Source and [Enterprise](../../07.enterprise/01.overview/01.enterprise-edition/index.md)
 - Automate plugin installation using Docker Compose
 - Link to plugin documentation and versioning support
@@ -23,7 +23,7 @@ To download plugins for a standalone worker or local development environment, us
 
 ## Plugin basics in Kestra Open Source
 
-Kestra plugins are distributed as individual JAR files and loaded at runtime. Plugins are not embedded by default in `-no-plugins` Docker images. You can:
+Kestra plugins are distributed as individual JAR files and loaded at runtime. Plugins are not embedded by default in `-slim` Docker images (formerly published as `-no-plugins`). You can:
 
 - Download specific [plugin JARs](https://repo.maven.apache.org/maven2/io/kestra/plugin/) manually or via `kestra plugins install`.
 - Mount them into `/app/plugins/` in your [Docker Compose](../../02.installation/03.docker-compose/index.md) setup.
@@ -42,14 +42,14 @@ You can run this inside a container (interactively or as part of Dockerfile) to 
 
 ## Automate plugin selection with Docker Compose
 
-If you're using the `kestra/kestra:*-no-plugins` image and want to add only selected plugins:
+If you're using the `kestra/kestra:*-slim` image and want to add only selected plugins:
 
 ### Option 1: Use `kestra plugins install` inside the container
 
 ```yaml
 services:
   kestra:
-    image: kestra/kestra:latest-no-plugins
+    image: kestra/kestra:latest-slim
     entrypoint: /bin/sh -c "
       kestra plugins install io.kestra.plugin:plugin-dbt:LATEST && \
       kestra plugins install io.kestra.plugin:plugin-scripts:LATEST && \
@@ -104,7 +104,7 @@ Learn more about versioned plugins in Enterprise:
 
 | Use Case                   | Recommendation                                       |
 | -------------------------- | ---------------------------------------------------- |
-| Minimal runtime image      | Use `kestra/kestra:*-no-plugins` with mounted JARs   |
+| Minimal runtime image      | Use `kestra/kestra:*-slim` with mounted JARs         |
 | Dynamic plugin setup       | Use `kestra plugins install` in entrypoint           |
 | Controlled plugin versions | Use Enterprise with versioned plugins                |
 | Custom plugin development  | Build and copy plugins into `/app/plugins/` manually |


### PR DESCRIPTION
## Summary
- Docker command switched from `kestra/kestra:latest` + `server local` → `kestra/kestra:latest-slim` + `server standalone` with `-e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true` on:
  - /get-started (`Hero.astro` + `SetupSteps.astro`, incl. copy button)
  - /docs/quickstart
  - /docs/installation/docker (single-container command)
- Explained **why** the `-slim` images ship without plugins (much smaller download) and how auto-install fetches missing plugins on demand:
  - /docs/quickstart — info alert after the command
  - /docs/installation/docker — "Official Docker images" + "Docker image tags" sections
  - /docs/installation/standalone-server — plugins warning now mentions auto-install (`KESTRA_PLUGINS_AUTO_INSTALL_ENABLED` / `kestra.plugins.auto-install.enabled`) alongside manual install

Part-of: https://github.com/kestra-io/kestra-ee/issues/6145

## Test plan
- [ ] Load /get-started, verify hero command + setup steps snippets show updated image/command
- [ ] Verify copy button copies updated command
- [ ] Load /docs/quickstart, verify docker command and the slim/auto-install note
- [ ] Load /docs/installation/docker, verify updated command and image tags section
- [ ] Load /docs/installation/standalone-server, verify updated plugins warning

## Update (2026-08-20)
- Image suffix renamed `-no-plugins` → `-slim` to match https://github.com/kestra-io/kestra/pull/16054 (which keeps `-no-plugins` as a deprecated alias for one release); added a deprecation note in /docs/installation/docker.
