### PR TITLE
fix(resources): backfill publish dates on 37 pages (stale 2026-07-07 -> real merge dates)

### DIFF
--- a/src/contents/resources/airbyte-orchestration/index.md
+++ b/src/contents/resources/airbyte-orchestration/index.md
@@ -4,7 +4,7 @@ description: "Dedicated orchestration tools elevate Airbyte's data integration c
 metaTitle: "Airbyte Orchestration: Guide to Automated Data Workflows"
 metaDescription: "Orchestrate Airbyte syncs with Kestra for automated data pipelines. Learn benefits, examples, and best practices to streamline data integration workflows."
 tag: "data"
-date: 2026-07-07
+date: 2026-07-14
 slug: "airbyte-orchestration"
 faq:
   - question: "What is Airbyte orchestration used for?"

--- a/src/contents/resources/api-orchestration/index.md
+++ b/src/contents/resources/api-orchestration/index.md
@@ -4,7 +4,7 @@ description: "API orchestration coordinates multiple APIs into complex, event-dr
 metaTitle: "What is API Orchestration? Definition & Practices"
 metaDescription: "Master API orchestration to streamline complex workflows, integrate multiple APIs, and enhance data management. Explore how Kestra simplifies API automation."
 tag: "infrastructure"
-date: 2026-07-07
+date: 2026-07-14
 slug: "api-orchestration"
 faq:
   - question: "What is API orchestration?"

--- a/src/contents/resources/aws-lambda-timeout/index.md
+++ b/src/contents/resources/aws-lambda-timeout/index.md
@@ -4,7 +4,7 @@ description: "Understand AWS Lambda timeout settings, limits, and best practices
 metaTitle: "AWS Lambda Timeout: Limits & How to Work Around Them"
 metaDescription: "Optimize AWS Lambda timeout settings and limits. Configure, troubleshoot, and orchestrate Lambda functions with Kestra for resilient serverless apps."
 tag: "infrastructure"
-date: 2026-07-07
+date: 2026-07-21
 slug: "aws-lambda-timeout"
 faq:
   - question: "What is the timeout for AWS Lambda?"

--- a/src/contents/resources/azure-batch/index.md
+++ b/src/contents/resources/azure-batch/index.md
@@ -4,7 +4,7 @@ description: "Explore Azure Batch for managing compute-intensive tasks at scale 
 metaTitle: "Azure Batch Orchestration for Large-Scale Compute"
 metaDescription: "Manage large-scale parallel computing with Azure Batch. Kestra orchestrates Batch jobs with declarative YAML, triggers, and monitoring for automated compute."
 tag: "infrastructure"
-date: 2026-07-07
+date: 2026-07-14
 slug: "azure-batch"
 faq:
   - question: "What is Azure Batch?"

--- a/src/contents/resources/batch-scheduling-platform-alternatives/index.md
+++ b/src/contents/resources/batch-scheduling-platform-alternatives/index.md
@@ -4,7 +4,7 @@ description: "Explore top alternatives to traditional batch scheduling platforms
 metaTitle: "Batch Scheduling Platforms: Top Solutions Compared (2026)"
 metaDescription: "Compare batch scheduling platforms for modern IT. Kestra, ActiveBatch, Redwood, and others offer declarative, event-driven, and unified workflow automation."
 tag: "infrastructure"
-date: 2026-07-07
+date: 2026-07-21
 slug: "batch-scheduling-platform-alternatives"
 faq:
   - question: "Why should I consider an alternative to my current batch scheduling platform?"

--- a/src/contents/resources/dead-letter-queue/index.md
+++ b/src/contents/resources/dead-letter-queue/index.md
@@ -4,7 +4,7 @@ description: "Explore the concept of a dead letter queue (DLQ) and its vital rol
 metaTitle: "Dead Letter Queue (DLQ) Explained"
 metaDescription: "Understand what a dead letter queue (DLQ) is and why it's crucial for robust messaging. Learn how Kestra provides declarative orchestration for DLQ management."
 tag: "infrastructure"
-date: 2026-07-07
+date: 2026-07-10
 slug: "dead-letter-queue"
 faq:
   - question: "What is the point of a dead-letter queue (DLQ)?"

--- a/src/contents/resources/delta-lake/index.md
+++ b/src/contents/resources/delta-lake/index.md
@@ -4,7 +4,7 @@ description: "Explore Delta Lake, an open-source storage layer that brings ACID 
 metaTitle: "Delta Lake: ACID, Lakehouse, Orchestration"
 metaDescription: "Delta Lake provides ACID transactions, schema enforcement, and time travel for lakehouses. Understand its architecture and how Kestra orchestrates it."
 tag: "data"
-date: 2026-07-07
+date: 2026-07-10
 slug: "delta-lake"
 faq:
   - question: "What is Delta Lake and why is it important?"

--- a/src/contents/resources/ecs-vs-fargate/index.md
+++ b/src/contents/resources/ecs-vs-fargate/index.md
@@ -4,7 +4,7 @@ description: "Understand the core differences between AWS ECS and Fargate to sel
 metaTitle: "ECS vs Fargate: Which to Use for Your Workloads"
 metaDescription: "Compare AWS ECS and Fargate to choose the optimal container orchestration for your applications. Learn about their features, costs, and use cases."
 tag: infrastructure
-date: 2026-07-07
+date: 2026-07-21
 slug: ecs-vs-fargate
 faq:
   - question: Can you use ECS without Fargate?

--- a/src/contents/resources/elastic-search-alternatives/index.md
+++ b/src/contents/resources/elastic-search-alternatives/index.md
@@ -4,7 +4,7 @@ description: "Explore the best Elasticsearch alternatives for your data search a
 metaTitle: "Elasticsearch Alternatives: Top Search & Analytics Tools"
 metaDescription: "Explore top Elasticsearch alternatives for data, analytics, and AI: open-source, cloud, and specialized search engines, plus how Kestra orchestrates them."
 tag: "data"
-date: 2026-07-07
+date: 2026-07-17
 slug: "elastic-search-alternatives"
 faq:
   - question: "Why do companies look for Elasticsearch alternatives?"

--- a/src/contents/resources/elastic-search/index.md
+++ b/src/contents/resources/elastic-search/index.md
@@ -4,7 +4,7 @@ description: "Elasticsearch is a powerful open-source search and analytics engin
 metaTitle: "Elasticsearch: Real-time Search & Analytics Guide"
 metaDescription: "Understand Elasticsearch's real-time search and analytics capabilities. Learn its architecture, features, and use cases for logs, full-text search, and BI."
 tag: data
-date: 2026-07-07
+date: 2026-07-17
 slug: "elastic-search"
 faq:
   - question: "What is Elasticsearch used for?"

--- a/src/contents/resources/exponential-backoff/index.md
+++ b/src/contents/resources/exponential-backoff/index.md
@@ -4,7 +4,7 @@ description: "Explore exponential backoff, a crucial retry strategy for building
 metaTitle: "What Is Exponential Backoff? Retry Patterns Explained"
 metaDescription: "Exponential backoff is a vital retry mechanism for resilient distributed systems. Learn its benefits over linear backoff and how to implement it effectively."
 tag: infrastructure
-date: 2026-07-07
+date: 2026-07-21
 slug: exponential-backoff
 faq:
   - question: "What is an exponential backoff?"

--- a/src/contents/resources/fast-mcp/index.md
+++ b/src/contents/resources/fast-mcp/index.md
@@ -4,7 +4,7 @@ description: "Explore FastMCP, the Pythonic framework for building Model Context
 metaTitle: "FastMCP: Build LLM Tools with Declarative Workflows"
 metaDescription: "FastMCP simplifies LLM tooling and agent development. This declarative framework streamlines building and deploying Model Context Protocol (MCP) servers."
 tag: "ai"
-date: 2026-07-07
+date: 2026-07-15
 slug: "fast-mcp"
 faq:
   - question: "What is FastMCP?"

--- a/src/contents/resources/file-transfer-automation/index.md
+++ b/src/contents/resources/file-transfer-automation/index.md
@@ -4,7 +4,7 @@ description: "Explore the essentials of automated file transfer (AFT) and how it
 metaTitle: "File Transfer Automation: Orchestrate SFTP/FTP Workflows"
 metaDescription: "Automate file transfers for secure, efficient, and auditable data exchange. Discover how Kestra orchestrates AFT within your data and infrastructure workflows."
 tag: "infrastructure"
-date: 2026-07-07
+date: 2026-07-21
 slug: "file-transfer-automation"
 faq:
   - question: "What is file transfer automation?"

--- a/src/contents/resources/fuzzy-search/index.md
+++ b/src/contents/resources/fuzzy-search/index.md
@@ -4,7 +4,7 @@ description: "Understand fuzzy search, a technique for finding approximate match
 metaTitle: "Fuzzy Search: Flexible Data Querying and Orchestration"
 metaDescription: "Fuzzy search enhances data retrieval through flexible querying. Approximate string matching improves user experience and system orchestration."
 tag: data
-date: 2026-07-07
+date: 2026-07-17
 slug: fuzzy-search
 faq:
   - question: "What is the core principle behind fuzzy search?"

--- a/src/contents/resources/google-cloud-scheduler/index.md
+++ b/src/contents/resources/google-cloud-scheduler/index.md
@@ -4,7 +4,7 @@ description: "A cloud scheduler automates tasks based on a predefined schedule, 
 metaTitle: "Cloud Scheduler: Definition, Use Cases & Kestra"
 metaDescription: "What a cloud scheduler is, its benefits for automation, and how Kestra orchestrates time-based jobs across any cloud with declarative workflows."
 tag: infrastructure
-date: 2026-07-07
+date: 2026-07-14
 slug: "google-cloud-scheduler"
 faq:
   - question: "What is a Cloud Scheduler?"

--- a/src/contents/resources/how-to-build-an-ai-agent/index.md
+++ b/src/contents/resources/how-to-build-an-ai-agent/index.md
@@ -4,7 +4,7 @@ description: "Learn to build production-ready AI agents using Kestra's declarati
 metaTitle: "Build AI Agents: Step-by-Step with Kestra Orchestration"
 metaDescription: "Build AI agents with declarative orchestration, LLM integration, tool definition, and governance. Master robust AI workflows from concept to production."
 tag: "ai"
-date: 2026-07-07
+date: 2026-07-10
 slug: "how-to-build-an-ai-agent"
 faq:
   - question: "Is it free to build an AI agent?"

--- a/src/contents/resources/human-in-the-loop-orchestration/index.md
+++ b/src/contents/resources/human-in-the-loop-orchestration/index.md
@@ -4,7 +4,7 @@ description: "Human-in-the-Loop (HITL) orchestration integrates human intelligen
 metaTitle: "Human-in-the-Loop (HITL) Orchestration Explained"
 metaDescription: "Learn how Human-in-the-Loop (HITL) orchestration adds human approval gates to AI agents and automated workflows for accuracy, compliance, and edge cases."
 tag: "ai"
-date: 2026-07-07
+date: 2026-07-23
 slug: "human-in-the-loop-orchestration"
 faq:
   - question: "What is the concept of Human-in-the-Loop (HITL)?"

--- a/src/contents/resources/idempotency/index.md
+++ b/src/contents/resources/idempotency/index.md
@@ -4,7 +4,7 @@ description: "Idempotency is the property of an operation that produces the same
 metaTitle: "Idempotency for Reliable Distributed Workflows"
 metaDescription: "Idempotency keeps APIs, data pipelines, and event-driven systems reliable. Learn its principles, patterns, and how Kestra ensures repeatable operations."
 tag: "infrastructure"
-date: 2026-07-07
+date: 2026-07-10
 slug: "idempotency"
 faq:
   - question: "What is idempotency in API?"

--- a/src/contents/resources/job-orchestration/index.md
+++ b/src/contents/resources/job-orchestration/index.md
@@ -4,7 +4,7 @@ description: "Job orchestration goes beyond simple scheduling, coordinating comp
 metaTitle: "Job Orchestration: Definition & Tools"
 metaDescription: "Understand job orchestration, its benefits over traditional scheduling, and how a declarative platform unifies automated processes across data, IT, and AI."
 tag: "infrastructure"
-date: 2026-07-07
+date: 2026-07-21
 slug: "job-orchestration"
 faq:
   - question: "What is job orchestration?"

--- a/src/contents/resources/job-scheduling-software/index.md
+++ b/src/contents/resources/job-scheduling-software/index.md
@@ -4,7 +4,7 @@ description: "Job scheduling software automates tasks, from simple cron jobs to 
 metaTitle: "Job Scheduling Software: The Complete Guide (2026)"
 metaDescription: "Explore modern job scheduling software to automate and optimize tasks across data, AI, and infrastructure. Enhance workflow governance and developer experience."
 tag: "infrastructure"
-date: 2026-07-07
+date: 2026-07-21
 slug: "job-scheduling-software"
 faq:
   - question: "What is modern job scheduling software?"

--- a/src/contents/resources/kinesis-vs-kafka/index.md
+++ b/src/contents/resources/kinesis-vs-kafka/index.md
@@ -4,7 +4,7 @@ description: "Compare Amazon Kinesis and Apache Kafka to understand their archit
 metaTitle: "Kinesis vs. Kafka: Streaming Platform Comparison"
 metaDescription: "Compare Amazon Kinesis and Apache Kafka for data streaming. Understand architectures, features, performance, and costs to pick the right platform."
 tag: data
-date: 2026-07-07
+date: 2026-07-15
 slug: kinesis-vs-kafka
 faq:
   - question: "What is the core architectural difference between Kinesis and Kafka?"

--- a/src/contents/resources/message-queue/index.md
+++ b/src/contents/resources/message-queue/index.md
@@ -4,7 +4,7 @@ description: "Explore message queues as a core component of distributed systems,
 metaTitle: "Message Queue: A Guide to Asynchronous Communication"
 metaDescription: "What a message queue is and its role in distributed systems for resilience and scalability — plus how Kestra orchestrates event-driven queue workflows."
 tag: "infrastructure"
-date: 2026-07-07
+date: 2026-07-10
 slug: "message-queue"
 faq:
   - question: "What is a message queue?"

--- a/src/contents/resources/migrate-from-cron/index.md
+++ b/src/contents/resources/migrate-from-cron/index.md
@@ -4,7 +4,7 @@ description: "Transitioning from cron to a modern orchestrator can seem daunting
 metaTitle: "Migrate from Cron to Kestra: Step-by-Step Guide"
 metaDescription: "Move off cron jobs without losing your schedules. Translate crontab to Kestra, add retries, observability and backfill — step-by-step migration guide."
 tag: "infrastructure"
-date: 2026-07-07
+date: 2026-07-15
 slug: "migrate-from-cron"
 faq:
   - question: "How do I migrate my cron jobs to Kestra?"

--- a/src/contents/resources/ml-orchestration/index.md
+++ b/src/contents/resources/ml-orchestration/index.md
@@ -4,7 +4,7 @@ description: "ML orchestration automates, manages, and monitors the entire lifec
 metaTitle: "ML Orchestration: Automate Machine Learning Pipelines"
 metaDescription: "Automate and manage your machine learning workflows with ML orchestration. Explore best practices, tools, and how Kestra simplifies scaling your ML models."
 tag: "ai"
-date: 2026-07-07
+date: 2026-07-14
 slug: "ml-orchestration"
 faq:
   - question: "What is ML orchestration?"

--- a/src/contents/resources/ndjson/index.md
+++ b/src/contents/resources/ndjson/index.md
@@ -4,7 +4,7 @@ description: "NDJSON is a powerful format for handling large, streaming JSON dat
 metaTitle: "NDJSON: Newline Delimited JSON Explained"
 metaDescription: "NDJSON is the newline-delimited JSON format for streaming and large datasets. Explore its benefits, how it compares to JSON, and how Kestra processes it."
 tag: data
-date: 2026-07-07
+date: 2026-07-10
 slug: "ndjson"
 faq:
   - question: "What is NDJSON format?"

--- a/src/contents/resources/open-source-job-scheduler/index.md
+++ b/src/contents/resources/open-source-job-scheduler/index.md
@@ -4,7 +4,7 @@ description: "Explore the leading open source job schedulers, from traditional c
 metaTitle: "Best Open-Source Job Schedulers in 2026 (Ranked)"
 metaDescription: "Compare open source job schedulers: Airflow, DolphinScheduler, Kestra. Find a modern, lightweight, and scalable solution for workflow automation."
 tag: "infrastructure"
-date: 2026-07-07
+date: 2026-07-21
 slug: "open-source-job-scheduler"
 faq:
   - question: "What is the primary difference between a job scheduler and a workflow orchestrator?"

--- a/src/contents/resources/open-source-workflow-engine/index.md
+++ b/src/contents/resources/open-source-workflow-engine/index.md
@@ -4,7 +4,7 @@ description: "Explore the top open source workflow engines available today, incl
 metaTitle: "Open Source Workflow Engine: Top Tools & Selection Guide"
 metaDescription: "Find the best open source workflow engine. Compare Kestra, Airflow, Temporal, and others to automate and manage your data, AI, and infrastructure workflows."
 tag: "infrastructure"
-date: 2026-07-07
+date: 2026-07-15
 slug: "open-source-workflow-engine"
 faq:
   - question: "What is an open source workflow engine?"

--- a/src/contents/resources/parquet-file-format/index.md
+++ b/src/contents/resources/parquet-file-format/index.md
@@ -4,7 +4,7 @@ description: "Explore the Parquet file format, an open-source columnar storage s
 metaTitle: "Parquet File Format: Data Storage for Analytics"
 metaDescription: "Parquet is an open-source columnar storage format for big-data analytics. Learn its benefits, how it compares to CSV, and its role in modern data pipelines."
 tag: "data"
-date: 2026-07-07
+date: 2026-07-10
 slug: "parquet-file-format"
 faq:
   - question: "Is Parquet better than CSV?"

--- a/src/contents/resources/pubsub-vs-kafka/index.md
+++ b/src/contents/resources/pubsub-vs-kafka/index.md
@@ -4,7 +4,7 @@ description: "Compare Google Cloud Pub/Sub and Apache Kafka for event streaming 
 metaTitle: "Pub/Sub vs. Kafka: Event Streaming Platform Comparison"
 metaDescription: "Pub/Sub vs. Kafka: Compare architectures, operational models, and use cases to choose the right event streaming platform for your data pipelines."
 tag: data
-date: 2026-07-07
+date: 2026-07-15
 slug: "pubsub-vs-kafka"
 faq:
   - question: "What is the core difference between Kafka and Pub/Sub?"

--- a/src/contents/resources/python-orchestration/index.md
+++ b/src/contents/resources/python-orchestration/index.md
@@ -4,7 +4,7 @@ description: "Explore Python orchestration, its role in automating complex workf
 metaTitle: "Python Orchestration: Building & Scaling Workflows"
 metaDescription: "Learn about Python orchestration, its benefits for data and AI workflows, and how Kestra's declarative approach simplifies managing and scaling Python tasks."
 tag: "data"
-date: 2026-07-07
+date: 2026-07-14
 slug: "python-orchestration"
 faq:
   - question: "What is Python orchestration?"

--- a/src/contents/resources/s3-lifecycle-policy/index.md
+++ b/src/contents/resources/s3-lifecycle-policy/index.md
@@ -4,7 +4,7 @@ description: "S3 lifecycle policies automate storage management, transitioning d
 metaTitle: "S3 Lifecycle Policy | Automate Storage & Costs"
 metaDescription: "Automate S3 data retention and optimize storage costs with lifecycle policies. Learn to orchestrate efficient, compliant cloud data management for your buckets."
 tag: "infrastructure"
-date: 2026-07-07
+date: 2026-07-14
 slug: "s3-lifecycle-policy"
 faq:
   - question: "What is an S3 lifecycle policy?"

--- a/src/contents/resources/s3-presigned-url/index.md
+++ b/src/contents/resources/s3-presigned-url/index.md
@@ -4,7 +4,7 @@ description: "S3 Presigned URLs offer a secure, temporary way to share or upload
 metaTitle: "S3 Presigned URLs: Secure Access to Amazon S3 Objects"
 metaDescription: "S3 presigned URLs provide secure, time-limited access to Amazon S3 objects. Learn how they work and automate their generation for uploads and downloads."
 tag: "infrastructure"
-date: 2026-07-07
+date: 2026-07-14
 slug: "s3-presigned-url"
 faq:
   - question: "What is an S3 presigned URL?"

--- a/src/contents/resources/semantic-search/index.md
+++ b/src/contents/resources/semantic-search/index.md
@@ -4,7 +4,7 @@ description: "Explore semantic search, how it moves beyond keyword matching to u
 metaTitle: "What is Semantic Search? Principles & Orchestration"
 metaDescription: "Understand semantic search: its core principles, how it differs from keyword search, and how Kestra orchestrates advanced AI applications using it."
 tag: "ai"
-date: 2026-07-07
+date: 2026-07-17
 slug: "semantic-search"
 faq:
   - question: "What is the core difference between semantic search and keyword search?"

--- a/src/contents/resources/sftp-automation/index.md
+++ b/src/contents/resources/sftp-automation/index.md
@@ -4,7 +4,7 @@ description: "SFTP automation is crucial for secure, efficient, and auditable da
 metaTitle: "SFTP Automation: Secure File Transfers"
 metaDescription: "Master SFTP automation for secure and efficient data exchange. This guide covers SFTP fundamentals, benefits, and how Kestra simplifies implementation."
 tag: "infrastructure"
-date: 2026-07-07
+date: 2026-07-14
 slug: "sftp-automation"
 faq:
   - question: "Can SFTP be automated?"

--- a/src/contents/resources/snowflake-time-travel/index.md
+++ b/src/contents/resources/snowflake-time-travel/index.md
@@ -4,7 +4,7 @@ description: "Explore Snowflake Time Travel's capabilities for data recovery, hi
 metaTitle: "Snowflake Time Travel: Recover & Audit Data"
 metaDescription: "Snowflake Time Travel recovers historical data, audits changes, and analyzes past states. Learn how Kestra orchestrates advanced Time Travel workflows in YAML."
 tag: "data"
-date: 2026-07-07
+date: 2026-07-10
 slug: "snowflake-time-travel"
 faq:
   - question: "What is Snowflake Time Travel?"

--- a/src/contents/resources/sqs-vs-sns/index.md
+++ b/src/contents/resources/sqs-vs-sns/index.md
@@ -4,7 +4,7 @@ description: "Understand the fundamental differences between Amazon SQS and SNS,
 metaTitle: "AWS SQS vs SNS: Messaging for Modern Workflows"
 metaDescription: "Compare Amazon SQS and SNS to choose the best AWS messaging service for your application. Learn their differences, use cases, and how Kestra orchestrates them."
 tag: infrastructure
-date: 2026-07-07
+date: 2026-07-15
 slug: sqs-vs-sns
 faq:
   - question: "Is Kafka similar to SNS or SQS?"

--- a/src/contents/resources/workflow-engine/index.md
+++ b/src/contents/resources/workflow-engine/index.md
@@ -4,7 +4,7 @@ description: "A workflow engine is the software core that automates task sequenc
 metaTitle: "Workflow Engine: Definition, Benefits, and Orchestration"
 metaDescription: "Understand what a workflow engines is, its key benefits for automation, and how Kestra provides a declarative, event-driven platform for unified orchestration."
 tag: "infrastructure"
-date: 2026-07-07
+date: 2026-07-14
 slug: "workflow-engine"
 faq:
   - question: "What is a workflow engine?"


### PR DESCRIPTION
## Summary

Backfills the `date` (publish date) on **37 resource pages** that were imported with a stale value of `2026-07-07`.

### Root cause
The import tooling used a **hardcoded "today" of `2026-07-07`** to normalize future-dated drafts. That constant was never updated, so pages imported and merged between **2026-07-10 and 2026-07-23** all shipped with `date: 2026-07-07` — a publish date up to 16 days in the past, which is a poor SEO/freshness signal.

### Fix
Each affected page's `date` is set to the **merge date of its import PR** (its actual go-live date). Only pages currently dated `2026-07-07` are touched; pages with other (correct) dates are left untouched.

| Merge date | Pages |
|-----------|-------|
| 2026-07-10 | dead-letter-queue, delta-lake, how-to-build-an-ai-agent, idempotency, message-queue, ndjson, parquet-file-format, snowflake-time-travel |
| 2026-07-14 | airbyte-orchestration, api-orchestration, azure-batch, google-cloud-scheduler, ml-orchestration, python-orchestration, s3-lifecycle-policy, s3-presigned-url, sftp-automation, workflow-engine |
| 2026-07-15 | fast-mcp, kinesis-vs-kafka, migrate-from-cron, open-source-workflow-engine, pubsub-vs-kafka, sqs-vs-sns |
| 2026-07-17 | elastic-search, elastic-search-alternatives, fuzzy-search, semantic-search |
| 2026-07-21 | aws-lambda-timeout, batch-scheduling-platform-alternatives, ecs-vs-fargate, exponential-backoff, file-transfer-automation, job-orchestration, job-scheduling-software, open-source-job-scheduler |
| 2026-07-23 | human-in-the-loop-orchestration |

Supersedes #5225 (single-page fix for human-in-the-loop-orchestration).

Going forward, imports keep the draft's real generation date (set by the pipeline) and never hardcode "today".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
