### PR TITLE
fix(resources): correct human-in-the-loop-orchestration publish date (2026-07-07 -> 2026-07-23)

### DIFF
--- a/src/contents/resources/human-in-the-loop-orchestration/index.md
+++ b/src/contents/resources/human-in-the-loop-orchestration/index.md
@@ -4,7 +4,7 @@ description: "Human-in-the-Loop (HITL) orchestration integrates human intelligen
 metaTitle: "Human-in-the-Loop (HITL) Orchestration Explained"
 metaDescription: "Learn how Human-in-the-Loop (HITL) orchestration adds human approval gates to AI agents and automated workflows for accuracy, compliance, and edge cases."
 tag: "ai"
-date: 2026-07-07
+date: 2026-07-23
 slug: "human-in-the-loop-orchestration"
 faq:
   - question: "What is the concept of Human-in-the-Loop (HITL)?"


### PR DESCRIPTION
The import script used a stale hardcoded 'today' (2026-07-07) and pushed the page's `date` back to 2026-07-07 (16 days in the past). The draft's real date was 2026-07-23. This restores it.

Note: the same stale-today bug likely affected other recently-merged W29/W30 import PRs — audit pending.