### PR TITLE
docs(system): document ui-anonymous-usage-report flag

### DIFF
--- a/src/contents/docs/10.administrator-guide/usage/index.md
+++ b/src/contents/docs/10.administrator-guide/usage/index.md
@@ -14,6 +14,22 @@ The `kestra.anonymous-usage-report.enabled` option is mandatory: decide whether 
 - `kestra.anonymous-usage-report.initial-delay`: (default 5m)
 - `kestra.anonymous-usage-report.fixed-delay`: (default 1h)
 
+Kestra collects anonymous usage through **two independent streams**, each controlled by its own option:
+
+- `kestra.anonymous-usage-report.enabled`: the **server-side** report (host, plugins, flow, and execution data listed below).
+- `kestra.ui-anonymous-usage-report.enabled`: (default true) the **UI (frontend)** usage report, sent separately from the browser to help us understand user experience in the interface.
+
+To disable **all** anonymous usage reporting, set **both** options to `false`:
+
+```yaml
+kestra:
+  anonymous-usage-report:
+    enabled: false
+  ui-anonymous-usage-report:
+    enabled: false
+```
+
+Setting only `kestra.anonymous-usage-report.enabled` to `false` stops the server-side report but leaves UI reporting enabled (and vice versa).
 
 The collected data can be found [here](https://github.com/kestra-io/kestra/tree/develop/core/src/main/java/io/kestra/core/models/collectors). We collect only **anonymous data** that allows us to understand how you use Kestra. The data collected includes:
 


### PR DESCRIPTION
## What

Documents the `kestra.ui-anonymous-usage-report.enabled` flag on the **Administrator Guide → Usage** page (`administrator-guide/usage`), and clarifies that Kestra has **two independent anonymous-telemetry streams**:

- `kestra.anonymous-usage-report.enabled` → server-side report (`api.kestra.io/v1/reports/server-events`)
- `kestra.ui-anonymous-usage-report.enabled` → UI/frontend telemetry (PostHog)

Adds a YAML snippet showing that disabling **all** anonymous reporting requires setting **both** flags to `false`.

## Why

In kestra-io/kestra#15904 a user set `kestra.anonymous-usage-report.enabled: false` and still observed UI telemetry requests. Root cause is a **documentation gap**: the usage page (the one linked in the issue) only documented the server-side flag and never mentioned the separate UI flag. The code behaves as designed — the UI PostHog gate correctly honors `ui-anonymous-usage-report.enabled`, which the user hadn't set.

No code change is needed in kestra/kestra-ee. Since the docs site is single-sourced from `main` (no per-version doc branches), this single change covers all versions including 1.3.x and develop.

Closes kestra-io/kestra#15904