### PR TITLE
feat(resources): per-tab hero copy + business workflows in /resources SEO tags

### DIFF
--- a/src/components/resources/ResourceSearchHero.vue
+++ b/src/components/resources/ResourceSearchHero.vue
@@ -1,12 +1,7 @@
 <template>
     <div class="resource-hero">
-        <h1>All Orchestration Resources</h1>
-        <p class="subtitle">
-            Discover a comprehensive index of in-depth guides, whitepapers,
-            and playbooks spanning data orchestration, AI workflows, business
-            operations and infrastructure automation — built for engineers and
-            platform teams shipping production workflows at every stage.
-        </p>
+        <h1>{{ heading }}</h1>
+        <p class="subtitle">{{ subtitle }}</p>
         <label class="search">
             <Magnify class="search-icon" />
             <input
@@ -22,6 +17,8 @@
 <script setup lang="ts">
     import { ref, watch, onMounted } from "vue"
     import Magnify from "vue-material-design-icons/Magnify.vue"
+
+    defineProps<{ heading: string; subtitle: string }>()
 
     const query = ref("")
 

--- a/src/components/resources/ResourceSearchHero.vue
+++ b/src/components/resources/ResourceSearchHero.vue
@@ -3,9 +3,9 @@
         <h1>All Orchestration Resources</h1>
         <p class="subtitle">
             Discover a comprehensive index of in-depth guides, whitepapers,
-            and playbooks spanning data orchestration, AI workflows, and
-            infrastructure automation — built for engineers and platform
-            teams shipping production workflows at every stage.
+            and playbooks spanning data orchestration, AI workflows, business
+            operations and infrastructure automation — built for engineers and
+            platform teams shipping production workflows at every stage.
         </p>
         <label class="search">
             <Magnify class="search-icon" />

--- a/src/components/resources/resourcesContent.ts
+++ b/src/components/resources/resourcesContent.ts
@@ -3,6 +3,8 @@ import { ALL_RESOURCES } from "./tags"
 type Section = {
     metaTitle: string
     metaDescription: string
+    heading: string
+    subtitle: string
 }
 
 const resourceSections: Record<string, Section> = {
@@ -11,35 +13,53 @@ const resourceSections: Record<string, Section> = {
             "Kestra Resources: Guides for Data, AI, Infrastructure & Business Workflows",
         metaDescription:
             "Browse Kestra's orchestration resources — guides, listicles, and playbooks for data engineering, AI workflows, business operations and infrastructure automation.",
+        heading: "All Orchestration Resources",
+        subtitle:
+            "Discover a comprehensive index of in-depth guides, whitepapers, and playbooks spanning data orchestration, AI workflows, business operations and infrastructure automation — built for engineers and platform teams shipping production workflows at every stage.",
     },
     infrastructure: {
         metaTitle:
             "Infrastructure Automation Resources: Terraform, Ansible, IaC",
         metaDescription:
             "Explore practical infrastructure automation resources — Terraform, Ansible, Kubernetes, and IaC orchestration patterns for modern platform engineering teams.",
+        heading: "Infrastructure Automation Resources",
+        subtitle:
+            "Guides and playbooks for automating the infrastructure layer — Terraform, Ansible, Kubernetes and IaC orchestration patterns for platform teams running production estates.",
     },
     data: {
         metaTitle:
             "Data Engineering Resources: ETL, Orchestration & Pipelines",
         metaDescription:
             "Practical data engineering resources on orchestration, ETL/ELT pipelines, dbt, Snowflake, Databricks, and migrating from Airflow to a declarative orchestrator.",
+        heading: "Data Engineering Resources",
+        subtitle:
+            "Everything data teams need to move data reliably — ETL/ELT pipeline design, dbt, Snowflake and Databricks orchestration, and migrating off Airflow without a rewrite.",
     },
     ai: {
         metaTitle:
             "AI Orchestration Resources: LLMOps, RAG & Agentic Workflows",
         metaDescription:
             "AI orchestration resources covering LLMOps, RAG pipelines, agentic workflows, prompt management, and integrating Kestra with LangChain and MCP servers.",
+        heading: "AI Orchestration Resources",
+        subtitle:
+            "Guides for putting AI into production — LLMOps practices, RAG pipelines, agentic workflows, prompt management, and wiring Kestra into LangChain and MCP servers.",
     },
     business: {
         metaTitle:
             "Business Process Orchestration Resources: Automation & Workflows",
         metaDescription:
             "Business process orchestration resources — automate approvals, reporting, and cross-team workflows by connecting your business apps and systems with Kestra.",
+        heading: "Business Process Resources",
+        subtitle:
+            "Playbooks for automating the work that runs between teams — approvals, recurring reporting, onboarding and cross-system processes that connect your business apps without glue code.",
     },
     whitepapers: {
         metaTitle: "Kestra Whitepapers: Orchestration Guides for Engineering Leaders",
         metaDescription:
             "In-depth Kestra whitepapers on orchestration strategy, platform migrations, and production workflow patterns for data, AI, and infrastructure teams.",
+        heading: "Kestra Whitepapers",
+        subtitle:
+            "Long-form reports for engineering leaders — orchestration strategy, platform migrations, and the architecture patterns behind production workflows at scale.",
     },
 }
 

--- a/src/components/resources/resourcesContent.ts
+++ b/src/components/resources/resourcesContent.ts
@@ -7,9 +7,10 @@ type Section = {
 
 const resourceSections: Record<string, Section> = {
     [ALL_RESOURCES]: {
-        metaTitle: "Kestra Resources: Guides for Data, AI & Infrastructure",
+        metaTitle:
+            "Kestra Resources: Guides for Data, AI, Infrastructure & Business Workflows",
         metaDescription:
-            "Browse Kestra's orchestration resources — hands-on guides, listicles, and playbooks for data engineering, AI workflows, and infrastructure automation.",
+            "Browse Kestra's orchestration resources — guides, listicles, and playbooks for data engineering, AI workflows, business operations and infrastructure automation.",
     },
     infrastructure: {
         metaTitle:

--- a/src/pages/resources/[tag].astro
+++ b/src/pages/resources/[tag].astro
@@ -33,7 +33,11 @@ const section = getResourceSection(tag)
     description={section.metaDescription}
 >
     <Mesh>
-        <ResourceSearchHero client:load />
+        <ResourceSearchHero
+            heading={section.heading}
+            subtitle={section.subtitle}
+            client:load
+        />
     </Mesh>
     <ResourceList resources={resources} tag={tag} />
     <SeeHow cta={{ text: "Get Started", href: "/get-started" }}>


### PR DESCRIPTION
## What

Two related changes to the resources hub.

### 1. `/resources` mentions business workflows

The `business` category is live in the resources tabs, but the hub's SEO copy still only mentioned data, AI and infrastructure.

- **Meta title** — `Kestra Resources: Guides for Data, AI, Infrastructure & Business Workflows | Kestra`
- **Meta description** — `Browse Kestra's orchestration resources — guides, listicles, and playbooks for data engineering, AI workflows, business operations and infrastructure automation.` (161 chars)

### 2. Each tab gets its own H1 and subtitle

All 6 hub pages rendered the same `All Orchestration Resources` H1 and the same generic subtitle — a duplicated intro and a duplicated H1 across 6 indexed URLs. `heading` and `subtitle` now live in `resourcesContent.ts` next to the meta tags, and are passed to `ResourceSearchHero` as props.

| URL | H1 |
|---|---|
| `/resources` | All Orchestration Resources *(unchanged)* |
| `/resources/infrastructure` | Infrastructure Automation Resources |
| `/resources/data` | Data Engineering Resources |
| `/resources/ai` | AI Orchestration Resources |
| `/resources/business` | Business Process Resources |
| `/resources/whitepapers` | Kestra Whitepapers |

Each subtitle now describes its own scope (Terraform/Ansible/K8s for Infrastructure, ETL-ELT/dbt/Snowflake for Data, LLMOps/RAG/agentic for AI, approvals/reporting/onboarding for Business, long-form reports for Whitepapers).

Adding or retitling a tab is now a single edit in `resourcesContent.ts`.

## Notes

- The ` | Kestra` suffix is owned by the layout, so only the base string lives in `metaTitle`.
- `ResourceSearchHero` has a single call site (`src/pages/resources/[tag].astro`), so both props are required rather than defaulted.

## Verified locally

`astro dev` on all 6 tabs: expected `<title>`, `<meta name="description">`, `og:title`, `og:description`, H1 and subtitle. Hydration checked too — H1 and subtitle survive client hydration and the search box still filters the grid. `oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)