### PR TITLE
fix(plugins): autofocus search input

### DIFF
--- a/src/components/plugins/PluginsLists.vue
+++ b/src/components/plugins/PluginsLists.vue
@@ -12,6 +12,7 @@
                 <input
                     v-model="searchQuery"
                     type="text"
+                    autofocus
                     :placeholder="`Search across ${props.totalPluginCount} plugins`"
                 />
                 <Close


### PR DESCRIPTION
## Summary
- Autofocus search input on /plugins page load, native `autofocus` attr.

## Test plan
- [ ] Load /plugins, confirm search input focused