### PR TITLE
fix(content): repair three internal 404s outside /docs

### DIFF
--- a/src/contents/orchestration/gemini.yaml
+++ b/src/contents/orchestration/gemini.yaml
@@ -341,7 +341,7 @@ resources:
     - kind: "resource"
       title: "What is an AI agent?"
       description: "The building blocks of agentic systems, and where an orchestrator fits around a model call."
-      href: "/resources/ai-agent"
+      href: "/resources/ai/ai-agent"
     - kind: "plugin"
       title: "Gemini plugin reference"
       description: "Every Gemini task, property, and parameter, with copy-ready YAML examples."

--- a/src/contents/resources/cron-replacement/index.md
+++ b/src/contents/resources/cron-replacement/index.md
@@ -171,6 +171,6 @@ Whatever you pick, evaluate against the failure modes that made you leave cron: 
 
 ## From Cron to Kestra in Practice
 
-Migrating doesn't mean rewriting everything at once. The typical path: inventory your crontabs, port schedules one-to-one into Kestra Schedule triggers (the cron syntax carries over unchanged), then progressively add what cron never gave you — retries, dependencies, alerting, backfill. Our step-by-step guide covers the full process: [migrate from cron to Kestra](/resources/infrastructure/migrate-from-cron-to-kestra).
+Migrating doesn't mean rewriting everything at once. The typical path: inventory your crontabs, port schedules one-to-one into Kestra Schedule triggers (the cron syntax carries over unchanged), then progressively add what cron never gave you — retries, dependencies, alerting, backfill. Our step-by-step guide covers the full process: [migrate from cron to Kestra](/resources/infrastructure/migrate-from-cron).
 
 Ready to see it on your own jobs? [Get started with Kestra](/get-started) or [book a demo](/demo).

--- a/src/contents/resources/dbt-tests-explained/index.md
+++ b/src/contents/resources/dbt-tests-explained/index.md
@@ -270,7 +270,7 @@ When a test fails, dbt provides the information you need to diagnose the problem
 
 While `dbt test` is a powerful command-line tool, its true potential is unlocked when it's automated and integrated into your broader data ecosystem. This is [why an orchestration platform like Kestra](https://kestra.io/docs/why-kestra) comes in.
 
-Kestra allows you to [orchestrate dbt workflows](https://kestra.io/use-cases/dbt) with a simple, declarative YAML interface. You can easily create a pipeline that builds your dbt models and then runs your tests as two separate, observable steps within a single workflow. You can also build [scalable dbt workflows with Kestra's built-in Code Editor and Git Sync features](https://kestra.io/blogs/2024-10-08-dbt-kestra).
+Kestra allows you to [orchestrate dbt workflows](/docs/use-cases/dbt) with a simple, declarative YAML interface. You can easily create a pipeline that builds your dbt models and then runs your tests as two separate, observable steps within a single workflow. You can also build [scalable dbt workflows with Kestra's built-in Code Editor and Git Sync features](https://kestra.io/blogs/2024-10-08-dbt-kestra).
 
 Here’s an example of a Kestra flow that runs dbt tests after building the models. Note the `WorkingDirectory` task, which ensures the cloned repository is available to the dbt tasks that follow:
 


### PR DESCRIPTION
## Context

Companion to #5241, which covers the `/docs` 404s. These are the three remaining internal 404s from the same Screaming Frog crawl of kestra.io. All three were confirmed against the live site: each links to a page that exists, at a different path.

## Changes

| File | Broken link | Fixed to | Why |
|---|---|---|---|
| `resources/cron-replacement` | `/resources/infrastructure/migrate-from-cron-to-kestra` | `/resources/infrastructure/migrate-from-cron` | The page slug is `migrate-from-cron` |
| `resources/dbt-tests-explained` | `https://kestra.io/use-cases/dbt` | `/docs/use-cases/dbt` | The page lives under `/docs`; there is no top-level `/use-cases/dbt` |
| `orchestration/gemini.yaml` | `/resources/ai-agent` | `/resources/ai/ai-agent` | The category segment was missing |

Two details worth a look:

- The dbt link is now root-relative rather than absolute. Both styles are in use across `src/contents/resources` (roughly 1700 root-relative to 1100 absolute), and the root-relative form also stops the renderer treating an internal link as external — the absolute URL was picking up `target="_blank"` and `rel="noopener noreferrer"`. The adjacent blog link on the same line is left as-is since it resolves correctly; converting the rest is a separate style pass.
- I checked every `/resources/*` href in `src/contents/orchestration`: the Gemini card is the only one missing a category segment, so this is isolated rather than a pattern across the 38 orchestration pages.

## Note on impact

None of these URLs has Search Console impressions. This is internal link equity and reader experience, not traffic recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)