### PR TITLE
seo(resources): add 8 W30 pages (lambda-timeout, ecs-vs-fargate, schedulers, backoff, file-transfer, job-orchestration)

### DIFF
--- a/src/contents/resources/aws-lambda-timeout/index.md
+++ b/src/contents/resources/aws-lambda-timeout/index.md
@@ -1,0 +1,108 @@
+---
+title: "AWS Lambda Timeout: Limits & How to Work Around Them"
+description: "Understand AWS Lambda timeout settings, limits, and best practices. Learn how to configure, troubleshoot, and proactively manage Lambda function timeouts with Kestra to build more resilient serverless applications."
+metaTitle: "AWS Lambda Timeout: Limits & How to Work Around Them"
+metaDescription: "Optimize AWS Lambda timeout settings and limits. Configure, troubleshoot, and orchestrate Lambda functions with Kestra for resilient serverless apps."
+tag: "infrastructure"
+date: 2026-07-07
+slug: "aws-lambda-timeout"
+faq:
+  - question: "What is the timeout for AWS Lambda?"
+    answer: "AWS Lambda timeout defines the maximum duration a function can run before AWS terminates it. The default is 3 seconds, configurable up to 900 seconds (15 minutes). This setting is crucial for controlling resource consumption and preventing runaway processes, ensuring your serverless applications remain cost-effective and responsive."
+  - question: "Why is Lambda limited to 15 minutes?"
+    answer: "The 15-minute timeout limit for AWS Lambda functions is a design choice to encourage serverless architectures suitable for short, event-driven tasks. It simplifies resource management for AWS and guides developers toward using other services like AWS Batch or EKS for longer-running, compute-intensive workloads. This helps maintain the serverless paradigm's efficiency and cost model."
+  - question: "What is the timeout for Lambda integration?"
+    answer: "For AWS API Gateway integrations, the default timeout limit is 29 seconds. This means if your Lambda function takes longer than 29 seconds to respond to an API Gateway invocation, the API Gateway will time out the request, even if the Lambda function itself has a longer timeout configured. This limit can be increased via a quota request for specific API types."
+  - question: "How to overcome Lambda timeout?"
+    answer: "Overcoming Lambda timeouts involves several strategies: optimizing code for efficiency, setting realistic timeouts, using asynchronous invocation for long-running tasks, and offloading heavy processing to other services. For API calls, setting short event source timeouts (3-6 seconds) and robust monitoring with CloudWatch and X-Ray are essential to fine-tune and prevent issues."
+  - question: "How to tell if Lambda timed out?"
+    answer: "To determine if a Lambda function timed out, check its logs in AWS CloudWatch. Navigate to the Lambda console, select your function, go to the Monitor tab, and choose 'View CloudWatch logs.' Look for entries indicating a 'Task timed out' message, which will confirm the execution exceeded its configured timeout duration."
+  - question: "Can Kestra manage AWS Lambda timeouts?"
+    answer: "Yes, Kestra can manage AWS Lambda timeouts by orchestrating Lambda invocations and applying custom timeout logic at the workflow level. Kestra workflows can proactively invoke Lambda functions, set specific timeouts for the invocation, and define comprehensive error handling and retry strategies for timeout failures, providing a higher level of control and observability."
+---
+
+> **TL;DR** — AWS Lambda timeout is the maximum time a function can run before being terminated, defaulting to 3 seconds and capping at 15 minutes. Proper configuration and proactive orchestration, especially for integrations, are crucial to prevent errors, manage costs, and ensure reliable serverless application performance.
+
+AWS Lambda functions are a cornerstone of modern serverless architectures, offering unparalleled scalability and cost-efficiency for event-driven tasks. However, effectively managing their execution duration, particularly the 'timeout' setting, is critical for operational stability and cost control. An improperly configured timeout can lead to failed processes, wasted compute cycles, or even cascading system failures.
+
+This guide delves into AWS Lambda timeouts, explaining their defaults, limits, and the best practices for configuration. More importantly, we'll explore how Kestra, an open-source orchestration platform, can elevate your Lambda timeout management, moving beyond simple settings to proactive error handling, retries, and comprehensive monitoring across your serverless landscape.
+
+## How AWS Lambda Timeout Works
+
+The AWS Lambda timeout is a fundamental configuration that dictates the maximum amount of time a function can run per invocation. When you invoke a Lambda function, AWS starts a timer. If the function completes its execution before the timer reaches the configured timeout value, the execution is successful. If the timer expires before the function finishes, AWS forcibly terminates the execution environment, and the invocation results in a timeout error.
+
+This mechanism is crucial for several reasons:
+- **Cost Control:** Lambda pricing is based on execution duration. A timeout prevents a malfunctioning or long-running function from incurring unexpected costs.
+- **Resource Management:** It ensures that compute resources are not tied up indefinitely by stuck or inefficient processes.
+- **System Stability:** It prevents runaway functions from consuming excessive resources and impacting other parts of your application.
+
+The default timeout for a new Lambda function is **3 seconds**. You can configure this value from 1 second up to a maximum of **900 seconds (15 minutes)**.
+
+A critical aspect to understand is the interaction with other AWS services. For instance, when a Lambda function is invoked via an API Gateway, the API Gateway itself has a hard integration timeout of **29 seconds**. This means if your Lambda function takes 30 seconds to respond, the API Gateway will return a timeout error to the client, even if your Lambda function's own timeout is set to 5 minutes. Understanding these integration points is key to building reliable systems. For a deeper dive into AWS integrations, you can explore how to [orchestrate AWS with Kestra](/orchestration/aws).
+
+## Why Managing Lambda Timeouts Needs Orchestration
+
+Simply setting a timeout value in the AWS console is a reactive measure. Production-grade serverless applications require a more proactive and intelligent approach to managing execution duration and handling failures. This is where an external orchestration platform becomes essential.
+
+Orchestration provides a control plane that sits above individual Lambda functions, enabling you to:
+
+*   **Implement Advanced Error Handling:** Native Lambda retries are basic. An orchestrator can implement sophisticated retry strategies with exponential backoff, trigger compensation logic to roll back changes, or route failures to a dead-letter queue for manual inspection.
+*   **Decouple Long-Running Processes:** When a task is expected to take longer than 15 minutes, you can't solve it by increasing the timeout. An orchestrator can break the process into smaller, manageable Lambda invocations, passing state between them and managing the end-to-end logic.
+*   **Gain Centralized Observability:** Instead of digging through CloudWatch logs for each function, an orchestrator provides a single view of the entire workflow. You can see which step failed, why it failed (including timeouts), and how it impacts downstream tasks.
+*   **Coordinate Across Services:** Lambda functions often need to interact with databases, message queues, and external APIs. An orchestrator manages these interactions, handling credentials, state, and the logic required to chain these services together reliably. It allows you to manage timeouts not just for the Lambda function, but for the entire business process.
+
+By externalizing this control logic, your Lambda functions remain simple, focused, and stateless, adhering to serverless best practices. This approach enhances resilience and maintainability, allowing you to build more complex and robust applications without overloading your functions with boilerplate error-handling code. You can find more details on how Kestra handles this in the documentation for [Task Timeouts](/docs/workflow-components/timeout).
+
+## Orchestrate AWS Lambda Timeout Management with Kestra: a Proactive Approach
+
+Kestra provides an orchestration-level control layer that enhances AWS Lambda's native timeout capabilities. Instead of relying solely on the function's configuration, you can define timeouts, retries, and error handling declaratively within your Kestra workflow.
+
+Consider a scenario where you need to invoke a Lambda function that processes user data. The process should ideally complete within 30 seconds, and if it fails or times out, the operations team must be notified immediately on Slack.
+
+Here’s how you can implement this with Kestra:
+
+```yaml
+id: lambda_timeout_orchestration
+namespace: dev.aws
+
+description: Orchestrates a Lambda invocation with a Kestra-level timeout and error handling.
+
+tasks:
+  - id: my_lambda_function
+    type: io.kestra.plugin.aws.lambda.Invoke
+    timeout: PT30S # Kestra-level timeout applied to the Lambda invocation
+    functionName: "MyProcessingFunction"
+    payload: '{"key": "value"}'
+    # The Lambda's own timeout should also be set appropriately in AWS
+
+errors:
+  - id: handle_timeout_error
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    payload: |
+      {"text": "🚨 Kestra detected a Lambda timeout for `{{ flow.namespace }}.{{ flow.id }}` (execution {{ execution.id }})."}
+```
+
+There are several key advantages to this approach:
+
+*   **Orchestration-Level Timeout:** The `timeout: PT30S` property on the Kestra task acts as a client-side timeout. Kestra will terminate the task if the Lambda invocation doesn't complete within 30 seconds, providing a crucial guardrail that is independent of the Lambda's own setting.
+*   **Declarative Error Handling:** The `errors` block is a powerful Kestra feature. It defines a separate workflow that triggers automatically if any task in the main flow fails, including a timeout. This cleanly separates your business logic from your failure recovery logic.
+*   **Simplified Function Code:** Your Lambda function (`MyProcessingFunction`) doesn't need any special code for timeout handling or Slack notifications. It can focus solely on its core processing task. All the surrounding operational logic is handled by the orchestrator.
+*   **Centralized Visibility:** The timeout event, the Lambda logs, and the subsequent Slack notification are all captured and visible within a single Kestra execution view, simplifying troubleshooting and providing a complete audit trail. You can see this pattern in action in blueprints like the one for [invoking multiple AWS Lambda functions in parallel](/blueprints/aws-lambda).
+
+## Where Smart Lambda Timeout Management Pays Off
+
+Adopting a proactive, orchestration-driven approach to Lambda timeout management delivers tangible benefits across various use cases:
+
+*   **Responsive APIs:** By enforcing strict timeouts at the orchestration layer, you can ensure your backend services respond quickly, preventing API Gateway timeouts and improving user experience.
+*   **Resilient Data Processing:** For tasks like ETL or data validation, orchestration allows you to manage long-running jobs by breaking them into smaller, idempotent steps, each with its own timeout, making the entire pipeline more robust.
+*   **Reliable Microservice Choreography:** In a microservices architecture, a single slow service can cause cascading failures. An orchestrator can isolate the failing service by enforcing a timeout and trigger fallback or alerting mechanisms.
+*   **Cost Optimization:** Proactive timeouts prevent runaway functions from running longer than necessary, directly reducing your AWS bill and optimizing resource utilization across your [infrastructure automation](/infra-automation) stack.
+*   **Self-Healing Systems:** By combining timeouts with automated error handling and retry logic, you can build systems that can detect and recover from transient failures without manual intervention.
+
+## Related concepts
+- [Orchestrate AWS with Kestra: S3 triggers, Lambda, EMR, Glue, cross-account chains](/orchestration/aws)
+- [Task Timeouts in Kestra – Limit Run Duration](/docs/workflow-components/timeout)
+- [Microservice orchestration: invoke multiple AWS Lambda functions in parallel](/blueprints/aws-lambda)
+- [Infrastructure Automation Resources: Terraform, Ansible & IaC Playbooks](/resources/infrastructure)
+- [Kestra 0.12 simplifies building modular, event-driven and containerized workflows](/blogs/2023-09-28-release-0-12-subflow-logs-docker-builds-aws-lambda)

--- a/src/contents/resources/batch-scheduling-platform-alternatives/index.md
+++ b/src/contents/resources/batch-scheduling-platform-alternatives/index.md
@@ -1,0 +1,139 @@
+---
+title: "Batch Scheduling Platforms: Top Solutions Compared (2026)"
+description: "Explore top alternatives to traditional batch scheduling platforms. Compare modern solutions for unified, event-driven orchestration across data, AI, and infrastructure workflows."
+metaTitle: "Batch Scheduling Platforms: Top Solutions Compared (2026)"
+metaDescription: "Compare batch scheduling platforms for modern IT. Kestra, ActiveBatch, Redwood, and others offer declarative, event-driven, and unified workflow automation."
+tag: "infrastructure"
+date: 2026-07-07
+slug: "batch-scheduling-platform-alternatives"
+faq:
+  - question: "Why should I consider an alternative to my current batch scheduling platform?"
+    answer: "Traditional batch scheduling platforms often struggle with the demands of modern hybrid IT environments, lacking native cloud integration, event-driven capabilities, and support for diverse programming languages. Alternatives offer greater flexibility, scalability, and better governance for complex, cross-domain workflows, reducing operational overhead and vendor lock-in."
+  - question: "Is Kestra a suitable alternative for enterprise batch scheduling?"
+    answer: "Yes, Kestra is an open-source, declarative orchestration platform that can replace or augment enterprise batch schedulers. It offers advanced scheduling, event-driven triggers, polyglot task execution, and robust governance features like RBAC and audit logs, making it ideal for unifying data, AI, and infrastructure workflows at scale."
+  - question: "What are the key differences between legacy batch schedulers and modern orchestration platforms?"
+    answer: "Legacy batch schedulers are typically cron-based, process-centric, and often limited to specific operating systems or applications. Modern orchestration platforms, like Kestra, are event-driven, language-agnostic, cloud-native, and designed to manage complex dependencies across diverse systems, including data pipelines, AI models, and infrastructure automation."
+  - question: "Can open-source batch scheduling tools meet enterprise requirements?"
+    answer: "Many open-source tools, including Kestra and Apache Airflow, offer robust features for batch scheduling. While core open-source versions might lack advanced enterprise governance features like SSO, RBAC, and multi-tenancy, platforms like Kestra provide Enterprise Editions that cater to these requirements, offering a flexible path from community to enterprise-grade solutions."
+  - question: "How does a modern batch scheduling platform handle hybrid cloud environments?"
+    answer: "Modern platforms are designed for hybrid cloud by supporting deployments across on-premises, private cloud, and public cloud infrastructure. They offer agentless execution or lightweight task runners that can operate in diverse environments, allowing for centralized orchestration of workloads regardless of where they run, ensuring consistent control and visibility."
+  - question: "What should I prioritize when choosing a batch scheduling alternative?"
+    answer: "Prioritize platforms that offer declarative workflow definitions (like YAML), event-driven capabilities, broad integration with your existing stack (data, cloud, DevOps tools), strong observability, and a clear path to enterprise governance (RBAC, SSO, audit logs). Consider deployment flexibility (self-hosted, managed cloud) and community support."
+---
+
+Traditional batch scheduling platforms, while foundational, often struggle to keep pace with the demands of modern, hybrid IT environments. Teams find themselves wrestling with complex dependencies, limited cloud-native integration, and the rigidity of legacy systems that weren't built for today's event-driven, polyglot workloads. The shift to agile development, AI integration, and multi-cloud strategies highlights a growing gap between what legacy schedulers offer and what platform engineers and data teams truly need.
+
+This article explores the top alternatives to conventional batch scheduling platforms. We'll examine solutions that offer greater flexibility, scalability, and unified orchestration, helping you navigate the evolving landscape of workload automation to find the right platform for your data, AI, and infrastructure operations in 2026.
+
+## Why traditional batch scheduling platforms fall short
+
+Legacy batch schedulers were designed for a different era of IT—one characterized by monolithic applications, on-premises data centers, and predictable, time-based job execution. While effective in that context, their architecture often creates friction in today's dynamic, distributed environments.
+
+Key limitations include:
+*   **Rigid, Time-Based Scheduling:** Most traditional systems are built around cron-like scheduling. This model is inefficient for workflows that should run in response to events, such as a file arriving in an S3 bucket or a new record in a database. This forces teams to either over-poll or accept delays, leading to inefficient resource use and slower response times. The process of [modernizing scheduled workflows](/resources/infrastructure/migrate-from-cron) involves moving beyond these limitations.
+*   **Poor Hybrid and Multi-Cloud Integration:** Legacy schedulers often require complex agent-based setups to manage workloads across different environments. They lack the native API integrations and cloud-native design needed to seamlessly orchestrate tasks across on-premises systems, private clouds, and multiple public cloud providers.
+*   **High Operational Burden:** Managing, scaling, and maintaining legacy scheduling platforms can be a significant operational drain. Their complex architectures, proprietary interfaces, and lack of modern observability features make troubleshooting difficult and time-consuming. This contrasts with the goals of modern [infrastructure orchestration vs. job scheduling](/resources/infrastructure/infrastructure-orchestration-vs-job-scheduling), which prioritizes automation and reduced overhead.
+*   **Developer-Unfriendly Workflows:** Workflow definitions in older systems are often locked behind graphical user interfaces or proprietary scripting languages. This disconnects them from modern software development practices like version control, code review, and CI/CD. Even tools that adopt code-based definitions may lock teams into a single language, alienating a diverse engineering organization.
+
+## What to look for in a modern batch scheduling alternative
+
+As organizations move beyond simple batch processing, the requirements for a scheduling platform have evolved. A modern alternative should function as a true orchestration control plane, providing visibility and control over all automated processes.
+
+Essential capabilities include:
+*   **Declarative Workflow Definition:** Workflows should be defined as code, typically in a human-readable format like YAML. This aligns with [GitOps principles](/resources/infrastructure/gitops), enabling version control, automated testing, and auditable changes.
+*   **Event-Driven and Real-Time Capabilities:** The platform must be able to trigger workflows from a wide range of events—not just time. This includes webhooks, message queues, database changes, and file system events, enabling responsive and efficient automation. True [event-driven orchestration](/resources/infrastructure/event-driven-orchestration) is a core tenet of modern systems.
+*   **Polyglot Execution:** A modern orchestrator must support the tools and languages your teams already use. It should be able to run Python scripts, shell commands, SQL queries, Docker containers, and Java applications as first-class citizens, without forcing everything into a single-language wrapper.
+*   **Scalability and High Availability:** The platform should be architected to scale horizontally, handling thousands of concurrent workflow executions without a single point of failure. It needs to support distributed execution to manage workloads across different geographical regions and cloud environments.
+*   **Enterprise Governance:** As orchestration becomes central to operations, robust governance is critical. This includes features like Role-Based Access Control ([RBAC](/resources/infrastructure/rbac)), integration with SSO providers, and detailed audit logs to ensure security and compliance.
+*   **Observability:** Deep visibility into workflow executions is non-negotiable. The platform should provide detailed logs, metrics, execution traces, and intuitive dashboards to simplify debugging and performance monitoring.
+
+## How we evaluated these alternatives
+
+We evaluated each alternative on its ability to meet the demands of a modern IT landscape, moving beyond the narrow definition of a [job scheduler](/resources/infrastructure/job-scheduler). Our criteria included the deployment model (self-hosted, SaaS, hybrid), license (open-source vs. proprietary), primary use case, integration ecosystem, scalability, and enterprise governance features. The focus is on platforms that deliver true workflow orchestration rather than just task scheduling.
+
+## Top batch scheduling platform alternatives for 2026
+
+### 1. Kestra: The open-source orchestration control plane
+
+[Kestra](/) is an open-source, declarative orchestration platform designed to unify data, AI, and infrastructure workflows. It treats workflows as code, using a simple YAML interface that makes complex processes easy to define, version, and share.
+
+Kestra is event-driven by design, with native support for schedules, webhooks, file detections, and message queue triggers. Its language-agnostic architecture allows teams to run tasks in any language, including Python, Bash, SQL, and any code packaged in a Docker container. This flexibility makes it a central control plane for coordinating tools across the entire stack.
+
+The platform is built on a robust, scalable architecture that can be deployed anywhere—from a single laptop to a large-scale Kubernetes cluster. With over 1,700 plugins, Kestra provides deep integration with databases, cloud services, and DevOps tools. For enterprise needs, the [Enterprise Edition](/docs/enterprise/overview/enterprise-edition) adds features like RBAC, SSO, multi-tenancy, and audit logs. This has enabled organizations like JPMorgan Chase and Crédit Agricole to orchestrate critical cybersecurity and infrastructure operations at scale.
+
+*   **Best for:** Teams seeking a flexible, vendor-agnostic, and future-proof orchestration platform to unify all workflow types across [data](/data), [infrastructure](/infra-automation), and [AI](/ai-automation).
+
+### 2. ActiveBatch: Enterprise workload automation
+
+ActiveBatch is a mature and comprehensive workload automation platform known for its extensive library of pre-built integrations and its focus on cross-platform job scheduling. It provides a drag-and-drop UI for designing workflows, which can appeal to operations teams less comfortable with code.
+
+Its strength lies in its ability to manage complex dependencies and schedules across a wide range of legacy and modern systems, from mainframes to cloud services. However, its GUI-centric approach can be a limitation for teams that have adopted Infrastructure as Code practices. The platform is proprietary, and its architecture is more aligned with traditional Workload Automation (WLA) than with cloud-native orchestration patterns.
+
+*   **Best for:** Large enterprises with diverse, complex batch workloads needing robust scheduling and monitoring capabilities across legacy and modern systems.
+
+### 3. Redwood RunMyJobs: SaaS-native workload automation
+
+Redwood RunMyJobs is a fully managed SaaS platform for workload automation. Its primary value proposition is offloading the operational burden of managing scheduling infrastructure. Redwood offers deep integrations with enterprise applications, particularly SAP, making it a strong choice for organizations heavily invested in that ecosystem.
+
+As a SaaS-only solution, it provides less flexibility for teams that require self-hosted or air-gapped deployments. While it excels at automating enterprise processes, its model can lead to vendor lock-in and may not be the best fit for engineering teams seeking a more customizable, code-centric orchestration tool. You can find more details in this comparison of [Redwood alternatives](/resources/infrastructure/redwood-alternatives).
+
+*   **Best for:** Organizations that prefer a fully managed service for enterprise workload automation, especially those with significant SAP investments, wanting to minimize operational overhead.
+
+### 4. Stonebranch Universal Automation Center (UAC): Hybrid IT orchestration
+
+Stonebranch UAC positions itself as a real-time IT automation platform designed for hybrid environments. It offers a centralized point of control for orchestrating workloads across on-premises mainframes, private clouds, and public cloud services.
+
+Stonebranch excels at event-driven automation and provides robust capabilities for managing dependencies in real-time. Its focus is squarely on large enterprises with complex, distributed IT landscapes. Like other enterprise WLA tools, it is a proprietary solution with a pricing model that can be a significant investment, making it less accessible for smaller teams or projects.
+
+*   **Best for:** Large enterprises needing to automate complex, real-time workloads across diverse hybrid IT landscapes with a single control point.
+
+### 5. Apache Airflow: Data-centric workflow management
+
+Apache Airflow is the dominant open-source platform for data pipeline orchestration. Its key feature is defining workflows (DAGs) as Python code, which provides flexibility and appeals to data engineers. It has a massive community and an extensive ecosystem of pre-built operators for interacting with various data systems.
+
+However, its Python-centric nature is also a limitation, making it less suitable for teams with diverse language needs. Airflow's operational complexity is notoriously high, requiring significant effort to set up and maintain its various components (scheduler, webserver, metadata database, executor). While powerful for [batch vs. streaming processing](/resources/data/batch-vs-streaming-processing) in the data world, it is not a general-purpose orchestrator.
+
+*   **Best for:** Python-heavy data engineering teams with existing Airflow investment, focused primarily on data pipelines.
+
+### 6. JAMS Scheduler: Windows-centric job scheduling
+
+JAMS is a workload automation and job scheduling tool with strong roots in the Windows ecosystem. It provides a user-friendly graphical interface for defining, managing, and monitoring batch jobs and their dependencies.
+
+Its strengths include robust support for Windows-based applications, PowerShell scripting, and integrations with Microsoft products. While it supports cross-platform scheduling, its core architecture is less aligned with modern, cloud-native principles like containerization and declarative configuration.
+
+*   **Best for:** Organizations with a heavy reliance on Windows servers and Microsoft applications, seeking a user-friendly, centralized scheduler.
+
+### 7. IBM Workload Automation: Legacy enterprise scheduler
+
+IBM Workload Automation (formerly Tivoli) is a long-standing enterprise scheduler designed to manage massive volumes of batch and real-time workloads. It offers powerful capabilities for managing complex dependencies, ensuring SLAs, and providing centralized control across mainframe, distributed, and cloud platforms.
+
+As a legacy enterprise tool, it comes with significant complexity and cost. Its architecture and user experience are often seen as less developer-friendly compared to modern alternatives. It remains a viable option for large enterprises with deep investments in IBM's ecosystem and mission-critical batch operations tied to legacy systems.
+
+*   **Best for:** Large enterprises with deeply embedded legacy systems and critical batch operations across diverse, often mainframe-connected, environments.
+
+## Comparison table: Modern batch scheduling alternatives at a glance
+
+| Tool | License | Deployment | Best for | Key Differentiator | Core Strength | Main Limitation |
+|---|---|---|---|---|---|---|
+| **Kestra** | Apache 2.0 (OSS) + Enterprise | Self-hosted, Kestra Cloud | Unified orchestration across all domains | Declarative YAML & event-driven core | Polyglot, flexible, and scalable | Newer to the market than legacy WLA tools |
+| **ActiveBatch** | Proprietary | Self-hosted, Cloud | Enterprise-wide workload automation | Extensive pre-built integration library | Cross-platform support | GUI-centric, less aligned with IaC |
+| **Redwood** | Proprietary | SaaS | Managed WLA, SAP-heavy environments | Fully managed SaaS model | Low operational overhead | SaaS-only, potential vendor lock-in |
+| **Stonebranch** | Proprietary | Self-hosted, Cloud | Hybrid IT and real-time automation | Real-time, event-based orchestration | Hybrid cloud control | High enterprise cost, complex |
+| **Apache Airflow** | Apache 2.0 (OSS) | Self-hosted, Managed | Python-centric data pipelines | Workflows as Python code (DAGs) | Large community & ecosystem | High operational complexity, data-focused |
+| **JAMS Scheduler**| Proprietary | Self-hosted | Windows-heavy environments | Strong Microsoft ecosystem integration | User-friendly GUI | Less cloud-native, Windows-centric |
+| **IBM WLA** | Proprietary | Self-hosted, Cloud | Mainframe & complex enterprise batch | Deep legacy system integration | SLA and dependency management | High cost and complexity, legacy UX |
+
+## Choosing the right batch scheduling platform for your needs
+
+Selecting the right platform depends on your team's primary use cases, technical skills, and strategic goals.
+
+*   **For data engineering teams:** Prioritize platforms with strong integration for the modern data stack, support for SQL and Python, and features for managing complex data dependencies. Kestra and Airflow are strong contenders here, with Kestra offering a more flexible, language-agnostic approach. Explore more on [declarative orchestration for data engineers](/data).
+*   **For infrastructure & DevOps teams:** Look for declarative, API-driven platforms that integrate with IaC tools like Terraform and Ansible. Support for hybrid cloud, containerization, and robust governance features like RBAC are key. Kestra's YAML-based workflows and versatile runners make it a natural fit for [infrastructure automation](/infra-automation).
+*   **For AI/ML platform teams:** Your focus should be on orchestrating complex pipelines that mix data preparation, model training, and deployment. The ability to run containerized workloads and integrate with ML frameworks is crucial. Kestra's flexibility allows it to serve as the control plane for end-to-end [AI automation](/ai-automation).
+*   **For organizations modernizing from legacy systems:** The priority is finding a platform that reduces operational complexity and cost while providing a clear migration path. A declarative, event-driven model like Kestra's can simplify workflows previously managed by complex legacy schedulers, offering a more agile and maintainable solution.
+
+## The future of batch scheduling: Towards unified orchestration
+
+The concept of a standalone batch scheduler is becoming outdated. Modern enterprises require a unified control plane that can orchestrate all automated processes, whether they are time-based batches, real-time event responses, or complex, multi-stage workflows. The future lies in platforms that break down the silos between data, infrastructure, and application teams.
+
+Platforms like [Kestra](/overview) represent this shift, providing a common, declarative language for all automation. By offering advanced [scheduling and automation](/features/scheduling-and-automation) within a flexible, scalable, and observable platform, they empower organizations to move faster, reduce operational friction, and gain holistic control over their entire IT landscape.

--- a/src/contents/resources/ecs-vs-fargate/index.md
+++ b/src/contents/resources/ecs-vs-fargate/index.md
@@ -1,0 +1,166 @@
+---
+title: "ECS vs Fargate: Which to Use for Your Workloads"
+description: "Understand the core differences between AWS ECS and Fargate to select the best container orchestration solution for your cloud workloads. Explore their features, cost models, and ideal use cases for data and infrastructure automation."
+metaTitle: "ECS vs Fargate: Which to Use for Your Workloads"
+metaDescription: "Compare AWS ECS and Fargate to choose the optimal container orchestration for your applications. Learn about their features, costs, and use cases."
+tag: infrastructure
+date: 2026-07-07
+slug: ecs-vs-fargate
+faq:
+  - question: Can you use ECS without Fargate?
+    answer: Yes, Fargate is an optional compute engine for ECS. You can run ECS tasks on EC2 instances that you manage yourself, providing more control over the underlying infrastructure. Fargate offers a serverless compute option, abstracting away server management.
+  - question: Is ECS essentially Docker?
+    answer: While ECS works directly with Docker containers, it is not simply Docker. ECS is a fully managed container orchestration service that schedules, launches, and manages your Docker containers across a cluster of EC2 instances or using Fargate serverless compute.
+  - question: Is ECS Fargate cheaper than EC2?
+    answer: For workloads with unpredictable traffic or low baseline utilization, Fargate often delivers better cost efficiency as you pay only for the resources your containers consume. However, for consistently high-load workloads, EC2-backed ECS can be more cost-effective.
+  - question: Why choose Fargate over EC2?
+    answer: Fargate excels when simplicity and ease of use are critical. It removes the operational overhead of managing EC2 servers, patching, and scaling. Use Fargate for applications that benefit from a serverless model, allowing you to focus purely on containerized applications.
+  - question: When should you choose ECS on EC2 over Fargate?
+    answer: ECS on EC2 is preferred when you need full control over the underlying operating system, network settings, and storage. It's ideal for highly utilized workloads, complex microservices, and applications requiring custom instance types or advanced configurations.
+  - question: Is Fargate cheaper than ECS?
+    answer: Fargate is a compute option *for* ECS, not a separate service. The question is whether Fargate is cheaper than running ECS tasks on EC2 instances. For compute-intensive workloads with consistent high usage, ECS on EC2 is generally more cost-effective due to combined resource pricing.
+---
+
+Navigating AWS container services can be complex, especially when choosing between ECS and Fargate. Many teams face the challenge of balancing infrastructure control with operational simplicity and cost efficiency. Understanding the fundamental differences and how these services interoperate is crucial for building scalable and resilient cloud-native applications.
+
+This article will break down Amazon ECS and AWS Fargate, explain their unique strengths, and guide you through the decision-making process. We’ll compare their operational models, cost structures, and ideal use cases, helping you determine which solution best fits your organization's data and [infrastructure automation](/infra-automation) needs.
+
+## Understanding Container Orchestration on AWS
+
+To compare ECS and Fargate, it's essential to first understand their roles. They aren't direct competitors; instead, they work together. One is an orchestrator, and the other is a compute engine.
+
+### What is Amazon Elastic Container Service (ECS)?
+
+Amazon Elastic Container Service (ECS) is a fully managed container orchestration service from AWS. Its primary job is to make it easy to run, stop, and manage Docker containers on a cluster. ECS handles the lifecycle of your containers, including scheduling their placement, managing their state, and integrating with other AWS services like IAM, VPC, and CloudWatch.
+
+ECS itself doesn't run the containers. It needs a compute layer to launch them on. This is where the choice between different "launch types" comes in: EC2 and Fargate.
+
+### What is AWS Fargate, and how does it relate to ECS?
+
+AWS Fargate is a serverless compute engine for containers. When you use the Fargate launch type with ECS, you don't have to provision, configure, or manage any of the underlying virtual machines. Fargate abstracts away the entire server infrastructure. You simply package your application into a container, specify the CPU and memory it needs, define networking and IAM policies, and Fargate launches and scales the containers for you.
+
+Think of it this way: ECS is the "brain" that orchestrates the containers, while Fargate is one of the "brawn" options that actually runs them, without requiring you to manage the servers.
+
+## ECS vs. Fargate: Core Differences in Management and Control
+
+The primary difference between using ECS with Fargate and ECS with EC2 lies in the level of control and responsibility you have over the compute infrastructure.
+
+### Managing compute: EC2 instances vs. serverless Fargate
+
+With the **EC2 launch type**, you are responsible for the cluster of EC2 instances that host your containers. You choose the instance type, manage scaling with Auto Scaling Groups, configure the operating system (using Amazon ECS-optimized AMIs), and handle security patching and updates for the instances. This model gives you granular control over your environment. You can use specific instance types (like those with GPUs), apply custom security configurations, and optimize costs using Reserved Instances or Spot Instances.
+
+With the **Fargate launch type**, AWS manages the entire underlying infrastructure. You don't see or interact with any EC2 instances. This serverless approach eliminates the need for you to manage servers, patch operating systems, or worry about cluster capacity. You focus on your application's resource requirements at the container level (vCPU and memory), and Fargate handles the rest. This simplicity is a major advantage for teams looking to reduce operational overhead.
+
+### Operational overhead and infrastructure responsibilities
+
+The trade-off for the control offered by the EC2 launch type is increased operational responsibility. Your team must monitor instance health, manage OS updates, and configure cluster scaling. While AWS provides tools to help, the burden is still on you.
+
+Fargate significantly reduces this burden. Because AWS manages the compute plane, your operational tasks are limited to container-level monitoring and management. This allows development teams to deploy and scale applications faster, without deep infrastructure expertise. This is a key benefit when using tools like [Task Runners to run your code across any environment](/blogs/2024-05-15-task-runners).
+
+### When to use ECS without Fargate
+
+You can absolutely use ECS without Fargate. This is the traditional way ECS has been used since its inception. By choosing the EC2 launch type, you deploy a cluster of EC2 instances into your VPC, and ECS schedules your container tasks onto those instances.
+
+This approach is necessary when you need:
+*   **Specific EC2 instance types:** For workloads that require GPUs, specific CPU/memory ratios not available in Fargate, or other specialized hardware.
+*   **More control over networking:** If you need to use host networking mode or have complex networking requirements at the instance level.
+*   **Custom AMIs:** When you need to run specific daemons, agents for security or monitoring, or require a customized operating system environment.
+*   **Cost optimization for steady-state workloads:** For applications with predictable, high utilization, running them on a cluster of optimized EC2 instances (especially with Savings Plans or Reserved Instances) can be cheaper than Fargate's on-demand pricing.
+
+## Cost Comparison: Optimizing Spend with ECS and Fargate
+
+Cost is a critical factor in choosing a launch type. The pricing models for Fargate and EC2 are fundamentally different, leading to different cost outcomes depending on your workload patterns.
+
+### Pricing models: Per-second vs. instance-based
+
+**Fargate** pricing is based on the vCPU and memory resources your containerized application requests, billed per second with a one-minute minimum. You pay only for the resources your tasks consume while they are running. This model is ideal for isolating costs per application and avoiding payment for idle resources.
+
+**EC2** pricing is based on the instances you launch, billed per second or per hour depending on the instance type and OS. You pay for the entire instance for as long as it's running, regardless of whether your containers are using all of its capacity. This means you can have idle capacity that you're still paying for. However, you can run multiple containers on a single instance, potentially leading to higher resource utilization and lower costs if managed effectively.
+
+### Is Fargate cheaper than EC2 for your workloads?
+
+There is no universal answer; it depends entirely on your application's usage pattern.
+*   **For spiky or unpredictable workloads:** Fargate is often more cost-effective. If you have a service that experiences bursts of traffic followed by long idle periods, Fargate allows you to scale to meet demand and then scale to zero, paying only for the time resources were actually used.
+*   **For consistent, high-utilization workloads:** The EC2 launch type is typically cheaper. If you have an application that runs 24/7 with high resource consumption, you can pack multiple tasks onto optimized EC2 instances and leverage AWS Savings Plans or Reserved Instances to achieve significant discounts, often making it more economical than Fargate's on-demand rates.
+
+### When Fargate's serverless model saves money
+
+Beyond direct compute costs, Fargate's serverless model can lead to indirect savings by reducing operational overhead. The time your engineers would have spent managing, patching, and scaling a cluster of EC2 instances can be redirected to developing new features. This reduction in "people cost" is a significant, though harder to quantify, benefit of Fargate. The choice between a fully managed service and a self-managed one often comes down to this balance, similar to deciding between an [Open-Source vs. Enterprise Edition of Kestra](/docs/oss-vs-paid).
+
+## Choosing the Right AWS Container Solution: Use Cases and Considerations
+
+The decision between Fargate and EC2 launch types for ECS should be driven by your specific application needs, team structure, and operational priorities.
+
+### Ideal scenarios for AWS Fargate
+
+Fargate is the best choice when your priority is simplicity, speed, and reducing operational load.
+*   **Microservices and APIs:** Services that can be easily containerized and have variable traffic patterns are a perfect fit.
+*   **Batch processing jobs:** For short-lived tasks that need to be run periodically, Fargate can provision resources on-demand and shut them down when done, ensuring you only pay for what you use.
+*   **Development and testing environments:** Quickly spin up isolated environments without worrying about underlying infrastructure.
+*   **Teams without dedicated operations staff:** Fargate empowers development teams to own their applications from code to deployment without needing deep infrastructure expertise.
+
+### When ECS on EC2 provides critical control
+
+The EC2 launch type remains essential for workloads that require deep control and customization.
+*   **High-performance computing (HPC):** Applications that need GPU acceleration or other specialized hardware must run on specific EC2 instance types.
+*   **Legacy applications:** Applications that require tight coupling with the host OS or rely on specific host-level configurations.
+*   **Compliance-heavy environments:** When you need to run specific security agents or meet strict compliance requirements that demand control over the host environment.
+*   **Cost-sensitive, steady-state applications:** When you have a predictable, high-traffic application, you can fine-tune your EC2 cluster for maximum cost efficiency.
+
+The distinction is similar to the choice between [Task Runners vs Worker Groups](/docs/task-runners/task-runners-vs-worker-groups) in an orchestration platform, where one offers on-demand execution and the other provides dedicated, controlled capacity.
+
+## Orchestrating AWS ECS and Fargate Workflows with Kestra
+
+Regardless of your chosen launch type, a powerful orchestration platform can automate the deployment and management of your containerized workloads. Kestra provides a declarative, YAML-based approach to orchestrating complex workflows that can include tasks running on AWS.
+
+### Declarative workflows for AWS container management
+
+With Kestra, you can define your entire infrastructure and application deployment process as a series of steps in a simple YAML file. This includes provisioning infrastructure with tools like Terraform, building container images, pushing them to a registry, and deploying them to ECS.
+
+### Automating task deployment to Fargate and ECS
+
+Kestra can integrate directly with AWS services to automate container management. Using the [AWS plugin](/plugins/plugin-ee-aws), you can trigger ECS task definitions, monitor their execution, and orchestrate downstream actions based on their success or failure. This is particularly powerful for complex data pipelines or [Python workflows](/docs/use-cases/python-workflows) that involve multiple containerized steps.
+
+### Real-world examples: AWS Batch Task Runner
+
+For more advanced use cases, Kestra's Enterprise Edition offers [AWS Task Runners](/plugins/plugin-ee-aws/aws-task-runners) that can offload task execution to AWS Batch. AWS Batch can be configured to use Fargate or EC2 compute environments, allowing you to run individual Kestra tasks on your chosen AWS compute layer.
+
+Here's an example of a Kestra flow that uses the [Terraform plugin](/plugins/plugin-terraform) to provision an S3 bucket and then runs a Python script as an AWS Batch job on Fargate using the [AWS Batch Task Runner](/docs/task-runners/types/aws-batch-task-runner):
+
+```yaml
+id: aws-batch-orchestration
+namespace: company.team.production
+
+tasks:
+  - id: provision_s3
+    type: io.kestra.plugin.terraform.cli.TerraformCLI
+    commands:
+      - terraform init
+      - terraform apply -auto-approve
+
+  - id: run_processing_job
+    type: io.kestra.plugin.scripts.python.Script
+    taskRunner:
+      type: io.kestra.plugin.ee.aws.runner.Batch
+      jobDefinition: arn:aws:batch:us-east-1:123456789012:job-definition/my-fargate-job
+      jobQueue: arn:aws:batch:us-east-1:123456789012:job-queue/my-fargate-queue
+    script: |
+      import boto3
+      print("Running Python script on AWS Batch with Fargate!")
+      # Your processing logic here
+```
+This flow demonstrates how you can combine infrastructure-as-code with serverless task execution, all managed from a single declarative workflow. You can explore a more detailed example in this [AWS Batch with Terraform blueprint](/blueprints/aws-batch-terraform-git).
+
+## Integrating with the Broader AWS Ecosystem
+
+Your choice of container runtime doesn't exist in isolation. It's part of a larger architecture that includes databases, storage, messaging, and more.
+
+### ECS, Fargate, and EKS: A comprehensive view
+
+It's worth noting that Amazon also offers the Elastic Kubernetes Service (EKS) for teams that want to run Kubernetes on AWS. Fargate can also be used as a serverless compute option for EKS, providing a similar benefit of abstracting away node management. The choice between ECS and EKS is a separate, larger discussion, but both can leverage Fargate to simplify operations.
+
+### How container choices impact your overall architecture
+
+Both ECS on EC2 and Fargate integrate seamlessly with the AWS ecosystem. They can access services like S3, RDS, and SQS through IAM roles, and their logs can be streamed to CloudWatch. Your choice will primarily impact your operational model and cost structure, but not your ability to connect to other services. An orchestration platform like Kestra can serve as the connective tissue, managing dependencies and data flow between your containerized tasks and other services, such as a flow to [process an S3 file only when it has changed](/blueprints/process-s3-file-if-changed).
+
+Ultimately, both ECS with EC2 and ECS with Fargate are powerful options for running containers on AWS. By understanding their core differences in control, cost, and operational overhead, you can make an informed decision that aligns with your technical requirements and business goals. Explore more [infrastructure automation resources](/resources/infrastructure) to see how orchestration can streamline your cloud operations.

--- a/src/contents/resources/exponential-backoff/index.md
+++ b/src/contents/resources/exponential-backoff/index.md
@@ -1,0 +1,145 @@
+---
+title: "What Is Exponential Backoff? Retry Patterns Explained"
+description: "Explore exponential backoff, a crucial retry strategy for building resilient systems. Learn how it prevents service overload and ensures stability in distributed architectures, with practical examples."
+metaTitle: "What Is Exponential Backoff? Retry Patterns Explained"
+metaDescription: "Exponential backoff is a vital retry mechanism for resilient distributed systems. Learn its benefits over linear backoff and how to implement it effectively."
+tag: infrastructure
+date: 2026-07-07
+slug: exponential-backoff
+faq:
+  - question: "What is an exponential backoff?"
+    answer: "Exponential backoff is a standard error handling strategy for distributed systems and network applications. It involves periodically retrying a failed request with progressively increasing delays between attempts. This adaptive delay mechanism helps prevent overwhelming a struggling service with repeated requests and allows transient issues to resolve, thereby improving overall system resilience and stability."
+  - question: "How does exponential backoff apply to API calls?"
+    answer: "In API calls, exponential backoff is a technique where an application retries a failed operation by increasing the wait time exponentially with each successive failure. This strategy is crucial for interacting with external services that might be temporarily unavailable or rate-limiting requests. It allows the client to recover from transient failures without flooding the API with continuous requests, ensuring a more stable and reliable integration."
+  - question: "Why choose exponential backoff over linear backoff?"
+    answer: "Exponential backoff is generally more efficient for preventing network congestion and resource contention than linear backoff. While linear backoff uses a fixed or incrementally constant delay, exponential backoff's increasing delay scales more effectively, giving services more time to recover. This makes it superior for unpredictable or high-load environments where aggressive retries could worsen the problem."
+  - question: "What is the Fibonacci backoff strategy?"
+    answer: "Fibonacci backoff is a retry strategy that uses the Fibonacci sequence to determine increasing wait times between retries. Instead of exponentially multiplying the delay, each subsequent delay is the sum of the two preceding ones (e.g., 1, 1, 2, 3, 5 seconds). This provides a gentler increase in delay compared to pure exponential backoff, often with added jitter, and can be suitable for specific scenarios where a less aggressive backoff is preferred."
+  - question: "How does jitter improve exponential backoff?"
+    answer: "Jitter, or a small random delay, is often added to exponential backoff intervals. This prevents a 'thundering herd' problem where many clients retry simultaneously after the same delay, potentially causing another service overload. By randomizing the exact retry time slightly, jitter spreads out the load, making the system more robust and reducing the chance of cascading failures."
+  - question: "Can exponential backoff be used in data pipelines?"
+    answer: "Absolutely. Exponential backoff is highly valuable in data pipelines, especially when interacting with external data sources, APIs, or databases that might experience transient failures or rate limits. Implementing backoff for tasks like data ingestion, API calls for enrichment, or database writes ensures that the pipeline can gracefully recover from temporary issues without requiring manual intervention, making the overall data process more robust."
+---
+
+> **TL;DR** — Exponential backoff is a retry strategy where a system progressively increases the wait time between retries of a failed operation. This adaptive delay helps prevent overwhelming a struggling service, reduces network congestion, and improves the overall resilience of distributed systems by allowing transient issues to resolve.
+
+Distributed systems are complex. Services can be temporarily unavailable, APIs might rate-limit, and network glitches are inevitable. When a task fails due to a transient issue, simply retrying immediately can often worsen the problem, overwhelming the struggling service or creating a "thundering herd" effect.
+
+This is where exponential backoff comes in. It's a fundamental strategy for building resilient systems, allowing your applications and workflows to gracefully recover from temporary failures without causing further strain. This article will explain how exponential backoff works, why it's superior to simpler retry methods, and how Kestra can help you implement it for robust, self-healing operations.
+
+## How Exponential Backoff Enhances System Resilience
+
+At its core, exponential backoff is an algorithm that uses feedback—specifically, the failure of a request—to multiplicatively decrease the rate at which it retries. This gives a struggling system breathing room to recover.
+
+### Understanding the Core Mechanism
+
+The mechanism is straightforward:
+1.  A client makes a request to a service.
+2.  The request fails due to a transient error (e.g., HTTP 503 Service Unavailable, HTTP 429 Too Many Requests).
+3.  The client waits for a short initial interval (e.g., 1 second) and retries.
+4.  If the retry fails, the client doubles the wait interval (e.g., 2 seconds) and retries again.
+5.  This process continues, with the wait time increasing exponentially after each failure, until the request succeeds or a maximum number of retries is reached.
+
+For example, a typical sequence of delays might be 1s, 2s, 4s, 8s, and so on. This adaptive delay is the key to its effectiveness.
+
+### Why Exponential Beats Linear Backoff for Stability
+
+A simpler approach is linear backoff, where the delay increases by a constant amount (e.g., 5s, 10s, 15s). While better than no delay at all, linear backoff is less effective in preventing congestion.
+
+| Strategy | Delay Pattern (Example) | Behavior | Best For |
+| --- | --- | --- | --- |
+| **No Backoff** | 0s, 0s, 0s, ... | Immediately retries, often causing a "retry storm" that can crash a service. | Not recommended for production systems. |
+| **Linear Backoff** | 5s, 10s, 15s, ... | Predictable, but can still lead to synchronized retries and overload a recovering service. | Simple cases where load is low and predictable. |
+| **Exponential Backoff** | 1s, 2s, 4s, 8s, ... | Rapidly increases delay, giving the service significant time to recover and preventing congestion. | Most distributed systems, especially high-traffic APIs. |
+
+Exponential backoff provides a much wider window for recovery, making it the standard for building robust applications that interact with external services.
+
+### The Role of Jitter and Maximums
+
+Two important refinements are often added to the basic exponential backoff algorithm:
+*   **Jitter:** A small, random amount of time is added to each delay. This prevents the "thundering herd" problem, where multiple clients that failed at the same time all retry simultaneously, causing another spike in traffic. Jitter spreads out the retries, smoothing the load on the service.
+*   **Maximum Delay:** A cap is placed on the wait interval. This ensures that the delay doesn't grow to an unreasonably long duration (e.g., hours or days) for persistent failures.
+
+## Why Transient Failures Need Orchestration
+
+Implementing a simple retry loop in code is one thing, but managing it in a production environment across dozens of services introduces new complexities. This is where orchestration becomes critical. An orchestrator handles the state and logic that surrounds the retry mechanism itself.
+
+*   **Coordinating Complex Retries:** A single business process might involve calls to multiple services. If one service fails, an orchestrator can manage the backoff for that specific task while ensuring downstream tasks are not executed prematurely.
+*   **State Management:** An orchestration platform tracks the number of attempts, the current delay, and the overall status of the workflow. This removes the need to build and maintain complex state-handling logic within each application.
+*   **Alerting and Dead Letters:** What happens when all retries fail? An orchestrator can trigger alerts to an on-call team or move the failed message to a [Dead Letter Queue (DLQ)](/resources/infrastructure/dead-letter-queue) for later analysis, preventing data loss. For more on this, see how to [handle errors in Kestra with retries and alerts](/docs/tutorial/errors).
+*   **Centralized Control:** Instead of scattering retry logic across various microservices, an orchestrator centralizes the definition and control of this resilience pattern, making it easier to manage, monitor, and update.
+
+## Orchestrate Retries with Kestra: Handling Flaky APIs
+
+With an orchestration platform like Kestra, you can implement robust retry policies declaratively, without writing custom code. The retry logic is defined directly in your YAML workflow alongside the task itself.
+
+Consider a workflow that needs to fetch data from an external API that is occasionally unreliable. Instead of building a custom retry loop, you can configure Kestra's built-in retry mechanism.
+
+```yaml
+id: api-call-with-exponential-backoff
+namespace: company.team.production
+
+tasks:
+  - id: call-flaky-api
+    type: io.kestra.plugin.core.http.Request
+    uri: https://api.mocki.io/v2/c899c72c/503-endpoint # This endpoint returns a 503 error
+    method: GET
+    retry:
+      type: EXPONENTIAL
+      interval: PT1S
+      maxInterval: PT1M
+      maxAttempts: 5
+
+  - id: process-successful-response
+    type: io.kestra.plugin.scripts.shell.Commands
+    commands:
+      - echo "API call successful after {{ taskrun.attemptsCount }} attempts"
+
+errors:
+  - id: notify-on-final-failure
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    payload: |
+      {
+        "text": "Flow `{{ flow.namespace }}.{{ flow.id }}` failed for execution `{{ execution.id }}`. The task `{{ task.id }}` failed after {{ taskrun.attemptsCount }} attempts."
+      }
+```
+
+This workflow demonstrates several key benefits of orchestrated retries:
+*   **Declarative:** The entire retry policy is defined with a few lines of YAML (`type: EXPONENTIAL`, `interval`, `maxInterval`, `maxAttempts`). No custom code is needed.
+*   **Stateful:** Kestra automatically tracks the number of attempts and calculates the next delay.
+*   **Integrated Error Handling:** The `errors` block provides a clean, built-in way to trigger notifications or other remediation tasks only after all retries have been exhausted.
+*   **Contextual:** The notification payload can include rich context about the flow, execution, and task, making debugging faster. You can explore more patterns in our [blueprints for retries](/blueprints/retries).
+
+Many plugins, like the [Cloudflare D1 Import task](/plugins/plugin-cloudflare/cloudflare-d1/io.kestra.plugin.cloudflare.d1.Import), have built-in exponential backoff for their internal polling mechanisms, providing resilience by default. For a deeper dive into configuring different strategies, refer to the [documentation on retry strategies](/docs/workflow-components/retries).
+
+### Beyond Exponential: Fibonacci Backoff
+
+A less common but interesting alternative is the Fibonacci backoff. Instead of doubling the delay, it increases according to the Fibonacci sequence (e.g., 1s, 1s, 2s, 3s, 5s...). This provides a gentler, less aggressive increase in delay, which can be useful in specific scenarios where you want to avoid very long waits while still preventing rapid-fire retries.
+
+## Practical Applications of Exponential Backoff
+
+Exponential backoff is a fundamental pattern applicable across various domains of software and data engineering.
+
+### Integrating with Cloud Services and APIs
+
+This is the most common use case. Major cloud providers like AWS, Google Cloud, and Azure explicitly recommend and often require clients to use exponential backoff when interacting with their APIs. It's essential for:
+*   Calling rate-limited API endpoints.
+*   Handling transient network errors when communicating with cloud storage (S3, GCS, Blob Storage).
+*   Managing requests to serverless functions or other managed services that might have temporary "cold start" delays or capacity limits.
+
+### Beyond APIs: Data Pipelines and Microservices
+
+The pattern is equally valuable in other contexts:
+*   **Data Pipelines:** A task that reads from or writes to a database might fail if the database is temporarily overloaded or undergoing a brief failover. Exponential backoff allows the pipeline to self-heal without failing entirely.
+*   **Microservice Communication:** In a microservices architecture, one service calling another can use this pattern to gracefully handle temporary unavailability of the downstream service, preventing cascading failures.
+*   **Event-Driven Systems:** A consumer processing messages from a queue might fail to process a message due to a dependency being down. Retrying with backoff allows the dependency to recover before the message is moved to a dead-letter queue.
+
+By adopting exponential backoff as a standard practice, you build more resilient, stable, and autonomous systems that can withstand the transient failures inherent in distributed environments.
+
+## Related concepts
+
+- [Webhook Security Best Practices for Robust Integrations](/resources/infrastructure/webhook-security-best-practices)
+- [Infrastructure Automation Resources: Terraform, Ansible & IaC Playbooks](/resources/infrastructure)
+
+To see how Kestra can help you orchestrate your entire stack with built-in resilience, explore our [solutions for infrastructure automation](/infra-automation).

--- a/src/contents/resources/file-transfer-automation/index.md
+++ b/src/contents/resources/file-transfer-automation/index.md
@@ -1,0 +1,147 @@
+---
+title: "File Transfer Automation: Orchestrate SFTP/FTP Workflows"
+description: "Explore the essentials of automated file transfer (AFT) and how it enhances security, efficiency, and compliance. Learn how Kestra unifies file transfers within broader, event-driven workflows, ensuring reliable and auditable data exchange across your enterprise."
+metaTitle: "File Transfer Automation: Orchestrate SFTP/FTP Workflows"
+metaDescription: "Automate file transfers for secure, efficient, and auditable data exchange. Discover how Kestra orchestrates AFT within your data and infrastructure workflows."
+tag: "infrastructure"
+date: 2026-07-07
+slug: "file-transfer-automation"
+faq:
+  - question: "What is file transfer automation?"
+    answer: "File transfer automation (FTA) is the process of using software to automatically move digital files between computer systems or servers without manual intervention. This includes scheduling transfers, handling various protocols like SFTP or FTP, and integrating these transfers into larger workflows, enhancing efficiency, security, and reliability."
+  - question: "Why is security important in file transfer automation?"
+    answer: "Security is paramount in file transfer automation to protect sensitive data from unauthorized access, breaches, and corruption. Automated solutions often include features like encryption (in-transit and at-rest), access controls, audit logs, and compliance reporting, which are crucial for meeting regulatory requirements and maintaining data integrity."
+  - question: "How does Kestra handle different file transfer protocols?"
+    answer: "Kestra offers a comprehensive plugin for file system operations, supporting various protocols such as SFTP, FTP, and FTPS. These plugins enable declarative configuration of file transfers, allowing users to define tasks for listing, uploading, downloading, moving, and deleting files across different hosts, all within a unified workflow."
+  - question: "Can file transfer automation integrate with other systems?"
+    answer: "Yes, a key benefit of robust file transfer automation is its ability to integrate seamlessly with other enterprise systems. Kestra, for example, can orchestrate file transfers as part of a larger workflow that might include database operations, API calls, cloud storage interactions, or custom script executions, creating end-to-end automated processes."
+  - question: "What are the benefits of using Kestra for file transfer automation?"
+    answer: "Kestra provides a declarative, YAML-based approach to file transfer automation, offering benefits like version control, auditable execution logs, and robust error handling. It allows for the integration of file transfers into complex, event-driven workflows across data, AI, and infrastructure domains, ensuring reliability, scalability, and enhanced governance."
+  - question: "How does file transfer automation improve compliance?"
+    answer: "File transfer automation improves compliance by providing detailed audit trails of every transfer, including who accessed what, when, and from where. It enforces security policies, such as encryption and access controls, consistently across all transfers, helping organizations meet regulatory requirements like GDPR, HIPAA, and SOC 2."
+---
+
+> **TL;DR** — Automated File Transfer (AFT) uses software to streamline and secure the movement of digital files between systems, replacing manual processes with efficient, auditable, and error-resistant workflows.
+
+Manual file transfers are a silent drain on productivity, often leading to errors, security vulnerabilities, and compliance headaches. Whether moving sensitive customer data, syncing application logs, or exchanging critical business documents, relying on manual processes or fragmented scripts introduces unnecessary risk and operational overhead.
+
+Automated file transfer (AFT) addresses these challenges head-on. By streamlining the movement of data between systems, AFT ensures that information flows efficiently, securely, and reliably. This article will explore how AFT works, its key benefits, and how Kestra provides a unified platform to orchestrate these critical operations, transforming file transfers from a liability into a strategic asset.
+
+## How Automated File Transfer Works
+
+Automated File Transfer (AFT) is more than just a collection of scripts. It's a systematic approach to managing the entire lifecycle of file movement, governed by a central platform. The process begins with a trigger, which can be a fixed schedule, a specific event like a new file arriving, or an API call from another application. Once triggered, the AFT software executes a predefined workflow.
+
+The core mechanisms of AFT involve several key components:
+*   **Protocols:** AFT solutions support a wide range of protocols to interact with different systems. This includes secure methods like [SFTP (SSH File Transfer Protocol)](/resources/infrastructure/sftp-automation), FTPS (FTP over SSL/TLS), and HTTPS, as well as cloud storage APIs for services like Amazon S3, Google Cloud Storage, and Azure Blob Storage. Support for legacy protocols like FTP is also common for interacting with older systems.
+*   **Workflows:** Instead of a simple point-to-point transfer, AFT uses workflows to define a sequence of steps. This could involve fetching a file, decompressing it, validating its contents, transforming the data, and then loading it into a target system.
+*   **Centralized Management:** AFT software provides a single console to define, monitor, and manage all file transfer activities. This centralization eliminates the "cron sprawl" and fragmented scripts that are difficult to maintain and audit.
+*   **Logging and Auditing:** Every action, from login attempts to file transfers and workflow executions, is logged. This creates a comprehensive audit trail, which is essential for security analysis and regulatory compliance. The landscape of [schedulers and orchestrators](/blogs/2023-10-17-schedulers-landscape) has evolved to make this a standard expectation.
+
+Kestra's [file system plugin](/plugins/plugin-fs) abstracts these protocols, allowing you to define interactions with various file systems through a consistent, declarative interface.
+
+## Why File Transfer Automation Needs Orchestration
+
+Simply automating the transfer of a file from point A to point B is only half the battle. In a production environment, file transfers are rarely isolated events. They are part of larger business processes that require coordination, error handling, and visibility. This is where orchestration becomes critical.
+
+Orchestration platforms like Kestra elevate AFT from a simple task to a governed, reliable component of your [infrastructure automation](/resources/infrastructure/automation) strategy. Here’s why that matters:
+
+*   **Guaranteed delivery and error recovery:** What happens if a network connection drops mid-transfer or a target server is unavailable? An orchestration engine can automatically retry the operation, route the file to a dead-letter queue for later processing, or trigger an alternative workflow and notify the on-call team.
+*   **End-to-end visibility:** Orchestration provides a single pane of glass to monitor the entire process. You can see not only that a file was transferred, but also what happened before and after—the data transformation job that ran, the database that was updated, and the API that was called.
+*   **Integration with broader workflows:** A file arrival might need to trigger a dbt model run, a Spark job, or a microservice. An orchestrator connects these disparate systems, ensuring that the file transfer is seamlessly integrated into the end-to-end business logic.
+*   **Compliance and auditability:** Orchestration centralizes all logs and execution history in one place. This makes it straightforward to answer auditors' questions about who transferred what data, when it happened, and whether the process succeeded.
+*   **Scalability and resource management:** As the volume of transfers grows, an orchestration platform can manage concurrency, prioritize critical jobs, and distribute the workload across a pool of workers, ensuring that performance doesn't degrade.
+
+## Orchestrate Secure File Transfers with Kestra: An SFTP Example
+
+Kestra uses a declarative YAML interface to define workflows, which makes them easy to version, review, and manage as code. This approach is particularly powerful for file transfer automation, as it allows you to codify complex interactions in a simple, readable format.
+
+Consider a common scenario: a daily batch process that needs to download a sales report from a partner's SFTP server, perform a quick data validation and transformation, and then upload the processed file to an internal SFTP server for ingestion. The entire process must be auditable, and if any step fails, the operations team should be notified on Slack.
+
+Here’s how you would define this workflow in Kestra:
+
+```yaml
+id: sftp-file-processing-and-upload
+namespace: company.team.finance
+
+description: Downloads a daily sales report, processes it, and uploads it to an internal SFTP server.
+
+tasks:
+  - id: download-sales-report
+    type: io.kestra.plugin.fs.sftp.Download
+    host: partner-sftp.com
+    port: "22"
+    username: "{{ secret('PARTNER_SFTP_USER') }}"
+    password: "{{ secret('PARTNER_SFTP_PASS') }}"
+    from: /outgoing/sales_report_{{ now() | date("yyyy-MM-dd") }}.csv
+    to: sales_report.csv
+
+  - id: process-report
+    type: io.kestra.plugin.scripts.shell.Commands
+    runner: DOCKER
+    docker:
+      image: bash:latest
+    commands:
+      - echo "Processing file..."
+      # Example processing: remove header and save to a new file
+      - tail -n +2 {{ outputs['download-sales-report'].uri }} > processed_report.csv
+    outputFiles:
+      - processed_report.csv
+
+  - id: upload-processed-report
+    type: io.kestra.plugin.fs.sftp.Upload
+    host: internal-sftp.ourcompany.com
+    port: "22"
+    username: "{{ secret('INTERNAL_SFTP_USER') }}"
+    password: "{{ secret('INTERNAL_SFTP_PASS') }}"
+    from: "{{ outputs['process-report'].outputFiles['processed_report.csv'] }}"
+    to: /incoming/processed_sales_{{ now() | date("yyyy-MM-dd") }}.csv
+
+errors:
+  - id: send-failure-notification
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    payload: |
+      {
+        "text": "File transfer workflow `{{ flow.namespace }}.{{ flow.id }}` failed at task `{{ taskrun.taskId }}` with error: {{ error.message }}"
+      }
+
+triggers:
+  - id: daily-schedule
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 2 * * *"
+```
+
+A few things are worth noticing in this flow:
+*   **Declarative Definition:** The entire workflow is defined in a single YAML file, which can be stored in Git, peer-reviewed, and deployed through CI/CD pipelines.
+*   **Robust Error Handling:** The `errors` block provides a built-in mechanism for failure recovery and notification, ensuring that you are immediately alerted to any issues.
+*   **Integrated Task Types:** The flow seamlessly combines different types of tasks—[SFTP download](/plugins/plugin-fs/sftp-ssh-file-transfer-protocol/io.kestra.plugin.fs.sftp.download), shell script execution, and [SFTP upload](/plugins/plugin-fs/sftp-ssh-file-transfer-protocol/io.kestra.plugin.fs.sftp.upload)—into a single, cohesive unit.
+*   **Secure Credentials:** All sensitive information, such as usernames, passwords, and webhook URLs, is handled through Kestra's secrets management, preventing credentials from being exposed in the workflow definition.
+
+### Choosing the Right Protocol: SFTP, FTP, or FTPS?
+
+Kestra's file system plugins support multiple protocols, and choosing the right one is crucial for security.
+
+*   **SFTP (SSH File Transfer Protocol):** This is the modern standard for secure file transfers. It runs over the SSH protocol, encrypting both credentials and data in transit. It is the preferred choice for transferring sensitive data over untrusted networks.
+*   **FTPS (File Transfer Protocol Secure):** This protocol adds a layer of SSL/TLS encryption to the traditional FTP protocol. It is also secure, but it can be more complex to configure due to firewall and NAT issues with its use of multiple ports. You can find tasks for FTPS within Kestra's [file system plugins](/plugins/plugin-fs/ftps-file-transfer-protocol-secure).
+*   **FTP (File Transfer Protocol):** This is the original file transfer protocol. It is unencrypted and sends credentials and data in plain text. Its use should be avoided for any sensitive data and restricted to internal, trusted networks. Kestra provides [FTP tasks](/plugins/plugin-fs/ftp-file-transfer-protocol) for interacting with legacy systems.
+
+As a rule of thumb, always default to SFTP unless you have a specific requirement to use FTPS or are interacting with a legacy system that only supports FTP on a secure internal network.
+
+## Where File Transfer Automation Pays Off
+
+Automated and orchestrated file transfers provide significant value across various industries by ensuring data moves securely and efficiently.
+
+*   **Retail & E-commerce:** Automating the exchange of inventory files with suppliers, processing daily sales data from stores, and syncing product catalogs with partners. Kestra helps build robust [retail and e-commerce workflows](/use-cases/retail) around these transfers.
+*   **Healthcare:** Securely transferring patient records (EHR/EMR), lab results, and insurance claims between providers, labs, and payers, while maintaining HIPAA compliance. These processes are central to [healthcare data orchestration](/use-cases/healthcare).
+*   **Financial Services:** Automating the ingestion of market data, processing of bank statements, reconciliation of transactions, and submission of regulatory reports. This is a core component of modern [banking data pipeline automation](/resources/data/banking-data-pipeline-automation).
+*   **IT Operations:** Orchestrating the collection of log files from thousands of servers, distributing configuration updates, and automating backup and restore processes in [data center automation](/resources/infrastructure/data-center-automation).
+*   **Data Pipelines:** Acting as the first step in an ETL/ELT process by automatically moving raw data from source systems into cloud storage or a data warehouse for further processing.
+
+## Related concepts
+
+*   [Control-M Alternatives](/resources/infrastructure/control-m-alternatives)
+*   [Redwood Alternatives](/resources/infrastructure/redwood-alternatives)
+*   [Workflow Secret Management](/resources/infrastructure/secrets-rotation-automation)
+*   [File Access in Kestra](/docs/concepts/file-access)
+*   [Infrastructure Automation Control Plane](/infra-automation)
+*   [Infrastructure Automation Resources](/resources/infrastructure)

--- a/src/contents/resources/job-orchestration/index.md
+++ b/src/contents/resources/job-orchestration/index.md
@@ -1,0 +1,152 @@
+---
+title: "Job Orchestration: Definition & Tools"
+description: "Job orchestration goes beyond simple scheduling, coordinating complex, interdependent tasks across diverse systems. Learn how to build resilient, automated job workflows."
+metaTitle: "Job Orchestration: Definition & Tools"
+metaDescription: "Understand job orchestration, its benefits over traditional scheduling, and how a declarative platform unifies automated processes across data, IT, and AI."
+tag: "infrastructure"
+date: 2026-07-07
+slug: "job-orchestration"
+faq:
+  - question: "What is job orchestration?"
+    answer: "Job orchestration involves coordinating and managing complex, interdependent tasks (jobs) across various systems and platforms. Unlike simple scheduling, it handles dependencies, conditional logic, error recovery, and resource allocation to ensure end-to-end process completion and reliability."
+  - question: "What is the difference between job scheduling and job orchestration?"
+    answer: "Job scheduling triggers tasks at predetermined times or intervals. Job orchestration, however, extends this by managing dependencies between tasks, reacting to events, handling failures, and dynamically allocating resources, ensuring a cohesive multi-step process rather than isolated tasks."
+  - question: "What is an example of job orchestration?"
+    answer: "An example is an automated software deployment workflow. This might involve fetching code from Git, building a Docker image, provisioning infrastructure with Terraform, deploying to Kubernetes, running integration tests, and notifying teams—all coordinated as a single, interdependent process."
+  - question: "Why is job orchestration important for IT operations?"
+    answer: "Job orchestration centralizes control over diverse IT tasks, reducing manual effort, improving reliability through automated error handling, and providing comprehensive visibility into complex processes. This leads to more efficient resource utilization and faster incident resolution."
+  - question: "What are the key features of effective job orchestration tools?"
+    answer: "Effective job orchestration tools offer declarative workflow definitions, polyglot task execution, event-driven triggers, robust error handling (retries, timeouts), monitoring and logging, scalability, and integration with a wide range of systems and APIs."
+  - question: "How does Kestra support job orchestration?"
+    answer: "Kestra provides a declarative, YAML-based platform for job orchestration, enabling users to define complex workflows that span data, infrastructure, and AI. Its event-driven nature, polyglot task execution, and extensive plugin ecosystem facilitate seamless coordination across heterogeneous environments."
+---
+
+> **TL;DR** — Job orchestration involves coordinating and managing complex, interdependent tasks (jobs) across various systems and platforms. Unlike simple scheduling, it handles dependencies, conditional logic, error recovery, and resource allocation to ensure end-to-end process completion and reliability.
+
+In today's complex enterprise environments, simply scheduling individual jobs is no longer sufficient. Modern operations demand a sophisticated approach to coordinating interdependent tasks across disparate systems, from data pipelines and cloud infrastructure deployments to AI model training and business process automation. Without a unified view and intelligent control, these "jobs" become isolated silos, leading to manual oversight, increased errors, and critical delays.
+
+This is where job orchestration becomes indispensable. It’s about more than just telling a task when to run; it’s about intelligently managing its dependencies, reacting to its outcomes, and ensuring its reliable completion within a larger, end-to-end workflow. This article will explore the fundamentals of job orchestration, its critical role in modern IT, and how a declarative platform like Kestra can unify your operational workflows.
+
+## How Modern Job Orchestration Works
+
+At its core, job orchestration is the practice of automating, coordinating, and managing multi-step processes that span multiple systems. While traditional job scheduling focuses on initiating tasks at specific times (e.g., cron jobs), orchestration manages the entire lifecycle of a workflow.
+
+The key differences lie in a few core capabilities:
+
+*   **Dependency Management:** Orchestration understands that Job B can only start after Job A succeeds. It manages complex dependency graphs, ensuring tasks execute in the correct order.
+*   **Conditional Logic:** A modern orchestrator can make decisions based on the outcome of previous tasks. If a test job fails, the orchestration platform can trigger a rollback process instead of proceeding with deployment.
+*   **State Management:** Orchestration platforms maintain the state of a workflow, passing data and artifacts from one task to the next. This allows a build job's output (e.g., a container image ID) to be used as an input for a subsequent deployment job.
+*   **Event-Driven Execution:** Instead of relying solely on time-based schedules, job orchestration can react to real-time events, such as a new file arriving in cloud storage, a new commit in a Git repository, or an alert from a monitoring system.
+
+The distinction between a simple scheduler and a true orchestrator is crucial. A deeper dive into [infrastructure orchestration vs. job scheduling](/resources/infrastructure/infrastructure-orchestration-vs-job-scheduling) reveals how this shift enables more resilient and dynamic automation. A powerful [workflow engine](/resources/infrastructure/workflow-engine) is the heart of any modern orchestration tool, providing the logic to manage these complex interactions.
+
+## Why Unified Job Orchestration Is Essential
+
+Without a centralized orchestration platform, teams often resort to a patchwork of cron jobs, shell scripts, and manual handoffs. This approach is fragile, opaque, and difficult to scale. Unified job orchestration addresses these challenges directly.
+
+**Benefits of a Unified Approach:**
+
+*   **Improved Reliability:** Centralized error handling, automatic retries, and defined recovery paths mean that transient failures don't cascade into system-wide outages.
+*   **Increased Efficiency:** Automating manual handoffs and repetitive tasks frees up engineering time for higher-value work.
+*   **Enhanced Visibility:** A single platform provides a comprehensive view of all automated processes, making it easier to monitor, debug, and audit workflows.
+*   **Greater Scalability:** Orchestration tools are designed to manage a high volume of concurrent jobs and can scale with your operational needs.
+*   **Reduced Manual Toil:** By automating complex sequences, orchestration eliminates the need for engineers to manually monitor and trigger dependent jobs.
+*   **Auditability and Governance:** Centralized logs and version-controlled workflow definitions provide a clear audit trail for compliance and security.
+
+Attempting to manage modern IT and data systems without orchestration often leads to significant [orchestration problems and complexity](/resources/infrastructure/orchestration-problems-complexity), including siloed automation efforts, inconsistent error handling, and slow incident response times.
+
+## Orchestrate Your Jobs with Kestra: An End-to-End Deployment Example
+
+Declarative orchestration platforms like Kestra allow you to define complex job workflows as simple configuration files. This makes them versionable, reviewable, and easy to manage.
+
+The following example demonstrates a multi-stage application deployment workflow. It pulls the latest code, runs a simulated build and test, and then, based on the test outcome, either proceeds with deployment or sends a failure alert.
+
+```yaml
+id: end-to-end-deployment
+namespace: company.team.cicd
+
+tasks:
+  - id: clone_repo
+    type: io.kestra.plugin.scripts.shell.Commands
+    commands:
+      - git clone https://github.com/kestra-io/kestra.git
+
+  - id: build_and_test
+    type: io.kestra.plugin.scripts.shell.Commands
+    commands:
+      # Simulate build and test steps
+      - echo "Building application..."
+      - sleep 10
+      - echo "Running tests..."
+      # This command will randomly succeed or fail for demonstration
+      - exit $((RANDOM % 2))
+    allowFailure: true # Allow this task to fail so the If condition can be evaluated
+
+  - id: check_test_result
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ outputs.build_and_test.exitCode == 0 }}"
+    then:
+      - id: successful_deployment
+        type: io.kestra.plugin.core.flow.Sequential
+        tasks:
+          - id: deploy_to_k8s
+            type: io.kestra.plugin.scripts.shell.Commands
+            commands:
+              - echo "Deploying to Kubernetes..."
+              - kubectl apply -f k8s-deployment.yaml
+          - id: notify_success
+            type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+            url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+            payload: |
+              {
+                "text": "✅ Deployment Succeeded for flow {{ flow.id }} with execution {{ execution.id }}"
+              }
+    else:
+      - id: notify_failure
+        type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+        url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+        payload: |
+          {
+            "text": "❌ Deployment Failed for flow {{ flow.id }}. Please check execution {{ execution.id }}."
+          }
+```
+
+**What’s worth noticing in this flow:**
+
+*   **Declarative Definition:** The entire multi-stage process is defined in a single, easy-to-read [YAML file](/blogs/yaml-for-workflow-orchestration).
+*   **Conditional Logic:** The `If` task checks the exit code of the test script and directs the flow down either a success or failure path.
+*   **Stateful Execution:** The `condition` dynamically accesses the output (`exitCode`) of a previous task.
+*   **Integrated Notifications:** The flow communicates its status directly to a Slack channel without requiring a separate monitoring script.
+*   **Secrets Management:** Sensitive information like the Slack webhook URL is securely handled using Kestra's secret management.
+
+This single workflow can coordinate tasks across various tools, from Git and Docker to [Kubernetes](/orchestration/kubernetes) and [Ansible](/orchestration/ansible).
+
+### Choosing the Right Orchestration Approach
+
+The market offers a variety of orchestration tools, each with a different focus. Understanding these categories helps in selecting the right platform:
+
+*   **Data Orchestration Tools:** Primarily focused on ETL/ELT pipelines and data transformation workflows.
+*   **Workflow Orchestration Platforms:** General-purpose tools designed to automate a wide range of business and IT processes.
+*   **Enterprise Job Orchestration Solutions:** Legacy platforms often designed for mainframe and on-premises batch processing.
+*   **Cloud-Native Orchestration Tools:** Platforms tightly integrated with a specific cloud provider's ecosystem (e.g., AWS Step Functions, Azure Logic Apps).
+
+When selecting a tool, consider factors like its authoring paradigm (declarative vs. imperative code), support for multiple programming languages, scalability, governance features, and deployment model (self-hosted vs. cloud). A comprehensive list of [cloud orchestration tools](/resources/infrastructure/cloud-orchestration-tools) can provide further context, while understanding the specifics of [data orchestration](/resources/data/data-orchestration) or [AI-native orchestration](/resources/ai/ai-native-orchestration-platform) is crucial for specialized use cases.
+
+## Where Unified Job Orchestration Delivers Value
+
+Job orchestration is a foundational capability that unlocks automation across the enterprise. Common use cases include:
+
+*   **Data Pipeline Automation:** Coordinating data ingestion, transformation (dbt), and loading processes across databases, data warehouses, and data lakes.
+*   **IT Operations and Infrastructure Management:** Automating routine maintenance, such as [patch orchestration](/blueprints/patch-orchestration-uat-prod), server provisioning, and disaster recovery procedures.
+*   **CI/CD Pipelines:** Extending CI/CD beyond code commits to orchestrate complex deployment, testing, and rollback strategies. Explore how it fits with [CI/CD orchestration](/resources/infrastructure/ci-cd-orchestration).
+*   **Microservices Orchestration:** Managing the complex interactions and data flows between distributed services, a key aspect of modern [microservices orchestration](/use-cases/microservices-orchestration).
+*   **Business Process Automation:** Integrating various business applications (e.g., CRM, ERP) to automate end-to-end processes like customer onboarding or order fulfillment.
+
+## Related Concepts
+
+*   [Event-Driven Orchestration](/resources/infrastructure/event-driven-orchestration)
+*   [GitOps for Workflows](/resources/infrastructure/gitops)
+*   [Multi-Cloud Orchestration](/resources/infrastructure/multi-cloud-orchestration)
+*   [Job Scheduler](/resources/infrastructure/job-scheduler)
+
+Ready to unify your job orchestration? [Explore Kestra's open-source platform](/infra-automation).

--- a/src/contents/resources/job-scheduling-software/index.md
+++ b/src/contents/resources/job-scheduling-software/index.md
@@ -1,0 +1,167 @@
+---
+title: "Job Scheduling Software: The Complete Guide (2026)"
+description: "Job scheduling software automates tasks, from simple cron jobs to complex enterprise workflows. Explore how modern solutions go beyond basic scheduling to provide robust orchestration, governance, and developer experience for data, AI, and infrastructure teams."
+metaTitle: "Job Scheduling Software: The Complete Guide (2026)"
+metaDescription: "Explore modern job scheduling software to automate and optimize tasks across data, AI, and infrastructure. Enhance workflow governance and developer experience."
+tag: "infrastructure"
+date: 2026-07-07
+slug: "job-scheduling-software"
+faq:
+  - question: "What is modern job scheduling software?"
+    answer: "Modern job scheduling software is an advanced platform that automates, manages, and monitors tasks and workflows across an organization's diverse systems. Unlike traditional schedulers, it offers features like declarative definitions, event-driven triggers, polyglot task execution, and robust error handling, extending beyond simple time-based execution to coordinate complex, interdependent processes."
+  - question: "How does job scheduling differ from workflow orchestration?"
+    answer: "Job scheduling primarily focuses on executing individual tasks or jobs at specific times or intervals. Workflow orchestration, while encompassing scheduling, goes further by managing the dependencies, data flow, error handling, and overall lifecycle of interconnected tasks across multiple systems and domains, ensuring end-to-end process integrity and visibility."
+  - question: "What features are essential in enterprise job scheduling software?"
+    answer: "Essential features for enterprise job scheduling software include high availability, robust security (RBAC, SSO), comprehensive audit logs, multi-tenancy support, advanced error handling and retry mechanisms, deep integration capabilities with various systems (databases, cloud services, APIs), and a scalable architecture to handle high volumes of concurrent workflows."
+  - question: "Are there free and open-source job scheduling tools?"
+    answer: "Yes, many free and open-source job scheduling tools exist, ranging from basic cron utilities to full-fledged workflow orchestration platforms like Kestra. These tools offer flexibility and cost savings, but often require more operational overhead for setup, maintenance, and scaling compared to commercial or managed solutions, especially in enterprise environments."
+  - question: "How can job scheduling software improve operational efficiency?"
+    answer: "Job scheduling software improves operational efficiency by automating repetitive tasks, reducing manual errors, ensuring timely execution of critical processes, and providing centralized visibility into all scheduled jobs. This leads to faster execution cycles, better resource utilization, and allows teams to focus on higher-value activities rather than manual supervision and troubleshooting."
+  - question: "Can job scheduling software manage complex dependencies?"
+    answer: "Yes, modern job scheduling and workflow orchestration software is specifically designed to manage complex dependencies. It allows users to define the order of execution, conditional logic, and parallel tasks, ensuring that jobs only run when their prerequisites are met. This is crucial for maintaining data integrity and logical flow in interdependent processes."
+---
+
+From simple nightly scripts to intricate data pipelines and critical infrastructure operations, scheduled tasks are the backbone of modern business. Yet, relying on disparate cron jobs or outdated schedulers often leads to "cron sprawl"—a tangled mess of dependencies, manual oversight, and opaque failures. This fragmented approach stifles innovation and drains engineering resources.
+
+Modern job scheduling software moves beyond simple time-based triggers. It evolves into a powerful orchestration layer, unifying diverse automation needs under a single, declarative control plane. This article explores how these advanced solutions streamline operations, enhance governance, and empower teams to manage complex workflows across data, AI, and infrastructure with unprecedented clarity and control.
+
+## Beyond basic cron: what modern job scheduling software offers
+
+For decades, the cron utility on Unix-like systems has been the default tool for time-based job scheduling. While effective for simple, isolated tasks, its limitations become apparent as organizations scale. Managing hundreds of cron jobs across multiple servers leads to a lack of visibility, complex dependency management, and no centralized error handling. Modern [job scheduling software](/resources/infrastructure/job-scheduler) is designed to solve these problems by providing a robust framework for defining, executing, and monitoring automated workflows.
+
+### From simple tasks to complex dependencies
+
+The primary evolution from cron to modern schedulers is the shift from managing individual tasks to orchestrating entire workflows. A workflow is a sequence of interconnected tasks that must execute in a specific order, often with dependencies on each other's outputs. For example, a data pipeline might involve extracting data from an API, transforming it with a script, loading it into a warehouse, and then notifying a Slack channel.
+
+Modern software handles these dependencies natively, ensuring that tasks only run when their prerequisites are met. This is a fundamental difference from cron, where dependencies must be managed through complex shell scripting and custom logic. The distinction between [infrastructure orchestration and job scheduling](/resources/infrastructure/infrastructure-orchestration-vs-job-scheduling) lies in this ability to manage the entire lifecycle of interconnected processes, not just their initiation.
+
+### Key capabilities of advanced job schedulers
+
+Advanced job schedulers, often called workflow orchestration platforms, offer a rich set of features that go far beyond what's possible with basic tools. These capabilities are essential for building reliable, scalable, and maintainable automation.
+
+*   **Complex Scheduling:** Beyond cron expressions, modern tools support event-driven triggers (e.g., file arrival, API call), conditional execution, and dynamic scheduling based on runtime conditions.
+*   **Dependency Management:** Natively define dependencies between tasks, creating complex Directed Acyclic Graphs (DAGs) of execution that ensure logical consistency.
+*   **Error Handling and Retries:** Automatically retry failed tasks with configurable backoff strategies, define custom error-handling logic, and set up alerts for persistent failures.
+
+*   **Centralized Monitoring and Logging:** A unified interface provides a single pane of glass to view the status of all jobs, inspect logs, and visualize workflow execution, eliminating the need to SSH into multiple machines.
+*   **Parameterization:** Pass parameters to workflows at runtime, making them reusable and adaptable for different scenarios without changing the underlying definition.
+*   **Parallel Execution:** Run multiple tasks concurrently to significantly reduce the total execution time of a workflow, optimizing resource usage.
+*   **Scalability:** Designed to handle thousands of concurrent workflows and millions of task executions, with architectures that can scale horizontally to meet demand.
+
+These features collectively transform job scheduling from a simple utility into a strategic platform for enterprise-wide automation and [scheduling](/features/scheduling-and-automation).
+
+## The evolving landscape of job scheduling solutions
+
+The market for job scheduling software is diverse, with solutions tailored to different needs, scales, and technical environments. Understanding the main categories helps in navigating the options and finding the right fit.
+
+### Categories of job scheduling tools: legacy, cloud-native, and orchestrators
+
+Job schedulers can be broadly grouped into three categories, each reflecting a different era of IT infrastructure and development practices.
+
+1.  **Legacy Enterprise Schedulers:** Tools like [Control-M](/resources/infrastructure/control-m-alternatives), [IBM Workload Automation](/resources/infrastructure/ibm-workload-automation-alternatives), and [Dollar Universe](/resources/infrastructure/broadcom-dollar-universe-alternatives) have been staples in large enterprises for decades. They offer robust, centralized control over batch processing, especially in mainframe and hybrid environments. While powerful, they are often characterized by high licensing costs, complex infrastructure, and a steeper learning curve that is less aligned with modern DevOps and GitOps practices. A detailed [comparison of scheduling platforms](/blogs/2023-10-17-schedulers-landscape) can help clarify their position.
+
+2.  **Cloud-Native Schedulers:** As organizations moved to the cloud, services like AWS Step Functions, Azure Logic Apps, and Google Cloud Workflows emerged. These are tightly integrated into their respective cloud ecosystems, offering managed, serverless execution for orchestrating cloud services. Their primary strength is deep integration within a single cloud provider, but they can introduce vendor lock-in and become complex when orchestrating processes across multiple clouds or on-premises systems.
+
+3.  **Modern Open-Source Orchestrators:** A new wave of tools, including Kestra, Airflow, and Prefect, has gained popularity. These platforms are designed with developers in mind, emphasizing principles like declarative configuration (workflows as code), language-agnostic task execution, and extensibility through plugins. They offer the flexibility to run anywhere—from a local Docker container to a large Kubernetes cluster—and integrate with a wide array of modern data and infrastructure technologies. This category represents some of the [best workflow automation tools](/resources/infrastructure/best-workflow-automation-tools) available today.
+
+### Open-source vs. commercial solutions
+
+The choice between open-source and commercial software often comes down to a trade-off between flexibility, cost, and support. Open-source platforms provide unparalleled flexibility and a low entry-cost, allowing teams to customize the tool to their exact needs. However, they place the burden of deployment, maintenance, scaling, and security on the user.
+
+Commercial solutions, including enterprise editions of open-source tools, typically offer additional features like advanced security (RBAC, SSO), multi-tenancy, high-availability configurations, and dedicated enterprise support. These features are often critical for mission-critical applications in large organizations.
+
+### Addressing the need for free work scheduling apps
+
+For smaller teams, startups, or specific projects, free and open-source job scheduling software is an excellent option. The open-source version of Kestra, for example, is fully-featured and capable of handling production workloads. These tools provide a powerful starting point for automation without initial financial investment, allowing teams to build and scale their workflows and later opt for enterprise features as their needs grow.
+
+## Choosing the right job scheduling software for your organization
+
+Selecting the right job scheduling software is a critical decision that impacts operational efficiency, developer productivity, and system reliability. The best choice depends on your organization's specific needs, technical maturity, and scale.
+
+### Evaluating features: scalability, reliability, and security
+
+When evaluating solutions, consider these core pillars:
+
+*   **Scalability:** Can the scheduler handle your current and future workload? Look for an architecture that supports horizontal scaling, high concurrency, and efficient resource management. Check the platform's [hardware and software requirements](/docs/administrator-guide/requirements) to ensure it can grow with you.
+*   **Reliability:** How does the platform ensure that jobs run successfully? Key features include high availability to prevent single points of failure, robust error handling, automatic retries, and disaster recovery options.
+*   **Security:** A scheduler often has access to sensitive systems and data. Strong security is non-negotiable. Look for features like [Role-Based Access Control (RBAC)](/resources/infrastructure/rbac), integration with SSO providers, and comprehensive audit logs to track all activities.
+
+### Integration with your existing tech stack
+
+A job scheduler must seamlessly connect with the tools and systems you already use. Evaluate the platform's ecosystem of plugins and integrations. Does it have pre-built connectors for your databases, cloud services, messaging queues, and data processing frameworks? A rich plugin library accelerates development and reduces the need to write custom integration code.
+
+### The role of developer experience and governance
+
+The best tool is one that your team will actually use. A positive developer experience is crucial for adoption and productivity. This includes clear documentation, an intuitive authoring process (e.g., declarative YAML vs. complex code), and tools for local testing and debugging.
+
+Simultaneously, the platform must provide strong [workflow governance](/resources/infrastructure/workflow-governance) to ensure consistency and compliance. Features like version control integration (GitOps), reusable templates (subflows), and multi-tenancy for isolating teams or environments are essential for managing automation at scale. The ability to leverage [open-source cost savings](/resources/infrastructure/open-source-orchestration-cost-savings) while having a clear path to enterprise-grade governance is a significant advantage.
+
+## Unifying job scheduling with declarative orchestration in Kestra
+
+Kestra represents the next generation of job scheduling software, moving beyond simple task execution to provide a unified, declarative orchestration platform. It is designed to manage workflows across diverse domains, including data engineering, infrastructure automation, and AI/ML pipelines.
+
+### Declarative YAML: a shift from code-heavy scheduling
+
+Unlike traditional schedulers that require writing complex Python or Java code to define workflows, Kestra uses a simple, declarative YAML interface. This approach separates the "what" (the workflow logic) from the "how" (the execution details).
+
+Benefits of declarative YAML include:
+*   **Accessibility:** Non-engineers can read and understand workflow logic.
+*   **Maintainability:** YAML files are easy to version, review in pull requests, and manage with GitOps practices.
+*   **Readability:** The structure is clean and focuses on the workflow itself, not boilerplate code.
+
+### Polyglot task execution for diverse workloads
+
+Kestra is language-agnostic. You can run scripts written in Python, R, Julia, or shell, execute SQL queries, run Docker containers, or call any API as first-class tasks within a single workflow. This flexibility allows teams to use the best tool for each job without being locked into a single language ecosystem.
+
+### Event-driven triggers for real-time automation
+
+While Kestra fully supports traditional [cron-based scheduling](/docs/workflow-components/triggers/schedule-trigger), its true power lies in its event-driven architecture. Workflows can be triggered by a wide range of events, such as a new file arriving in S3, a message in a Kafka topic, or an incoming webhook. This enables the creation of responsive, real-time automation that reacts to business events as they happen. Explore [advanced scheduling](/blueprints/advanced-scheduling) patterns and best practices for [scheduling data workflows](/resources/data/schedule-data-workflows) to see this in action.
+
+### Example: orchestrating a scheduled data job with Kestra
+
+This example demonstrates a daily scheduled workflow that extracts data from PostgreSQL, transforms it using dbt, and triggers a dashboard refresh.
+
+```yaml
+id: scheduled_data_refresh
+namespace: company.data
+
+description: "Refreshes the product analytics dashboard data daily."
+
+tasks:
+  - id: extract_raw_data
+    type: io.kestra.plugin.jdbc.postgresql.Query
+    url: jdbc:postgresql://postgres:5432/mydb
+    username: "{{ secret('POSTGRES_USER') }}"
+    password: "{{ secret('POSTGRES_PASSWORD') }}"
+    sql: "SELECT * FROM raw_product_events WHERE event_date = '{{ date.yesterday() | date('YYYY-MM-DD') }}';"
+    fetch: true
+
+  - id: transform_data_with_dbt
+    type: io.kestra.plugin.dbt.cli.Commands
+    dbtPath: /usr/local/bin/dbt
+    commands:
+      - "dbt build --select product_analytics --target prod"
+    runner:
+      type: DOCKER
+      image: ghcr.io/dbt-labs/dbt-postgres:1.7.0
+
+  - id: load_to_dashboard_tool
+    type: io.kestra.plugin.core.http.Request
+    uri: "https://api.dashboardtool.com/refresh"
+    method: POST
+    body: "{{ outputs.transform_data_with_dbt.exitCode }}"
+    headers:
+      Authorization: "Bearer {{ secret('DASHBOARD_API_TOKEN') }}"
+
+triggers:
+  - id: daily_schedule
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 2 * * *" # Run daily at 2:00 AM
+```
+This single YAML file defines the entire process, including its schedule, tasks, dependencies, and secrets management. It can be version-controlled in Git and managed as code, providing a clear, auditable, and maintainable workflow. Kestra's deep integration with tools like [dbt Core](/orchestration/dbt-core) makes such data engineering patterns straightforward.
+
+## The future of job scheduling: towards a unified control plane
+
+The concept of job scheduling is evolving. Organizations no longer need just a tool to run jobs on a schedule; they need a comprehensive control plane to manage all automated processes across the enterprise. The shift is from siloed schedulers for specific domains to a unified orchestration platform that can handle everything from [data pipelines](/data) to [infrastructure automation](/infra-automation) and [AI workflows](/ai-automation).
+
+This unified approach breaks down silos between teams, improves visibility, and enforces consistent governance standards. By embracing a declarative, language-agnostic, and event-driven model, platforms like Kestra are defining the future of job scheduling—one where automation is scalable, reliable, and accessible to everyone.

--- a/src/contents/resources/open-source-job-scheduler/index.md
+++ b/src/contents/resources/open-source-job-scheduler/index.md
@@ -1,0 +1,131 @@
+---
+title: "Best Open-Source Job Schedulers in 2026 (Ranked)"
+description: "Explore the leading open source job schedulers, from traditional cron replacements to advanced orchestration platforms. Understand their features, compare their capabilities, and find the right solution for your data, AI, and infrastructure automation needs."
+metaTitle: "Best Open-Source Job Schedulers in 2026 (Ranked)"
+metaDescription: "Compare open source job schedulers: Airflow, DolphinScheduler, Kestra. Find a modern, lightweight, and scalable solution for workflow automation."
+tag: "infrastructure"
+date: 2026-07-07
+slug: "open-source-job-scheduler"
+faq:
+  - question: "What is the primary difference between a job scheduler and a workflow orchestrator?"
+    answer: "A job scheduler primarily focuses on executing individual tasks at specific times or intervals, often with basic dependency management. A workflow orchestrator, like Kestra, provides a more comprehensive platform for defining, executing, and monitoring complex, multi-step workflows across diverse systems, offering advanced features like event-driven triggers, error handling, and cross-domain integrations."
+  - question: "Is Apache Airflow considered an open source job scheduler?"
+    answer: "Yes, Apache Airflow is a widely used open source job scheduler, particularly popular in data engineering for orchestrating data pipelines. While powerful, its Python-centric approach and operational complexity lead many teams to seek modern alternatives that offer declarative YAML, polyglot task execution, and broader cross-domain capabilities."
+  - question: "What are the benefits of choosing a lightweight open source job scheduler?"
+    answer: "Lightweight open source job schedulers offer benefits such as lower resource consumption, easier setup, and reduced operational overhead, making them ideal for smaller teams or specific use cases. However, they may lack the advanced features, scalability, and enterprise-grade governance required for complex, mission-critical workflows across diverse systems."
+  - question: "Can Kestra replace traditional cron jobs for scheduling tasks?"
+    answer: "Yes, Kestra is an excellent replacement for traditional cron jobs. It offers more robust scheduling capabilities, including cron expressions, event-driven triggers, and advanced dependency management. Migrating from cron to Kestra centralizes all scheduled tasks, provides better visibility, error handling, and version control for improved reliability and governance."
+  - question: "What should I consider when choosing an open source job scheduler?"
+    answer: "When selecting an open source job scheduler, consider factors like deployment model (self-hosted, Kubernetes-native), workflow definition (code-based, declarative YAML), language support, integration ecosystem, scalability, observability features, and community support. Aligning these with your team's technical stack and operational needs is crucial for long-term success."
+  - question: "Are there any open source job schedulers with strong enterprise features?"
+    answer: "While many open source job schedulers offer core functionality, enterprise-grade features like Role-Based Access Control (RBAC), Single Sign-On (SSO), audit logs, and multi-tenancy are often found in commercial editions or more mature platforms. Kestra, for example, offers these capabilities in its Enterprise Edition, alongside the fully open-source core."
+---
+
+The landscape of workflow automation has evolved dramatically. What began with simple cron jobs and basic schedulers has transformed into a complex ecosystem where modern teams demand more than just task execution. Today, organizations require robust, scalable, and versatile open source job schedulers capable of orchestrating intricate pipelines across data, AI, and infrastructure domains. Yet, many traditional open source options, while powerful, often come with significant operational overhead, steep learning curves, or limited flexibility beyond their primary use case.
+
+This shift has driven many platform and data engineers to seek alternatives that blend the power of open source with the agility and governance needed for modern operations. This article explores the top open source job schedulers available, comparing their strengths, ideal use cases, and the trade-offs involved. We'll delve into how these tools address the demands of diverse technical teams, from lightweight solutions for specific tasks to full-fledged orchestration platforms designed to unify your entire automation stack. By the end, you'll have a clear framework to choose the best open source job scheduler to streamline your workflows and reduce operational complexity.
+
+## Why Modern Teams Need More Than Traditional Job Schedulers
+
+Traditional job schedulers, particularly cron, have been the backbone of IT automation for decades. However, their limitations become apparent as infrastructure scales and workflows grow in complexity. Cron's lack of visibility, rudimentary error handling, and inability to manage complex dependencies create operational fragility. When a job fails, debugging becomes a manual, time-consuming process of sifting through logs on individual machines.
+
+Legacy enterprise schedulers attempted to solve these issues but often introduced their own challenges: steep learning curves, high operational costs, and domain-specific limitations that struggle to adapt to modern, polyglot environments. Today's platform and data teams need a [job scheduler](/resources/infrastructure/job-scheduler) that acts as a unified control plane, capable of orchestrating tasks across diverse systems—from data warehouses and machine learning models to infrastructure provisioning and business applications. The need for a modern [cron replacement](/resources/infrastructure/cron-replacement) is driven by the demand for a solution that can manage this complexity without becoming a bottleneck itself.
+
+## How We Evaluated the Top Open Source Job Schedulers
+
+To provide a clear comparison, we evaluated each open source job scheduler based on a set of criteria critical for modern engineering teams. These factors reflect the shift from simple task scheduling to comprehensive workflow orchestration:
+
+*   **Deployment Flexibility:** Can the tool run on various infrastructures, including Kubernetes, on-premises servers, and air-gapped environments?
+*   **Workflow Definition:** How are workflows defined? Is it through declarative YAML, which promotes GitOps and collaboration, or through code (e.g., Python), which may be preferred by specific teams but can limit accessibility?
+*   **Polyglot Support:** Does the scheduler natively support tasks written in multiple languages (Python, Bash, SQL, Java, etc.) and containerized environments (Docker)?
+*   **Event-Driven Capabilities:** Can workflows be triggered by events from external systems (e.g., webhooks, message queues, file uploads) in addition to cron-based schedules?
+*   **Scalability and Observability:** How does the tool scale to handle a high volume of concurrent workflows? What level of visibility, logging, and metrics does it provide for monitoring and debugging?
+*   **Community and Ecosystem:** How active is the open-source community, and how extensive is the library of pre-built plugins and integrations?
+
+## 1. Kestra: The Declarative, Event-Driven Orchestration Control Plane
+
+[Kestra](/) is an open-source platform that moves beyond traditional job scheduling to provide a unified, declarative control plane for all your workflows. It is designed from the ground up to be language-agnostic and event-driven, addressing the limitations of code-centric and batch-oriented schedulers.
+
+Workflows in Kestra are defined in simple, readable YAML files. This declarative approach decouples the workflow logic from the execution engine, making pipelines easier to version, review, and manage through GitOps practices. It also enables collaboration between technical and non-technical teams.
+
+Kestra's key strength lies in its ability to orchestrate tasks across any domain. Whether you're running Python scripts for data transformation, Bash commands for infrastructure management, SQL queries against a data warehouse, or interacting with cloud APIs, Kestra handles it all as a first-class citizen. Its extensive plugin ecosystem provides integrations for hundreds of tools and services.
+
+The platform's architecture is built for scale and flexibility, deployable via Docker, Kubernetes, or as a standalone binary in self-hosted and air-gapped environments. This makes it a strong fit for enterprises with diverse infrastructure needs. For example, JPMorgan Chase uses Kestra for cybersecurity analytics workflows, processing billions of rows, while Leroy Merlin built its DataMesh at scale on Kestra, increasing data production by 900%.
+
+**Best for:** Teams seeking a modern, unified, and highly scalable orchestration platform that supports diverse technical stacks and complex cross-domain workflows with a declarative, event-driven model. Explore the [open-source workflow engine](/resources/infrastructure/open-source-workflow-engine) and its powerful [scheduling and automation](/features/scheduling-and-automation) features.
+
+## 2. Apache Airflow: The Established Data Pipeline Orchestrator
+
+Apache Airflow is one of the most well-known open-source job schedulers, particularly dominant in the data engineering community. Its core concept is the Directed Acyclic Graph (DAG), where workflows are defined as Python code. This code-first approach gives data engineers immense power and flexibility to create dynamic and complex data pipelines.
+
+Airflow's main advantage is its vast ecosystem of operators and providers, which offer pre-built integrations for a wide range of data sources, destinations, and cloud services. Having been battle-tested in many large-scale environments, it is a mature and reliable choice for batch-oriented ETL/ELT processes.
+
+However, its strengths also come with trade-offs. The reliance on Python for DAG definition can be a barrier for non-Python developers and makes workflows less accessible to other teams. Furthermore, managing an Airflow deployment can be operationally complex, requiring careful configuration of schedulers, workers, and a metadata database. For teams looking for a more modern and less code-centric approach, several powerful [Airflow alternatives](/resources/data/airflow-alternatives) have emerged.
+
+**Best for:** Python-heavy data engineering teams with an existing investment in the Airflow ecosystem who need a robust, code-first scheduler primarily for data pipelines.
+
+## 3. Apache DolphinScheduler: Visual, Distributed Data Workflow Orchestration
+
+Apache DolphinScheduler is another open-source project from the Apache Software Foundation, positioning itself as a distributed and cloud-native workflow orchestration platform. Its standout feature is a powerful visual DAG interface that allows users to build and manage workflows through a drag-and-drop UI.
+
+DolphinScheduler is designed for big data environments, with strong support for tasks involving Spark, Flink, and Hive. It offers features like multi-tenancy and resource management, which are valuable for larger organizations managing shared infrastructure. Its distributed architecture ensures high availability and scalability for data-intensive workloads.
+
+While the visual interface is a significant advantage for accessibility, it can be less conducive to version control and GitOps practices compared to a purely declarative or code-based approach.
+
+**Best for:** Big data teams that prefer a visual, drag-and-drop interface for building and managing distributed data processing workflows.
+
+## 4. Quartz Scheduler: Lightweight Java Job Scheduling
+
+Quartz is a widely-used, open-source job scheduler designed specifically for the Java ecosystem. It is not a standalone platform but rather a library that can be embedded directly into Java applications. This makes it an incredibly lightweight and flexible option for scheduling tasks within a single application's context.
+
+Quartz provides robust features for cron-like scheduling, job persistence, and clustering for high availability. It is highly configurable and allows developers to manage job execution with fine-grained control. Its focus is purely on scheduling, without the broader workflow management, dependency tracking, or cross-system orchestration capabilities of platforms like Kestra or Airflow.
+
+Its tight integration with Java makes it less suitable for polyglot environments or for orchestrating workflows that span multiple services and systems.
+
+**Best for:** Java development teams that need a reliable, lightweight, and embeddable scheduler for in-application tasks.
+
+## 5. Argo Workflows: Kubernetes-Native Container Orchestration
+
+Argo Workflows is an open-source, container-native workflow engine for orchestrating jobs on Kubernetes. Unlike other schedulers that can run on Kubernetes, Argo is fundamentally built on it. Workflows are defined as Kubernetes Custom Resource Definitions (CRDs) in YAML, making them first-class citizens of the Kubernetes ecosystem.
+
+This native approach makes Argo Workflows an excellent choice for tasks that are already containerized, such as CI/CD pipelines, machine learning model training, and large-scale batch processing. It excels at managing complex dependencies and parallelism at the container level.
+
+The primary trade-off is its tight coupling to Kubernetes. It is not designed to run outside of a K8s cluster, and it's less flexible for orchestrating non-containerized tasks like simple scripts or SQL queries without wrapping them in a container. For teams not fully committed to a Kubernetes-centric world, other [Argo Workflows alternatives](/resources/infrastructure/argo-workflows-alternatives) might be more suitable for [Kubernetes workflow orchestration](/resources/infrastructure/kubernetes-workflow-orchestration).
+
+**Best for:** Kubernetes-native teams seeking a container-centric workflow orchestrator for CI/CD, batch jobs, and machine learning pipelines.
+
+## 6. JobRunr: Modern, Distributed Background Processing for Java
+
+JobRunr is another open-source scheduler focused on the Java ecosystem, but with a modern twist. It is designed for simple, distributed background job processing. Developers can create background jobs with just a single line of code, and JobRunr handles the persistence, scheduling, and execution across a cluster of servers.
+
+It offers a clean dashboard for monitoring jobs and supports persistent storage backends like SQL databases or NoSQL stores. JobRunr's philosophy is "fire-and-forget," making it ideal for offloading long-running tasks from the main application thread.
+
+Like Quartz, it is more of a background job library than a full-fledged workflow orchestration platform. It excels at its specific purpose but does not provide the tools for building complex, multi-step, cross-system workflows.
+
+**Best for:** Java applications that need a modern, simple, and distributed library for scheduling and executing background jobs.
+
+## Comparison Table: Open Source Job Schedulers at a Glance
+
+| Tool | License | Deployment | Workflow Definition | Primary Use Case | Polyglot Support | Event-Driven | Enterprise Features |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **Kestra** | Apache 2.0 | Kubernetes, Docker, Bare Metal | Declarative YAML | Unified Orchestration | Yes (Native) | Yes (Core) | Yes (EE) |
+| **Apache Airflow** | Apache 2.0 | Kubernetes, Docker, VMs | Python Code | Data Pipelines | Limited (via Python) | Limited | Yes (Managed) |
+| **Apache DolphinScheduler** | Apache 2.0 | Kubernetes, Docker, Standalone | Visual UI, API | Big Data Workflows | Limited | Yes | Yes |
+| **Quartz Scheduler** | Apache 2.0 | Embedded in Java App | Java Code | In-Application Java Jobs | No | Limited | No |
+| **Argo Workflows** | Apache 2.0 | Kubernetes-Only | Declarative YAML (CRDs) | Kubernetes-Native Jobs | Yes (Containers) | Yes | Yes (Managed) |
+| **JobRunr** | LGPL-3.0 | Embedded in Java App | Java Code | Java Background Jobs | No | No | Yes (Pro) |
+
+## Choosing the Right Open Source Job Scheduler for Your Needs
+
+Selecting the right tool depends entirely on your team's context, technical stack, and the nature of the workflows you need to automate.
+
+*   **For data engineering teams,** the choice often comes down to the trade-off between the code-first flexibility of Airflow and the declarative, polyglot model of Kestra. If your world is Python and batch ETL, Airflow is a proven choice. If your pipelines involve multiple languages and need to integrate with infrastructure tasks, a platform like Kestra offers a more unified approach. Explore more [data engineering resources](/resources/data) to guide your decision.
+*   **For infrastructure & DevOps teams,** the key considerations are GitOps alignment and integration with IaC tools. Argo Workflows is a perfect fit for teams living entirely within Kubernetes. Kestra provides a more versatile solution that can orchestrate Terraform and Ansible alongside containerized and non-containerized tasks, bridging the gap between on-prem, cloud, and K8s environments. See our [infrastructure automation resources](/resources/infrastructure) for more.
+*   **For AI/ML platform teams,** reproducibility and the ability to orchestrate heterogeneous workloads (e.g., data prep, GPU training, model serving) are critical. Container-native tools like Argo Workflows are popular, but a platform like Kestra can orchestrate the entire end-to-end ML lifecycle, from data ingestion to model deployment and monitoring. Check out our [AI orchestration resources](/resources/ai) to learn more.
+*   **For small teams or specific application needs,** lightweight, embedded schedulers like Quartz or JobRunr are excellent. They solve the immediate problem of in-application scheduling without the operational overhead of a full orchestration platform.
+
+## Conclusion: Modernizing Your Automation with the Right Orchestrator
+
+The term "job scheduler" has expanded. While the need for reliable, time-based execution remains, modern engineering demands platforms that can handle event-driven triggers, complex dependencies, and a diverse set of tools and languages. The move is from isolated schedulers to a centralized, declarative orchestration layer that provides visibility, governance, and scalability.
+
+Platforms like Kestra represent this evolution, offering a single control plane to unify automation across your entire organization. By embracing a declarative, language-agnostic, and event-driven approach, you can reduce complexity, empower your teams, and build more resilient and scalable systems.


### PR DESCRIPTION
## Summary

Imports 8 W30 SEO drafts from `vfanucci/kestra-seo` (#273–#280) into the resources hub. Titles locked to the agreed W30 mapping (`title` + `metaTitle`).

| Page | Type | URL | Source |
|------|------|-----|--------|
| AWS Lambda Timeout: Limits & How to Work Around Them | concept | `/resources/infrastructure/aws-lambda-timeout` | #273 |
| ECS vs Fargate: Which to Use for Your Workloads | standard | `/resources/infrastructure/ecs-vs-fargate` | #274 |
| Best Open-Source Job Schedulers in 2026 (Ranked) | listicle | `/resources/infrastructure/open-source-job-scheduler` | #275 |
| What Is Exponential Backoff? Retry Patterns Explained | concept | `/resources/infrastructure/exponential-backoff` | #276 |
| Job Scheduling Software: The Complete Guide (2026) | standard | `/resources/infrastructure/job-scheduling-software` | #277 |
| File Transfer Automation: Orchestrate SFTP/FTP Workflows | concept | `/resources/infrastructure/file-transfer-automation` | #278 |
| Batch Scheduling Platforms: Top Solutions Compared (2026) | listicle | `/resources/infrastructure/batch-scheduling-platform-alternatives` | #279 |
| Job Orchestration: Definition & Tools | concept | `/resources/infrastructure/job-orchestration` | #280 |

No slug collisions.

## Notes
- Titles locked to the agreed W30 mapping (metaTitle ≤60, no ` | Kestra` suffix).
- **#279** ships with the pipeline's listicle slug `batch-scheduling-platform-alternatives`. If you prefer `batch-scheduling-platform`, tell me and I'll rename before merge.
- **Cannibalization watch** (as flagged): `job-scheduling-software`, `batch-scheduling-platform-alternatives`, `open-source-job-scheduler`, `job-orchestration` overlap on the "job scheduling" intent — canonical/internal-link strategy to apply across the cluster.

## Front-matter hygiene
Stray front-matter fence removed (fences balanced); future `date:` → `2026-07-07`; `## ##` normalized; metaTitle ≤60 without ` | Kestra`; no `image:`/`author:`; metaDescription 140–160; no unresolved markers; no duplicated headings. Concept-page plugin FQCNs verified against `context/plugin-classes.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
