### PR TITLE
redirect: /contact → /contact-us

### DIFF
--- a/src/contents/redirects/index.yml
+++ b/src/contents/redirects/index.yml
@@ -10,5 +10,7 @@
   to: "/blogs"
 - regexp: "/changelog"
   to: "/docs/changelog"
+- regexp: "/contact$"
+  to: "/contact-us"
 - regexp: "/tutorial-videos(.*)"
   to: "/videos$1"


### PR DESCRIPTION
## What

Adds a 301 redirect from the legacy `/contact` path to the canonical `/contact-us` page.

## Why

`https://kestra.io/contact` currently 404s; `/contact-us` is the real page. This redirect captures any inbound links/traffic to `/contact` and preserves SEO equity.

## How

Single-segment paths are resolved against `index.yml` by the redirect middleware (`src/middleware.ts`), so the entry is added there. The regexp is anchored with `$` so it matches `/contact` exactly and does **not** rewrite `/contact-us` into `/contact-us-us`.

```yaml
- regexp: "/contact$"
  to: "/contact-us"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)