### PR TITLE
fix(tracking): push bookdemo_form to dataLayer directly (Book a Demo conversion)

### DIFF
--- a/src/components/demo/Meeting.vue
+++ b/src/components/demo/Meeting.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
     import { onMounted, ref, useTemplateRef } from "vue"
     import posthog from "posthog-js"
-    import { useGtm } from "@gtm-support/vue-gtm"
     import identify from "~/utils/identify"
     import { getHubspotTracking } from "~/utils/hubspot.js"
     import { getStoredClickId } from "~/scripts/gclid"
@@ -12,7 +11,6 @@
     } from "~/composables/useMeeting.js"
     import { $fetch } from "~/utils/fetch"
 
-    const gtm = useGtm()
     const valid = ref(false)
     const message = ref("")
     const meetingUrl = ref<string>()
@@ -117,7 +115,12 @@
                     "trackCustomBehavioralEvent",
                     { name: "bookdemo_form" },
                 ])
-                gtm?.trackEvent({
+                // Push directly to the dataLayer: the vue-gtm plugin is
+                // initialized with `enabled: false` (GTM is loaded manually
+                // after cookie consent in cookieconsent.ts), so
+                // gtm.trackEvent() is a no-op and never reaches the dataLayer.
+                window.dataLayer = window.dataLayer || []
+                window.dataLayer.push({
                     event: "bookdemo_form",
                     noninteraction: false,
                 })


### PR DESCRIPTION
## Problem

The **Book a Demo** Google Ads conversion never fires on form submit. Verified in Tag Assistant: after submitting the demo form, the `bookdemo_form` custom event **never appears** in the dataLayer — only auto-events (`gtm.click`, `gtm.formInteract`, `content-view`) show up.

## Root cause

`Meeting.vue` emitted the event via `gtm.trackEvent()` from the **vue-gtm** plugin. But the plugin is initialized with **`enabled: false`** in `src/vue-setup.ts` (GTM is loaded manually after cookie consent in `cookieconsent.ts`). When disabled, `gtm.trackEvent()` is a **no-op** — nothing is pushed to the dataLayer.

That's why events pushed **directly** (`content-view`, `enable_marketing`, `identify` in `cookieconsent.ts`) work, while every `gtm.trackEvent()` call does not.

## Fix

Push `bookdemo_form` directly to `window.dataLayer`, exactly like `content-view` does. Removed the now-unused `useGtm` import.

This unblocks both:
- the **Google Ads** Book a Demo conversion (GTM trigger `ce - bookdemo_form`), and
- the **LinkedIn** `Booked a demo` tag (same trigger event).

## Test

1. Deploy, open GTM Preview / Tag Assistant on the demo page (accept the cookie banner).
2. Submit the demo form → a **`bookdemo_form`** event appears in the dataLayer → **Book a Demo - Google Ads** tag fires.

## Note — same bug elsewhere (follow-up)

The other form events rely on the same disabled-plugin `gtm.trackEvent()` and are therefore also not reaching the dataLayer: `cloud_form`, `contact_form_submission`, `enterprise_trial_form`, `newsletter_form`, `partner_form_submission`, `early_adopter_form` (in their components and in `src/utils/hubspot.ts` / `src/utils/newsletterSubmit.js` / `src/utils/identify.js`). Recommend a follow-up to fix them all (or a shared `pushDataLayerEvent` helper). This PR scopes to the Book a Demo conversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)