### PR TITLE
seo(resources): add directed-agentic-graphs page

### DIFF
--- a/src/contents/resources/directed-agentic-graphs/index.md
+++ b/src/contents/resources/directed-agentic-graphs/index.md
@@ -1,0 +1,167 @@
+---
+title: "Directed Agentic Graphs: Orchestrating Adaptive AI Workflows"
+description: "Explore directed agentic graphs, an advanced framework for building adaptive AI workflows. Understand how these dynamic, decision-making graphs empower intelligent automation and how Kestra orchestrates them in production."
+metaTitle: "Directed Agentic Graphs for Adaptive AI Orchestration"
+metaDescription: "Directed agentic graphs orchestrate adaptive AI workflows. Explore these dynamic, decision-making structures that Kestra manages end to end."
+tag: "ai"
+date: 2026-07-24
+slug: "directed-agentic-graphs"
+faq:
+  - question: "What is the primary difference between a traditional DAG and a Directed Agentic Graph?"
+    answer: "A traditional Directed Acyclic Graph (DAG) defines a fixed sequence of tasks that execute predictably. In contrast, a Directed Agentic Graph incorporates AI agents at its nodes, allowing for dynamic decision-making, conditional branching, and adaptive execution based on real-time inputs and environmental feedback. This introduces non-determinism and intelligence into the workflow's path."
+  - question: "Why are Directed Agentic Graphs important for AI automation?"
+    answer: "Directed Agentic Graphs are crucial for AI automation because they enable the creation of more intelligent, flexible, and resilient systems. They allow AI agents to dynamically choose tools, alter execution paths, and adapt to unforeseen circumstances, moving beyond rigid, pre-defined sequences to handle complex, real-world problems more effectively and autonomously."
+  - question: "What are the key components of a Directed Agentic Graph?"
+    answer: "Key components include nodes (representing individual AI agents or tasks), edges (representing the flow of data or control between agents), agents (autonomous entities with decision-making capabilities and access to tools), and tools (functions or services agents can call to interact with the environment). The graph's 'directed' nature implies a flow, but the 'agentic' aspect introduces dynamic path determination."
+  - question: "How does Kestra support the orchestration of Directed Agentic Graphs?"
+    answer: "Kestra supports Directed Agentic Graphs through its declarative YAML syntax, powerful flow control tasks (If, Switch, ForEach, Subflow), and native AI agent plugins. This allows users to define dynamic workflows where AI agents can make choices and trigger subsequent actions, while Kestra provides the underlying execution, observability, and governance framework."
+  - question: "Can Directed Agentic Graphs integrate with human-in-the-loop processes?"
+    answer: "Yes, Directed Agentic Graphs can seamlessly integrate human-in-the-loop processes. Kestra's orchestration capabilities allow for tasks that require human approval or input, ensuring that complex decisions or sensitive actions can be reviewed and authorized by human operators before the agentic workflow proceeds. This balances automation with necessary oversight."
+  - question: "What are common use cases for Directed Agentic Graphs?"
+    answer: "Common use cases include adaptive customer support (where agents dynamically route queries or fetch information), automated incident response (where agents diagnose and apply fixes based on real-time alerts), dynamic data analysis pipelines (where agents choose analysis methods based on data characteristics), and personalized content generation."
+---
+
+> **TL;DR** — A Directed Agentic Graph is a workflow model where nodes are intelligent AI agents. Unlike traditional DAGs with fixed paths, these agents can make decisions, use tools, and dynamically alter the execution flow based on real-time context, enabling adaptive and autonomous automation.
+
+Traditional workflows, often modeled as Directed Acyclic Graphs (DAGs), excel at executing predefined sequences of tasks. However, as AI systems become more sophisticated, the need for dynamic, adaptive automation that can make decisions and alter its own path based on real-time context becomes paramount. This is where Directed Agentic Graphs emerge as a powerful paradigm.
+
+Unlike their static predecessors, Directed Agentic Graphs incorporate intelligent agents at their core, allowing for flexible execution, conditional branching, and autonomous decision-making. This article explores what these advanced graphs are, why they are essential for modern AI automation, and how Kestra provides the robust orchestration layer to bring them to life.
+
+## How Directed Agentic Graphs Work
+
+A Directed Agentic Graph is a workflow structure where the nodes are not just simple tasks but intelligent, autonomous agents. These agents can perceive their environment, make decisions, and take actions to achieve specific goals. This fundamentally changes the nature of the workflow from a rigid, deterministic process to a dynamic, adaptive one.
+
+The primary difference from a traditional DAG lies in control flow. A standard DAG has a fixed, predictable path from start to finish. In an agentic graph, the path is emergent; it's determined at runtime by the decisions of the agents within it.
+
+The core components of a Directed Agentic Graph include:
+*   **Nodes (Agents):** Each node is an AI agent, powered by a large language model (LLM). It possesses a reasoning engine and can be equipped with memory and a set of tools.
+*   **Edges:** These represent the potential flow of data and control between agents. An agent's decision determines which outbound edge is taken.
+*   **Tools:** These are functions, APIs, or services that an agent can call to interact with its environment. Examples include searching a database, calling a weather API, or executing a piece of code.
+*   **Memory:** Agents can have short-term memory (context within a single run) or long-term memory (persistent knowledge from past interactions) to inform their decisions.
+
+An agent's decision-making process often follows a pattern similar to the OODA loop (Observe, Orient, Decide, Act). It observes the current state and inputs, orients itself using its instructions and memory, decides on the next best action (which might involve using a tool), and then acts, passing its output to the next node in the dynamically chosen path. This makes [agentic AI](/resources/ai/agentic-ai) a powerful component for building intelligent systems with a clear structure for [agentic orchestration](/resources/ai/agentic-orchestration).
+
+## Why Directed Agentic Graphs Need Orchestration
+
+While the autonomy of agents is powerful, it also introduces complexity and non-determinism that can be risky in production environments. A robust orchestration layer is essential to govern, manage, and scale these dynamic workflows.
+
+Orchestration provides critical capabilities that agents alone cannot:
+*   **Governance and Auditability:** An orchestrator tracks every decision made by each agent, every tool called, and all inputs and outputs. This creates an auditable trail, which is crucial for debugging, compliance, and understanding system behavior.
+*   **Reliability and Error Handling:** What happens if an agent hallucinates, a tool's API is down, or a decision loop occurs? An orchestration platform provides mechanisms for retries, fallbacks, timeouts, and alerting, ensuring the overall process is resilient.
+*   **Human-in-the-Loop:** Not all decisions should be fully autonomous. Orchestration allows for the integration of human approval steps, where a workflow pauses until a person validates a critical action proposed by an agent.
+*   **Tool Integration and Security:** An orchestrator provides a secure and standardized way to equip agents with tools. It manages credentials, controls access, and abstracts the underlying systems, so agents can focus on decision-making.
+*   **State Management:** The orchestrator is responsible for reliably persisting the state of the workflow, including agent memory and the context passed between nodes, even across long-running or distributed executions.
+*   **Scalability:** An [open-source workflow engine](/resources/infrastructure/open-source-workflow-engine) can manage resource allocation, handle concurrent executions of multiple agentic graphs, and scale workers to meet demand.
+
+Without orchestration, a system of interacting agents can become a "black box" that is difficult to manage, debug, and trust. Orchestration provides the structure and guardrails needed to [build production-ready AI agents](/blogs/orchestrate-ai-agents-kestra) safely.
+
+## Orchestrate Directed Agentic Graphs with Kestra: Building an Adaptive AI Workflow
+
+Kestra's declarative platform is well-suited for defining and governing Directed Agentic Graphs. Its flow control tasks and native AI agent plugins allow you to build complex, adaptive workflows in a structured and observable way.
+
+Consider a scenario where we need an AI agent to answer user queries. For simple, internal queries, it should consult a private knowledge base. For complex or external topics, it should perform a web search. The agent itself will make this decision.
+
+Here is how you can implement this adaptive workflow in Kestra:
+
+```yaml
+id: adaptive-research-agent
+namespace: company.team.ai
+
+triggers:
+  - id: api
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: "ask-agent"
+
+tasks:
+  - id: classify_intent
+    type: io.kestra.plugin.ai.agent.AIAgent
+    model: gpt-4
+    systemPrompt: |
+      You are an intent classification agent.
+      Your job is to determine the best tool to answer the user's query: '{{ trigger.body.query }}'.
+      Respond with ONLY ONE of the following tool names: 'internal_search' or 'web_search'.
+      - Use 'internal_search' for questions about our company, products, or internal processes.
+      - Use 'web_search' for all other questions, including general knowledge, current events, or external topics.
+
+  - id: route_based_on_intent
+    type: io.kestra.plugin.core.flow.Switch
+    value: "{{ outputs.classify_intent.content }}"
+    cases:
+      internal_search:
+        - id: perform_internal_search
+          type: io.kestra.plugin.core.http.Request
+          uri: "https://api.internal-kb.com/search"
+          method: GET
+          queries:
+            q: "{{ trigger.body.query }}"
+      web_search:
+        - id: perform_web_search
+          type: io.kestra.plugin.scripts.python.Script
+          script: |
+            # This is a placeholder for a real web search tool call
+            # e.g., using a library like 'requests' and 'beautifulsoup' or an API
+            print(f"Performing simulated web search for: {{ trigger.body.query }}")
+            # In a real scenario, this would return structured search results.
+            search_results = "Web search found that Directed Agentic Graphs are a key paradigm for adaptive AI."
+            from kestra import Kestra
+            Kestra.outputs({'results': search_results})
+
+  - id: summarize_findings
+    type: io.kestra.plugin.openai.ChatCompletion
+    apiKey: "{{ secret('OPENAI_API_KEY') }}"
+    model: gpt-4
+    prompt: |
+      Based on the following context, please provide a concise answer to the user's query: '{{ trigger.body.query }}'.
+
+      Context:
+      ---
+      {% if outputs.perform_internal_search %}
+      {{ outputs.perform_internal_search.body }}
+      {% elif outputs.perform_web_search %}
+      {{ outputs.perform_web_search.vars.results }}
+      {% endif %}
+      ---
+
+errors:
+  - id: notify_on_failure
+    type: io.kestra.plugin.notifications.slack.SlackExecution
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    channel: "#ai-alerts"
+```
+
+This flow demonstrates a simple Directed Agentic Graph:
+*   **Worth Noticing:** The `AIAgent` task acts as the decision-making node. Its output is not a final answer but a choice of which path to take.
+*   **Dynamic Branching:** The `Switch` task directs the flow based on the agent's decision, creating a dynamic execution path.
+*   **Tool Integration:** The `http.Request` and `python.Script` tasks act as tools the agent effectively "calls" via the `Switch` logic.
+*   **Observability:** Kestra's UI provides a full audit trail of the agent's decision (`classify_intent` output) and which tool was used, making the non-deterministic behavior transparent.
+*   **Governance:** Secrets for APIs are managed securely, and the `errors` block ensures that any failure in the agentic process is immediately reported.
+
+This declarative approach allows you to build powerful [agentic workflows](/resources/ai/agentic-workflows) with the full power of an [AI automation platform](/ai-automation).
+
+### Choosing the Right Agent Configuration
+
+The behavior of your agentic graph is heavily influenced by the agent's configuration. Parameters like the LLM `model` (e.g., GPT-4 vs. a smaller, fine-tuned model), `temperature` (creativity vs. determinism), and the specific tools you grant it access to will shape its decisions.
+
+A good rule of thumb is to use specialized agents for well-defined decision points. For a highly complex process with multiple decision stages, consider breaking it down into a series of subflows, each managed by a dedicated agent. This creates a more modular and maintainable graph, where each agent has a clear, focused responsibility.
+
+## Where Directed Agentic Graphs Pay Off
+
+Directed Agentic Graphs are not just a theoretical concept; they unlock practical value across various domains by enabling more intelligent and autonomous systems.
+
+*   **Adaptive Customer Support:** An agentic graph can triage incoming support tickets, decide whether to query a knowledge base, access user account data, or escalate to a human, providing a more personalized and efficient resolution path.
+*   **Automated Incident Response:** Upon receiving an alert, an agent can decide which diagnostic tools to run, analyze the results, and attempt a fix (e.g., restarting a service). If that fails, it can try another approach or escalate with full context.
+*   **Dynamic Data Analysis:** Instead of a fixed ETL pipeline, an agent can inspect a new dataset, decide on the appropriate cleaning and validation steps, select the best statistical model for analysis, and generate a report.
+*   **Personalized Marketing Campaigns:** An agentic system can analyze user behavior in real time and dynamically decide which message, offer, or channel is most likely to be effective, adapting the campaign on an individual level.
+
+These use cases move beyond simple automation, using agentic graphs to perform tasks that traditionally required human judgment and adaptation, such as in advanced [RAG pipeline](/resources/ai/rag-pipeline) orchestration. Explore more resources on [AI orchestration](/resources/ai) to see what's possible.
+
+## Related Concepts
+
+*   [What is Agentic AI? Explained Simply](/resources/ai/agentic-ai)
+*   [What is Agentic Orchestration? Definition & Components](/resources/ai/agentic-orchestration)
+*   [Agentic Workflows: Definition, Examples & How They Work](/resources/ai/agentic-workflows)
+*   [Open Source Workflow Engine: Top Tools & Selection Guide](/resources/infrastructure/open-source-workflow-engine)
+*   [Top Orchestra Alternatives for Data & System Integration](/resources/data/orchestra-alternatives)
+*   [Argo Workflows Alternatives for K8s Orchestration](/resources/infrastructure/argo-workflows-alternatives)
+
+Build, schedule, and monitor your most complex adaptive AI workflows with Kestra.


### PR DESCRIPTION
## Summary

Imports the ready draft `directed-agentic-graphs` from `vfanucci/kestra-seo#282` into the resources hub.

| Page | Tag | URL | Source |
|------|-----|-----|--------|
| Directed Agentic Graphs | ai | `/resources/ai/directed-agentic-graphs` | kestra-seo#282 |

New slug; no collision.

## Front-matter hygiene
- **Publish date kept as the draft's real date (`2026-07-24`)** — no more hardcoded-today normalization (per the date-handling fix).
- Stray fence removed (fences balanced); metaTitle 53 chars (no ` | Kestra`); metaDescription 140; no `image:`/`author:`; no unresolved markers; no duplicated headings.
- Plugin FQCNs verified against `context/plugin-classes.txt` (incl. `io.kestra.plugin.ai.agent.AIAgent`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
