### PR TITLE
perf(analytics): run GTM and its tag scripts in a Partytown web worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,56 @@ To resolve this issue, you will need to switch to the OpenSSL legacy provider by
 
 If you are using an Apple Silicon Mac, please ensure that you are using Node.js version 20 or higher.
 
+## Analytics: GTM runs in a web worker (Partytown)
+
+Google Tag Manager and every `gtag`/tag script it loads run inside a
+[Partytown](https://partytown.qwik.dev/) web worker instead of the main
+thread (PageSpeed attributed ~640 ms of main-thread work and ~618 KiB of
+transfer to the GTM stack). The wiring:
+
+- `astro.config.mjs` registers the `@astrojs/partytown` integration with
+  `forward: ["dataLayer.push"]`.
+- `src/scripts/cookieconsent.ts` injects `gtm.js` after cookie consent with
+  `type="text/partytown"` and dispatches the `ptupdate` event so Partytown
+  picks up the late-added script.
+- Site code must only talk to GTM through `window.dataLayer.push(...)`
+  (already the case — `vue-gtm` runs with `enabled: false`). Forwarded
+  pushes are queued even before the worker is ready, so ordering is safe.
+
+### Limitations to be aware of
+
+- **GTM Preview / Tag Assistant does not work** while GTM runs in the
+  worker. Verify tags with GA4 DebugView, the network panel, or by
+  temporarily loading GTM on the main thread (see rollback below).
+- **Tags execute inside the worker.** Any script a tag injects is fetched
+  with `fetch()` and must be CORS-readable; vendors that don't send
+  `Access-Control-Allow-Origin` fail silently. Google (GA4, Ads) serves
+  everything with CORS and is the officially supported case.
+- **DOM-heavy tags are risky in the worker** (widgets, heatmaps,
+  scroll/visibility triggers): every DOM access is proxied synchronously to
+  the main thread — slower, and occasionally incompatible.
+  `loadScriptsOnMainThread` in `astro.config.mjs` is the escape hatch; the
+  HubSpot loader (chat widget, banners) is already pinned there.
+- **`document.write`-based tags are not supported.**
+- **Main-thread code cannot read GTM state** (`window.google_tag_manager`,
+  `gtag(...)` return values). Only forwarded globals reach the worker.
+- **New tag domains need CSP entries in `connect-src`**
+  (`content-security-policy.config.js`): inside the worker, script
+  downloads and beacons go through `fetch()`, which `connect-src` governs
+  (on the main thread they were covered by `script-src`/`img-src`).
+- kestra.io is not cross-origin isolated, so Partytown uses its service
+  worker fallback (`/~partytown/partytown-sw.js`). Synchronous XHR
+  deprecation warnings in the console are expected and harmless.
+
+**When adding a tag to the GTM container**, check it against the list above
+(vendor script CORS-enabled? no `document.write`? not DOM-heavy?). If in
+doubt, add its script URL pattern to `loadScriptsOnMainThread` and its
+domains to the CSP, then verify on a preview deploy.
+
+**Rollback / debugging:** remove `type="text/partytown"` (and the
+`ptupdate` dispatch) in `src/scripts/cookieconsent.ts` to load GTM on the
+main thread again; the Partytown integration can stay enabled while unused.
+
 ## License
 Apache 2.0 © [Kestra Technologies](https://kestra.io)
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,7 @@ import cloudflare from "@astrojs/cloudflare"
 import node from "@astrojs/node"
 import vue from "@astrojs/vue"
 import mdx from "@astrojs/mdx"
+import partytown from "@astrojs/partytown"
 import icon from "astro-icon"
 import expressiveCode from "astro-expressive-code"
 
@@ -64,6 +65,31 @@ export default defineConfig({
         expressiveCode(),
         mdx(),
         icon(),
+        // Runs GTM (and the gtag/tag scripts it loads) in a web worker instead
+        // of the main thread — PageSpeed attributed ~640ms of main-thread work
+        // and ~618 KiB of transfer to the GTM stack on plugin pages. The
+        // gtm.js script itself is injected after cookie consent in
+        // cookieconsent.ts with type="text/partytown".
+        partytown({
+            config: {
+                // All GTM interaction on the site goes through
+                // window.dataLayer.push (vue-gtm runs with enabled: false), so
+                // forwarding it is enough for events pushed from the main
+                // thread to reach the worker.
+                forward: ["dataLayer.push"],
+                // The HubSpot loader builds the chat widget and marketing
+                // banners with heavy main-window DOM access; keep it (and
+                // whatever it loads itself) on the main thread rather than
+                // risk breaking it inside the worker sandbox.
+                loadScriptsOnMainThread: [
+                    /hs-scripts\.com/,
+                    /hs-banner\.com/,
+                    /hubspot\.com/,
+                    /hs-analytics\.net/,
+                    /hsadspixel\.net/,
+                ],
+            },
+        }),
     ],
     markdown: {
         processor: unified({

--- a/content-security-policy.config.js
+++ b/content-security-policy.config.js
@@ -81,6 +81,13 @@ export default {
         "ws://localhost:4000",
         "https://kestra.io",
         "https://*.kestra.io",
+        // GTM + the tags it loads run in a Partytown web worker, where every
+        // script download and beacon goes through fetch() and is therefore
+        // governed by connect-src (main-thread tags used script-src/img-src).
+        "https://*.googletagmanager.com",
+        "https://*.google-analytics.com",
+        "https://*.analytics.google.com",
+        "https://*.licdn.com",
         "https://*.google.com",
         "https://*.reddit.com",
         "https://*.redditstatic.com",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@astrojs/cloudflare": "^14.0.0",
         "@astrojs/markdown-remark": "^7.2.0",
         "@astrojs/mdx": "^7.0.0",
+        "@astrojs/partytown": "^2.1.7",
         "@astrojs/rss": "^4.0.18",
         "@astrojs/vue": "^7.0.0",
         "@cloudflare/workers-types": "^4.20260621.1",
@@ -499,6 +500,16 @@
       },
       "peerDependencies": {
         "astro": "^7.0.0-alpha.2"
+      }
+    },
+    "node_modules/@astrojs/partytown": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@astrojs/partytown/-/partytown-2.1.7.tgz",
+      "integrity": "sha512-dbffmNmJ+sAJ0/aXSaLX4aI04EZS/2C6Mm/+fmd4ikqWO7hV6nIi0sug8Z3c+yqedJNi1swFvpwluWmGjLHNzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@qwik.dev/partytown": "^0.13.2",
+        "mrmime": "^2.0.1"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -3805,6 +3816,21 @@
       "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.390.2.tgz",
       "integrity": "sha512-WcfKz2GNn2vfDX8vXmJYbKxegPxVWHuDQ/pHdAn0HoZDXDFnEp/+x3qBQA+fEvtbPjjtjgAt2wIgJMlM7asx7g==",
       "license": "MIT"
+    },
+    "node_modules/@qwik.dev/partytown": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@qwik.dev/partytown/-/partytown-0.13.2.tgz",
+      "integrity": "sha512-Umls4bSkuzqLVcGvf8OgwIn/OldproSAbaQ/iYGe8VPYBpl2CaOSxabWwkeC72LDFqxVL0b0q8XlI8MuChDyzg==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^16.4.7"
+      },
+      "bin": {
+        "partytown": "bin/partytown.cjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
@@ -8388,6 +8414,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drange": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@astrojs/cloudflare": "^14.0.0",
     "@astrojs/markdown-remark": "^7.2.0",
     "@astrojs/mdx": "^7.0.0",
+    "@astrojs/partytown": "^2.1.7",
     "@astrojs/rss": "^4.0.18",
     "@astrojs/vue": "^7.0.0",
     "@cloudflare/workers-types": "^4.20260621.1",

--- a/src/scripts/cookieconsent.ts
+++ b/src/scripts/cookieconsent.ts
@@ -39,10 +39,16 @@ const enabledAnalytics = async () => {
         event: "gtm.js",
     })
 
+    // Load GTM through Partytown so gtm.js and every gtag config it pulls in
+    // run inside a web worker instead of the main thread. Partytown only
+    // scans for `text/partytown` scripts at startup, so scripts appended
+    // later (like this consent-gated one) must be announced with `ptupdate`.
     const s = document.createElement("script")
     s.async = true
+    s.type = "text/partytown"
     s.src = `https://www.googletagmanager.com/gtm.js?id=${GTM_ID}`
     document.head.appendChild(s)
+    window.dispatchEvent(new CustomEvent("ptupdate"))
 
     const response = await $fetchApi<{
         posthog: { token: string }


### PR DESCRIPTION
# Why

Extracted from #5200 (per review) so the one risky change ships — and can be verified or rolled back — on its own.

The [PageSpeed report on a plugin task page](https://pagespeed.web.dev/analysis/https-kestra-io-plugins-core-asset-ee-io-kestra-plugin-ee-assets-assetshipper/oljkoyjg8n?hl=fr&form_factor=mobile) shows the GTM stack is the site's **single biggest Total Blocking Time contributor**: 618 KiB of transfer, ~640 ms of main-thread execution (gtm.js + three gtag configs), 5 of the 12 long tasks, and ~259 KiB of the "unused JavaScript" finding.

# What

[Partytown](https://partytown.qwik.dev/) runs `gtm.js` and every tag script it loads inside a web worker, taking that work off the main thread:

- `@astrojs/partytown` integration with `forward: ["dataLayer.push"]` — all GTM interaction on the site already goes through `window.dataLayer.push` (vue-gtm runs `enabled: false`), so page-views, consent events and conversion pushes (e.g. `Meeting.vue`) all reach the worker.
- The consent-gated injection in `cookieconsent.ts` appends the script with `type="text/partytown"` and dispatches `ptupdate` (Partytown only scans at startup; verified locally that the worker picks the script up and issues the gtm.js request).
- **HubSpot stays on the main thread** via `loadScriptsOnMainThread` — the chat widget/banners do heavy main-window DOM work and are the most likely thing to break inside the worker sandbox.
- CSP `connect-src` gains the GTM/GA/LinkedIn origins: inside the worker every script download and beacon goes through `fetch()`, which `connect-src` governs (on the main thread they went through `script-src`/`img-src`).

# Limitations (documented in the README by this PR)

- **GTM Preview / Tag Assistant doesn't work** while GTM is in the worker — verify tags with GA4 DebugView or the network panel instead (or temporarily revert to main-thread loading, a 2-line change in `cookieconsent.ts`).
- Vendor scripts injected by tags are fetched with CORS inside the worker; **vendors without `Access-Control-Allow-Origin` fail silently**. `loadScriptsOnMainThread` is the escape hatch.
- `document.write` tags and DOM-heavy tags (widgets, heatmaps, scroll/visibility triggers) are the incompatibility hot spots.
- Main-thread code can only reach GTM via forwarded `dataLayer.push` — no reading `window.google_tag_manager` (nothing in this codebase does).
- New tag domains must be added to CSP `connect-src`.

# Current tag inventory — expected compatibility

| Tag (from the PSI report) | Where it runs now | Status |
|---|---|---|
| GA4 (`G-EYVNS03HHR`) | worker | ✅ Officially supported case (Google serves gtag with CORS) |
| Google Ads ×2 (`AW-…`) + doubleclick/ccm conversion pings | worker (pings proxied as main-thread images) | ✅ Supported |
| LinkedIn Insight (`snap.licdn.com`) | worker | ⚠️ Beacon-style, expected to work — **verify on preview** |
| vector.co pixel | worker | ⚠️ DOM-scraping form tracker — **verify on preview**; pin to main thread if broken |
| Common Room (`cdn.cr-relay.com`) | worker | ⚠️ **Verify on preview** |
| HubSpot suite (analytics, banner, web-interactives, adspixel) | main thread (pinned) | ✅ Unaffected |
| Cloudflare beacon, PostHog | main thread (not loaded via GTM) | ✅ Unaffected |

# Verification & rollback

**Wiring is verified end-to-end locally** (worker boots, picks up the consent-injected script, issues the gtm.js request, `dataLayer.push` forwarding active). Actual per-tag firing can't be tested offline — ⚠️ **before merging, please check GA4 DebugView + the network tab on the preview deploy**, focusing on the three ⚠️ rows above.

Rollback: remove `type="text/partytown"` + the `ptupdate` dispatch in `cookieconsent.ts` (GTM loads on the main thread again; the integration can stay enabled while unused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LucFExZgpDSm9YQ2FXky6J

---
_Generated by [Claude Code](https://claude.ai/code/session_01LucFExZgpDSm9YQ2FXky6J)_