### PR TITLE
docs(kubernetes-task-runner): document fileSidecar.image PATH requirements

### DIFF
--- a/src/contents/docs/task-runners/04.types/03.kubernetes-task-runner/index.md
+++ b/src/contents/docs/task-runners/04.types/03.kubernetes-task-runner/index.md
@@ -424,6 +424,8 @@ taskRunner:
         memory: "64Mi"
 ```
 
+A custom `fileSidecar.image` must provide, on its `PATH`, a POSIX shell (`sh`), `test`/`[`, and `sleep` — required by the polling script that waits for the file transfer to complete before the container exits. `find` and `wc` are also used, on a best-effort basis, to verify that uploaded files were fully transferred; if they're missing, verification is skipped rather than failing the task.
+
 `fileSidecar.defaultSpec` applies additional container spec fields to the file transfer containers only, and takes precedence over `containerDefaultSpec` for those containers:
 
 ```yaml


### PR DESCRIPTION
## Summary

- Documents the minimum tooling a custom `fileSidecar.image` must provide (`sh`, `test`, `sleep` on `PATH`), and that `find`/`wc` are used best-effort for post-upload verification.
- Without this, overriding `fileSidecar.image` to a non-default image (e.g. for cluster-policy reasons) can silently stall file transfer for minutes with no error logged.

part-of: https://github.com/kestra-io/plugin-ee-kubernetes/issues/170

Follows up on kestra-io/plugin-ee-kubernetes#171, which added the equivalent note to the plugin's `SideCar.image` schema description.

## Test plan

- [ ] Rendered doc page reads correctly around the `fileSidecar` section