### PR TITLE
seo(resources): add human-in-the-loop-orchestration page

### DIFF
--- a/src/contents/resources/human-in-the-loop-orchestration/index.md
+++ b/src/contents/resources/human-in-the-loop-orchestration/index.md
@@ -1,0 +1,177 @@
+---
+title: "Human-in-the-Loop (HITL) Orchestration for AI and Automation"
+description: "Human-in-the-Loop (HITL) orchestration integrates human intelligence into automated workflows, ensuring accuracy, ethical oversight, and robust decision-making for AI agents, data pipelines, and infrastructure operations."
+metaTitle: "Human-in-the-Loop (HITL) Orchestration Explained"
+metaDescription: "Learn how Human-in-the-Loop (HITL) orchestration adds human approval gates to AI agents and automated workflows for accuracy, compliance, and edge cases."
+tag: "ai"
+date: 2026-07-07
+slug: "human-in-the-loop-orchestration"
+faq:
+  - question: "What is the concept of Human-in-the-Loop (HITL)?"
+    answer: "Human-in-the-Loop (HITL) is an approach that integrates human judgment into automated processes, particularly in AI and machine learning. Humans validate decisions, approve critical actions, or intervene in edge cases that automated systems cannot handle reliably, ensuring accuracy, ethical alignment, and compliance."
+  - question: "What is the difference between Human-in-the-Loop and Human-on-the-Loop?"
+    answer: "Human-in-the-Loop (HITL) requires active human intervention before a workflow can proceed — the system pauses and waits for a decision. Human-on-the-Loop (HOTL) means humans supervise and audit outcomes without gating each decision, allowing greater automation scale while keeping accountability. Most production systems combine both: HITL gates for high-stakes actions, HOTL monitoring everywhere else."
+  - question: "Why is Human-in-the-Loop essential for AI agents in production?"
+    answer: "AI agents can draft responses, classify requests, and prepare actions, but in regulated or high-stakes contexts, an irreversible action (sending a customer email, approving a transaction, provisioning infrastructure) needs explicit human sign-off. HITL provides the approval gate that lets teams deploy agents to production without giving them unsupervised authority, and creates an audit trail of who approved what."
+  - question: "How do you implement Human-in-the-Loop in an automated workflow?"
+    answer: "A HITL gate typically has four parts: a notification to the reviewer (Slack, Teams, email), a pause step that halts execution until an external decision arrives, a structured way to capture the decision (approve/reject with a reason), and conditional branching based on that decision. In Kestra, this is a declarative Pause task resumed via the UI, API, or a webhook, with the human decision recorded in the execution logs."
+  - question: "What are common applications of Human-in-the-Loop systems?"
+    answer: "Common HITL applications include reviewing AI agent outputs before they reach customers, fraud detection and transaction approvals, document and identity validation, data labeling for model training, content moderation, and infrastructure provisioning with approval gates. HITL is essential wherever stakes, ambiguity, or regulation require human judgment."
+  - question: "What is the '30% rule' for AI?"
+    answer: "The '30% rule' is an informal heuristic suggesting that even highly automated AI systems should keep humans involved in roughly 30% of decisions — typically the ambiguous, high-stakes, or novel cases — while automation handles the routine majority. It is not a formal standard; the right ratio depends on the domain, risk tolerance, and system maturity, and mature HITL systems shrink the human share over time as confidence grows."
+---
+
+> **TL;DR** — Human-in-the-Loop (HITL) orchestration integrates human decisions into automated workflows as explicit, auditable approval gates — essential for deploying AI agents, data pipelines, and infrastructure automation in high-stakes or regulated contexts.
+
+AI agents can now classify incoming requests, parse documents, draft responses, and call APIs end to end. What they can't do is take responsibility. When a workflow is about to send a customer-facing reply, approve a transaction, or modify production infrastructure, someone accountable needs to say yes.
+
+Human-in-the-Loop (HITL) orchestration is how you build that "yes" into an automated system without breaking it: the workflow pauses, routes the decision to the right person, waits — for minutes or for days — and resumes with the human decision recorded in the audit trail. This article covers what HITL orchestration is, why it's the prerequisite for putting AI agents in production, and how to implement it declaratively.
+
+## What is Human-in-the-Loop (HITL) Orchestration?
+
+Human-in-the-Loop (HITL) orchestration is a design pattern where an automated workflow explicitly pauses its execution to require human input before proceeding. It's a formal mechanism for embedding human judgment, validation, and decision-making into otherwise automated processes. Instead of a fully autonomous system, you create a collaborative one where machines handle the repetitive work and humans handle the exceptions, ambiguity, and high-stakes decisions.
+
+The key principles of a HITL system include:
+*   **Human judgment at critical decision points:** Automation stops at pre-defined gates where a human must review data, validate a machine's conclusion, or make a final decision.
+*   **Continuous feedback loop:** Human interactions are not just one-off decisions; they can be used to retrain and improve the underlying AI/ML models, reducing the need for future interventions.
+*   **Explicit error handling and escalation:** When an automated system encounters a low-confidence scenario or a novel edge case, it doesn't fail silently. It formally escalates the task to a human operator for resolution.
+
+HITL is one of three common models for human-AI collaboration, each suited to different levels of risk and autonomy.
+
+| Approach | Who Decides | When Humans Act | Typical Use Case |
+|---|---|---|---|
+| **Human-in-the-Loop (HITL)** | Human | Before an action is taken. The system pauses and waits for approval. | Approving financial transactions, validating AI-generated patient reports, confirming critical infrastructure changes. |
+| **Human-on-the-Loop (HOTL)** | AI System | After an action is taken. Humans monitor, audit, and can override decisions. | Reviewing content moderation flags, auditing fraud detection systems, analyzing system performance alerts. |
+| **Fully Autonomous** | AI System | Never. The system operates without direct human oversight on individual decisions. | Automated stock trading algorithms, dynamic ad placement, predictive maintenance scheduling based on sensor data. |
+
+## Why HITL is Essential for Reliable AI and Automated Workflows
+
+While full automation is the goal, HITL is the bridge that makes advanced automation practical and safe in the real world. It addresses the core limitations of AI and complex systems where errors have significant consequences.
+
+*   **Accountability for irreversible actions:** An AI agent can draft a legal document or a customer service response, but a human must be accountable for sending it. HITL creates a clear point of sign-off, ensuring that a person, not an algorithm, is responsible for critical, irreversible actions. The agent does the work; the human takes responsibility.
+*   **Compliance and ethical oversight:** In regulated industries like [healthcare data orchestration](/use-cases/healthcare), finance, and insurance, many decisions legally require human oversight. HITL provides the auditable, traceable mechanism to enforce these compliance rules, proving that a qualified person reviewed and approved a specific action.
+*   **Handling edge cases and ambiguity:** No model is perfect. When an automated system encounters a novel situation or its confidence score drops below a certain threshold, it's safer to escalate than to guess. A robust HITL pattern doesn't just fail; it routes the ambiguous case to a human reviewer with a machine-generated summary of why it stalled, turning a potential failure into a structured resolution process.
+*   **Bias mitigation and model improvement:** AI models can inherit and amplify biases present in their training data. Human reviewers in the loop can identify and correct biased outcomes, providing critical feedback to data science teams. This feedback is invaluable for retraining models and building fairer, more accurate systems over time.
+
+## Anatomy of a Human-in-the-Loop Gate
+
+A robust HITL gate isn't just a `sleep(60)` command. It's a structured, stateful process with four distinct mechanical parts:
+
+1.  **Notify:** The workflow sends a notification to the designated human reviewer or group. This message contains the context of the decision needed and a direct link to the paused workflow or decision interface.
+2.  **Pause:** The workflow execution halts completely. Crucially, a production-grade pause must wait indefinitely for an external signal (an API call, a webhook, or a UI action), not on a fixed timer. A compliance review or a manager's approval doesn't happen on a 60-second schedule; it might take hours or days. Event-based pausing waits exactly as long as needed without consuming resources or failing on a timeout.
+3.  **Capture Decision:** When the human acts, the system must capture their decision in a structured format. This is more than a simple "resume" signal; it should include who made the decision, when they made it, and the outcome (e.g., "approve," "reject," "escalate") along with a reason or comments.
+4.  **Branch:** The workflow resumes and immediately branches its logic based on the captured human input. An "approve" decision triggers one set of tasks, while a "reject" decision triggers another, such as logging the rejection or sending it back to the originator.
+
+This entire sequence—pause, decision, and outcome—must be logged in the workflow's execution history, creating an immutable audit trail for compliance and debugging.
+
+## Orchestrating Human-in-the-Loop Workflows with Kestra
+
+Kestra implements HITL patterns declaratively using the `Pause` task. This allows you to build complex approval gates directly into your YAML workflows without custom code. The engine handles the state management, notifications, and capturing of the human response.
+
+Consider a fraud detection workflow. It ingests transactions, uses a Python script to apply a risk model, and if a transaction is flagged, it pauses for a human analyst's review before proceeding.
+
+```yaml
+id: fraud-detection-with-human-approval
+namespace: company.team.finance
+
+tasks:
+  - id: fetch_transactions
+    type: io.kestra.plugin.jdbc.postgresql.Query
+    sql: "SELECT * FROM transactions WHERE status = 'pending';"
+    store: true
+
+  - id: flag_for_review
+    type: io.kestra.plugin.scripts.python.Script
+    runner: DOCKER
+    docker:
+      image: python:slim
+    script: |
+      import json
+      from kestra import Kestra
+      
+      data = Kestra.get_storage_object("{{ outputs.fetch_transactions.uri }}")
+      transactions = [json.loads(line) for line in data.splitlines()]
+      
+      flagged = []
+      for t in transactions:
+        # Dummy fraud logic: flag any transaction over 1000
+        if t['amount'] > 1000:
+          flagged.append(t['transaction_id'])
+      
+      Kestra.outputs({'flagged_ids': flagged})
+
+  - id: check_if_flagged
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ outputs.flag_for_review.vars.flagged_ids | length > 0 }}"
+    then:
+      - id: notify_reviewer
+        type: io.kestra.plugin.core.http.Request
+        uri: "{{ secret('SLACK_WEBHOOK_URL') }}"
+        method: POST
+        body: |
+          {
+            "text": "Fraud review required for transactions: {{ outputs.flag_for_review.vars.flagged_ids }}. Please review at {{ flow.uri }}/executions/{{ execution.id }}"
+          }
+
+      - id: human_review
+        type: io.kestra.plugin.core.flow.Pause
+        onResume:
+          - id: decision
+            type: STRING
+            name: decision
+            defaults: "approve"
+            validations:
+              - NotBlank
+              - Enum(values=['approve', 'reject'])
+          - id: reason
+            type: STRING
+            name: reason
+            defaults: "Approved per policy"
+
+      - id: process_decision
+        type: io.kestra.plugin.core.flow.If
+        condition: "{{ outputs.human_review.onResume.decision == 'approve' }}"
+        then:
+          - id: approve_transactions
+            type: io.kestra.plugin.jdbc.postgresql.Query
+            sql: "UPDATE transactions SET status = 'approved', review_notes = '{{ outputs.human_review.onResume.reason }}' WHERE transaction_id IN ({{ outputs.flag_for_review.vars.flagged_ids | join(', ') }});"
+        else:
+          - id: reject_transactions
+            type: io.kestra.plugin.jdbc.postgresql.Query
+            sql: "UPDATE transactions SET status = 'rejected', review_notes = '{{ outputs.human_review.onResume.reason }}' WHERE transaction_id IN ({{ outputs.flag_for_review.vars.flagged_ids | join(', ') }});"
+```
+
+What's worth noticing in this flow:
+*   **Declarative Pause:** The `human_review` task is a simple `Pause` task. By default, it has no timeout and will wait indefinitely until action is taken.
+*   **Structured Decision Capture:** The `onResume` property defines a form that appears in the Kestra UI when a user resumes the flow. This captures a structured decision (`approve` or `reject`) and a free-text `reason`, which become auditable outputs.
+*   **Conditional Branching:** The `process_decision` task uses a simple `If` condition to check the output from the pause task (`{{ outputs.human_review.onResume.decision }}`) and route the flow accordingly.
+*   **Unified View:** An analyst can see all workflows pending their approval directly in the Kestra UI, alongside all other running and completed data pipelines.
+
+## HITL for AI Agents
+
+The principles of HITL are even more critical for the new generation of AI agents. While agentic frameworks are powerful, deploying them to production requires governance. HITL provides the control layer that makes agentic automation safe.
+
+The common pattern for [production-ready AI agents](/blogs/orchestrate-ai-agents-kestra) is: agent classifies/drafts → human approves → workflow executes. The HITL gate converts a powerful but unsupervised agent demo into a reliable, auditable production system.
+
+This pattern can be applied with fine granularity. Using a `ForEach` task, a workflow can process a batch of items, and only those flagged by an agent will trigger a `Pause` for review. The rest flow through automatically, ensuring human attention is focused only where it's needed.
+
+Modern orchestration platforms also allow reviewers to submit their decisions via webhooks. This means an approval can be triggered from a button in a Slack message, a custom internal application, or any tool that can make an HTTP request, allowing reviewers to stay in their native tools without opening the orchestrator's UI.
+
+## Common Applications of Human-in-the-Loop Across Domains
+
+HITL is not just for fraud detection. The pattern is fundamental across any domain where automation needs accountability:
+
+*   **AI Agent Output Review:** Approving AI-generated customer service emails, marketing copy, or technical documentation before it's published.
+*   **Fraud Detection and Risk Assessment:** Validating flagged insurance claims or loan applications.
+*   **Document and Identity Validation:** Having a human verify documents that an OCR or AI model couldn't parse with high confidence.
+*   **ITSM and Infrastructure Provisioning:** Requiring a manager's approval before a workflow provisions costly cloud resources or makes changes to a production environment.
+*   **Data Labeling:** Humans labeling or correcting data to train and fine-tune machine learning models.
+
+## Related Concepts
+
+*   [Add Human-in-the-Loop Approvals to Automated Workflows](/docs/use-cases/approval-processes)
+*   [Blueprint: Human-in-the-Loop Product Ordering](/blueprints/product-order-approval-hitl)
+*   [Blueprint: Business Processes workflow example](/blueprints/business-processes)
+*   [How to Pause and Resume Flows in Kestra](/docs/how-to-guides/pause-resume)
+*   [AI-Native Orchestration Platforms: Tools & Comparison](/resources/ai/ai-native-orchestration-platform)
+*   [Orchestrate Your Entire Infrastructure from One Control Plane](/infra-automation)


### PR DESCRIPTION
## Summary

Imports the ready draft `human-in-the-loop-orchestration` from `vfanucci/kestra-seo#281` (built from the curated v2 outline) into the resources hub.

| Page | Tag | URL | Source |
|------|-----|-----|--------|
| Human-in-the-Loop (HITL) Orchestration | ai | `/resources/ai/human-in-the-loop-orchestration` | kestra-seo#281 |

New slug; no collision.

## Front-matter hygiene
Stray fence removed (fences balanced); `date` normalized; `## ##` normalized; metaTitle 48 chars (no ` | Kestra`); metaDescription 153; no `image:`/`author:`; no unresolved markers; no duplicated headings.

## Confidentiality check
The v2 outline carried a redline (customer-call-derived patterns must stay fully generic — no client name, no insurance/underwriting scenario). Verified: the draft contains no client name and no identifiable pipeline details; "insurance" appears only as a generic regulated-industry / application example (as allowed by the outline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
