### PR TITLE
Update JobRunr section: correct workflow, scheduling and deployment details

### DIFF
--- a/src/contents/resources/open-source-job-scheduler/index.md
+++ b/src/contents/resources/open-source-job-scheduler/index.md
@@ -98,11 +98,11 @@ The primary trade-off is its tight coupling to Kubernetes. It is not designed to
 
 JobRunr is another open-source scheduler focused on the Java ecosystem, but with a modern twist. It is designed for simple, distributed background job processing. Developers can create background jobs with just a single line of code, and JobRunr handles the persistence, scheduling, and execution across a cluster of servers.
 
-It offers a clean dashboard for monitoring jobs and supports persistent storage backends like SQL databases or NoSQL stores. JobRunr's philosophy is "fire-and-forget," making it ideal for offloading long-running tasks from the main application thread.
+It offers a clean dashboard for monitoring jobs and supports persistent storage backends like SQL databases or NoSQL stores. Alongside fire-and-forget jobs it handles delayed jobs, recurring cron jobs, and carbon-aware scheduling that shifts flexible workloads to windows when the electricity grid is cleaner.
 
-Like Quartz, it is more of a background job library than a full-fledged workflow orchestration platform. It excels at its specific purpose but does not provide the tools for building complex, multi-step, cross-system workflows.
+It is a background job library rather than a general-purpose orchestration platform, and it does not aim to coordinate workflows across heterogeneous systems and languages. Within the JVM it does handle multi-step processes, through job chaining, atomic batches, and durable executions that checkpoint each completed step so a retried job resumes where it left off rather than restarting from the top.
 
-**Best for:** Java applications that need a modern, simple, and distributed library for scheduling and executing background jobs.
+**Best for:** Java and Kotlin applications that need a modern, distributed library for scheduling and executing background jobs, from small services through to enterprise deployments such as Decathlon's inventory reconciliation across 1700 stores.
 
 ## Comparison Table: Open Source Job Schedulers at a Glance
 
@@ -113,7 +113,7 @@ Like Quartz, it is more of a background job library than a full-fledged workflow
 | **Apache DolphinScheduler** | Apache 2.0 | Kubernetes, Docker, Standalone | Visual UI, API | Big Data Workflows | Limited | Yes | Yes |
 | **Quartz Scheduler** | Apache 2.0 | Embedded in Java App | Java Code | In-Application Java Jobs | No | Limited | No |
 | **Argo Workflows** | Apache 2.0 | Kubernetes-Only | Declarative YAML (CRDs) | Kubernetes-Native Jobs | Yes (Containers) | Yes | Yes (Managed) |
-| **JobRunr** | LGPL-3.0 | Embedded in Java App | Java Code | Java Background Jobs | No | No | Yes (Pro) |
+| **JobRunr** | LGPL-3.0 | Embedded or Standalone Worker JVMs | Java / Kotlin Code | Java Background Jobs | No | No | Yes (Pro) |
 
 ## Choosing the Right Open Source Job Scheduler for Your Needs
 
@@ -122,7 +122,7 @@ Selecting the right tool depends entirely on your team's context, technical stac
 *   **For data engineering teams,** the choice often comes down to the trade-off between the code-first flexibility of Airflow and the declarative, polyglot model of Kestra. If your world is Python and batch ETL, Airflow is a proven choice. If your pipelines involve multiple languages and need to integrate with infrastructure tasks, a platform like Kestra offers a more unified approach. Explore more [data engineering resources](/resources/data) to guide your decision.
 *   **For infrastructure & DevOps teams,** the key considerations are GitOps alignment and integration with IaC tools. Argo Workflows is a perfect fit for teams living entirely within Kubernetes. Kestra provides a more versatile solution that can orchestrate Terraform and Ansible alongside containerized and non-containerized tasks, bridging the gap between on-prem, cloud, and K8s environments. See our [infrastructure automation resources](/resources/infrastructure) for more.
 *   **For AI/ML platform teams,** reproducibility and the ability to orchestrate heterogeneous workloads (e.g., data prep, GPU training, model serving) are critical. Container-native tools like Argo Workflows are popular, but a platform like Kestra can orchestrate the entire end-to-end ML lifecycle, from data ingestion to model deployment and monitoring. Check out our [AI orchestration resources](/resources/ai) to learn more.
-*   **For small teams or specific application needs,** lightweight, embedded schedulers like Quartz or JobRunr are excellent. They solve the immediate problem of in-application scheduling without the operational overhead of a full orchestration platform.
+*   **For teams that need scheduling inside an existing Java application,** embedded schedulers like Quartz or JobRunr are excellent at any company size. They solve in-application scheduling and background job execution without the operational overhead of a separate orchestration platform.
 
 ## Conclusion: Modernizing Your Automation with the Right Orchestrator
 

--- a/src/contents/resources/open-source-job-scheduler/index.md
+++ b/src/contents/resources/open-source-job-scheduler/index.md
@@ -80,9 +80,9 @@ JobRunr is an open-source scheduler built for the Java ecosystem, designed aroun
 
 It offers a clean dashboard for monitoring jobs and supports persistent storage backends like SQL databases or NoSQL stores. Alongside fire-and-forget jobs it handles delayed jobs, recurring cron jobs, and carbon-aware scheduling that shifts flexible workloads to windows when the electricity grid is cleaner.
 
-It is a background job library rather than a general-purpose orchestration platform, and it does not aim to coordinate workflows across heterogeneous systems and languages. Within the JVM it does handle multi-step processes, through job chaining, atomic batches, and durable executions that checkpoint each completed step so a retried job resumes where it left off rather than restarting from the top.
+It is a background job library rather than a general-purpose orchestration platform, and it does not aim to coordinate workflows across heterogeneous systems and languages. Within the JVM it does handle multi-step processes: the open-source core provides durable executions, which checkpoint each completed step so a retried job resumes where it left off rather than restarting from the top, while job chaining and atomic batches are part of the paid Pro edition.
 
-**Best for:** Java and Kotlin applications that need a modern, distributed library for scheduling and executing background jobs, from small services through to enterprise deployments such as Decathlon's inventory reconciliation across 1700 stores.
+**Best for:** Java and Kotlin applications that need a modern, distributed library for scheduling and executing background jobs, from small services through to enterprise-scale deployments.
 
 ## 5. Quartz Scheduler: Lightweight Java Job Scheduling
 

--- a/src/contents/resources/open-source-job-scheduler/index.md
+++ b/src/contents/resources/open-source-job-scheduler/index.md
@@ -74,7 +74,17 @@ While the visual interface is a significant advantage for accessibility, it can 
 
 **Best for:** Big data teams that prefer a visual, drag-and-drop interface for building and managing distributed data processing workflows.
 
-## 4. Quartz Scheduler: Lightweight Java Job Scheduling
+## 4. JobRunr: Modern, Distributed Background Processing for Java
+
+JobRunr is an open-source scheduler built for the Java ecosystem, designed around a modern developer experience and simple, distributed background job processing. Developers can create background jobs with just a single line of code, and JobRunr handles the persistence, scheduling, and execution across a cluster of servers.
+
+It offers a clean dashboard for monitoring jobs and supports persistent storage backends like SQL databases or NoSQL stores. Alongside fire-and-forget jobs it handles delayed jobs, recurring cron jobs, and carbon-aware scheduling that shifts flexible workloads to windows when the electricity grid is cleaner.
+
+It is a background job library rather than a general-purpose orchestration platform, and it does not aim to coordinate workflows across heterogeneous systems and languages. Within the JVM it does handle multi-step processes, through job chaining, atomic batches, and durable executions that checkpoint each completed step so a retried job resumes where it left off rather than restarting from the top.
+
+**Best for:** Java and Kotlin applications that need a modern, distributed library for scheduling and executing background jobs, from small services through to enterprise deployments such as Decathlon's inventory reconciliation across 1700 stores.
+
+## 5. Quartz Scheduler: Lightweight Java Job Scheduling
 
 Quartz is a widely-used, open-source job scheduler designed specifically for the Java ecosystem. It is not a standalone platform but rather a library that can be embedded directly into Java applications. This makes it an incredibly lightweight and flexible option for scheduling tasks within a single application's context.
 
@@ -84,7 +94,7 @@ Its tight integration with Java makes it less suitable for polyglot environments
 
 **Best for:** Java development teams that need a reliable, lightweight, and embeddable scheduler for in-application tasks.
 
-## 5. Argo Workflows: Kubernetes-Native Container Orchestration
+## 6. Argo Workflows: Kubernetes-Native Container Orchestration
 
 Argo Workflows is an open-source, container-native workflow engine for orchestrating jobs on Kubernetes. Unlike other schedulers that can run on Kubernetes, Argo is fundamentally built on it. Workflows are defined as Kubernetes Custom Resource Definitions (CRDs) in YAML, making them first-class citizens of the Kubernetes ecosystem.
 
@@ -94,16 +104,6 @@ The primary trade-off is its tight coupling to Kubernetes. It is not designed to
 
 **Best for:** Kubernetes-native teams seeking a container-centric workflow orchestrator for CI/CD, batch jobs, and machine learning pipelines.
 
-## 6. JobRunr: Modern, Distributed Background Processing for Java
-
-JobRunr is another open-source scheduler focused on the Java ecosystem, but with a modern twist. It is designed for simple, distributed background job processing. Developers can create background jobs with just a single line of code, and JobRunr handles the persistence, scheduling, and execution across a cluster of servers.
-
-It offers a clean dashboard for monitoring jobs and supports persistent storage backends like SQL databases or NoSQL stores. Alongside fire-and-forget jobs it handles delayed jobs, recurring cron jobs, and carbon-aware scheduling that shifts flexible workloads to windows when the electricity grid is cleaner.
-
-It is a background job library rather than a general-purpose orchestration platform, and it does not aim to coordinate workflows across heterogeneous systems and languages. Within the JVM it does handle multi-step processes, through job chaining, atomic batches, and durable executions that checkpoint each completed step so a retried job resumes where it left off rather than restarting from the top.
-
-**Best for:** Java and Kotlin applications that need a modern, distributed library for scheduling and executing background jobs, from small services through to enterprise deployments such as Decathlon's inventory reconciliation across 1700 stores.
-
 ## Comparison Table: Open Source Job Schedulers at a Glance
 
 | Tool | License | Deployment | Workflow Definition | Primary Use Case | Polyglot Support | Event-Driven | Enterprise Features |
@@ -111,9 +111,9 @@ It is a background job library rather than a general-purpose orchestration platf
 | **Kestra** | Apache 2.0 | Kubernetes, Docker, Bare Metal | Declarative YAML | Unified Orchestration | Yes (Native) | Yes (Core) | Yes (EE) |
 | **Apache Airflow** | Apache 2.0 | Kubernetes, Docker, VMs | Python Code | Data Pipelines | Limited (via Python) | Limited | Yes (Managed) |
 | **Apache DolphinScheduler** | Apache 2.0 | Kubernetes, Docker, Standalone | Visual UI, API | Big Data Workflows | Limited | Yes | Yes |
+| **JobRunr** | LGPL-3.0 | Embedded or Standalone Worker JVMs | Java / Kotlin Code | Java Background Jobs | No | No | Yes (Pro) |
 | **Quartz Scheduler** | Apache 2.0 | Embedded in Java App | Java Code | In-Application Java Jobs | No | Limited | No |
 | **Argo Workflows** | Apache 2.0 | Kubernetes-Only | Declarative YAML (CRDs) | Kubernetes-Native Jobs | Yes (Containers) | Yes | Yes (Managed) |
-| **JobRunr** | LGPL-3.0 | Embedded or Standalone Worker JVMs | Java / Kotlin Code | Java Background Jobs | No | No | Yes (Pro) |
 
 ## Choosing the Right Open Source Job Scheduler for Your Needs
 
@@ -122,7 +122,7 @@ Selecting the right tool depends entirely on your team's context, technical stac
 *   **For data engineering teams,** the choice often comes down to the trade-off between the code-first flexibility of Airflow and the declarative, polyglot model of Kestra. If your world is Python and batch ETL, Airflow is a proven choice. If your pipelines involve multiple languages and need to integrate with infrastructure tasks, a platform like Kestra offers a more unified approach. Explore more [data engineering resources](/resources/data) to guide your decision.
 *   **For infrastructure & DevOps teams,** the key considerations are GitOps alignment and integration with IaC tools. Argo Workflows is a perfect fit for teams living entirely within Kubernetes. Kestra provides a more versatile solution that can orchestrate Terraform and Ansible alongside containerized and non-containerized tasks, bridging the gap between on-prem, cloud, and K8s environments. See our [infrastructure automation resources](/resources/infrastructure) for more.
 *   **For AI/ML platform teams,** reproducibility and the ability to orchestrate heterogeneous workloads (e.g., data prep, GPU training, model serving) are critical. Container-native tools like Argo Workflows are popular, but a platform like Kestra can orchestrate the entire end-to-end ML lifecycle, from data ingestion to model deployment and monitoring. Check out our [AI orchestration resources](/resources/ai) to learn more.
-*   **For teams that need scheduling inside an existing Java application,** embedded schedulers like Quartz or JobRunr are excellent at any company size. They solve in-application scheduling and background job execution without the operational overhead of a separate orchestration platform.
+*   **For teams that need scheduling inside an existing Java application,** embedded schedulers like JobRunr or Quartz are excellent at any company size. They solve in-application scheduling and background job execution without the operational overhead of a separate orchestration platform.
 
 ## Conclusion: Modernizing Your Automation with the Right Orchestrator
 


### PR DESCRIPTION
Hi Kestra team, and thanks for including JobRunr in this roundup.

I am Nicholas, co-founder of JobRunr. A few details in our section are a version or two behind, so rather than send an email asking you to change them I figured a PR with sources attached would be easier for you to check and merge. Every claim below links to our public docs so you can verify rather than take my word for it. Push back on any of it.

## Factual corrections

**1. Multi-step workflows**

The section said JobRunr "does not provide the tools for building complex, multi-step, cross-system workflows." The cross-system half is fair and I have kept it. The multi-step half is out of date:

- Job chaining via `continueWith` / `onFailure`: https://www.jobrunr.io/en/documentation/pro/job-chaining/
- Atomic batches, with batch continuation added in v8.7: https://www.jobrunr.io/en/documentation/pro/batches/
- Durable executions via `runStepOnce`, which checkpoints each completed step so a retry resumes instead of restarting: https://www.jobrunr.io/en/guides/advanced/durable-executions/

**2. Scheduling modes**

"Fire-and-forget" is one of four modes. JobRunr also does delayed, recurring cron, and carbon-aware scheduling.

- https://www.jobrunr.io/en/documentation/background-methods/
- https://www.jobrunr.io/en/documentation/background-methods/carbon-aware-jobs/

**3. Deployment column**

`useBackgroundJobServerIf` and `useDashboardIf` toggle the job server and dashboard independently, so dedicated worker JVMs with no dashboard are a normal deployment, scaled separately from the web tier. On Kubernetes, Pro exposes metrics that drive KEDA autoscaling.

- https://www.jobrunr.io/en/documentation/getting-started/java/
- https://www.jobrunr.io/en/guides/advanced/k8s-autoscaling/

**4. Workflow Definition column**

Kotlin is a first-class integration with its own guide and Kotlin Serialization support. Scala and Groovy work via the `JobRequest` pattern.

- https://www.jobrunr.io/en/documentation/getting-started/kotlin/
- https://www.jobrunr.io/en/documentation/getting-started/other/

**5. "For small teams"**

The closing bullet framed embedded schedulers as a small-team choice. Company size is not really the axis; whether you want scheduling inside your existing application or a separate orchestration tier is. JobRunr runs in production at enterprise scale:

- Decathlon reconciles inventory across 1700 stores with millions of scans a day: https://www.jobrunr.io/en/use-case/jobrunr-pro-decathlon/
- Prophia processes thousands of commercial leases nightly: https://www.jobrunr.io/en/use-case/jobrunr-pro-prophia/
- Fincarna built a monetization platform for banks on it: https://www.jobrunr.io/en/use-case/jobrunr-pro-fincarna/
- SSO, multi-cluster dashboard and database fault tolerance are not small-team features: https://www.jobrunr.io/en/documentation/pro/sso-authentication/ , https://www.jobrunr.io/en/documentation/pro/jobrunr-pro-multi-dashboard/ , https://www.jobrunr.io/en/documentation/pro/database-fault-tolerance/

I named Decathlon in the "Best for" line because the Kestra section names JPMorgan Chase and Leroy Merlin, so it seemed consistent with the article's own style. Happy to drop the name if you would rather keep customer references to your own section.

## Ordering, and one copy fix that depends on it

I also moved JobRunr from 6th to 4th, directly above Quartz. This is the one change here that is a judgement call rather than a fact, so it is in its own commit and you can drop it without losing anything above.

The reasoning is internal consistency rather than a claim to a higher slot generally. The section introduced JobRunr as a modern take on Quartz while ranking it two places below Quartz, even though on the dimensions this article measures it is a superset: distributed execution out of the box, a built-in dashboard, and multi-step workflows. Placing the two Java embedded schedulers next to each other, newer first, also makes them easier to compare, and it leaves your top three untouched.

Two copy changes follow from the move:

- The section opened with "JobRunr is another open-source scheduler focused on the Java ecosystem," where "another" pointed back at Quartz. With Quartz now following, that reference no longer resolves, so the opener stands on its own.
- The closing bullet listed "Quartz or JobRunr"; I flipped it to match the new presentation order.

Both are in the ordering commit, so dropping that commit reverts them cleanly along with the move.

## What I did not change

To be clear about restraint, I left these alone because you have them right:

- LGPL-3.0 license
- **Polyglot Support: No**. We are JVM-only and your criterion means Python/Bash/SQL/Docker, so "No" is correct.
- **Event-Driven: No**. We ship no native connector for webhooks or message queues, so this is fair too.
- Kestra at number 1, and the framing of the article overall.

I have not added any links to jobrunr.io in the page itself, deliberately. The sources are here in the PR for verification, not as a link-building exercise.

Thanks again for the mention, and no hard feelings if you close this.
