### PR TITLE
Add edge caching for plugin and blueprint pages

### DIFF
--- a/src/middlewares/worker.ts
+++ b/src/middlewares/worker.ts
@@ -88,6 +88,80 @@ const noIndex = defineCFMiddleware(async (url, next) => {
 
 const middlewares: CFMiddleware[] = [setupContentSecurityPolicyHeaders, noIndex]
 
+// TTL (seconds) for edge-cached SSR HTML. Kept in sync with the 1h upstream
+// API cache in src/utils/fetch.ts so a page's HTML and its data expire
+// together. Once s-maxage lapses the next request is a cache miss and re-renders.
+// `stale-while-revalidate` is advisory for browsers and any downstream shared
+// cache (the Workers Cache API does not revalidate in the background itself).
+const EDGE_CACHE_TTL = 60 * 60
+const EDGE_CACHE_SWR = 60 * 60 * 24
+
+// The plugin & blueprint templates declare `prerender = false`, so every hit
+// re-runs a full Astro render inside the Worker (high TTFB — see issue #5158).
+// Their HTML is public and request-independent (any content that varies —
+// `?version=` on plugins, `?q=` on pattern pages — is part of the URL and
+// therefore part of the cache key), so it is safe to serve from Cloudflare's
+// edge cache. Other `prerender = false` routes (/api/*, /t/*, careers apply,
+// cloud-early-access, hubspot-submit, …) are intentionally excluded.
+function isEdgeCacheablePage(url: URL): boolean {
+    const path = url.pathname
+    return (
+        path === "/plugins" ||
+        path.startsWith("/plugins/") ||
+        path === "/blueprints" ||
+        path.startsWith("/blueprints/")
+    )
+}
+
+// Analytics/campaign query params never change the rendered HTML. Stripping
+// them (and sorting the rest) from the cache key keeps campaign traffic from
+// fragmenting the cache into per-visitor misses.
+const TRACKING_PARAMS = new Set([
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "utm_term",
+    "utm_content",
+    "utm_id",
+    "gclid",
+    "gbraid",
+    "wbraid",
+    "fbclid",
+    "msclkid",
+    "mc_cid",
+    "mc_eid",
+    "ref",
+    "ref_src",
+    "yclid",
+    "twclid",
+    "igshid",
+    "_hsenc",
+    "_hsmi",
+])
+
+// `caches.default` is a Cloudflare Workers runtime extension that is absent
+// from the ambient DOM `CacheStorage` type, so we narrow it explicitly (the
+// runtime values here are DOM `Request`/`Response`).
+interface EdgeCache {
+    match(request: Request): Promise<Response | undefined>
+    put(request: Request, response: Response): Promise<void>
+}
+
+function edgeCache(): EdgeCache {
+    return (caches as unknown as { default: EdgeCache }).default
+}
+
+function edgeCacheKey(url: URL): Request {
+    const keyUrl = new URL(url.toString())
+    for (const param of [...keyUrl.searchParams.keys()]) {
+        if (TRACKING_PARAMS.has(param.toLowerCase())) {
+            keyUrl.searchParams.delete(param)
+        }
+    }
+    keyUrl.searchParams.sort()
+    return new Request(keyUrl.toString(), { method: "GET" })
+}
+
 export default {
     async fetch(
         request: Parameters<typeof handle>[0],
@@ -125,6 +199,24 @@ export default {
             return handle(request, env, ctx)
         }
 
+        // Edge-cache the rendered HTML of the SSR plugin & blueprint pages.
+        // Because `run_worker_first: true` routes every request through this
+        // Worker, Cloudflare's CDN never caches the generated HTML on its own;
+        // we do it explicitly via the Cache API so each page is rendered at
+        // most once per TTL (and the CSP is rebuilt at most once per TTL too).
+        const canEdgeCache =
+            request.method === "GET" &&
+            url.host === "kestra.io" &&
+            isEdgeCacheablePage(url)
+        const cacheKey = canEdgeCache ? edgeCacheKey(url) : undefined
+
+        if (cacheKey) {
+            const hit = await edgeCache().match(cacheKey)
+            if (hit) {
+                return hit
+            }
+        }
+
         let response: Response | undefined = undefined
         function next() {
             if (response) {
@@ -136,6 +228,24 @@ export default {
         for (const middleware of middlewares) {
             response = await middleware(new URL(request.url), next, request)
         }
-        return await next()
+
+        const finalResponse = await next()
+
+        if (cacheKey && finalResponse.status === 200) {
+            const cachedResponse = new Response(
+                finalResponse.body,
+                finalResponse,
+            )
+            cachedResponse.headers.set(
+                "Cache-Control",
+                `public, s-maxage=${EDGE_CACHE_TTL}, stale-while-revalidate=${EDGE_CACHE_SWR}`,
+            )
+            ctx.waitUntil(
+                edgeCache().put(cacheKey, cachedResponse.clone()),
+            )
+            return cachedResponse
+        }
+
+        return finalResponse
     },
 }

--- a/src/middlewares/worker.ts
+++ b/src/middlewares/worker.ts
@@ -232,18 +232,35 @@ export default {
         const finalResponse = await next()
 
         if (cacheKey && finalResponse.status === 200) {
-            const cachedResponse = new Response(
-                finalResponse.body,
-                finalResponse,
-            )
-            cachedResponse.headers.set(
+            const response = new Response(finalResponse.body, finalResponse)
+            response.headers.set(
                 "Cache-Control",
                 `public, s-maxage=${EDGE_CACHE_TTL}, stale-while-revalidate=${EDGE_CACHE_SWR}`,
             )
+
+            // Cloudflare's Cache API rejects `put()` on any response carrying a
+            // `Set-Cookie` header. Because the write runs inside
+            // `ctx.waitUntil`, that rejection would be swallowed — silently
+            // disabling the cache and re-rendering on every request. These
+            // routes are public and request-independent (no server-set cookies
+            // today), but strip `Set-Cookie` from the stored copy so a future
+            // cookie can never quietly break caching, and guard the write so a
+            // failed `put()` degrades to "not cached" instead of an unhandled
+            // rejection. The response returned to this (cache-miss) visitor is
+            // left untouched.
+            const toStore = response.clone()
+            toStore.headers.delete("Set-Cookie")
             ctx.waitUntil(
-                edgeCache().put(cacheKey, cachedResponse.clone()),
+                edgeCache()
+                    .put(cacheKey, toStore)
+                    .catch((error) => {
+                        console.error(
+                            `Edge cache put failed for ${cacheKey.url}: ${error}`,
+                        )
+                    }),
             )
-            return cachedResponse
+
+            return response
         }
 
         return finalResponse


### PR DESCRIPTION
## Summary
Implements edge caching for plugin and blueprint template pages in the Cloudflare Workers middleware. These pages are rendered on every request due to `prerender = false`, causing high time-to-first-byte (TTFB). Since their HTML is public and request-independent, they can now be safely cached at the edge.

## Key Changes
- **Edge cache configuration**: Added `EDGE_CACHE_TTL` (1 hour) and `EDGE_CACHE_SWR` (24 hours) constants synchronized with upstream API cache TTL
- **Page eligibility detection**: Implemented `isEdgeCacheablePage()` to identify cacheable routes (`/plugins`, `/plugins/*`, `/blueprints`, `/blueprints/*`)
- **Cache key normalization**: Added `edgeCacheKey()` function that strips analytics/campaign tracking parameters (utm_*, gclid, fbclid, etc.) and sorts remaining params to prevent cache fragmentation from campaign traffic
- **Cache API integration**: Added `edgeCache()` helper to access Cloudflare's `caches.default` with proper TypeScript typing
- **Request/response handling**: 
  - Check cache before rendering and return cached response if available
  - After rendering, store successful (200 status) responses in edge cache with appropriate `Cache-Control` headers
  - Use `ctx.waitUntil()` to ensure cache write completes without blocking response

## Implementation Details
- Cache key is based on normalized URL (tracking params removed, remaining params sorted) to ensure consistent cache hits across different campaign sources
- Only GET requests to kestra.io are cached to avoid caching redirects or other non-idempotent responses
- Cache headers include `stale-while-revalidate` for graceful degradation if cache expires
- Response body is cloned before caching to avoid consuming the stream

https://claude.ai/code/session_01A1JMAsuvdD5HXBFaURVteN