### PR TITLE
fix(docs): amend tenant exclusion

### DIFF
--- a/src/contents/docs/11.migration-guide/v0.23.0/tenant-migration-ee/index.md
+++ b/src/contents/docs/11.migration-guide/v0.23.0/tenant-migration-ee/index.md
@@ -82,7 +82,7 @@ If your repository is Elasticsearch, your instance likely stores a large amount 
 kestra migrate default-tenant \
     --tenant-id=tenant \
     --tenant-name="Tenant Name" \
-    --excludes=executions,logs,metrics \
+    --excludes=kestra_executions,kestra_logs,kestra_metrics \
     [--dry-run]
 ```
 


### PR DESCRIPTION
Used index names which worked during a live migration.