### PR TITLE
seo(resources): add 7 W31 pages under /business/ (+ it-process-automation)

### DIFF
--- a/src/contents/resources/approval-workflow/index.md
+++ b/src/contents/resources/approval-workflow/index.md
@@ -1,0 +1,204 @@
+---
+title: "Approval Workflow: Automate Decisions & Governance"
+description: "Approval workflows are essential for formalizing decision-making and ensuring compliance across business operations. Learn how declarative orchestration can automate, track, and govern your approval processes, from IT changes to financial sign-offs."
+metaTitle: "Approval Workflow Automation & Governance"
+metaDescription: "Automate crucial decisions with approval workflows. Learn how to design, orchestrate, and govern processes for IT, finance, HR, and more with Kestra."
+tag: business
+date: 2026-07-30
+slug: "approval-workflow"
+faq:
+  - question: "What is an approval workflow?"
+    answer: "An approval workflow is a structured sequence of steps designed to route tasks, documents, or decisions through a defined set of human or automated reviews and authorizations. It ensures that critical actions or changes are formally reviewed and authorized by designated stakeholders before they can proceed, enhancing control and compliance."
+  - question: "What are the steps in the approval process?"
+    answer: "Typically, an approval process involves initiation (a request is submitted), routing (the request is sent to the appropriate approvers), review (approvers evaluate the request), decision (approvers approve or reject), and final action (the system acts based on the decision or notifies the initiator). Automation helps streamline these steps."
+  - question: "How do you create an effective approval workflow?"
+    answer: "To create an effective approval workflow, first identify the process needing approval and its stakeholders. Map out current steps, then design the optimal flow by defining roles, rules, and stages. Choose a suitable orchestration tool, implement the workflow, and continuously test and refine it for efficiency and compliance."
+  - question: "How do you approve a workflow in Kestra?"
+    answer: "In Kestra, you can approve a workflow by interacting with a human-in-the-loop task, often via a custom UI (App) or a notification (e.g., Slack). The workflow pauses at an approval step, awaiting a decision. Once an approver acts, the workflow resumes, executing subsequent tasks based on the 'approve' or 'reject' outcome."
+  - question: "What is the difference between a workflow and an approval workflow?"
+    answer: "A workflow is a sequence of tasks designed to achieve a specific outcome, which can be fully automated. An approval workflow is a specific type of workflow that explicitly incorporates human or automated decision points where a task or process must be explicitly approved or rejected before it can continue, adding a layer of governance."
+  - question: "What are common use cases for approval workflows?"
+    answer: "Common use cases include invoice approvals, document and contract sign-offs, expense report processing, new hire onboarding, IT change management, marketing campaign approvals, and project management milestones. Any process requiring formal review and authorization can benefit from an approval workflow."
+  - question: "What features should I look for in approval workflow software?"
+    answer: "Look for features like customizable forms and inputs, automated notifications and reminders, real-time tracking and reporting, robust integration capabilities with your existing systems (e.g., ERP, ITSM), strong security features (RBAC, audit logs), and the ability to handle complex conditional logic for dynamic approvals."
+---
+
+> **TL;DR** — An approval workflow is a structured process that routes tasks, documents, or decisions through a defined sequence of human or automated reviews and authorizations before they can proceed. It ensures compliance, transparency, and accountability.
+
+Manual approval processes are a common source of organizational friction, leading to delays, lost requests, and a frustrating "email ping-pong" that slows down critical operations. Whether it's a new software release, a financial transaction, or a marketing campaign, the need for human review and sign-off is often unavoidable.
+
+However, the process itself doesn't have to be manual. By formalizing these decision points into automated approval workflows, organizations can eliminate bottlenecks, enhance transparency, and ensure compliance. This article explores how to design, orchestrate, and govern these essential workflows, leveraging automation to transform your decision-making.
+
+## How Approval Workflows Drive Efficiency
+
+At its core, an approval workflow formalizes and automates the path a request takes from submission to resolution. Instead of relying on manual follow-ups and ambiguous chains of command, it establishes a clear, predictable, and auditable process for decision-making.
+
+### What defines an approval workflow?
+
+An approval workflow is a specific type of business process that requires formal authorization from one or more stakeholders before an action can be completed. It's a system of rules that dictates who needs to approve what, under which conditions, and in what order. This structure is essential for maintaining control over critical operations, managing resources, and mitigating risk. By codifying these rules, organizations can ensure that decisions are made consistently and in compliance with internal policies and external regulations.
+
+### Key components of an effective approval process
+
+A well-designed approval process consists of several distinct components that work together to ensure smooth and reliable execution:
+
+*   **Approvers:** The individuals or groups responsible for reviewing and making decisions on a request. Roles should be clearly defined to avoid confusion.
+*   **Stages:** The distinct steps in the approval process. A simple workflow might have a single stage, while a complex one could involve multiple stages with different approvers at each level.
+*   **Conditions:** The rules that determine how a request is routed. For example, an expense report over $5,000 might require an additional level of approval from a department head.
+*   **Notifications:** Automated alerts that inform stakeholders of pending requests, decisions, and status changes. This eliminates the need for manual follow-ups.
+*   **Audit Trail:** A complete, unchangeable record of every action taken within the workflow, including who submitted the request, who approved or rejected it, when they did so, and any comments they provided. This is crucial for compliance and accountability.
+
+For a deeper dive into how these components come together, you can explore guides on how to [automate manual approval processes](/docs/use-cases/approval-processes).
+
+## Types of Approval Flows for Every Scenario
+
+Approval workflows are not one-size-fits-all. The structure of the flow depends on the complexity of the decision and the number of stakeholders involved.
+
+### Sequential approvals
+
+In a sequential workflow, approvals happen in a specific, linear order. A request must be approved by the first person in the chain before it moves to the next. This is common in hierarchical structures, such as an employee's expense report being approved by their direct manager before being sent to the finance department.
+
+### Parallel approvals
+
+A parallel workflow allows multiple people to approve a request simultaneously. The process can proceed once all required approvers have given their consent, or sometimes when just one person from a designated group approves. This model is useful for decisions that require input from different departments, like a new marketing campaign that needs approval from legal, brand, and product teams at the same time.
+
+### Conditional and dynamic approvals
+
+These are the most sophisticated types of approval workflows. The approval path changes dynamically based on the data within the request. For example, a purchase order under $1,000 might be auto-approved, while an order between $1,000 and $10,000 requires a manager's approval, and anything over $10,000 is routed to a VP. This logic is built directly into the workflow, ensuring the right people are involved without manual intervention.
+
+## Why Orchestration is Critical for Production Approvals
+
+While simple approval tools exist, managing these processes at scale in a production environment requires a robust orchestration platform. Orchestration goes beyond simple routing; it provides the reliability, integration, and governance needed for mission-critical decisions.
+
+An orchestration platform is essential for:
+
+*   **Ensuring consistency and repeatability:** Every approval request follows the exact same process, eliminating inconsistencies and ensuring that all compliance checks are met every time.
+*   **Providing comprehensive audit trails:** Orchestrators automatically log every step, decision, and data point, creating an immutable record for compliance audits and internal reviews.
+*   **Integrating with diverse systems:** Modern approvals often require data from or actions in multiple systems (ITSM, ERP, HR platforms, Slack, email). An orchestration platform with a rich plugin ecosystem can connect these disparate tools into a single, cohesive workflow.
+*   **Handling retries, timeouts, and error scenarios:** What happens if an approver doesn't respond? Or if a downstream system is temporarily unavailable? An orchestration platform can manage these [workflow errors](/docs/workflow-components/errors) with automated retries, timeouts, and fallback procedures.
+*   **Enabling human-in-the-loop decisions:** The ability to [pause and resume flows](/docs/how-to-guides/pause-resume) is fundamental to approval workflows. Orchestration platforms provide this as a core feature, allowing a fully automated process to halt for a human decision and then resume based on the outcome, a key principle of [Human-in-the-Loop (HITL) Orchestration](/resources/ai/human-in-the-loop-orchestration).
+
+## Orchestrate Approval Workflows with Kestra: An Expense Report Scenario
+
+Let's illustrate how orchestration works with a practical example: an automated expense report approval process. An employee submits their expenses through a simple form, which triggers a Kestra workflow via a webhook. The workflow then automates the entire approval process.
+
+The YAML below defines this flow. It listens for a webhook submission, sends a formatted approval request to a manager in Slack, and pauses execution. Based on the manager's decision (made by resuming the flow with a specific status), it either proceeds to a mock payment processing step or notifies the employee of the rejection.
+
+```yaml
+id: expense-report-approval
+namespace: finance.team
+
+triggers:
+  - id: listen-for-submission
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: "expense-report-key"
+
+tasks:
+  - id: send-approval-request
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    payload: |
+      {
+        "text": "New Expense Report for Approval",
+        "blocks": [
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "An expense report from *{{ trigger.body.employee_name }}* for *${{ trigger.body.amount }}* requires your approval."
+            }
+          },
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "Reason: _{{ trigger.body.reason }}_"
+            }
+          },
+          {
+            "type": "actions",
+            "elements": [
+              {
+                "type": "button",
+                "text": {
+                  "type": "plain_text",
+                  "text": "Approve"
+                },
+                "style": "primary",
+                "action_id": "approve"
+              },
+              {
+                "type": "button",
+                "text": {
+                  "type": "plain_text",
+                  "text": "Reject"
+                },
+                "style": "danger",
+                "action_id": "reject"
+              }
+            ]
+          }
+        ]
+      }
+
+  - id: wait-for-decision
+    type: io.kestra.plugin.core.flow.Pause
+    timeout: PT3D # Pause for up to 3 days
+
+  - id: process-decision
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ parent.outputs['wait-for-decision'].state.name == 'SUCCESS' }}"
+    then:
+      - id: process-payment
+        type: io.kestra.plugin.scripts.python.Script
+        script: |
+          print("Processing payment for employee: {{ trigger.body.employee_name }} for amount {{ trigger.body.amount }}")
+          # Add API call to financial system here
+    else:
+      - id: notify-rejection
+        type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+        url: "{{ secret('SLACK_EMPLOYEE_WEBHOOK_URL') }}"
+        payload: |
+          {
+            "text": "Your expense report for ${{ trigger.body.amount }} was rejected. Reason: {{ parent.outputs['wait-for-decision'].state.value }}"
+          }
+
+```
+
+Points worth noticing in this example:
+
+*   **Declarative Logic:** The entire approval process, including integrations and conditional logic, is defined in a single, version-controllable YAML file.
+*   **Human-in-the-Loop:** The built-in [`Pause` task](/plugins/core/flow/io.kestra.plugin.core.flow.pause) is designed specifically for human interaction, cleanly separating the automated and manual steps.
+*   **Integrated Communication:** The workflow communicates directly with users on platforms like Slack for notifications and decision-making, meeting them where they work.
+*   **Full Audit Trail:** Kestra automatically logs the initial submission, the pause for approval, and the final decision, providing a complete and auditable history of the entire process.
+*   **Extensibility:** The Python script for payment processing can be easily replaced with a dedicated plugin or API call to any financial system, making the pattern adaptable to various [business processes](/blueprints/business-processes).
+
+## Key Capabilities in Approval Workflow Software
+
+When selecting a tool to manage your approval workflows, look for a platform that provides a comprehensive set of capabilities to handle real-world complexity.
+
+*   **Customizable Inputs and Forms:** The ability to collect necessary information from users is crucial. This can be achieved through webhooks that receive data from external forms or through features like [Kestra Apps](/blogs/introducing-apps), which allow you to build custom user interfaces directly on top of your workflows.
+*   **Automated Notifications and Reminders:** The system should automatically notify approvers of pending tasks and remind them if a decision is overdue. Integration with multiple channels (Email, Slack, Teams, PagerDuty) is essential.
+*   **Real-time Tracking, Logs, and Reporting:** Stakeholders need visibility into the status of any request. A centralized UI with detailed logs, execution history, and audit trails provides the necessary transparency.
+*   **Integration Capabilities:** The tool must connect to your existing systems. A platform with a large library of plugins (Kestra offers over 1,700) can easily integrate with databases, cloud services, ITSM platforms, and business applications.
+*   **Security and Compliance Features:** For enterprise-grade approvals, features like [Role-Based Access Control (RBAC)](/resources/infrastructure/rbac-workflow-orchestration), SSO integration, and secure [workflow secret management](/resources/infrastructure/workflow-secret-management) are non-negotiable.
+
+## Common Use Cases for Automated Approvals
+
+Approval workflows are applicable across virtually every department in an organization, bringing structure and efficiency to critical decision points.
+
+*   **Finance:** Automating invoice processing and expense report approvals ensures timely payments and compliance with financial controls. This is a core process in [financial services](/use-cases/financial-services) and retail operations.
+*   **IT and Operations:** Managing IT change requests, provisioning new infrastructure with a [Terraform approval gate](/blueprints/terraform-approval-plan-apply), or granting access to systems requires a formal, auditable approval process. Companies like Crédit Agricole (CAGIP) and Dataport rely on orchestration to govern their complex infrastructure operations.
+*   **Human Resources:** From new hire onboarding and vacation requests to compensation changes, HR workflows are filled with decision points that benefit from automation and clear audit trails.
+*   **Legal and Compliance:** Contract review and document sign-off processes can be streamlined, ensuring all legal and regulatory requirements are met. This is particularly vital in regulated industries like [healthcare](/use-cases/healthcare).
+*   **Supply Chain and Retail:** For global brands like FILA, orchestrating complex ERP and supply-chain workflows, including purchase order approvals, is essential for operational efficiency.
+*   **Data and Analytics:** Before promoting a dbt model to production, an approval gate can ensure a senior engineer has reviewed the code and its impact, as shown in this [dbt Core approval blueprint](/blueprints/dbt-core-approval-gate).
+
+## Related concepts
+*   [Workflow Governance: Manage & Automate Operations](/resources/infrastructure/workflow-governance)
+*   [RBAC Workflow Orchestration: Secure Access with Kestra](/resources/infrastructure/rbac-workflow-orchestration)
+*   [Human-in-the-Loop (HITL) Orchestration Explained](/resources/ai/human-in-the-loop-orchestration)
+*   [Kestra Blueprints for Approval Workflows](/blueprints)
+*   [Introducing Apps: Custom UIs for Kestra Workflows](/blogs/introducing-apps)
+*   [Automate Manual Approval Processes](/docs/use-cases/approval-processes)
+
+Ready to automate your approval processes? Explore Kestra's capabilities and blueprints.

--- a/src/contents/resources/bpmn/index.md
+++ b/src/contents/resources/bpmn/index.md
@@ -1,0 +1,129 @@
+---
+title: "BPMN: Business Process Model and Notation Explained"
+description: "Understand Business Process Model and Notation (BPMN), the standard for modeling business processes. Explore its core elements, benefits, and how modern orchestration platforms integrate with BPMN for automation."
+metaTitle: "BPMN: Business Process Model and Notation Explained"
+metaDescription: "Explore BPMN, the standard for business process modeling. Learn its key elements, benefits, and how declarative orchestration platforms integrate with it."
+tag: business
+date: 2026-07-30
+slug: "bpmn"
+faq:
+  - question: "What is the difference between BPMN and Gantt?"
+    answer: "BPMN describes workflows independent of time, focusing on the logical flow and participants of a business process. Gantt charts, on the other hand, are project management tools that visualize tasks against a timeline, emphasizing scheduling and dependencies. While BPMN models the 'what' and 'how' of a process, Gantt charts focus on the 'when'."
+  - question: "What is BPMN vs UML?"
+    answer: "BPMN (Business Process Model and Notation) is specifically designed for modeling business processes and their flow, making it accessible to business users and analysts. UML (Unified Modeling Language) is a broader standard used for specifying, visualizing,constructing, and documenting artifacts of software systems, covering structural and behavioral aspects of applications. They serve different, though sometimes complementary, purposes."
+  - question: "Is BPMN still relevant?"
+    answer: "Yes, BPMN remains highly relevant for defining structured processes with clear state, controls, and audit trails. In environments where AI agents need robust orchestration or where complex business logic requires explicit definition, BPMN provides the necessary rigor. It helps ensure clarity and governance, especially in regulated industries or large enterprises."
+  - question: "Is Visio a BPMN?"
+    answer: "Microsoft Visio supports BPMN 2.0, offering built-in templates and shapes that allow users to drag and drop elements to create compliant BPMN diagrams efficiently. It provides a user-friendly interface for visually modeling processes according to the BPMN standard, making it a popular tool for business analysts."
+  - question: "What are the core elements of a BPMN diagram?"
+    answer: "A BPMN diagram consists of four main categories of elements: Flow Objects (Events, Activities, Gateways), Connecting Objects (Sequence Flow, Message Flow, Association), Swimlanes (Pools, Lanes), and Artifacts (Data Object, Group, Text Annotation). These elements combine to visually represent the steps, decisions, and participants in a business process."
+  - question: "What are the main benefits of using BPMN?"
+    answer: "BPMN offers several key benefits, including improved process clarity and communication, enhanced collaboration between technical and business stakeholders, and better identification of bottlenecks and areas for optimization. It provides a standardized notation that reduces ambiguity, making processes easier to understand, analyze, and automate across an organization."
+---
+
+In an increasingly automated world, understanding and defining how work flows through an organization is more critical than ever. Whether coordinating data pipelines, infrastructure changes, or customer service requests, a clear blueprint for your processes is essential for efficiency and governance.
+
+This article introduces Business Process Model and Notation (BPMN), the internationally recognized standard for graphically representing business processes. We’ll explore its core elements, compare it to other modeling notations, and discuss its enduring relevance in modern automation. You'll also learn how platforms like Kestra integrate with and complement BPMN for technical orchestration.
+
+## Why a universal language for business processes matters
+
+Every organization runs on processes. Some are simple, like approving a vacation request. Others are complex, involving multiple departments, systems, and decision points. Without a standardized way to describe these processes, ambiguity can lead to errors, inefficiencies, and communication breakdowns between teams. This is where a universal notation becomes invaluable.
+
+### Defining BPMN: The ISO standard for clarity
+
+Business Process Model and Notation (BPMN) is a graphical notation used to specify business processes in a diagram. Maintained by the Object Management Group (OMG), BPMN 2.0 is recognized as the international standard ISO/IEC 19510. Its primary goal is to provide a notation that is readily understandable by all business stakeholders, from business analysts who create the initial drafts of the processes, to the technical developers responsible for implementing the technology that will perform those processes, and finally, to the business people who will manage and monitor those processes.
+
+By creating a standardized bridge between business process design and implementation, BPMN helps align business objectives with IT execution. It serves as a common language, reducing the friction and misinterpretations that often arise when translating business requirements into technical specifications for a [workflow engine](/resources/infrastructure/workflow-engine).
+
+## Understanding the foundational elements of BPMN diagrams
+
+A BPMN diagram is constructed from a small set of graphical elements, which can be combined to model complex process logic. These elements are grouped into four main categories, providing a rich vocabulary for process representation.
+
+### Flow Objects: Events, activities, and gateways
+
+Flow Objects are the primary graphical elements that define the behavior of a business process.
+*   **Events:** Represented by circles, events signify something that happens during a process. There are Start, Intermediate, and End events. They can be triggered by various factors, such as a message arriving, a specific time being reached, or an error occurring.
+*   **Activities:** Shown as rounded-corner rectangles, activities represent work that is performed within a process. An activity can be a task (an atomic piece of work) or a sub-process (a compound activity that contains its own set of activities).
+*   **Gateways:** Depicted as diamonds, gateways are used to control the divergence and convergence of sequence flows. They represent decision points, determining which path the process should take based on certain conditions (Exclusive Gateway), or enabling parallel execution of tasks (Parallel Gateway).
+
+### Connecting Objects: Sequence flow, message flow, and associations
+
+These objects connect the Flow Objects to structure the process diagram and show the flow of work and information.
+*   **Sequence Flow:** A solid line with a solid arrowhead, this shows the order in which activities will be performed in a process.
+*   **Message Flow:** A dashed line with an open arrowhead, this represents the flow of messages between two separate process participants (e.g., between different departments or organizations).
+*   **Association:** A dotted line, this is used to associate an Artifact (like a text annotation) or data with a Flow Object.
+
+### Swimlanes and Artifacts: Organizing participants and context
+
+Swimlanes and Artifacts provide additional layers of detail and organization to the diagram.
+*   **Swimlanes:** These are graphical containers that organize activities. A **Pool** represents a major participant in a process (e.g., a company) and can contain multiple **Lanes**, which are used to organize activities associated with a specific role or department within that participant (e.g., Sales, HR).
+*   **Artifacts:** These provide extra information about the process without directly affecting its flow. Common artifacts include **Data Objects** (showing data required or produced by an activity), **Groups** (used to group elements visually), and **Text Annotations** (for adding explanatory notes).
+
+## The strategic value of BPMN for organizations
+
+Adopting BPMN is more than a technical exercise; it provides tangible strategic benefits that can drive significant business improvements. By visualizing processes in a clear and consistent manner, organizations can unlock new levels of efficiency, collaboration, and control.
+
+### Enhancing communication and collaboration
+
+One of the most significant advantages of BPMN is its ability to create a shared understanding of processes across different parts of the business. Business analysts can model a process that is easily understood by managers and executives, while also providing the precision needed for developers to implement it. This common visual language breaks down silos and ensures everyone is working from the same blueprint, reducing rework and speeding up project timelines.
+
+### Identifying bottlenecks and optimizing efficiency
+
+When a process is mapped out in a BPMN diagram, inefficiencies, redundant steps, and bottlenecks become much easier to spot. The visual representation allows teams to analyze the flow of work, question existing steps, and identify opportunities for improvement. This analytical capability is the foundation of continuous process improvement initiatives, enabling organizations to systematically refine their operations for better performance and lower costs.
+
+### Enabling process automation and governance
+
+A well-defined BPMN diagram is an executable model for automation. It provides a clear specification for what needs to be automated, how decisions should be handled, and how exceptions should be managed. This clarity is crucial for effective [workflow governance](/resources/infrastructure/workflow-governance), ensuring that automated processes are compliant, auditable, and secure. With features like role-based swimlanes, BPMN also supports robust access control, aligning process execution with organizational security policies and [RBAC workflow orchestration](/resources/infrastructure/rbac-workflow-orchestration).
+
+## BPMN in context: Comparing with other modeling notations
+
+While BPMN is a powerful standard for business processes, it's important to understand how it differs from other common notations used in business and technology.
+
+### BPMN vs. Gantt charts: Process flow vs. project schedule
+
+The most fundamental difference lies in their purpose. BPMN is used to model the logical flow of work—the sequence of activities, decision points, and participants involved in a process, independent of time. A Gantt chart, conversely, is a project management tool that visualizes a project schedule. It maps tasks against a timeline, showing start and end dates, dependencies, and overall project duration.
+
+You might use BPMN to design *how* a customer order is fulfilled, detailing every step from order placement to shipping. You would then use a Gantt chart to manage the project of implementing that new fulfillment process, scheduling the tasks for the team building it.
+
+### BPMN vs. UML: Business processes vs. software systems
+
+BPMN and Unified Modeling Language (UML) are both standards maintained by the OMG, but they serve distinct domains. BPMN is tailored for modeling business processes, with a notation designed to be accessible to both business and technical users. Its focus is on the operational flow of an organization.
+
+UML is a much broader and more complex language used in software engineering to model the architecture, design, and behavior of software systems. It includes various diagram types, such as Class Diagrams (for structure), Sequence Diagrams (for interactions), and Activity Diagrams (which have some overlap with BPMN but are focused on software logic). While a UML Activity Diagram can model a workflow, it lacks the rich, business-oriented semantics of BPMN.
+
+## Practical applications and tools for BPMN
+
+The adoption of BPMN has been driven by its practical utility and the availability of robust tooling that supports the standard.
+
+### How BPMN 2.0 streamlines process design
+
+The evolution to BPMN 2.0 introduced significant enhancements, solidifying its role as a comprehensive standard. Key improvements included a formal metamodel, the ability to define different types of diagrams (e.g., process, collaboration, choreography), and, most importantly, a standardized XML format for storing and exchanging diagrams. This means a BPMN diagram created in one tool can be opened and edited in another, and can even be directly executed by a compatible process engine. This interoperability is crucial for modern, multi-vendor environments.
+
+### Popular software for creating BPMN diagrams
+
+A variety of tools are available for creating BPMN diagrams, catering to different needs and user types.
+*   **Microsoft Visio:** A popular choice among business analysts, Visio includes BPMN 2.0 templates and shapes, allowing users to create diagrams using a familiar drag-and-drop interface.
+*   **Camunda Modeler:** An [open-source workflow engine](/resources/infrastructure/open-source-workflow-engine) and modeler that provides a dedicated, powerful environment for creating and editing BPMN diagrams that are directly executable on the Camunda platform. There are also many [Camunda alternatives](/resources/infrastructure/camunda-alternatives) that offer different approaches to process automation.
+*   **Lucidchart, Draw.io:** Web-based diagramming tools that offer extensive support for BPMN, facilitating collaborative modeling and easy sharing.
+
+These tools make it possible to apply BPMN to real-world scenarios, such as modeling [business processes](/blueprints/business-processes) like vacation approvals or customer onboarding.
+
+## BPMN's role in modern orchestration platforms
+
+While BPMN provides an excellent framework for modeling formal business processes, modern technical workflows often require a different approach. The rise of DevOps, data engineering, and AI has created a need for orchestration platforms that are declarative, code-native, and language-agnostic.
+
+### When BPMN engines excel (e.g., Camunda)
+
+BPMN-native engines like Camunda are powerful for orchestrating complex, long-running business processes, especially those involving human interaction and strict, auditable logic. They are designed to execute BPMN models directly, making them a strong fit for use cases in regulated industries like finance, insurance, and healthcare, where process compliance is paramount. However, this model can introduce overhead for purely technical workflows where engineering teams prefer to define logic as code.
+
+### Kestra's declarative approach: Orchestrating processes beyond BPMN
+
+Platforms like Kestra offer a complementary, declarative approach centered on YAML. This model is ideal for engineering-led automation, where workflows are treated as code and managed through GitOps practices. While Kestra is not a BPMN engine, it can orchestrate the technical tasks that form part of a larger, BPMN-modeled business process. For example, a BPMN diagram might specify a "Process Customer Data" task, and a Kestra flow could implement the underlying data pipeline that executes this task.
+
+This separation of concerns allows business analysts to model the high-level process in BPMN, while engineers build and manage the robust, scalable technical components in Kestra. This approach avoids the limitations of trying to fit all types of automation into a single paradigm, offering a more flexible and powerful solution. For more on [why Kestra](/docs/why-kestra) takes this approach, and to see how it compares to other tools like [Temporal](/resources/infrastructure/temporal-alternatives), you can explore our documentation.
+
+## Looking ahead: The future of BPMN and unified orchestration
+
+Is BPMN still relevant in an era of AI and agile development? The answer is yes, but its role is evolving. For structured, human-centric, and regulated processes, BPMN's clarity and standardization remain indispensable. It provides the governance and auditability that are often required in enterprise environments.
+
+The future lies in unified orchestration platforms that can bridge the gap between business process modeling and technical execution. An ideal platform should be able to trigger and manage technical workflows defined as code, while providing visibility and control within the context of the broader business process. This allows organizations to leverage the strengths of BPMN for design and governance, while using declarative, developer-friendly tools for implementation. By integrating these worlds, businesses can achieve true end-to-end [infrastructure automation](/infra-automation) and process efficiency. For more resources on this topic, explore our [infrastructure automation guides](/resources/infrastructure).

--- a/src/contents/resources/business-process-automation/index.md
+++ b/src/contents/resources/business-process-automation/index.md
@@ -1,0 +1,169 @@
+---
+title: "Business Process Automation: Orchestrating Workflows Across Your Enterprise"
+description: "Understand Business Process Automation (BPA), its benefits, and how it differs from RPA. Explore real-world examples and learn how Kestra unifies your business, data, and infrastructure workflows."
+metaTitle: "Business Process Automation: Guide to Enterprise Workflows"
+metaDescription: "Business Process Automation (BPA) streamlines operations, cuts costs, and strengthens compliance. Learn how BPA works and how to orchestrate it end to end."
+tag: business
+date: 2026-07-30
+slug: "business-process-automation"
+faq:
+  - question: "What is Business Process Automation (BPA)?"
+    answer: "Business Process Automation (BPA) uses technology to automate complex, multi-step business processes. Unlike simple task automation, BPA focuses on end-to-end workflows, often involving multiple systems and human decision points, to improve efficiency, accuracy, and compliance across an organization."
+  - question: "What are the 5 stages of Business Process Management (BPM)?"
+    answer: "The five stages of Business Process Management (BPM) are Design, Modeling, Execution, Monitoring, and Optimization. This cycle ensures continuous improvement, allowing organizations to iteratively refine their automated processes for maximum efficiency and effectiveness, adapting to changing business needs."
+  - question: "How does Business Process Automation differ from Robotic Process Automation (RPA)?"
+    answer: "BPA focuses on automating entire end-to-end business processes, often integrating directly with systems via APIs. RPA, on the other hand, automates repetitive, rule-based tasks by mimicking human interaction with user interfaces. BPA is about system-level integration and workflow logic, while RPA targets screen-level task replication."
+  - question: "Is Robotic Process Automation (RPA) dead?"
+    answer: "RPA is not dead; its role is evolving. While traditional RPA excels at automating repetitive, rule-based tasks, its limitations in handling unstructured data and complex decision-making are being addressed by integration with AI. AI-powered RPA, or intelligent automation, combines RPA's execution capabilities with AI's cognitive abilities, making it more adaptable and powerful."
+  - question: "What is an example of Business Process Automation?"
+    answer: "A common example of BPA is automating customer onboarding. This involves a sequence of steps like data entry, identity verification, system provisioning, welcome email sequences, and internal notifications. BPA tools coordinate these steps across CRM, identity management, and communication systems, reducing manual effort and accelerating the onboarding time."
+  - question: "Which types of processes are best suited for BPA?"
+    answer: "Processes that are repetitive, rule-based, high-volume, time-sensitive, and involve multiple systems or departments are ideal candidates for BPA. Examples include invoice processing, HR onboarding, IT service requests, customer support workflows, and financial reporting, where consistency, speed, and accuracy are critical."
+---
+
+Fragmented, manual processes are a silent drain on enterprise efficiency. From slow customer onboarding to error-prone invoice processing, reliance on human intervention for repetitive tasks creates bottlenecks, inflates costs, and introduces compliance risks. Modern organizations need a better way to coordinate these critical operations.
+
+Business Process Automation (BPA) offers a strategic solution, transforming disjointed tasks into streamlined, automated workflows. This guide will clarify what BPA is, how it differs from Robotic Process Automation (RPA), and provide practical examples. We'll explore the stages of implementation and demonstrate how a declarative orchestration platform can unify your business, data, and infrastructure automation under one control plane.
+
+## What is Business Process Automation?
+
+Business Process Automation (BPA) is the strategic use of technology to orchestrate and execute complex, multi-step business processes from start to finish. It moves beyond automating individual tasks to managing the entire lifecycle of a workflow, which often spans multiple departments, applications, and systems.
+
+### Defining BPA: Beyond simple task automation
+
+At its core, BPA is about integration and logic. It connects disparate systems—like your CRM, ERP, and HR platforms—at the API level, enabling them to exchange data and trigger actions based on predefined business rules. This approach ensures that processes are executed consistently, reliably, and in the correct sequence, with or without human intervention.
+
+A key characteristic of BPA is its focus on the end-to-end process. Instead of just automating data entry into a single form, a BPA solution would manage the entire journey: from initial data capture, through validation and approval steps, to final system updates and notifications. This holistic view is what differentiates it from more tactical automation methods.
+
+### How BPA differs from Robotic Process Automation (RPA)
+
+BPA and Robotic Process Automation (RPA) are often discussed together, but they solve different problems. Understanding their distinction is crucial for choosing the right automation strategy.
+
+*   **Robotic Process Automation (RPA)** automates repetitive, rule-based tasks by mimicking human actions on a user interface (UI). Think of an RPA bot as a digital worker that can click, type, and copy-paste data between applications just like a person would. It's best suited for legacy systems without APIs or for automating highly circumscribed tasks. [UiPath is a well-known platform in the RPA space](/resources/infrastructure/what-is-uipath).
+
+*   **Business Process Automation (BPA)** operates at a deeper, systemic level. It integrates directly with application backends via APIs, webhooks, and database connections. BPA orchestrates complex workflows, manages conditional logic, handles exceptions, and coordinates tasks across the entire technology stack. It is designed for durability and scale, automating the core processes of the business itself.
+
+The primary difference is the method of integration: RPA works from the "outside-in" by simulating user interaction, while BPA works from the "inside-out" through direct system communication. While RPA is a valuable tool for specific tasks, many organizations find that as they scale, they require the robust, API-driven orchestration that BPA provides. This has led many to seek out [alternatives to traditional RPA solutions](/resources/infrastructure/uipath-alternatives).
+
+| Feature | Business Process Automation (BPA) | Robotic Process Automation (RPA) |
+|---|---|---|
+| **Focus** | End-to-end business processes | Individual, repetitive tasks |
+| **Integration** | API, database, system-level | User Interface (UI), screen scraping |
+| **Scope** | Strategic, cross-departmental | Tactical, task-specific |
+| **Resilience** | High (APIs are stable) | Low (UI changes can break bots) |
+| **Use Case** | Customer onboarding, invoice processing | Data entry, form filling, report generation |
+
+## Why Business Process Automation Matters for Enterprise Efficiency
+
+Implementing BPA is more than a technical upgrade; it's a strategic business decision that delivers compounding returns in efficiency, cost savings, and resilience.
+
+### Boosting operational efficiency and reducing costs
+
+By automating manual, time-consuming tasks, BPA frees up employees to focus on higher-value work that requires critical thinking and creativity. Workflows that once took days of manual coordination can be executed in minutes, dramatically accelerating service delivery and response times. This reduction in manual labor and process cycle time directly translates to lower operational costs and increased throughput.
+
+### Enhancing compliance, data accuracy, and auditability
+
+Manual processes are inherently prone to human error, leading to inconsistent data and potential compliance breaches. BPA enforces business rules with perfect consistency, ensuring that every step of a process is executed correctly and in the right order. Automated workflows also create a digital audit trail, logging every action, decision, and data change. This provides complete visibility and makes it easier to demonstrate compliance with regulations like GDPR or SOX. Effective [workflow governance](/resources/infrastructure/workflow-governance) becomes built-in, not bolted on.
+
+### Empowering teams with self-service and improved decision-making
+
+BPA platforms can expose complex backend processes as simple, self-service actions. For example, a sales team member could trigger a complex customer provisioning workflow by simply updating a field in their CRM. This empowerment reduces dependencies on IT and operations teams. Furthermore, by centralizing process data, BPA provides managers with real-time insights into performance, bottlenecks, and trends, enabling more informed, data-driven decisions.
+
+## Common Business Process Automation Examples
+
+BPA can be applied across virtually any department to streamline operations. Here are a few common examples:
+
+### Automating customer onboarding and service request workflows
+
+A new customer sign-up can trigger an automated workflow that creates an account in the CRM, provisions access in the product platform, sends a welcome email sequence, and assigns an account manager. This ensures a consistent, fast, and error-free onboarding experience.
+
+### Streamlining financial operations like invoice processing and expense management
+
+When a new invoice arrives in a designated inbox, a BPA workflow can automatically extract key data (vendor, amount, due date), match it against a purchase order, route it for digital approval, and schedule the payment in the ERP system. This reduces payment delays and minimizes manual data entry. For businesses using systems like Microsoft Dynamics, direct integration via plugins for [creating invoices and managing customers](/plugins/plugin-microsoft365/microsoft-dynamics-365-business-central) is possible.
+
+### Modernizing HR request management and employee lifecycle processes
+
+From new hire onboarding to offboarding, BPA can manage the entire employee lifecycle. This includes provisioning equipment, granting system access, managing payroll setup, and handling vacation requests. A common use case is building automated [approval processes](/docs/use-cases/approval-processes) for leave requests, which can be modeled with clear, auditable steps.
+
+### Orchestrating IT and infrastructure provisioning workflows
+
+BPA is a cornerstone of a modern [IT automation platform](/resources/infrastructure/it-automation-platform). When a new developer joins, an automated workflow can provision a virtual machine, install standard software, create accounts in development tools like GitHub and Jira, and assign them to the correct user groups, all based on their role.
+
+## Implementing Business Process Automation: A Structured Approach
+
+Successful BPA implementation is a continuous cycle of improvement, not a one-time project. It follows the established principles of Business Process Management (BPM).
+
+### The stages of Business Process Management (BPM)
+
+BPM provides a structured methodology for applying BPA effectively. The lifecycle consists of five key stages:
+1.  **Design:** Identify the process to be automated, define its objectives, and map out the existing steps, stakeholders, and systems involved.
+2.  **Model:** Create a visual representation of the new, automated workflow. Define the business rules, data flows, and exception-handling logic.
+3.  **Execute:** Implement the process using a BPA tool. This involves configuring integrations, building the workflow logic, and testing it thoroughly.
+4.  **Monitor:** Track the performance of the automated process in real-time. Collect data on key metrics like cycle time, error rates, and cost per transaction.
+5.  **Optimize:** Analyze the performance data to identify bottlenecks or areas for improvement. Use these insights to refine the workflow, and then repeat the cycle.
+
+### Choosing the right BPA tools and solutions
+
+The market for automation tools is vast. Selecting the right solution depends on your organization's specific needs, technical maturity, and strategic goals. Consider these factors:
+
+*   **Integration Capabilities:** Does the tool offer pre-built connectors for your key systems (ERP, CRM, cloud services)? Can it easily call any API?
+*   **Scalability and Performance:** Can the platform handle your expected volume of transactions and scale as your business grows?
+*   **Governance and Security:** Does it provide features like role-based access control (RBAC), audit logs, and secure secret management?
+*   **Authoring Experience:** Is the workflow definition process accessible to your team? Options range from visual, no-code interfaces to declarative, code-first approaches.
+
+When evaluating the [best workflow automation tools](/resources/infrastructure/best-workflow-automation-tools), you'll encounter a range of options, from iPaaS solutions like [Workato](/resources/ai/workato-alternatives) and [Make](/resources/infrastructure/make-alternatives) to developer-focused engines. Many teams also explore [open-source workflow engines](/resources/infrastructure/open-source-workflow-engine) for maximum flexibility and control, comparing options like [n8n](/resources/infrastructure/n8n-alternatives) and more formal BPM tools like [Camunda](/resources/infrastructure/camunda-alternatives).
+
+## Kestra's Approach to Unified Business Process Automation
+
+Kestra provides a declarative, event-driven orchestration platform that unifies business process automation with your data, AI, and infrastructure workflows.
+
+### Declarative YAML for transparent and governed workflows
+
+In Kestra, all workflows are defined as simple, human-readable YAML files. This "automation-as-code" approach makes your business processes transparent, versionable, and auditable. Workflows can be stored in Git, reviewed through pull requests, and deployed as part of a CI/CD pipeline, bringing DevOps best practices to your business automation.
+
+This example shows a simple vacation approval workflow that requires human-in-the-loop validation:
+
+```yaml
+id: vacation-approval
+namespace: company.hr
+
+tasks:
+  - id: request-details
+    type: io.kestra.plugin.core.inputs.String
+    title: "Enter reason for vacation request."
+
+  - id: human-approval
+    type: io.kestra.plugin.core.flow.Pause
+    description: "Manager approval required. Please review and resume."
+
+  - id: submit-to-hr-system
+    type: io.kestra.plugin.core.http.Request
+    uri: https://api.hrsystem.com/leave
+    method: POST
+    body: |
+      {
+        "employeeId": "{{ trigger.userId }}",
+        "reason": "{{ outputs['request-details'].value }}",
+        "status": "APPROVED"
+      }
+```
+
+### Polyglot execution for any business logic, anywhere
+
+Business logic isn't confined to one language. Kestra is language-agnostic, allowing you to run Python scripts, shell commands, SQL queries, and Docker containers as native tasks within a single workflow. This flexibility means you can use the best tool for each job without being locked into a single ecosystem. It's an ideal platform for [software engineers](/use-cases/software-engineers) who need to orchestrate diverse technical components.
+
+### Unifying data, AI, and infrastructure workflows under one control plane
+
+True enterprise automation requires breaking down silos. Kestra's power lies in its ability to serve as a single control plane for all your automated processes. You can orchestrate an [infrastructure automation](/infra-automation) workflow to provision a new server, a data pipeline to populate it with customer data, and a business process to grant user access—all from the same platform. This unified approach provides end-to-end visibility and control, enabling complex, cross-domain automation scenarios, including orchestrating [AI and agentic workflows](/ai-automation).
+
+## The Future of Business Process Automation: Intelligent Automation and Human-in-the-Loop
+
+BPA is continuously evolving, driven by advances in artificial intelligence and a deeper understanding of human-computer collaboration.
+
+### Is RPA dead? The evolving role of AI in automation
+
+RPA is not disappearing; it's being augmented by AI to create "Intelligent Automation." While traditional RPA bots are limited to structured data and predefined rules, AI gives them the ability to handle unstructured data (like emails and documents), make decisions, and adapt to changing conditions. The future isn't about replacing RPA but enhancing it, a trend seen in the evaluation of [alternatives to platforms like Automation Anywhere](/resources/infrastructure/automation-anywhere-alternatives).
+
+### Continuous improvement and adaptive workflows
+
+The future of BPA is adaptive. Modern orchestration platforms can use machine learning to analyze workflow performance and suggest optimizations automatically. Human-in-the-loop patterns are becoming more sophisticated, ensuring that automation assists human experts rather than replacing them. This creates a powerful synergy where automated systems handle the repetitive work, while humans provide strategic oversight and manage exceptions, leading to more resilient and intelligent business operations.

--- a/src/contents/resources/business-rules-engine/index.md
+++ b/src/contents/resources/business-rules-engine/index.md
@@ -1,0 +1,176 @@
+---
+title: "Business Rules Engine: Automate Complex Decisions with Orchestration"
+description: "A business rules engine (BRE) automates decision-making by applying predefined logic to data. Learn how integrating a BRE with an orchestration platform streamlines complex business processes and enhances agility across your enterprise."
+metaTitle: "Business Rules Engine: Automate Decisions with Orchestration"
+metaDescription: "A business rules engine externalizes decision logic from code. Learn how it works, its benefits, and how Kestra orchestrates rule-driven workflows."
+tag: business
+date: 2026-07-30
+slug: "business-rules-engine"
+faq:
+  - question: "What is a business rules engine (BRE)?"
+    answer: "A business rules engine (BRE) is a software system that executes one or more predefined business rules in a runtime environment. It externalizes decision logic from application code, allowing non-technical users to manage and update rules without requiring code changes or redeployments. BREs are used to automate complex decision-making processes across various domains."
+  - question: "Are business rules engines obsolete in the age of AI?"
+    answer: "No, business rules engines are not obsolete. While AI and Machine Learning handle predictive analytics and pattern recognition, BREs provide the explicit, auditable logic for policy enforcement, compliance, and deterministic decisions. Modern approaches often combine BREs with AI, where AI might generate recommendations and the BRE applies the final governance rules."
+  - question: "What are the key benefits of using a business rules engine?"
+    answer: "Implementing a business rules engine offers several benefits, including increased agility in adapting to market changes, improved consistency in decision-making by centralizing logic, and reduced reliance on IT for frequent rule updates. It also enhances compliance, simplifies audit trails, and accelerates the automation of complex operational processes."
+  - question: "What are the common types of business rules?"
+    answer: "Business rules can take various forms, including conditional rules (if-then statements), declarative rules (stating what should be true), and decision tables (matrix-based rules). They govern aspects like data validation, calculations, derivations, constraints, and operational procedures, ensuring consistent application of policies across an organization."
+  - question: "What is the difference between a Business Rules Engine (BRE) and a Business Rules Management System (BRMS)?"
+    answer: "A Business Rules Engine (BRE) is the component that executes business rules. A Business Rules Management System (BRMS) is a broader platform that includes the BRE, along with tools for defining, testing, deploying, and managing rules throughout their lifecycle. A BRMS provides governance and a centralized repository for all business logic."
+  - question: "Can a business rules engine integrate with other automation tools?"
+    answer: "Yes, BREs are designed to integrate with other systems and automation tools, including workflow orchestrators, ERP systems, CRM platforms, and data pipelines. This integration allows BREs to receive inputs from various sources, apply rules, and trigger actions or update other systems based on the outcomes, creating end-to-end automated processes."
+---
+
+> **TL;DR** — A business rules engine (BRE) is a software system that automates complex decision-making by executing predefined business logic. It separates rules from application code, enabling greater agility, consistency, and easier management of policies across various operational workflows and systems.
+
+In an environment where agility and consistency are paramount, organizations often struggle with hardcoding critical business logic directly into application code. This approach creates bottlenecks, slows down policy updates, and introduces risks of inconsistency and errors. The challenge isn't just automating tasks, but automating complex decisions that adapt rapidly to changing market conditions and regulatory demands.
+
+This article explores the role of a business rules engine (BRE) in externalizing and automating these decisions. We’ll delve into how BREs function, why they benefit from orchestration, and how Kestra acts as the control plane to unify decision logic with broader operational workflows across your enterprise.
+
+## How Business Rules Engines Work
+
+A business rules engine operates by processing incoming data against a predefined set of rules to produce a decision or outcome. It effectively decouples the "what" (the business rule) from the "how" (the application code).
+
+### Defining a Business Rules Engine
+A BRE is a software component that manages and executes business rules. Instead of embedding `if-then-else` logic deep within multiple applications, a BRE centralizes this logic in a single, manageable repository. This allows business analysts, policy managers, and other non-technical stakeholders to modify rules without needing to change, recompile, and redeploy application code.
+
+### Key Components of a Business Rules Engine
+A typical BRE consists of several core components:
+*   **Rule Repository:** A database or file system that stores the business rules.
+*   **Rule Authoring Interface:** A user-friendly tool for creating, modifying, and testing rules, often using decision tables, trees, or a simplified natural language syntax.
+*   **Execution Engine:** The runtime component that evaluates the rules against input data and determines the appropriate action. It uses pattern-matching algorithms to efficiently find and apply relevant rules.
+*   **Integration Layer:** APIs that allow applications to send data to the engine and receive decisions back.
+
+### How Decision Logic Flows Through a BRE
+The process generally follows these steps:
+1.  An application sends a data object (e.g., a loan application, an insurance claim) to the BRE.
+2.  The execution engine loads the relevant rules from the repository.
+3.  The engine matches the input data against the conditions defined in the rules.
+4.  When a condition is met, the engine executes the corresponding action (e.g., approve the loan, flag the claim for review).
+5.  The engine returns the outcome to the calling application.
+
+## Why Complex Business Rules Need Orchestration
+
+A business rules engine is a powerful decision-making component, but it doesn't operate in a vacuum. Production workflows require more than just rule execution; they need end-to-end coordination. This is where orchestration comes in.
+
+*   **Data Preparation:** Rules are only as good as the data they evaluate. Orchestration platforms can fetch, clean, and transform data from multiple sources before feeding it to the BRE.
+*   **Error Handling and Recovery:** What happens if the data source is unavailable or the rule evaluation fails? An orchestrator manages retries, implements dead-letter queues, and triggers alerts for failed evaluations.
+*   **Integration with Business Processes:** A decision is often just one step in a larger process. Orchestration integrates the BRE's output into broader workflows, such as triggering human approvals, updating CRM systems, or initiating compliance checks.
+*   **End-to-End Visibility:** Orchestration provides a single pane of glass for monitoring the entire decision flow, from data ingestion to final action, creating an auditable trail for compliance and debugging.
+
+## Orchestrate Business Rules with Kestra: Automating a Policy Decision Flow
+
+An orchestration platform like Kestra acts as the control plane that invokes the BRE and manages the entire lifecycle of the decision-making process. Let's consider a scenario: automating a policy decision for a customer loyalty program to determine eligibility for a premium discount based on purchase history and membership tier.
+
+This Kestra flow uses a webhook to receive customer data, evaluates it against a set of rules defined in a shell script, and then branches the workflow to send a tailored Slack notification based on the outcome.
+
+```yaml
+id: customer_loyalty_policy_decision
+namespace: company.sales
+
+description: Automates a customer loyalty discount decision based on purchase history and membership tier.
+
+inputs:
+  - id: customerId
+    type: STRING
+    description: The ID of the customer.
+  - id: totalPurchaseAmount
+    type: INT
+    description: Total purchase amount in the last 12 months.
+  - id: membershipTier
+    type: STRING
+    description: Current customer membership tier (e.g., Bronze, Silver, Gold).
+
+tasks:
+  - id: evaluate_discount_rules
+    type: io.kestra.plugin.scripts.shell.Commands
+    commands:
+      - |
+        DISCOUNT_PERCENT=0
+        if [ "{{ inputs.membershipTier }}" == "Gold" ] && [ {{ inputs.totalPurchaseAmount }} -ge 5000 ]; then
+          DISCOUNT_PERCENT=15
+        elif [ "{{ inputs.membershipTier }}" == "Silver" ] && [ {{ inputs.totalPurchaseAmount }} -ge 2000 ]; then
+          DISCOUNT_PERCENT=10
+        elif [ "{{ inputs.membershipTier }}" == "Bronze" ] && [ {{ inputs.totalPurchaseAmount }} -ge 500 ]; then
+          DISCOUNT_PERCENT=5
+        fi
+        echo "::{\"outputs\":{\"discountPercent\": ${DISCOUNT_PERCENT}}}"
+    outputs:
+      - discountPercent
+    description: Evaluates discount eligibility based on membership tier and total purchase amount.
+
+  - id: apply_or_notify_decision
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ outputs.evaluate_discount_rules.outputs.discountPercent > 0 }}"
+    then:
+      - id: send_discount_notification
+        type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+        url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+        text: |
+          *Customer Discount Applied!*
+          Customer ID: `{{ inputs.customerId }}`
+          Membership Tier: `{{ inputs.membershipTier }}`
+          Total Purchase: `${{ inputs.totalPurchaseAmount }}`
+          Discount: `{{ outputs.evaluate_discount_rules.outputs.discountPercent }}%`
+          Action: Discount applied to next purchase.
+        description: Notifies sales team about applied discount.
+    _else:
+      - id: notify_no_discount
+        type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+        url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+        text: |
+          *Customer Discount Not Applied*
+          Customer ID: `{{ inputs.customerId }}`
+          Membership Tier: `{{ inputs.membershipTier }}`
+          Total Purchase: `${{ inputs.totalPurchaseAmount }}`
+          Reason: Did not meet discount criteria.
+        description: Notifies sales team when no discount is applied.
+    description: Branches based on whether a discount was applied.
+
+triggers:
+  - id: webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    uri: /hook/customer-loyalty-decision
+    description: Triggers the flow via an HTTP webhook for real-time decision requests.
+```
+
+### What makes this orchestrated flow robust:
+
+*   **Event-driven execution:** The webhook trigger enables real-time decision requests from any system, such as a CRM or e-commerce platform.
+*   **Polyglot rule execution:** This example uses a simple shell script, but Kestra can execute rules defined in Python, Java, or any other language, or even call an external dedicated BRE via an API.
+*   **Conditional branching:** The `If` task allows for complex, multi-step decision paths based on the rule outcomes, ensuring the correct downstream actions are taken.
+*   **Integrated notifications:** The flow automatically alerts relevant teams (e.g., sales, support) about decision outcomes via Slack, closing the communication loop.
+*   **Auditable history:** Every execution, including the input data, decision logic outcome, and notification sent, is logged and auditable within Kestra. This provides a clear trail for compliance and troubleshooting.
+
+## Where Orchestrated Business Rules Pay Off
+
+Integrating a BRE with an orchestration platform delivers significant advantages across the enterprise.
+
+*   **Enhancing agility and adaptiveness:** Business teams can rapidly adjust rule logic in response to market changes or new regulations without waiting for IT development cycles and application redeployments.
+*   **Improving decision-making and consistency:** By centralizing decision logic, organizations ensure that the same rules are applied consistently across all operational touchpoints, from online portals to internal back-office systems.
+*   **Reducing reliance on IT for rule changes:** Empowering business users to manage rules directly, within a governed framework, frees up valuable engineering resources to focus on core application development.
+*   **Streamlining complex operational processes:** Automation becomes more powerful in use cases like [financial services](/use-cases/financial-services) for loan approvals, insurance for claims processing, and e-commerce for dynamic pricing and fraud detection.
+*   **Optimizing product configuration:** Companies can dynamically apply rules for product bundling, feature eligibility, and pricing tiers based on customer segments or other criteria.
+
+## Business Rules Management Systems (BRMS) and the Future
+
+As the need for sophisticated rule management grows, organizations often turn to a Business Rules Management System (BRMS).
+
+### What is a BRMS used for?
+A BRMS is a comprehensive platform that provides a full lifecycle management solution for business rules. It includes the BRE for execution, but adds tooling for rule discovery, authoring, testing, deployment, versioning, and governance. It serves as the central repository and system of record for an organization's decision logic.
+
+### Differentiating between BRE and BRMS
+Think of the BRE as the engine and the BRMS as the entire car. The BRE is the core component that executes rules, while the BRMS provides the complete environment for managing those rules, often with features like collaboration workflows, impact analysis, and performance monitoring.
+
+### Are business rules engines obsolete in the AI era?
+No, BREs are more relevant than ever. While AI and Machine Learning are excellent for identifying patterns and making predictions, they often operate as a "black box." BREs provide the transparent, deterministic, and auditable logic required for compliance and policy enforcement. The future lies in combining them: an ML model might predict a customer's churn risk, and a BRE would then apply a set of explicit business rules to determine the appropriate retention offer to make.
+
+## Related concepts
+- [Best Workflow Automation Tools of 2026](/resources/infrastructure/best-workflow-automation-tools)
+- [What is Data Lineage? Understand, Track & Visualize](/resources/data/data-lineage)
+- [Automate a vacation approval business process with Kestra](/blueprints/business-processes)
+- [Best IT Automation Platform: Ranked & Reviewed](/resources/infrastructure/it-automation-platform)
+- [How to Create a Data Pipeline: Complete Guide](/resources/data/create-data-pipeline)
+- [Financial Services Workflow Automation & Orchestration](/use-cases/financial-services)
+
+Experience declarative, event-driven orchestration for your business rules and beyond. [Explore Kestra for infrastructure automation](/infra-automation).

--- a/src/contents/resources/business-workflow/index.md
+++ b/src/contents/resources/business-workflow/index.md
@@ -1,0 +1,172 @@
+---
+title: "What is a Business Workflow and How to Automate It?"
+description: "A business workflow defines the steps and logic needed to achieve an organizational goal. Learn how to design, optimize, and automate your business processes for efficiency and reliability."
+metaTitle: "Business Workflow: Definition, Types & Automation"
+metaDescription: "Business workflows are task sequences for goals. Learn types, benefits, and how declarative orchestration platforms like Kestra automate your processes."
+tag: business
+date: 2026-07-30
+slug: "business-workflow"
+faq:
+  - question: "What is a workflow in business?"
+    answer: "A business workflow is a structured sequence of tasks, activities, or steps designed to achieve a specific business objective. It defines the order in which work is performed, who is responsible for each step, and how information or resources flow between stages. Effective workflows ensure consistency, efficiency, and clear accountability across an organization."
+  - question: "What are the 7 steps of the business process?"
+    answer: "While definitions vary, a common framework for business process steps includes: 1. Define the process, 2. Map existing workflow, 3. Analyze and identify improvements, 4. Redesign the process, 5. Implement the new process, 6. Monitor performance, and 7. Continuously optimize. This iterative approach ensures processes remain efficient and aligned with goals."
+  - question: "What is an example of a workflow in business?"
+    answer: "A common business workflow example is employee onboarding. It involves a sequence of tasks like HR paperwork, IT account provisioning, equipment setup, and training assignments. Another example is invoice processing, which includes receiving, verifying, approving, and paying invoices, often with multiple departmental handoffs."
+  - question: "How do I create my own workflow?"
+    answer: "To create a workflow, start by identifying the process you want to automate and its desired outcome. Document each step, including inputs, outputs, and responsible parties. Use a visual tool or a declarative language like YAML to define the sequence. Test thoroughly and refine based on feedback and performance metrics."
+  - question: "What is a simple workflow?"
+    answer: "A simple workflow outlines a straightforward, repeatable sequence of tasks to achieve a clear goal, often with minimal decision points. An example is a daily report generation: extract data, transform it, and send it to recipients. Simple workflows are easy to define and automate, providing quick wins for efficiency gains."
+---
+
+In today's complex operational environments, many organizations grapple with fragmented processes, manual handoffs, and a lack of clear accountability. These unmanaged sequences of tasks lead to inefficiencies, errors, and wasted resources, hindering productivity and strategic growth. Without a structured approach, critical business objectives can become bogged down in operational friction.
+
+This article demystifies business workflows, defining what they are and why they are essential for modern enterprises. We will explore how to design, implement, and optimize these processes, highlighting the role of modern orchestration platforms in transforming manual chaos into streamlined, automated operations.
+
+## Understanding Business Workflows: The Foundation of Efficient Operations
+
+At its core, a business workflow is the operational blueprint for achieving a specific organizational goal. It provides a structured, repeatable path for work to follow, ensuring that tasks are completed in the correct order by the right people or systems.
+
+### Defining a Business Workflow
+
+A business workflow is a defined sequence of tasks, activities, and decision points that move a piece of work from initiation to completion. It dictates the flow of data, documents, and resources between participants, whether they are human employees or automated systems. Think of it as the choreography of a business process, ensuring every step is executed precisely and consistently. Effective [workflow management](/resources/infrastructure/workflow-management) is the key to turning this choreography into a reliable operational reality.
+
+### Key Characteristics of Effective Workflows
+
+Not all workflows are created equal. The most effective ones share several key traits:
+*   **Repeatable:** The process is standardized and can be executed multiple times with consistent results.
+*   **Goal-Oriented:** Every workflow is designed to achieve a specific, measurable business outcome.
+*   **Sequential:** Tasks are arranged in a logical order, often with dependencies where one step must be completed before the next can begin.
+*   **Clearly Defined Roles:** It specifies who is responsible for each task, decision, and approval, eliminating ambiguity.
+*   **Measurable:** Its performance can be tracked through metrics like cycle time, cost per execution, and error rates, allowing for continuous improvement.
+
+## Why Orchestrating Business Workflows is Essential for Growth
+
+Simply defining a workflow isn't enough. Actively managing and orchestrating these processes unlocks significant value, transforming them from static diagrams into dynamic, automated assets that drive business performance.
+
+### Driving Efficiency and Productivity
+
+Orchestrated workflows eliminate the friction of manual handoffs and repetitive tasks. By automating the sequence of operations, you reduce the time employees spend on administrative overhead and allow them to focus on higher-value activities. This acceleration of cycle times means products get to market faster, customer requests are resolved sooner, and financial reports are generated more quickly.
+
+### Ensuring Consistency and Compliance
+
+Manual processes are prone to human error and variation. A well-defined, automated workflow ensures that every task is performed the same way, every time. This consistency is critical for quality control and customer satisfaction. Furthermore, in regulated industries, orchestrated workflows provide an auditable trail of every action and decision. This makes it easier to demonstrate compliance and enforce [workflow governance](/resources/infrastructure/workflow-governance) policies. Robust [workflow orchestration security](/resources/infrastructure/workflow-orchestration-security) also protects sensitive data as it moves through the process.
+
+## Common Business Workflow Patterns
+
+Business workflows exist in every department and at every level of an organization. They can be categorized based on their level of automation and the functional area they serve.
+
+### Manual vs. Automated Workflows
+
+*   **Manual Workflows:** These rely entirely on human intervention for each step. Examples include a manager manually approving an expense report via email or a designer handing off a file to a developer on a shared drive. They are flexible but slow, inconsistent, and difficult to scale.
+*   **Automated Workflows:** These use software to execute tasks and move work between stages without human input. An example is a system that automatically provisions a new employee's software accounts after an HR record is created.
+*   **Hybrid Workflows:** Most modern workflows are hybrid, combining automated tasks with human decision points. A "human-in-the-loop" process, like a system that automatically flags a large financial transaction for manual review, is a common example.
+
+### Operational, Data, and Cross-Functional Workflows
+
+Workflows can also be classified by their domain:
+*   **Operational Workflows:** These are the core processes that run the business day-to-day, such as order fulfillment, customer support ticketing, and supply chain logistics. They often require robust [infrastructure automation](/infra-automation).
+*   **Data Workflows:** These focus on moving, transforming, and analyzing data. Examples include ETL (Extract, Transform, Load) pipelines, machine learning model training, and business intelligence reporting. These are central to modern [data engineering](/data).
+*   **AI Workflows:** A newer category, these workflows orchestrate complex sequences involving Large Language Models (LLMs), agents, and data sources to perform tasks like document summarization or automated code generation. See how to manage [AI automation](/ai-automation).
+*   **Cross-Functional Workflows:** These span multiple departments, such as employee onboarding (HR, IT, Finance) or new product launches (Marketing, Sales, Engineering).
+
+## Designing and Implementing Effective Business Workflows
+
+Creating a successful workflow involves a systematic approach that moves from high-level strategy to detailed implementation.
+
+### The 7 Steps of Business Process Design
+
+A widely adopted framework for designing and refining business processes follows seven iterative steps:
+1.  **Define Goals:** Clearly state what the process is meant to achieve.
+2.  **Map the As-Is Process:** Document the current workflow, including all tasks, participants, and systems.
+3.  **Analyze and Identify Bottlenecks:** Pinpoint areas of inefficiency, delay, or high error rates.
+4.  **Redesign the To-Be Process:** Create a new, optimized workflow that addresses the identified issues.
+5.  **Implement the New Workflow:** Assign resources and deploy the necessary tools to execute the new process.
+6.  **Monitor Performance:** Track key metrics to measure the impact of the changes.
+7.  **Continuously Optimize:** Use performance data to make ongoing improvements.
+
+### How to Build Your First Workflow
+
+To get started with automation, begin with a simple, high-impact process. Follow these steps:
+1.  **Identify the Process:** Choose a repetitive, rule-based task that is currently manual.
+2.  **Document the Steps:** Write down every action required, from start to finish.
+3.  **Define Inputs and Outputs:** Determine what information or files are needed to start the process and what is produced at the end. You can learn more about defining [workflow inputs](/docs/workflow-components/inputs) in our documentation.
+4.  **Choose a Tool:** Select a workflow automation platform that fits your technical requirements.
+5.  **Build and Test:** Implement the logic in your chosen tool and run tests with sample data to ensure it works as expected. Our [Quickstart Guide](/docs/quickstart) can help you launch your first workflow in minutes.
+
+## Business Workflows in Action: Practical Examples
+
+Workflows are the engine of business operations across all industries. Here are a few concrete examples.
+
+### Streamlining Employee Onboarding
+
+A new hire triggers a workflow that automatically creates accounts in HR, IT, and payroll systems. It then assigns mandatory training modules, schedules a meeting with their manager, and notifies the facilities team to prepare their workspace. This ensures a consistent and efficient experience for every new employee.
+
+### Automating Financial Reporting
+
+At the end of each month, a scheduled workflow extracts sales data from a CRM, transaction data from an ERP, and expense data from accounting software. It consolidates the information, generates a P&L statement, and distributes the report to key stakeholders via email, all without manual intervention. You can explore a [business automation blueprint](/blueprints/business-automation) that exports data to files for stakeholders.
+
+### Managing Retail Operations
+
+In [retail](/use-cases/retail), a low-stock alert in the inventory system can trigger a workflow that automatically generates a purchase order, sends it to the supplier for approval, and updates the inventory forecast. This helps prevent stockouts and optimizes the supply chain. Similar principles apply in [public services](/use-cases/public-services) for managing procurement and resource allocation. For a more detailed example, see our [business processes blueprint](/blueprints/business-processes).
+
+## Workflow Management vs. Business Process Management: A Clear Distinction
+
+The terms "Workflow Management" (WfM) and "Business Process Management" (BPM) are often used interchangeably, but they represent different levels of scope and focus.
+
+BPM is a holistic, strategic discipline focused on analyzing, redesigning, and continuously improving end-to-end business processes to align with organizational goals. It's about *what* the business does and *why*.
+
+Workflow Management is the operational implementation of a process. It focuses on the *how*: coordinating and automating the sequence of tasks within a defined process. A workflow is a practical application of a BPM strategy. For teams looking for powerful automation without the overhead of traditional BPMN tools, exploring [Camunda alternatives](/resources/infrastructure/camunda-alternatives) can be a valuable step.
+
+### Overlaps and Synergies
+
+The two disciplines are complementary. BPM provides the high-level design and analysis, while workflow management provides the engine to execute and automate that design. An effective BPM initiative will identify processes ripe for automation, which are then implemented as workflows using a WfM system.
+
+## Leveraging Kestra for Modern Business Workflow Orchestration
+
+Modern business workflows span a complex landscape of applications, databases, and cloud services. Kestra is an orchestration platform designed to unify these disparate systems into coherent, reliable, and scalable automated processes.
+
+### Declarative YAML for Transparency and Control
+
+Instead of complex code or rigid graphical modelers, Kestra workflows are defined in simple, human-readable YAML. This declarative approach separates the "what" from the "how," making workflows easy to understand, version control, and review. This is a core reason why many teams find [YAML better than Python for orchestration](/blogs/yaml-vs-python-workflow).
+
+Here is an example of a simple vacation request approval workflow:
+
+```yaml
+id: vacation-request-approval
+namespace: human-resources.approvals
+
+tasks:
+  - id: new-request
+    type: io.kestra.plugin.core.http.Listen
+    description: "Listen for new vacation requests submitted via a form."
+
+  - id: manager-approval
+    type: io.kestra.plugin.core.flow.Pause
+    description: "Pause the workflow and wait for a manager to approve or reject."
+    timeout: P3D
+
+  - id: process-decision
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ outputs['manager-approval'].state.name == 'RESUMED' }}"
+    then:
+      - id: notify-hr-approved
+        type: io.kestra.plugin.notifications.slack.SlackExecution
+        message: "Vacation request for {{ trigger.data.employee_name }} has been approved."
+    else:
+      - id: notify-hr-rejected
+        type: io.kestra.plugin.notifications.slack.SlackExecution
+        message: "Vacation request for {{ trigger.data.employee_name }} has been rejected."
+```
+
+### Unifying Diverse Systems with a Rich Plugin Ecosystem
+
+A key challenge in business automation is connecting different tools. Kestra provides over 1,700 plugins to integrate with databases, cloud services, messaging systems, and business applications like [Microsoft Dynamics 365](/plugins/plugin-microsoft365/microsoft-dynamics-365-business-central) or even other automation tools like [n8n](/plugins/plugin-n8n/io.kestra.plugin.n8n.triggerworkflow). This rich ecosystem allows you to build end-to-end workflows that orchestrate your entire tech stack from a single control plane.
+
+### Building Resilient and Scalable Workflows
+
+Business-critical workflows must be reliable. Kestra includes powerful [features](/features) for building robust processes, including automatic retries, error handling, timeouts, and conditional logic. Its architecture is designed to scale from a few simple tasks to millions of complex executions, ensuring your automations can grow with your business.
+
+## The Future of Business Workflows: Automation and Intelligence
+
+The field of business workflow automation is rapidly evolving. The integration of AI and machine learning is enabling more intelligent and adaptive processes. [Agentic workflows](/resources/ai/agentic-workflows) can now handle complex decision-making, while platforms like Kestra are introducing [Apps](/blogs/introducing-apps) that provide custom, low-code user interfaces on top of powerful backend automations. This trend empowers business users to trigger and interact with complex workflows without needing to understand the underlying technology, bridging the gap between business needs and technical implementation. As organizations seek more agility, the adoption of the [best workflow automation tools](/resources/infrastructure/best-workflow-automation-tools) and a culture of continuous optimization will be critical for success. The market is also seeing a rise in flexible, developer-friendly platforms, as shown by the growing interest in [Make alternatives](/resources/infrastructure/make-alternatives).

--- a/src/contents/resources/it-process-automation/index.md
+++ b/src/contents/resources/it-process-automation/index.md
@@ -1,0 +1,172 @@
+---
+title: "IT Process Automation: Orchestrating Efficiency Across Operations"
+description: "IT process automation (ITPA) transforms manual, error-prone IT tasks into reliable, software-driven workflows. Learn how declarative orchestration unifies data, infrastructure, and business processes."
+metaTitle: "IT Process Automation: Orchestrating Efficiency"
+metaDescription: "IT process automation streamlines repetitive IT tasks and incident response. Learn its benefits, use cases, and how orchestration manages IT workflows."
+tag: infrastructure
+date: 2026-07-30
+slug: "it-process-automation"
+faq:
+  - question: "What is the meaning of IT process automation?"
+    answer: "IT process automation (ITPA) involves automating IT services, support, and administration tasks into structured workflows. This eliminates the time and cost associated with manual management, reducing human error and freeing up IT staff for more strategic work."
+  - question: "Is IT automation a good career?"
+    answer: "Yes, IT automation is a highly valuable and growing career path. Professionals with skills in workflow orchestration, scripting, and platform engineering are in high demand as organizations increasingly rely on automated systems to manage complex IT environments."
+  - question: "What are the 4 types of workplace automation?"
+    answer: "The four main types of workplace automation are: Robotic Process Automation (RPA) for repetitive, rule-based tasks; Business Process Automation (BPA) for end-to-end business workflows; IT Process Automation (ITPA) for IT-specific operations; and Intelligent Process Automation (IPA), which combines AI with RPA and BPA for more complex, cognitive tasks."
+  - question: "Can I learn RPA on my own?"
+    answer: "Yes, you can learn RPA on your own through online courses, tutorials, and free community editions of RPA tools. Many platforms offer extensive documentation and forums to support self-learners, making it accessible to those motivated to acquire new automation skills."
+  - question: "Which tool is used for process automation?"
+    answer: "Many tools are used for process automation, ranging from Robotic Process Automation (RPA) platforms like UiPath and Automation Anywhere to comprehensive workflow orchestrators like Kestra and Camunda. The best tool depends on the specific processes, technical requirements, and target users."
+  - question: "How does IT process automation reduce operational costs?"
+    answer: "IT process automation reduces costs by minimizing manual labor, preventing errors that lead to rework, and optimizing resource utilization. Automated processes run faster and more consistently, leading to lower operational expenses and improved efficiency across the IT landscape."
+  - question: "What are the key benefits of IT process automation?"
+    answer: "Key benefits include increased efficiency, reduced human error, faster service delivery, improved compliance, and better resource utilization. By automating routine and complex IT tasks, organizations can achieve greater operational consistency and free up skilled personnel for strategic initiatives."
+---
+
+In today's complex digital infrastructure, manual IT processes are a bottleneck. From provisioning servers to managing incidents and deploying software, human intervention introduces delays, errors, and significant operational overhead. This constant drain on resources diverts skilled engineers from innovation, trapping them in repetitive, reactive tasks.
+
+IT process automation (ITPA) offers a strategic exit from this cycle. By transforming manual IT tasks into reliable, software-driven workflows, ITPA not only boosts efficiency and reduces costs but also elevates operational consistency and security. This article explores how modern ITPA empowers organizations to unify their automation efforts, driving agility and freeing teams to focus on high-value work.
+
+## What IT Process Automation Really Means
+
+IT Process Automation (ITPA) is the use of software to execute, manage, and orchestrate recurring IT tasks and workflows that would otherwise require manual intervention. It goes beyond simple scripting by creating structured, repeatable processes that can interact with multiple systems, respond to events, and enforce business logic.
+
+While often used interchangeably with general automation, ITPA is distinct. Robotic Process Automation (RPA) typically focuses on mimicking human interaction with graphical user interfaces, while Business Process Automation (BPA) deals with end-to-end business workflows like invoicing or customer onboarding. ITPA specifically targets the engine room of the organization: IT operations, infrastructure management, and service delivery. It provides a foundational layer of [infrastructure automation](/resources/infrastructure/automation) that underpins the reliability and speed of all other business functions.
+
+## Why Modern IT Operations Demand Automation
+
+As IT environments grow in complexity—spanning on-premise data centers, multiple clouds, and edge devices—manual management becomes unsustainable. Adopting a robust automation strategy is no longer a luxury but a necessity for maintaining competitive advantage and operational stability.
+
+### Reducing Human Error and Enhancing Reliability
+
+Manual processes are inherently prone to error. A single typo in a configuration file or a missed step in a deployment checklist can lead to downtime, security vulnerabilities, or data loss. ITPA codifies these processes into workflows that execute consistently every time. This standardization eliminates variability and significantly improves the reliability of IT operations, from routine maintenance to complex disaster recovery procedures.
+
+### Accelerating Service Delivery and Incident Response
+
+In a manual world, fulfilling a request for a new virtual machine or responding to a critical alert can take hours or even days. ITPA reduces these timelines to minutes. By automating provisioning, configuration, and remediation tasks, IT teams can deliver services faster and resolve incidents before they escalate. This acceleration is crucial for supporting agile development cycles and meeting stringent service-level agreements (SLAs). Effective [data center automation](/resources/infrastructure/data-center-automation) is a prime example of how ITPA can transform operational efficiency.
+
+### Freeing Engineers for Strategic Initiatives
+
+Repetitive, manual tasks are a major source of engineer burnout and a poor use of highly skilled talent. When platform engineers and SREs are bogged down with ticket-based requests and manual troubleshooting, they have no time for the strategic work that drives business value, such as improving system architecture, developing new features, or optimizing performance. ITPA handles the toil, freeing up engineers to focus on innovation and complex problem-solving across the entire [hybrid cloud automation](/resources/infrastructure/hybrid-cloud-automation) landscape.
+
+## Core Use Cases for IT Process Automation
+
+ITPA can be applied across the entire spectrum of IT operations. Here are some of the most impactful use cases.
+
+### Infrastructure Provisioning and Management
+
+Automating the lifecycle of infrastructure components ensures consistency and speed. This includes provisioning virtual machines, configuring networks, and managing storage. For organizations running on cloud platforms, ITPA is essential for tasks like [AWS EC2 automation at scale](/resources/infrastructure/aws-ec2-automation-at-scale). Similarly, for those with on-premise or hybrid environments, robust [VMware automation](/resources/infrastructure/vmware-automation) is critical. For example, Amdocs, a leading provider of software and services to communications and media companies, uses orchestration to deliver end-to-end environment provisioning and automated validation as a service.
+
+### Automated Incident Response and Remediation
+
+Instead of just alerting an on-call engineer, an automated system can take the first steps to diagnose and resolve an issue. This could involve restarting a failed service, scaling resources in response to a traffic spike, or isolating a compromised host. By integrating with monitoring tools, ITPA enables self-healing systems and dramatically reduces mean time to resolution (MTTR). This is the core principle behind modern [runbook automation tools](/resources/infrastructure/runbook-automation-tools-2026).
+
+### Security and Compliance Workflows
+
+Security and compliance are areas where consistency and auditability are paramount. ITPA can enforce security policies across the entire infrastructure. Key workflows include:
+*   **[Automated patch management](/resources/infrastructure/patch-management-automation):** Ensuring all systems are up-to-date with the latest security patches.
+*   **[Secrets rotation automation](/resources/infrastructure/secrets-rotation-automation):** Regularly changing passwords, API keys, and certificates to minimize exposure.
+*   **Audit Trail Management:** Automatically collecting logs and generating compliance reports, simplifying [workflow secret management](/resources/infrastructure/workflow-secret-management) and evidence gathering.
+
+### CI/CD and DevOps Automation
+
+ITPA is a cornerstone of a healthy DevOps practice. It automates the software delivery lifecycle, creating a seamless [CI/CD pipeline](/resources/infrastructure/ci-cd-pipeline) from code commit to production deployment. This includes compiling code, running tests, provisioning test environments, and deploying applications. By automating these steps, organizations can release software faster and more reliably.
+
+## Choosing the Right IT Process Automation Platform
+
+Not all automation tools are created equal. Selecting the right platform depends on your organization's technical needs, team skills, and long-term strategic goals.
+
+### Key Features to Look For
+
+When evaluating an [IT automation platform](/resources/infrastructure/it-automation-platform), consider the following capabilities:
+*   **Declarative vs. Imperative:** Declarative platforms (e.g., defining workflows in YAML) are easier to version, audit, and manage than imperative scripts.
+*   **Event-Driven Capabilities:** The platform should be able to trigger workflows based on system events, not just fixed schedules.
+*   **Polyglot Support:** It must support the languages and tools your team already uses, whether it's Python, Bash, PowerShell, or Java.
+*   **Integrations:** A rich ecosystem of plugins for databases, cloud services, and enterprise applications is crucial.
+*   **Scalability and Governance:** The platform should scale to handle thousands of executions and provide features like Role-Based Access Control (RBAC) and audit logs.
+
+### Beyond RPA: Orchestration vs. Task Automation
+
+Many tools in the market, often categorized as RPA or low-code platforms, excel at automating simple, linear tasks. While useful, they often fall short when it comes to orchestrating complex, multi-system IT processes.
+
+[What is UiPath](/resources/infrastructure/what-is-uipath), for instance, is a leader in RPA, focusing on automating tasks via user interfaces. Tools like Make and n8n are excellent for connecting SaaS applications via APIs. However, true IT process automation requires an orchestrator that can manage dependencies, handle errors gracefully, execute code natively, and provide deep visibility into long-running processes. Comparing [UiPath alternatives](/resources/infrastructure/uipath-alternatives) or [Automation Anywhere alternatives](/resources/infrastructure/automation-anywhere-alternatives) reveals this distinction. While [Make alternatives](/resources/infrastructure/make-alternatives) and [n8n alternatives](/resources/infrastructure/n8n-alternatives) are strong in their niche, they are not designed to manage infrastructure as code or complex data pipelines. An orchestration platform acts as a central control plane, while a task automation tool typically addresses a point solution.
+
+## How Kestra Unifies IT Process Automation
+
+Kestra is an open-source orchestration platform designed to serve as a unified control plane for all your automated processes, from data pipelines to [infrastructure automation](/blueprints/infrastructure-automation). It bridges the gap between different teams and technologies with a declarative, event-driven, and language-agnostic approach.
+
+Workflows in Kestra are defined as simple YAML files, making them easy to version-control, review, and manage with GitOps practices. Its polyglot nature means you can run any script (Python, Shell, etc.), container, or application as part of a workflow, without being locked into a single language.
+
+With over 1,700 plugins, Kestra integrates seamlessly with the tools modern IT teams rely on, including Terraform, Ansible, Kubernetes, all major cloud providers, and ITSM platforms like ServiceNow. This allows organizations to build powerful, end-to-end automations. For instance, Dataport, Germany's public-sector IT provider, uses Kestra to create a government-grade orchestration control plane on its private cloud. Similarly, Crédit Agricole's IT production arm transformed its operations by using Kestra to scale workflows across more than 100 clusters.
+
+Here is an example of a Kestra workflow that uses Terraform to provision a new AWS S3 bucket, a common ITPA task:
+
+```yaml
+id: terraform-provision-s3-bucket
+namespace: company.team.it-ops
+
+description: Provisions a new S3 bucket using Terraform.
+
+inputs:
+  - id: bucketName
+    type: STRING
+    defaults: "kestra-tf-provisioned-bucket-{{ now() | date('yyyyMMddHHmmss') }}"
+
+tasks:
+  - id: setup-terraform-files
+    type: io.kestra.plugin.core.flow.WorkingDirectory
+    tasks:
+      - id: create-main-tf
+        type: io.kestra.plugin.core.storage.CreateFile
+        content: |
+          provider "aws" {
+            region = "us-east-1"
+          }
+
+          resource "aws_s3_bucket" "b" {
+            bucket = "{{ inputs.bucketName }}"
+          }
+
+          output "bucket_name" {
+            value = aws_s3_bucket.b.id
+          }
+        path: main.tf
+
+  - id: terraform-apply
+    type: io.kestra.plugin.terraform.cli.TerraformCLI
+    commands:
+      - terraform init
+      - terraform apply -auto-approve
+
+outputs:
+  - id: bucketName
+    value: "{{ outputs['terraform-apply'].outputs.bucket_name.value }}"
+```
+
+This declarative workflow automates the entire process, from creating the Terraform configuration to applying it, providing an auditable and repeatable way to manage cloud resources. From [automating IAM management](/docs/how-to-guides/iam-automation) to complex [IIS site provisioning](/blueprints/iis-site-provisioning-with-ssl), Kestra provides a single platform to manage any [Kubernetes workflow](/resources/infrastructure/kubernetes-workflow) or IT process.
+
+## Best Practices for Implementing ITPA
+
+Successfully implementing IT process automation is as much about strategy and culture as it is about technology.
+
+### Start Small, Scale Incrementally
+
+Don't try to automate everything at once. Identify a high-impact, low-complexity process as a pilot project. This could be a common user request, a repetitive maintenance task, or a frequent source of alerts. A successful pilot builds momentum, demonstrates value, and provides valuable lessons for broader implementation.
+
+### Foster Collaboration Between Teams
+
+Automation often crosses traditional team boundaries. A workflow might be triggered by a developer's code commit, provision infrastructure managed by the platform team, and update a ticket in the service desk system. Success requires collaboration. A shared orchestration platform can provide a common language and a single pane of glass for different teams to work together.
+
+### Prioritize Observability and Governance
+
+As you automate more processes, it's crucial to maintain visibility and control. Ensure your automation platform provides detailed logs, metrics, and alerts. Implement strong [workflow governance](/resources/infrastructure/workflow-governance) practices, including version control for workflows and clear ownership. For critical processes, build in [manual approval processes](/docs/use-cases/approval-processes) to ensure human oversight where needed.
+
+## The Future of IT Process Automation: AI and the Control Plane
+
+The future of ITPA lies in intelligent automation and the creation of a single, unified control plane for all automated processes. AI is already enhancing ITPA by enabling features like natural-language workflow generation and predictive analytics for identifying automation opportunities. Gravitee, a leader in API management, uses Kestra to combine orchestration and AI for optimizing their ML workflows.
+
+This evolution is leading towards [agentic orchestration](/resources/ai/agentic-orchestration), where AI agents can autonomously manage complex tasks, troubleshoot issues, and even build their own automation workflows. With a human-in-the-loop for oversight, these systems promise to handle a new level of complexity. The ultimate goal is a universal control plane where every process—whether it's a data job, an [AI pipeline](/resources/ai/ai-pipeline), an infrastructure change, or a business workflow—is managed, monitored, and governed from a single platform. You can even [trigger automation with an AI agent](/blueprints/ai-agent-calling-flows) to connect different systems and processes.
+
+## Why IT Automation Skills are in High Demand
+
+As organizations embrace automation, the demand for professionals who can design, build, and manage these systems is skyrocketing. A career in IT automation is not just about writing scripts; it's about understanding systems architecture, process design, and platform engineering. Roles like Platform Engineer, DevOps Engineer, and Site Reliability Engineer (SRE) are increasingly centered around building and maintaining the automated systems that run the business. Investing in these skills is a direct investment in career growth and organizational impact.

--- a/src/contents/resources/workflow-automation-software/index.md
+++ b/src/contents/resources/workflow-automation-software/index.md
@@ -1,0 +1,200 @@
+---
+title: "Workflow Automation Software: Unifying Data, AI, and Infrastructure Operations"
+description: "Explore the landscape of workflow automation software, comparing leading tools and understanding how Kestra provides a declarative, open-source platform to orchestrate data, AI, and infrastructure workflows."
+metaTitle: "Workflow Automation Software: Unifying Operations"
+metaDescription: "Workflow automation software unifies data, AI, and infrastructure operations. Kestra is a declarative orchestrator, streamlining your automation stack."
+tag: business
+date: 2026-07-30
+slug: "workflow-automation-software"
+faq:
+  - question: "What is workflow automation software?"
+    answer: "Workflow automation software streamlines and optimizes repeatable business and technical processes by automating tasks and coordinating their execution. It goes beyond simple task automation by managing complex sequences, dependencies, and integrations across different systems and applications, improving efficiency and reducing manual effort."
+  - question: "How does AI enhance workflow automation?"
+    answer: "AI enhances workflow automation by introducing intelligence into processes. This includes features like natural language processing for generating workflow definitions, predictive analytics for optimizing schedules, and autonomous agents that can make decisions and adapt workflows dynamically, leading to more resilient and intelligent automation."
+  - question: "What are the benefits of using workflow automation software?"
+    answer: "Implementing workflow automation software leads to significant benefits such as increased operational efficiency, reduced human error, faster process execution, improved compliance through auditable workflows, better resource utilization, and enhanced scalability to handle growing workloads without proportional increases in manual effort."
+  - question: "How do open-source workflow automation tools compare to proprietary solutions?"
+    answer: "Open-source workflow automation tools offer flexibility, community support, and lower initial costs, allowing for extensive customization and avoiding vendor lock-in. Proprietary solutions often provide comprehensive commercial support, pre-built integrations, and managed services, though they may come with higher licensing fees and less customization freedom."
+  - question: "Can workflow automation be applied to any industry or department?"
+    answer: "Yes, workflow automation is highly versatile and can be applied across virtually any industry or department. From automating data pipelines in finance to managing IT operations in healthcare, streamlining marketing campaigns, or orchestrating AI model training, the core principles of automating repeatable processes are universally beneficial for efficiency and governance."
+  - question: "What should I look for when choosing workflow automation software?"
+    answer: "When selecting workflow automation software, consider factors like deployment options (cloud, on-prem, hybrid), integration capabilities with your existing tech stack, scalability, ease of use for your team's technical level, governance and security features (RBAC, audit logs), and the cost model. Future-proofing with polyglot and event-driven capabilities is also key."
+---
+
+In an era defined by tool sprawl and increasing operational complexity, many organizations find themselves juggling disparate automation scripts, legacy schedulers, and point solutions. This fragmented approach leads to inconsistent processes, debugging nightmares, and a significant drain on engineering resources. The challenge isn't just to automate individual tasks, but to orchestrate entire workflows seamlessly across diverse domains—data, AI, and infrastructure—from a single, unified control plane.
+
+This article explores the landscape of workflow automation software, guiding you through leading tools and key considerations for 2026. We'll show how a declarative, open-source platform like Kestra can unify your automation efforts, reduce operational overhead, and empower your teams to build, deploy, and govern complex workflows with unprecedented efficiency.
+
+## The Expanding Role of Workflow Automation Software
+
+The demand for [infrastructure automation](/resources/infrastructure/automation) has moved far beyond simple scripting and scheduling. Modern enterprises require a centralized orchestration layer that can manage dependencies, handle errors intelligently, and provide visibility across the entire technology stack. This is the domain of the modern [workflow engine](/resources/infrastructure/workflow-engine).
+
+### Defining workflow automation: Beyond simple task execution
+
+Workflow automation is the design, execution, and management of processes based on a set of predefined rules. Unlike task automation, which focuses on a single, discrete action (e.g., sending an email), workflow automation orchestrates a sequence of tasks, often involving multiple systems, human approvals, and conditional logic.
+
+A robust workflow automation platform acts as a central nervous system for your operations. It understands the dependencies between a data ingestion job, a machine learning model training run, and an infrastructure provisioning script, ensuring they execute in the correct order and handling failures gracefully.
+
+### Key benefits of adopting a unified orchestration approach
+
+Adopting a single, unified platform for workflow automation brings significant advantages over a fragmented, tool-by-tool approach:
+
+*   **Reduced Complexity:** A single control plane eliminates the "glue code" needed to connect disparate automation tools, simplifying development and maintenance.
+*   **Enhanced Visibility:** Centralized logging, monitoring, and alerting provide a holistic view of all automated processes, accelerating troubleshooting.
+*   **Improved Governance:** Standardized practices for security, access control, and auditing can be applied universally, reducing compliance risks.
+*   **Increased Efficiency:** Teams can share and reuse workflow components, preventing duplicated effort and promoting best practices.
+*   **Greater Scalability:** A unified platform is designed to scale horizontally, managing thousands of concurrent workflows without becoming a bottleneck.
+
+## Top Workflow Automation Software Solutions in 2026
+
+The market for workflow automation software is diverse, with tools tailored to different personas, from business users to platform engineers. Below is a comparison of leading solutions that address various needs across the automation spectrum.
+
+| Name | Type | Open-Source | Pricing Model | Sweet Spot | Position vs Kestra |
+|---|---|---|---|---|---|
+| **Kestra** | Unified Orchestration | Yes (Apache 2.0) | Open-Source, Per-instance EE | Polyglot, cross-domain (data, AI, infra) workflows | N/A |
+| **Apache Airflow** | Data Orchestrator | Yes (Apache 2.0) | Open-Source, Managed offerings | Python-centric data engineering | Python-first & data-focused vs. polyglot & cross-domain |
+| **n8n** | Visual Automation | Yes (Fair-code) | Open-Source, Cloud tiers | SaaS integrations, AI agents | Visual/low-code for SaaS vs. declarative/code for engineering |
+| **Zapier** | No-code iPaaS | No | Per-task subscription | Business user SaaS-to-SaaS automation | No-code for business apps vs. declarative for technical workflows |
+| **Microsoft Power Automate** | Business Process Automation/RPA | No | Per-user/per-flow subscription | Microsoft ecosystem automation | Citizen developer in MS stack vs. engineering platform for any stack |
+| **Temporal** | Microservices Orchestrator | Yes (MIT) | Open-Source, Cloud offering | Durable application workflows (in code) | App-embedded logic vs. cross-system platform orchestration |
+| **Argo Workflows** | Kubernetes-native Orchestrator | Yes (Apache 2.0) | Open-Source | Container-first ML & CI/CD on Kubernetes | K8s-only vs. deployable anywhere |
+
+### Kestra: The Open-Source Control Plane for Unified Workflows
+
+Kestra is an open-source, declarative orchestration platform designed to unify data, AI, infrastructure, and business workflows. Its core philosophy is that workflows are configuration, not code, which makes them easier to manage, version, and scale. By using a simple [YAML interface](/blogs/yaml-for-workflow-orchestration), Kestra enables both technical and non-technical users to build and understand complex processes.
+
+Key differentiators include its language-agnostic nature—natively running Python, SQL, Bash, Docker, and more—and its event-driven architecture. Kestra is built to serve as a universal control plane, breaking down silos between data, operations, and development teams. It offers a comprehensive set of [powerful features](/features) for reliable workflow management.
+
+Here is an example of a Kestra flow that extracts data from a database, transforms it with Python, loads it to S3, and sends a Slack notification:
+
+```yaml
+id: unified-data-pipeline
+namespace: company.team
+description: An example of a unified workflow orchestrating data extraction, transformation, and notification.
+
+tasks:
+  - id: extract_data_from_db
+    type: io.kestra.plugin.jdbc.postgresql.Query
+    fetch: true
+    sql: SELECT * FROM raw_data WHERE created_at >= '{{ now() | date("YYYY-MM-DD") }}'
+    store: true
+
+  - id: transform_with_python
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      data.csv: "{{ outputs.extract_data_from_db.uri }}"
+    script: |
+      import pandas as pd
+      df = pd.read_csv("{{workingDir}}/data.csv")
+      df['processed'] = df['value'] * 2
+      df.to_csv("{{workingDir}}/processed_data.csv", index=False)
+    outputFiles:
+      - processed_data.csv
+
+  - id: load_to_s3
+    type: io.kestra.plugin.aws.s3.Upload
+    accessKeyId: "{{ secret('AWS_ACCESS_KEY_ID') }}"
+    secretKeyId: "{{ secret('AWS_SECRET_ACCESS_KEY') }}"
+    bucket: my-data-lake
+    key: processed/{{ now() | date("YYYY-MM-DD") }}/processed_data.csv
+    file: "{{ outputs.transform_with_python.outputFiles['processed_data.csv'] }}"
+
+  - id: send_slack_notification
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    payload: |
+      {
+        "text": "Daily data pipeline completed successfully for {{ now() | date("YYYY-MM-DD") }}."
+      }
+```
+For those new to the platform, the [quickstart guide](/docs/quickstart) is an excellent resource to get started.
+
+### Apache Airflow: The Python-centric data orchestrator
+
+Airflow is the dominant open-source tool in data engineering, defining workflows as Python code (DAGs). Its strengths lie in a massive ecosystem of pre-built operators and a large, mature community. It is the default choice for many data teams with deep Python expertise.
+
+However, its code-first approach can make workflows harder to review and manage for non-engineers. The operational complexity of managing its components (scheduler, executor, metadata database) can also be a significant undertaking. While powerful for ETL/ELT, its architecture is less suited for orchestrating non-data workloads like infrastructure automation. You can explore a detailed comparison in [Kestra vs. Airflow](/vs/airflow) or browse other [Airflow alternatives](/resources/data/airflow-alternatives).
+
+### n8n: Visual automation for SaaS and AI workflows
+
+n8n is a source-available tool that provides a visual, node-based interface for building workflows. It excels at connecting SaaS applications and APIs, making it a strong choice for business process automation and a self-hosted alternative to Zapier. Recently, n8n has invested heavily in AI capabilities, allowing users to build and orchestrate AI agents.
+
+Its visual-first nature is great for rapid prototyping and for users who prefer a low-code experience. The trade-off is that complex, logic-heavy workflows can become difficult to manage and version in a visual interface, which is where declarative tools often have an advantage. For more options, see this list of [n8n alternatives](/resources/infrastructure/n8n-alternatives).
+
+### Zapier: No-code integration for business users
+
+Zapier is a market-leading no-code platform that makes it incredibly simple to connect thousands of web applications. Its user-friendly interface allows business users with no coding knowledge to automate repetitive tasks between apps like Gmail, Slack, and Salesforce.
+
+Zapier's primary strength is its simplicity and vast library of integrations. However, it operates on a per-task pricing model, which can become expensive at scale. It is not designed for complex data pipelines, infrastructure orchestration, or workflows that require custom code execution and governance. It is a powerful tool for task automation but not a comprehensive workflow orchestration platform. For a deeper dive, consider these [Zapier alternatives](/resources/ai/zapier-alternatives).
+
+### Microsoft Power Automate: Business process automation for the Microsoft ecosystem
+
+Power Automate is Microsoft's low-code/no-code solution for automating workflows and business processes. Its key advantage is deep integration with the Microsoft 365, Dynamics 365, and Azure ecosystems. It also includes Robotic Process Automation (RPA) capabilities for automating legacy desktop applications.
+
+Power Automate empowers "citizen developers" to build automations within the Microsoft stack. It is an excellent choice for organizations heavily invested in Microsoft's cloud. Its limitations become apparent when orchestrating heterogeneous, multi-cloud environments or managing code-heavy engineering workflows.
+
+### Temporal: Durable execution for application development
+
+Temporal is a workflow-as-code platform designed for application developers. It provides SDKs in multiple languages (Go, Java, Python, TypeScript) to build durable, stateful, long-running application workflows directly within your codebase. It excels at handling complex business logic like user sign-ups, payment processing, and multi-step transactions.
+
+The key distinction is its focus: Temporal is for orchestrating logic *inside* an application, whereas Kestra orchestrates workflows *across* systems and applications. It is a powerful tool for microservices orchestration, but not the natural choice for data pipelines or infrastructure operations. Kestra offers a [Temporal plugin](/plugins/plugin-temporal/temporal-workflow) to integrate with existing Temporal workflows.
+
+### Argo Workflows: Kubernetes-native container orchestration
+
+Argo Workflows is an open-source, container-native workflow engine for Kubernetes. Workflows are defined as Kubernetes Custom Resource Definitions (CRDs) in YAML. It is exceptionally well-suited for orchestrating parallel jobs, making it a popular choice for ML training, data processing, and CI/CD pipelines that are already containerized.
+
+Its main strength is its tight integration with Kubernetes. This is also its main limitation: it cannot run outside of Kubernetes. For teams that are 100% Kubernetes-native, it's a strong contender. For those needing to orchestrate a mix of containerized and non-containerized tasks across hybrid environments, a more flexible platform is often required. Kestra provides robust [Kubernetes workflow orchestration](/resources/infrastructure/kubernetes-workflow-orchestration) and can be a compelling alternative.
+
+## How AI is Reshaping Workflow Automation
+
+Artificial intelligence is transforming workflow automation from a system of static, predefined rules into a dynamic, intelligent process. This evolution is creating more resilient, adaptive, and powerful automation platforms.
+
+### From predefined rules to intelligent agentic workflows
+
+Traditional automation follows a strict script. AI introduces the ability to interpret, decide, and act. [Agentic orchestration](/resources/ai/agentic-orchestration) is at the forefront of this shift. AI agents can now be first-class citizens in a workflow, tasked with goals rather than specific instructions. For example, an agent could be instructed to "analyze customer sentiment from recent support tickets and summarize key issues," using tools like database connectors and language models to achieve its goal.
+
+### Key AI-powered features in modern orchestration platforms
+
+Modern platforms are integrating [AI tools](/docs/ai-tools) to simplify and enhance the user experience:
+
+*   **AI Copilot:** Natural language prompts are used to generate complex workflow definitions in seconds, dramatically lowering the barrier to entry and accelerating development.
+*   **Autonomous Agents:** AI-driven agents can execute multi-step tasks, use external tools, and even self-correct based on outcomes, handling dynamic and unpredictable situations.
+*   **RAG Workflows:** Retrieval-Augmented Generation ([RAG](/docs/ai-tools/ai-rag-workflows)) pipelines can be orchestrated to build sophisticated question-answering systems that query internal knowledge bases to provide contextually-aware AI responses.
+
+## Choosing the Right Automation Software for Your Enterprise
+
+Selecting the right platform is a critical decision that impacts productivity, scalability, and governance. The ideal tool aligns with your team's skills, your technical environment, and your organization's long-term goals.
+
+### Evaluating deployment flexibility: Cloud, on-prem, hybrid, and air-gapped
+
+Your operational requirements dictate the deployment model. SaaS-only tools offer convenience but may not meet data residency or security requirements. For regulated industries or organizations with significant on-prem infrastructure, a platform that supports [self-hosted workflow orchestration](/resources/infrastructure/self-hosted-workflow-orchestration) is essential. A truly flexible solution should support deployment on any cloud, on-premises, in a hybrid model, or even in fully air-gapped environments.
+
+### Scalability, reliability, and enterprise-grade governance
+
+As automation scales, governance becomes paramount. A platform built for the enterprise must provide robust features to manage this complexity. This includes [Role-Based Access Control (RBAC)](/resources/infrastructure/rbac) to ensure users only have access to the resources they need. Comprehensive audit logs are critical for compliance and troubleshooting, providing a complete history of who did what, and when. Effective [workflow governance](/resources/infrastructure/workflow-governance) ensures that as automation adoption grows, it remains secure, compliant, and manageable.
+
+### Integration capabilities and polyglot support for diverse tech stacks
+
+No tool exists in a vacuum. The right automation software must seamlessly integrate with your existing technology stack, which is often a mix of languages, databases, and services. A platform with a language-agnostic (polyglot) architecture is future-proof. It allows you to orchestrate a Python script, a Java application, a SQL query, and a Terraform plan within the same workflow, without forcing all logic into a single language. This flexibility empowers teams to use the best tool for each job while maintaining centralized control.
+
+## Kestra: Your Declarative Control Plane for Unified Automation
+
+Kestra is designed to solve the fragmentation problem by providing a single, declarative control plane for all your automation needs. With over 1,700 plugins and a vibrant open-source community with 27,000+ GitHub stars, the platform is built for extensibility and reliability, having executed over 2 billion workflows in 2025 alone.
+
+By treating workflows as YAML-based configuration, Kestra brings the best practices of DevOps and GitOps to every process. This approach ensures that all workflows—whether for [data engineering](/data), [AI/ML pipelines](/ai-automation), or [infrastructure automation](/infra-automation)—are versionable, auditable, and easy to review.
+
+Leading organizations rely on Kestra for mission-critical operations:
+*   **JPMorgan Chase** orchestrates cybersecurity analytics workflows, processing billions of rows securely.
+*   **Crédit Agricole's** IT production arm transformed its infrastructure operations, unifying automation across more than 100 clusters.
+*   A 200-engineer **ML team at Apple** replaced Airflow with Kestra to orchestrate large-scale ETL and data pipelines.
+*   **Dataport**, Germany's public-sector IT provider, uses Kestra as a government-grade orchestration control plane for its private cloud.
+*   An API leader, **Gravitee**, combines orchestration and AI to automatically generate API documentation and optimize ML workflows.
+*   **A Fortune 500 industrial company** replaced VMware Aria Automation with Kestra, securing hybrid cloud automation across both IT and OT environments.
+
+## Future-Proofing Your Operations with Modern Workflow Automation
+
+The future of automation lies in platforms that are flexible, scalable, and intelligent. Choosing a tool that locks you into a single language, a single cloud, or a single paradigm creates the legacy systems of tomorrow. A modern, declarative, and event-driven orchestrator provides the foundation to adapt and evolve as your technology stack and business needs change.
+
+By unifying your data, AI, and infrastructure workflows on a single control plane, you can break down operational silos, accelerate innovation, and build more resilient systems.
+
+Explore Kestra's [blueprints](/blueprints/business-automation) to see how you can start unifying your automation today, or get started quickly with our [quickstart guide](/docs/quickstart).


### PR DESCRIPTION
## Summary

Imports 7 ready drafts from `vfanucci/kestra-seo` (#292–#298) into the resources hub, using the new **`business`** parent where the topic is process/decision-oriented rather than infrastructure.

| Page | Parent (tag) | URL | Source |
|------|--------------|-----|--------|
| Approval Workflow | **business** | `/resources/business/approval-workflow` | #292 |
| BPMN | **business** | `/resources/business/bpmn` | #293 |
| Business Rules Engine | **business** | `/resources/business/business-rules-engine` | #294 |
| Business Process Automation | **business** | `/resources/business/business-process-automation` | #295 |
| Business Workflow | **business** | `/resources/business/business-workflow` | #296 |
| IT Process Automation | infrastructure | `/resources/infrastructure/it-process-automation` | #297 |
| Workflow Automation Software | **business** | `/resources/business/workflow-automation-software` | #298 |

The drafts all shipped with `tag: infrastructure`; six were re-tagged to `business` on import (BPMN, business-*, approval-workflow, workflow-automation-software). `it-process-automation` stays under `infrastructure` (IT ops intent).

## Duplicate check

No slug collisions — neither within this batch nor against the 225 existing resource pages.

**Semantic overlaps to keep an eye on** (no action taken, flagged for a canonical / internal-linking decision):
- `workflow-automation-software` (#298) ↔ live `best-workflow-automation-tools`
- `business-process-automation` (#295) ↔ `business-workflow` (#296) ↔ live `workflow-management` — three pages sit close on the "automate business processes" intent
- `business-rules-engine` (#294) / `bpmn` (#293) ↔ live `camunda-alternatives` (BPMN engine territory)

## Front-matter hygiene
Publish `date` kept as the drafts' real date (`2026-07-30`, validated against system date); stray fences removed (balanced); `## ##` normalized; metaTitle ≤60 without ` | Kestra`; no `image:`/`author:`; metaDescription trimmed to 140–160 (`business-process-automation` 171→155, `it-process-automation` 167→151); no unresolved markers; no duplicated headings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
