### PR TITLE
seo(resources): add upsert + duckdb-alternatives + node-red-alternatives pages

### DIFF
--- a/src/contents/resources/duckdb-alternatives/index.md
+++ b/src/contents/resources/duckdb-alternatives/index.md
@@ -1,0 +1,162 @@
+---
+title: "8 Top DuckDB Alternatives for Analytical Workloads"
+description: "Explore leading DuckDB alternatives like ClickHouse, Polars, and cloud data warehouses. Understand their strengths, when to use them, and how Kestra orchestrates diverse analytical engines."
+metaTitle: "Top 8 DuckDB Alternatives for Analytical Workloads"
+metaDescription: "Compare the best DuckDB alternatives for embedded, OLAP, and cloud workloads. See how Kestra can orchestrate each of them within your modern data stack."
+tag: data
+date: 2026-08-03
+slug: "duckdb-alternatives"
+faq:
+  - question: "Is there anything better than DuckDB for analytical workloads?"
+    answer: "DuckDB excels for embedded, in-process analytics on local data. For petabyte-scale data or high-concurrency client-server models, alternatives like ClickHouse or cloud data warehouses (Snowflake, BigQuery) may offer better performance or operational benefits, depending on your specific use case."
+  - question: "How does Kestra integrate with DuckDB alternatives?"
+    answer: "Kestra provides plugins and native support to orchestrate workflows with various DuckDB alternatives. For instance, you can use Kestra to schedule ClickHouse queries, manage data loading into Snowflake, or run Python scripts with Polars, unifying diverse analytical tools under a single declarative control plane."
+  - question: "Can DuckDB replace Snowflake for all use cases?"
+    answer: "No, DuckDB cannot fully replace Snowflake for all use cases. DuckDB is optimized for local, in-process analytics, often outperforming Snowflake for smaller, interactive workloads. However, Snowflake offers managed scalability, high concurrency, and data sharing capabilities crucial for large-scale enterprise data warehousing that DuckDB isn't designed for."
+  - question: "Is DuckDB faster than MySQL for analytical queries?"
+    answer: "Yes, DuckDB is generally much faster than MySQL for analytical queries. DuckDB is a columnar database optimized for OLAP workloads, making it highly efficient for aggregations, joins, and complex analytical operations. MySQL, being a row-oriented transactional database (OLTP), is not designed for this type of workload."
+  - question: "What are the main limitations of DuckDB that might lead to seeking alternatives?"
+    answer: "While powerful, DuckDB's primary limitations include its embedded, in-process nature, which means it's not ideal for high-concurrency client-server applications or shared access without additional layers. It also has a smaller ecosystem for complex enterprise features like advanced security or data governance compared to larger platforms."
+  - question: "Is DuckDB better than Apache Spark for data processing?"
+    answer: "For many common analytical workloads up to a terabyte, DuckDB can often match or exceed Spark's performance and cost-efficiency by eliminating cluster overhead and complex serialization. Spark remains superior for truly massive, distributed datasets and complex ETL graphs that require a full cluster computing framework."
+---
+
+DuckDB has rapidly become a favorite for in-process analytical workloads, offering impressive speed and flexibility directly from your local environment. Its ability to query large [Parquet files](/resources/data/parquet-file-format) and perform complex analytics without a server has revolutionized how data practitioners approach lightweight ETL and ad-hoc analysis. However, as data volumes grow, concurrency needs increase, or integration with existing cloud ecosystems becomes critical, many teams find themselves exploring alternatives.
+
+This article dives into the top 8 DuckDB alternatives, examining their unique strengths and ideal use cases. From high-performance OLAP databases to scalable cloud data warehouses and versatile dataframe libraries, we'll help you navigate the landscape and choose the right tool to complement or extend your analytical capabilities.
+
+## Why Teams Seek Alternatives to DuckDB
+
+Despite its strengths, DuckDB is not a universal solution. Understanding its limitations is key to knowing when to look for an alternative. The primary drivers are architectural constraints, ecosystem gaps for enterprise needs, and specific workload types where other tools are a better fit.
+
+### Architectural Constraints for Scalability and Concurrency
+
+DuckDB's greatest strength—its embedded, in-process architecture—is also its main limitation. Because it runs within the application process, it's not designed for high-concurrency client-server workloads. A single DuckDB instance can only handle one write operation at a time, and while it supports multiple concurrent readers, managing shared access across many users or services can become a bottleneck.
+
+As you scale beyond a single machine, you need a different architecture. For teams looking to move from local development to a shared cloud environment, a solution like [MotherDuck offers a path to scale](/blogs/duckdb-vs-motherduck). For high-throughput scenarios involving both [batch and streaming data](/resources/data/batch-vs-streaming-processing), a dedicated client-server database is often required.
+
+### Ecosystem Gaps for Enterprise Needs
+
+Managed data platforms like Snowflake or BigQuery come with a suite of enterprise-grade features out of the box, including Role-Based Access Control (RBAC), advanced security protocols, and comprehensive monitoring tools. DuckDB, being a lightweight library, lacks these built-in features. Implementing robust security, governance, and observability requires significant manual effort and additional tooling around it.
+
+This is where an orchestration layer becomes crucial. A platform like Kestra can unify diverse data stacks, providing the governance and visibility needed to manage a complex data ecosystem. It allows teams to build robust [data warehouse ETL pipelines](/resources/data/data-warehouse-etl) that incorporate various tools while maintaining centralized control.
+
+### When DuckDB is Not the Optimal Solution
+
+Certain workloads are simply better suited to other technologies. These include:
+*   **Petabyte-scale processing:** While DuckDB can handle datasets larger than memory, truly massive analytics at the petabyte scale require distributed systems like Apache Spark or cloud data warehouses.
+*   **Low-latency streaming analytics:** Tools like ClickHouse are specifically designed for real-time analytical queries on high-velocity data streams.
+*   **Complex data governance:** Organizations with strict regulatory and compliance requirements often need the sophisticated data governance and lineage capabilities found in enterprise data platforms.
+
+Effective [data orchestration](/resources/data/data-orchestration) involves selecting the right tool for each job and ensuring they work together seamlessly.
+
+## How We Evaluated These DuckDB Alternatives
+
+To provide a clear comparison, we evaluated each alternative based on several key criteria. These include the deployment model (embedded, client-server, or cloud-native), license type (open-source or commercial), and primary use case, such as OLAP, ETL, or data science. We also considered performance characteristics like concurrency and data volume handling, the richness of the integration ecosystem, and the strength of community support. This framework helps clarify where each tool shines and how it fits into a modern data stack.
+
+## The Top 8 DuckDB Alternatives for Diverse Analytical Workloads
+
+The analytical database landscape is vast. Here are eight leading alternatives, each offering a different set of trade-offs and capabilities.
+
+### 1. Kestra: The Orchestration Layer for Any Analytical Engine
+
+Kestra is not a database but an orchestration platform that works with DuckDB and all its alternatives. In a modern data stack, you rarely use a single tool. Kestra provides the control plane to connect and manage workflows across your entire analytical ecosystem, from data ingestion and transformation to machine learning and reporting.
+
+Workflows are defined in declarative YAML, making them easy to version, review, and maintain. With over 1,700 plugins and polyglot task execution (Python, SQL, Shell), Kestra can run dbt models, execute Spark jobs, query ClickHouse, and load data into Snowflake, all within a single, unified workflow. Its event-driven architecture and robust error handling ensure that complex data pipelines run reliably and efficiently.
+
+**Best for:** Teams needing to orchestrate complex data pipelines that involve multiple analytical tools, ensuring reliability, visibility, and governance across their entire data stack.
+
+### 2. ClickHouse: High-Performance OLAP for Petabyte Scale
+
+ClickHouse is an open-source, columnar database management system designed for extreme OLAP performance. Built for speed, it excels at real-time analytical queries on massive datasets. Its client-server architecture is optimized for high query throughput and can handle petabytes of data with impressive scan speeds.
+
+Unlike DuckDB's embedded model, ClickHouse is built for concurrent access and is often used as the analytical backend for user-facing applications and large-scale monitoring systems. If your primary challenge is querying vast amounts of data with minimal latency, ClickHouse is a powerful contender.
+
+**Best for:** Organizations with vast amounts of data requiring lightning-fast analytical queries and high query throughput for real-time dashboards and applications.
+
+### 3. PostgreSQL with Analytical Extensions: Versatile and Mature
+
+PostgreSQL is a famously reliable and versatile open-source relational database. While traditionally an OLTP database, its rich ecosystem of extensions allows it to handle serious analytical workloads. Extensions like TimescaleDB for time-series data, PostGIS for geospatial analysis, and various columnar storage options can transform PostgreSQL into a capable OLAP engine.
+
+For teams already invested in the PostgreSQL ecosystem, using it for analytics can simplify the data stack and reduce operational overhead. It offers a mature, battle-tested foundation with strong SQL support and reliability.
+
+**Best for:** Teams already using PostgreSQL who want to extend its analytical capabilities without introducing a new database, or those needing a versatile, general-purpose database with OLAP features.
+
+### 4. SQLite: Simplicity and Ubiquitous Embedded Storage
+
+SQLite is the most widely deployed database engine in the world. Like DuckDB, it is an embedded, serverless, and zero-configuration database. However, its focus is on transactional workloads (OLTP) rather than analytics (OLAP). It uses a row-based storage format, making it less efficient for the column-heavy aggregations where DuckDB shines.
+
+While not a direct competitor for analytical tasks, SQLite is an excellent alternative when the primary need is simple, reliable, and lightweight data storage for an application. For a deeper dive into embedded databases, see our [comparison of DuckDB, SQLite, and Polars](/blogs/embedded-databases).
+
+**Best for:** Simple embedded data storage, local application data, or scenarios where a full analytical database is overkill and transactional consistency is paramount.
+
+### 5. Cloud Data Warehouses (Snowflake, BigQuery, Redshift): Managed Scalability
+
+Cloud data warehouses like Snowflake, Google BigQuery, and Amazon Redshift offer a fully managed, highly scalable solution for enterprise analytics. Their key architectural advantage is the separation of compute and storage, allowing for elastic scaling to handle high concurrency and massive data volumes.
+
+These platforms provide a suite of features for security, governance, and data sharing that are critical for large organizations. While they may not match DuckDB's raw speed for local, single-user queries, they are the standard for building a centralized, enterprise-wide analytics platform. They are a common destination for [open-source ETL tools](/resources/data/open-source-etl-tool) that process data before loading.
+
+**Best for:** Enterprises needing elastic scalability, high concurrency, and managed services for their central data warehousing and analytics platforms.
+
+### 6. Apache Spark: Distributed Processing for Big Data
+
+Apache Spark is the leading unified analytics engine for large-scale data processing. It is designed to run on distributed clusters and excels at complex, multi-stage ETL jobs, machine learning pipelines, and graph processing on petabyte-scale datasets. With APIs for SQL, Python, R, and Scala, it provides a flexible environment for a wide range of data tasks.
+
+While DuckDB often outperforms Spark on single-node workloads by avoiding cluster management overhead, Spark is unbeatable when data sizes and processing complexity demand a true distributed computing framework.
+
+**Best for:** Workloads involving truly massive, distributed datasets and complex, multi-stage data transformations, especially when integrated with large data lakes.
+
+### 7. Polars: Blazing Fast DataFrames in Rust/Python
+
+Polars is a high-performance dataframe library for Python and Rust. Like DuckDB, it is an in-process tool that leverages columnar processing and parallelism to achieve incredible speed. It is often seen as a modern successor to Pandas, offering better memory efficiency and performance on multi-core machines.
+
+Polars is not a database but a data manipulation library. It's an excellent choice for data scientists and engineers who perform complex data transformations and feature engineering within a Python environment. For a detailed look at how Polars compares to other [dataframe libraries](/blogs/dataframes), our analysis offers more insight.
+
+**Best for:** Data scientists and engineers who need a powerful, fast, and memory-efficient in-process data manipulation tool, especially for Python-based analytical workflows.
+
+### 8. MotherDuck: DuckDB in the Cloud with Managed Features
+
+MotherDuck isn't a competitor to DuckDB but rather its managed, serverless cloud counterpart. It aims to solve DuckDB's primary limitations—scalability and sharing—by offering a hybrid execution model. Users can run queries locally on their own hardware for speed and privacy, or push computation to the MotherDuck cloud service to handle larger datasets or share results with a team.
+
+It provides a seamless scaling path for DuckDB users who love the local experience but need the collaborative and scalable features of a cloud service.
+
+**Best for:** DuckDB users who need to scale their analytics, share data easily, or integrate with cloud storage without managing their own database instances.
+
+## Comparison Table: DuckDB Alternatives at a Glance
+
+| Tool | License | Deployment Model | Best for | Concurrency | Primary Language | Data Volume | Kestra Integration |
+|---|---|---|---|---|---|---|---|
+| **Kestra** | Apache 2.0 | Self-Hosted, Cloud | Orchestrating diverse analytical tools | High | YAML, SQL, Python, Shell | Any | Native |
+| **ClickHouse** | Apache 2.0 | Client-Server | Real-time OLAP at petabyte scale | High | SQL | PB+ | [JDBC Plugin](/plugins/plugin-jdbc-clickhouse) |
+| **PostgreSQL** | PostgreSQL License | Client-Server | Versatile OLTP with analytical extensions | High | SQL | TB+ | [JDBC Plugin](/plugins/plugin-jdbc-postgres) |
+| **SQLite** | Public Domain | Embedded | Simple, transactional embedded storage | Low (for writes) | SQL | GBs | [JDBC Plugin](/plugins/plugin-jdbc-sqlite) |
+| **Cloud DWs** | Commercial | Cloud-Native | Managed enterprise data warehousing | Very High | SQL | PB+ | Native Plugins |
+| **Apache Spark** | Apache 2.0 | Distributed Cluster | Massive-scale distributed ETL & ML | Very High | Python, Scala, SQL, R | PB+ | [Spark Plugin](/plugins/plugin-spark) |
+| **Polars** | MIT | Embedded Library | High-performance in-memory dataframes | Single-process | Python, Rust | GBs-TBs | [Python Plugin](/plugins/plugin-scripts-python) |
+| **MotherDuck** | Commercial | Cloud (Hybrid) | Scaling and sharing DuckDB analytics | Moderate | SQL | TBs | [DuckDB Plugin](/plugins/plugin-jdbc-duckdb) |
+
+## Choosing the Right DuckDB Alternative for Your Project
+
+The best choice depends entirely on your team's profile and project requirements.
+
+### For Data Engineering Teams Prioritizing Scale and Governance
+
+If you are building robust, production-grade data pipelines, your focus should be on tools that offer scalability, reliability, and governance. Cloud data warehouses (Snowflake, BigQuery) are often the default choice. For extreme OLAP performance needs, ClickHouse is a strong contender. To tie everything together, an orchestration platform like Kestra is essential for scheduling, monitoring, and managing dependencies across your entire [data engineering](/data) stack.
+
+### For Data Scientists and Analysts Needing Local Power
+
+When the priority is interactive analysis and rapid iteration on local data, in-process tools are king. Polars provides a powerful and fast API for data manipulation within Python, making it a natural choice for many data scientists. For those who need to scale slightly beyond their local machine or collaborate with a team, MotherDuck offers a compelling hybrid solution.
+
+### For Platform Engineers Building Unified Data Stacks
+
+Platform engineers are tasked with providing a reliable and flexible foundation for other teams. The goal is to create a unified stack that can accommodate various tools without creating operational chaos. Kestra serves as the ideal control plane, allowing platform teams to offer [infrastructure automation](/infra-automation) and data services that can integrate with any analytical engine, from PostgreSQL to Spark.
+
+### When Embedded Simplicity is Key
+
+For applications that need a simple, self-contained database for state management or light storage, the choice often comes down to SQLite or DuckDB. If the primary need is transactional consistency and simplicity, SQLite is a proven, reliable option. If you need to run analytical queries on the embedded data, DuckDB remains the superior choice. Our guide to [embedded databases](/blogs/embedded-databases) can help you decide.
+
+## Final Thoughts: Orchestrating Your Analytical Ecosystem
+
+There is no single "best" alternative to DuckDB. The modern data landscape is about using a combination of specialized tools, each chosen for its specific strengths. DuckDB excels at local, in-process analytics, but as your needs evolve, tools like ClickHouse, Polars, and cloud data warehouses provide the necessary capabilities for scale, performance, and collaboration.
+
+The key to managing this complexity is a powerful, flexible orchestration layer. Kestra allows you to build reliable, observable, and maintainable data workflows that integrate all of these tools, giving you a unified control plane for your entire analytical ecosystem.

--- a/src/contents/resources/node-red-alternatives/index.md
+++ b/src/contents/resources/node-red-alternatives/index.md
@@ -1,0 +1,196 @@
+---
+title: "Node-RED Alternatives: Top Platforms for Enterprise Automation"
+description: "Explore the best Node-RED alternatives for scalable, declarative, and production-ready workflow automation across data, infrastructure, and AI. Compare features, deployment, and ideal use cases to find the right orchestrator beyond Node-RED's visual flows."
+metaTitle: "Node-RED Alternatives for Enterprise Workflow Automation"
+metaDescription: "Compare top Node-RED alternatives: Kestra, n8n, Windmill. Find the best platform for scalable, governed enterprise workflow automation needs."
+tag: "infrastructure"
+date: 2026-08-03
+slug: "node-red-alternatives"
+faq:
+  - question: "Why should I consider an alternative to Node-RED?"
+    answer: "Node-RED excels at visual, flow-based automation, especially for IoT and lightweight integrations. However, for enterprise-grade needs like complex data pipelines, strict governance, advanced error handling, and Git-native versioning, its JavaScript-centric, code-based flows can introduce limitations in scalability, observability, and maintainability. Alternatives offer more robust solutions for production environments."
+  - question: "Is Kestra a direct replacement for Node-RED?"
+    answer: "Kestra offers a powerful alternative for users seeking declarative, polyglot, and scalable orchestration. While Node-RED focuses on visual, flow-based programming, Kestra emphasizes YAML-defined workflows, enabling GitOps practices, advanced technical integrations, and unified orchestration across data, infrastructure, and AI. It's a replacement for those needing an engineering-first platform rather than a visual programming tool."
+  - question: "What are the key features to look for in a Node-RED alternative?"
+    answer: "When evaluating Node-RED alternatives, prioritize features such as declarative workflow definition (e.g., YAML), support for multiple programming languages, robust error handling and retry mechanisms, advanced scheduling and event-driven capabilities, enterprise-grade governance (RBAC, audit logs), and flexible deployment options (Kubernetes, on-prem, cloud). Scalability and observability are also critical for production use."
+  - question: "Can I migrate my existing Node-RED flows to Kestra?"
+    answer: "Migrating from Node-RED to Kestra involves re-implementing flows using Kestra's declarative YAML syntax. While direct conversion tools are limited, Kestra's Node.js plugin allows you to run existing Node.js scripts or even parts of your Node-RED logic within Kestra workflows. This enables a phased migration, leveraging Kestra's orchestration capabilities while reusing existing code assets."
+  - question: "Which alternative is best for IoT and home automation, similar to Node-RED?"
+    answer: "While Node-RED is strong in IoT and home automation due to its visual nature and lightweight footprint, alternatives like n8n can also serve these use cases with broader SaaS integration. For more robust or complex IoT data processing and system integration, Kestra offers advanced capabilities, though it requires a more code-centric approach compared to Node-RED's visual editor."
+  - question: "How do Node-RED alternatives handle multi-cloud or hybrid environments?"
+    answer: "Many Node-RED alternatives, including Kestra, are designed for flexible deployment across various environments. Kestra, for instance, is Kubernetes-native and can run on any cloud, on-premise, or in hybrid setups, offering a unified control plane. This contrasts with Node-RED, which might require more manual setup and integration to span complex multi-cloud or hybrid infrastructure effectively."
+---
+
+Node-RED has earned its place as a popular tool for visual, flow-based programming, particularly for IoT, home automation, and lightweight integrations. Its drag-and-drop interface and JavaScript foundation make it accessible for rapid prototyping and connecting diverse systems. However, as organizations scale, the very strengths that make Node-RED appealing can become limitations. Teams often encounter challenges with version control, robust error handling, testing, and integrating complex code-based logic in a production-grade environment.
+
+For businesses moving beyond simple automations to enterprise-scale data pipelines, intricate infrastructure operations, or sophisticated AI workflows, the need for a more declarative, auditable, and scalable orchestration platform becomes apparent. The leading alternatives to Node-RED in 2026 include Kestra, n8n, Windmill, Prefect, and Apache Airflow—each suited to different workloads such as automating IT operations, building modern data platforms, or governing AI agent lifecycles. This article will explore why teams seek these alternatives, how they compare, and guide you in choosing the right platform for your evolving automation needs.
+
+## Why Teams Seek Alternatives to Node-RED for Enterprise Automation
+
+While Node-RED is excellent for getting started, teams running mission-critical processes often encounter structural challenges that prompt them to look for more robust solutions. These issues typically revolve around governance, scalability, and maintainability in production environments.
+
+*   **Limited Version Control and GitOps:** Node-RED stores flows as a single JSON file. While this can be version-controlled, diffing and reviewing changes to a large, visual flow in JSON format is notoriously difficult. This makes collaborative development, code reviews, and GitOps-style deployments cumbersome compared to declarative, human-readable formats like YAML.
+*   **Complex Error Handling and Recovery:** Basic error handling is possible in Node-RED, but implementing sophisticated retry logic, conditional failure paths, and stateful recovery for long-running workflows requires significant custom logic within JavaScript function nodes. This can lead to brittle and hard-to-maintain flows.
+*   **Scalability and Performance Bottlenecks:** Node-RED's single-threaded, event-loop architecture, inherited from Node.js, can become a bottleneck for high-throughput data processing or workflows with many concurrent tasks. Scaling out requires manual configuration and infrastructure management, which isn't a core strength of the platform.
+*   **Language and Ecosystem Constraints:** Node-RED is fundamentally JavaScript-centric. While it can execute shell commands, integrating other languages like Python, R, or Go requires wrapping them in external processes, adding complexity and losing the benefits of a native, polyglot environment.
+*   **Lack of Enterprise Governance:** Out of the box, Node-RED lacks critical enterprise features such as Role-Based Access Control (RBAC), detailed audit logs for compliance, centralized secrets management, and multi-tenancy. Implementing these requires third-party plugins or significant custom development.
+*   **Operational Overhead:** Deploying and maintaining Node-RED in a resilient, production-grade manner falls on the user. Without a declarative configuration model, replicating environments, managing dependencies, and ensuring consistency can become a significant operational burden, contributing to the overall [complexity of orchestration problems](/resources/infrastructure/orchestration-problems-complexity).
+
+These limitations lead teams to explore alternatives that are purpose-built for the engineering rigor required in modern [infrastructure automation](/resources/infrastructure).
+
+## How We Evaluated Node-RED Alternatives
+
+To provide a clear comparison, we evaluated each alternative based on criteria that directly address Node-RED's limitations for enterprise use. Our assessment focused on:
+
+*   **Workflow Authoring:** We compared declarative, code-as-configuration approaches (like YAML) against visual, flow-based interfaces.
+*   **Language and Ecosystem:** We assessed the flexibility to use multiple programming languages (polyglot support) versus a single-language focus.
+*   **Scalability and Performance:** We considered the architecture's ability to handle high-volume, concurrent, and long-running tasks in production.
+*   **Enterprise Governance:** We looked for built-in features like RBAC, audit logs, secrets management, and multi-tenancy.
+*   **Deployment Flexibility:** We evaluated how easily the tool can be deployed and managed in various environments, including cloud-native (Kubernetes), on-premise, and hybrid models.
+*   **Observability and Debugging:** We examined the native capabilities for monitoring workflow health, troubleshooting failures, and gaining insight into executions.
+
+## Top Node-RED Alternatives for Scalable Workflow Automation
+
+### 1. Kestra: Declarative Orchestration for Unified Workflows
+
+Kestra is an open-source, event-driven orchestration platform that provides a unified control plane for all workflows—data, infrastructure, AI, and business processes. It replaces Node-RED's visual, JavaScript-centric model with a declarative, language-agnostic approach centered on YAML.
+
+Workflows in Kestra are defined as simple YAML files, making them easy to version, review, and manage through GitOps practices. This declarative model separates the workflow logic from the execution engine, enhancing reliability and maintainability. Kestra's architecture is built for scale, capable of handling hundreds of thousands of concurrent executions.
+
+**Key Strengths:**
+*   **Declarative & Polyglot:** Define all workflows in YAML and run tasks in any language, including Python, Node.js, Shell, R, and SQL. This allows teams to use the best tool for each job without language constraints.
+*   **Enterprise-Grade Governance:** Kestra includes RBAC, SSO, audit logs, multi-tenancy, and worker groups out of the box in its Enterprise Edition, providing the security and compliance needed for regulated environments.
+*   **Event-Driven Architecture:** Natively supports event-driven workflows from sources like webhooks, message queues (Kafka, SQS), and file triggers, enabling reactive and real-time automation.
+*   **Migration Path for Node.js:** For teams migrating from Node-RED, Kestra's [Node.js plugin](/plugins/plugin-script-node/io.kestra.plugin.scripts.node.commands) allows you to reuse existing scripts directly within a Kestra workflow, facilitating a smoother transition.
+
+```yaml
+id: nodejs-api-processing
+namespace: company.team.production
+
+tasks:
+  - id: fetch-data
+    type: io.kestra.plugin.core.http.Request
+    uri: https://api.example.com/data
+  
+  - id: process-with-nodejs
+    type: io.kestra.plugin.scripts.node.Script
+    script: |
+      const logger = require('kestra-nodejs/logger');
+      const data = JSON.parse('{{ outputs['fetch-data'].body }}');
+      const processedData = data.map(item => ({ id: item.id, value: item.value * 2 }));
+      logger.info(`Processed ${processedData.length} items.`);
+      // Further processing logic here
+```
+
+Companies like [Víssimo](/customers/vissimo) chose Kestra over alternatives including n8n, Airflow, and Prefect for its ability to handle mission-critical e-commerce and BI workflows with reliability and scale.
+
+**Best for:** Engineering and platform teams seeking a unified, declarative, and scalable [orchestration control plane](/infra-automation) to manage complex workflows across the entire organization. Learn more about [Why Kestra](/docs/why-kestra) is built for these challenges.
+
+### 2. n8n: Visual Automation with Code Extensibility
+
+n8n is an open-source workflow automation tool that offers a visual, node-based interface similar to Node-RED but with a stronger focus on SaaS integrations and enterprise use cases. It positions itself as a more powerful, self-hostable alternative to Zapier.
+
+While it shares the visual paradigm with Node-RED, n8n provides a more structured experience with a vast library of pre-built nodes for hundreds of applications. It also allows for custom JavaScript or TypeScript code in function nodes, offering a degree of extensibility.
+
+**Key Strengths:**
+*   **Extensive SaaS Integrations:** n8n's primary strength is its large and growing collection of nodes for popular SaaS applications, making it ideal for automating business processes.
+*   **Visual-First with Code:** The platform is accessible to non-developers but allows technical users to write custom code where needed.
+*   **Self-Hosted and Cloud Options:** Offers both a self-hosted open-source version and a managed cloud product, providing deployment flexibility.
+
+**Best for:** Operations teams and developers automating workflows between SaaS applications, who prefer a visual interface but require more control and self-hosting capabilities than tools like Zapier. See a detailed comparison in [Kestra vs. n8n](/vs/n8n).
+
+### 3. Windmill: Open-Source Platform for Internal Tools and Workflows
+
+Windmill is an open-source developer platform for building internal tools, background jobs, and workflows. It takes a code-first approach, allowing you to turn scripts in Python, TypeScript, Go, and Bash into production-grade workflows and UIs.
+
+Unlike Node-RED's visual flows, Windmill treats scripts as the fundamental building blocks. It provides a robust environment for executing these scripts, with features like auto-generated UIs, role-based access controls, and a full audit trail.
+
+**Key Strengths:**
+*   **Code-First and Polyglot:** Write scripts in your preferred language and chain them into complex flows. This appeals to developers who find visual programming restrictive.
+*   **Internal Tool Generation:** Automatically creates UIs from scripts, enabling non-technical users to run them safely.
+*   **Open-Source and Self-Hostable:** Provides a strong open-source offering that can be deployed on your own infrastructure.
+
+**Best for:** Developer and DevOps teams building internal applications, automating operational tasks, and creating self-service tools for the rest of the organization. For more options in this space, see these [Windmill alternatives](/resources/infrastructure/windmill-alternatives).
+
+### 4. Prefect: Pythonic Orchestration for Data and ML
+
+Prefect is a modern workflow orchestration platform designed primarily for data and machine learning pipelines. It is Python-native, allowing developers to define workflows directly in Python code using decorators and a functional API.
+
+This approach provides a significant step up from Node-RED for data-intensive tasks, offering dynamic workflow generation, robust error handling with automatic retries, and excellent observability.
+
+**Key Strengths:**
+*   **Python-Native Developer Experience:** Highly regarded for its intuitive API that feels natural to Python developers.
+*   **Dynamic and Parameterized Workflows:** Easily build workflows that adapt at runtime based on data or parameters.
+*   **Hybrid Execution Model:** A managed cloud control plane orchestrates agents running on your own infrastructure, keeping data and code secure.
+
+**Best for:** Python-centric data and ML engineering teams that need a powerful, fault-tolerant platform for building and managing complex data pipelines. Explore other [Prefect alternatives](/resources/data/prefect-alternatives) or a direct [Kestra vs. Prefect](/vs/prefect) comparison.
+
+### 5. Apache Airflow: The Established Data Orchestrator
+
+Apache Airflow is the most established open-source platform for programmatically authoring, scheduling, and monitoring workflows. It is the de-facto standard in many data engineering teams. Workflows are defined as Directed Acyclic Graphs (DAGs) in Python.
+
+For teams outgrowing Node-RED for data processing, Airflow offers a battle-tested solution with a massive ecosystem of operators and a large community. It provides robust scheduling, dependency management, and scalability for handling complex ETL/ELT pipelines.
+
+**Key Strengths:**
+*   **Mature and Battle-Tested:** Proven at scale in thousands of companies over many years.
+*   **Vast Ecosystem:** A huge library of pre-built operators allows integration with nearly any data source or tool.
+*   **Strong Community Support:** Extensive documentation, tutorials, and community resources are available.
+
+**Best for:** Large data engineering organizations with deep Python expertise that require a mature, highly extensible platform for data orchestration. However, its operational complexity is a key consideration. For a deeper dive, see [Kestra vs. Airflow](/vs/airflow) and other [Airflow alternatives](/resources/data/airflow-alternatives).
+
+### 6. Apache NiFi: Visual Dataflow Management at Scale
+
+Apache NiFi is a powerful and scalable system for processing and distributing data. It provides a web-based, drag-and-drop interface for designing dataflows, making it the closest philosophical match to Node-RED in this list.
+
+However, NiFi is engineered from the ground up for high-throughput, reliable data movement. It offers features like guaranteed delivery, data provenance to track every piece of data, and back-pressure to handle data bursts gracefully.
+
+**Key Strengths:**
+*   **Visual Dataflow Paradigm:** The flow-based model is intuitive for users accustomed to Node-RED.
+*   **Data Provenance:** Automatically records and indexes a complete, queryable history of all data that flows through the system.
+*   **Designed for Data Movement:** Excels at routing, transforming, and mediating data between systems at a large scale.
+
+**Best for:** Teams who want to retain a visual, flow-based interface but need enterprise-grade capabilities specifically for large-scale data ingestion and routing. It is one of the key [Apache NiFi alternatives](/resources/data/apache-nifi-alternatives) for data-centric use cases.
+
+### 7. StackStorm: Event-Driven Automation for IT Operations
+
+StackStorm is an open-source, event-driven automation platform that specializes in auto-remediation and runbook automation. It uses a "sensors, triggers, rules, actions, workflows" model to wire together infrastructure and applications.
+
+Like Node-RED, StackStorm is fundamentally event-driven. It listens for events from monitoring systems, security tools, or chat platforms, and triggers automated workflows in response. This makes it a powerful tool for IT operations and SRE teams.
+
+**Key Strengths:**
+*   **Event-Driven "If-This-Then-That":** Excels at creating rules that tie specific events to automated responses, perfect for incident remediation.
+*   **Integration Packs:** A large library of integrations (packs) connects to common infrastructure and DevOps tools.
+*   **Runbook Automation:** A strong fit for automating operational procedures, from simple restarts to complex diagnostics.
+
+**Best for:** SRE and IT operations teams focused on automating incident response, security remediation, and other [runbook automation tools](/resources/infrastructure/runbook-automation-tools-2026). Its focus is narrower than a general-purpose orchestrator but deeper for [event-driven orchestration](/resources/infrastructure/event-driven-orchestration) in ops.
+
+## Comparison Table: Node-RED Alternatives
+
+| Tool | License | Primary Use Case | Workflow Definition | Language Support | Deployment | Governance |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **Kestra** | Open-Source (Apache 2.0) + Enterprise | Unified Orchestration (Data, Infra, AI) | Declarative YAML | Polyglot | Kubernetes, Docker, On-Prem | RBAC, SSO, Audit Logs, Tenants |
+| **n8n** | Open-Source (Sustainable Use) + Commercial | SaaS & Business Process Automation | Visual Flow Builder | JavaScript, TypeScript | Cloud, Docker, Kubernetes | User Management, SSO |
+| **Windmill** | Open-Source (MIT) + Enterprise | Internal Tools & Dev/Ops Workflows | Scripts + Low-Code UI | Python, TS, Go, Bash | Kubernetes, Docker | RBAC, Audit Logs |
+| **Prefect** | Open-Source (Apache 2.0) + Commercial | Data & ML Pipelines | Python Code (Decorators) | Python | Hybrid (Cloud + Self-Hosted Agents) | RBAC, SSO, Audit Logs |
+| **Apache Airflow** | Open-Source (Apache 2.0) | Data Engineering (ETL/ELT) | Python Code (DAGs) | Python | Kubernetes, VMs | RBAC, Audit Logs (via setup) |
+| **Apache NiFi** | Open-Source (Apache 2.0) | Large-Scale Data Ingestion & Routing | Visual Flow Builder | Java (custom processors) | VMs, Kubernetes | User Auth, Access Policies |
+| **StackStorm** | Open-Source (Apache 2.0) | IT Ops & Remediation Automation | YAML + Python | Python | Kubernetes, Docker | RBAC, LDAP |
+
+## Choosing the Right Node-RED Alternative for Your Needs
+
+Selecting the best alternative depends entirely on why you're moving away from Node-RED and what your primary use case is.
+
+*   **For data engineering teams:** If you are building complex, production-grade data pipelines, **Kestra**, **Prefect**, and **Airflow** are the strongest contenders. Kestra offers a language-agnostic, declarative approach, while Prefect and Airflow are excellent for Python-heavy teams. Your choice will depend on your preference for declarative YAML vs. Python code. Start exploring with Kestra for [modern data engineering](/data).
+*   **For infrastructure & DevOps teams:** If your focus is on IaC, CI/CD, and IT operations, **Kestra** and **Windmill** are top choices. Kestra provides a centralized control plane to orchestrate tools like Terraform and Ansible, while Windmill excels at turning scripts into self-service internal tools. See how Kestra can manage your entire [infrastructure automation](/infra-automation).
+*   **For AI & ML platform teams:** For orchestrating complex ML training pipelines and RAG applications, **Kestra** and **Prefect** offer the necessary flexibility and robustness. Kestra's polyglot nature is a plus for multi-language ML stacks, while Prefect's dynamic capabilities are powerful for experimentation. Kestra helps you build governed [AI automation](/ai-automation) workflows.
+*   **For teams seeking visual or low-code options:** If you like the visual paradigm of Node-RED but need more robust SaaS integrations, **n8n** is the logical next step. It offers a familiar experience with a greater focus on business process automation. Explore other [n8n alternatives](/resources/infrastructure/n8n-alternatives) if your needs are more technical.
+*   **For teams committed to a visual dataflow canvas at scale:** If your core task is high-volume data movement and you want to keep a visual interface, **Apache NiFi** is purpose-built for this. It is a direct upgrade path for the dataflow aspect of Node-RED. Compare it with other [Apache NiFi alternatives](/resources/data/apache-nifi-alternatives).
+*   **For SRE and IT ops automating remediation:** If your primary goal is event-driven automation for incident response, **StackStorm** and **Kestra** are ideal. StackStorm is specialized for this, while Kestra can handle remediation as part of a broader [event-driven orchestration](/resources/infrastructure/event-driven-orchestration) strategy.
+
+## Conclusion: Elevating Your Automation Beyond Node-RED
+
+Node-RED is an excellent tool for prototyping, IoT projects, and simple integrations. However, as automation becomes a mission-critical component of your operations, the need for a platform built on engineering principles of scalability, governance, and maintainability becomes crucial.
+
+The shift from Node-RED's visual flows to a declarative platform like Kestra represents a move towards treating your workflows as code. This enables robust versioning, collaborative development, and reliable deployments that can scale with your organization. By providing a unified control plane that is language-agnostic and event-driven, Kestra empowers teams to build, manage, and monitor all their automated processes from a single, auditable platform.
+
+Ready to see how a declarative approach can transform your automation? Explore our [documentation](/docs) or browse our library of workflow [Blueprints](/blueprints) to get started.

--- a/src/contents/resources/upsert/index.md
+++ b/src/contents/resources/upsert/index.md
@@ -1,0 +1,184 @@
+---
+title: "Upsert Explained: Combining Update and Insert for Data Consistency"
+description: "Understand what upsert means in databases, how it works across different SQL dialects, and how Kestra orchestrates idempotent upsert operations for reliable data pipelines."
+metaTitle: "Upsert: Update or Insert for Data Consistency"
+metaDescription: "Learn what the upsert database operation is, its SQL syntax in PostgreSQL, MySQL, and Snowflake, and how Kestra orchestrates idempotent upserts."
+tag: "data"
+date: 2026-08-03
+slug: "upsert"
+faq:
+  - question: "What does upsert mean?"
+    answer: "Upsert is a portmanteau of 'update' and 'insert.' It's a database operation that attempts to update an existing row if a specified unique key already exists in a table. If no matching key is found, it inserts a new row. This combines two operations into one, simplifying data synchronization and conflict resolution logic."
+  - question: "What's the difference between upsert and update?"
+    answer: "An UPDATE operation only modifies existing rows that match a specified condition. If no matching row exists, an UPDATE does nothing. In contrast, an UPSERT will update a row if it exists, but it will insert a new row if no matching record is found. This makes upsert suitable for scenarios where you need to both modify and create records."
+  - question: "Is upsert a good practice for data synchronization?"
+    answer: "Yes, upsert operations are highly recommended for data synchronization and conflict resolution. They ensure data consistency by preventing duplicates and efficiently handling scenarios where data might already exist or needs to be newly added. This is crucial for maintaining accurate datasets across disparate systems."
+  - question: "Is 'upsert' a real word in databases?"
+    answer: "While 'upsert' is a portmanteau and not a traditional dictionary word, it has become a widely accepted and standard term within the database and data engineering communities. Many modern relational and NoSQL databases, like PostgreSQL and MongoDB, directly support or provide syntax to achieve upsert functionality."
+  - question: "When should you use an upsert operation?"
+    answer: "You should use upsert when performing incremental data loads, synchronizing data between systems, or resolving data conflicts where a record might either need to be updated or inserted. It's ideal for maintaining an up-to-date view of data without complex conditional logic in your application or pipeline."
+---
+
+> **TL;DR** — Upsert is a database operation that intelligently combines "update" and "insert." If a record with a specified key already exists, it updates that record; otherwise, it inserts a new one. This ensures data consistency and prevents duplicates, making it crucial for synchronizing data across systems and handling conflict resolution efficiently.
+
+In the world of data, ensuring accuracy and avoiding duplicates is paramount. As data flows between applications, warehouses, and analytics platforms, records are constantly being created, updated, and sometimes deleted. The challenge lies in efficiently handling these changes: how do you insert a new record if it doesn't exist, or update an existing one without writing complex conditional logic?
+
+This is the problem the "upsert" operation solves. By intelligently combining the "update" and "insert" actions into a single atomic operation, upsert simplifies data synchronization, simplifies pipeline logic, and guarantees data integrity. This article will demystify upsert, explore its implementations across various databases, and demonstrate how Kestra orchestrates these critical operations for reliable data management.
+
+## Understanding the Upsert Operation
+
+### What is an Upsert and why does it matter?
+
+Upsert, a blend of "update" and "insert," is a database operation that modifies a row if it already exists or creates a new one if it doesn't. This conditional logic is handled directly by the database engine based on a unique key or constraint. Instead of first querying the database to check for a record's existence and then deciding whether to run an `INSERT` or `UPDATE` statement, an upsert performs this in a single, atomic step.
+
+This atomicity is critical for building reliable [data pipelines](/resources/data/data-pipeline). It prevents race conditions where two processes might check for the same record simultaneously, leading to duplicate entries or failed updates. The primary benefits of using upsert include:
+
+-   **Data Synchronization:** Keeps data consistent between different systems by ensuring records are always current.
+-   **Idempotency:** Allows an operation to be repeated multiple times without changing the result beyond the initial application. This is essential for fault-tolerant data ingestion.
+-   **Conflict Resolution:** Simplifies handling scenarios where incoming data might already exist, preventing duplicate key errors.
+-   **Performance:** Reduces network latency by combining two potential database calls into one.
+
+### Upsert vs. traditional SQL operations (INSERT, UPDATE, DELETE)
+
+To fully appreciate the value of upsert, it's helpful to compare it with standard SQL commands.
+
+| Operation | Action | Behavior if Record Exists | Behavior if Record Doesn't Exist |
+| --- | --- | --- | --- |
+| `INSERT` | Adds a new row. | Fails (unique constraint violation). | Creates the new row. |
+| `UPDATE` | Modifies an existing row. | Modifies the matching row(s). | Does nothing. |
+| `DELETE` | Removes an existing row. | Removes the matching row(s). | Does nothing. |
+| `UPSERT` | Adds or modifies a row. | Modifies the matching row. | Creates the new row. |
+
+A typical workflow without upsert would require a `SELECT` statement to check for the record, followed by conditional application logic to run either `INSERT` or `UPDATE`. This multi-step process is less efficient and more prone to errors, especially in concurrent environments. Upsert simplifies this entire flow into a single, declarative statement, which is a core principle of modern [data orchestration](/resources/data/data-orchestration).
+
+## How Databases Implement Upsert
+
+While the concept of upsert is universal, the specific SQL syntax varies across different database systems. Most modern relational databases provide a dedicated command or clause to perform this operation.
+
+### PostgreSQL's `ON CONFLICT` clause
+
+PostgreSQL implements upsert using the `INSERT ... ON CONFLICT` clause, which is highly flexible. You specify what to do when an insert would violate a unique constraint.
+
+```sql
+INSERT INTO customers (id, name, email)
+VALUES (1, 'Alice', 'alice@example.com')
+ON CONFLICT (id)
+DO UPDATE SET email = EXCLUDED.email;
+```
+
+Here, if a customer with `id = 1` already exists, the database updates their email. Otherwise, it inserts the new record.
+
+### MySQL's `ON DUPLICATE KEY UPDATE` and `REPLACE` statement
+
+MySQL offers two primary ways to perform an upsert. The most common is `INSERT ... ON DUPLICATE KEY UPDATE`.
+
+```sql
+INSERT INTO customers (id, name, email)
+VALUES (1, 'Alice', 'alice@example.com')
+ON DUPLICATE KEY UPDATE email = VALUES(email);
+```
+
+This statement requires a `PRIMARY KEY` or `UNIQUE` index. If a duplicate key is found, the `UPDATE` clause is executed. MySQL also has a `REPLACE` statement, which first deletes the old row and then inserts the new one. This approach can be less efficient as it involves a `DELETE` and an `INSERT`, which can have cascading effects on related tables.
+
+### Snowflake's `MERGE` statement for data warehousing
+
+In data warehousing, upsert operations are fundamental to loading dimension tables and fact tables. Snowflake uses the powerful `MERGE` statement, which aligns with the SQL standard.
+
+```sql
+MERGE INTO customers AS target
+USING source_data AS source
+ON target.id = source.id
+WHEN MATCHED THEN
+    UPDATE SET target.email = source.email
+WHEN NOT MATCHED THEN
+    INSERT (id, name, email) VALUES (source.id, source.name, source.email);
+```
+
+The `MERGE` statement is highly expressive, allowing you to define actions for matched and unmatched rows, making it ideal for complex synchronization logic. You can find a range of [Snowflake](/plugins/plugin-jdbc-snowflake) tasks and blueprints in Kestra.
+
+### Other approaches: SQLite and NoSQL databases
+
+-   **SQLite:** Uses the `INSERT ... ON CONFLICT` syntax, similar to PostgreSQL, often with `DO UPDATE SET`.
+-   **NoSQL Databases (e.g., MongoDB):** Most NoSQL databases have built-in upsert functionality. MongoDB's `updateOne()` and `updateMany()` methods accept an `{ upsert: true }` option to achieve this.
+
+## Orchestrate Upsert with Kestra: Idempotent Data Synchronization
+
+In a production environment, an upsert operation is rarely a one-off task. It's typically part of a scheduled, automated workflow that keeps a target system synchronized with a source. Kestra excels at orchestrating these processes declaratively.
+
+Consider a common scenario: you need to sync product inventory data from a source file into a Snowflake data warehouse every hour. The workflow must be idempotent, meaning running it multiple times with the same input data won't create duplicates or errors. The [Snowflake Incremental MERGE Upsert blueprint](/blueprints/snowflake-incremental-merge-upsert) provides a perfect template for this.
+
+```yaml
+id: snowflake-incremental-upsert
+namespace: prod.inventory
+
+tasks:
+  - id: generate_source_data
+    type: io.kestra.plugin.scripts.shell.Commands
+    runner: DOCKER
+    commands:
+      # This task simulates generating a new data file.
+      # In a real workflow, this could be a file download or API call.
+      - |
+        cat > products.json <<'EOF'
+        {"id": 101, "product_name": "Wireless Mouse", "stock": 95}
+        {"id": 102, "product_name": "Mechanical Keyboard", "stock": 50}
+        {"id": 103, "product_name": "USB-C Hub", "stock": 120}
+        EOF
+    outputFiles:
+      - products.json
+
+  - id: stage_and_merge
+    type: io.kestra.plugin.jdbc.snowflake.Query
+    url: "{{ secret('SNOWFLAKE_URL') }}"
+    username: "{{ secret('SNOWFLAKE_USER') }}"
+    password: "{{ secret('SNOWFLAKE_PASSWORD') }}"
+    from: "{{ outputs.generate_source_data.outputFiles['products.json'] }}"
+    sql: |
+      -- Create a temporary stage for the source data
+      CREATE OR REPLACE TEMPORARY STAGE kestra_stage
+        FILE_FORMAT = (TYPE = JSON);
+
+      -- Put the source file into the stage
+      PUT file://{{ workingDir }}/products.json @kestra_stage;
+
+      -- Merge the staged data into the target table
+      MERGE INTO product_inventory AS target
+      USING (SELECT $1:id::int AS id, $1:product_name::string AS product_name, $1:stock::int AS stock FROM @kestra_stage) AS source
+      ON target.id = source.id
+      WHEN MATCHED AND target.stock <> source.stock THEN
+          UPDATE SET target.stock = source.stock
+      WHEN NOT MATCHED THEN
+          INSERT (id, product_name, stock) VALUES (source.id, source.product_name, source.stock);
+
+triggers:
+  - id: hourly_schedule
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 * * * *"
+```
+
+### Key Advantages of Kestra for Upsert Workflows
+
+This Kestra flow demonstrates how orchestration elevates a simple upsert into a reliable data process:
+
+-   **Declarative & Versioned:** The entire logic is defined in a simple YAML file. It can be version-controlled in Git, reviewed, and deployed like any other piece of code.
+-   **State Management:** Kestra handles the transfer of data between tasks. The file generated by the shell script is passed directly to the Snowflake task.
+-   **Scheduling:** The `Schedule` trigger ensures the synchronization runs automatically every hour, requiring no manual intervention.
+-   **Error Handling & Retries:** Kestra's built-in retry mechanisms can automatically re-run a failed task, adding resilience to the pipeline. If the `MERGE` fails due to a temporary network issue, Kestra can handle it gracefully.
+-   **Observability:** Every execution is logged, with detailed metrics and outputs available in the UI. You can easily track when the sync ran, what data was processed, and whether it succeeded.
+
+## Where Upsert Pays Off in Modern Data Stacks
+
+Upsert operations are a cornerstone of many data-intensive applications and workflows:
+
+-   **Change Data Capture (CDC):** As changes are captured from a source database, an upsert operation is the most efficient way to apply those inserts, updates, and deletes to a target warehouse. Learn more about [Change Data Capture](/resources/data/change-data-capture).
+-   **Search Index Synchronization:** Keeping search indexes like Algolia, Typesense, or Pinecone up-to-date requires constant upserts to reflect changes in the source data. Kestra offers plugins for [Pinecone](/plugins/plugin-pinecone/io.kestra.plugin.pinecone.upsert), [Typesense](/plugins/plugin-typesense), and a blueprint for [syncing with Algolia](/blueprints/algolia-index-sync).
+-   **CRM/ERP Data Integration:** When syncing customer or order data between systems, upserts ensure that records are not duplicated and that the latest information is always available.
+-   **Real-time Analytics:** Ingesting streaming data into analytical databases often relies on high-frequency upserts to maintain an accurate, real-time view of business metrics.
+
+## Related concepts
+
+-   [Data Orchestration for Modern Data Engineers](/data)
+-   [ETL vs. ELT: Understanding the Differences](/resources/data/etl-vs-elt)
+-   [What is Data Lineage and Why is it Important?](/resources/data/data-lineage)
+-   [Ensuring Data Quality in your Pipelines](/resources/data/data-quality)
+-   [Explore Data Engineering Resources](/resources/data)


### PR DESCRIPTION
## Summary

Imports 3 ready drafts from `vfanucci/kestra-seo` into the resources hub.

| Page | Type | URL | Source |
|------|------|-----|--------|
| Upsert | concept | `/resources/data/upsert` | #235 |
| DuckDB Alternatives | listicle | `/resources/data/duckdb-alternatives` | #299 |
| Node-RED Alternatives | listicle | `/resources/infrastructure/node-red-alternatives` | #270 |

No slug collisions.

## Publish date

All three pages use the **real publication date (`2026-08-03`)** — the date they actually go live — rather than the draft generation date (upsert's draft was generated 2026-07-08).

## Notes on `node-red-alternatives` (#270)

The original outline listed only 5 alternatives, all data/infra orchestrators (Kestra, n8n, Windmill, Prefect, Airflow), which under-covered Node-RED's actual visual/event-driven usage. Two entries were added before the draft ran, in the outline's existing writing pattern: **Apache NiFi** (closest visual dataflow analogue) and **StackStorm** (event-driven IT ops / remediation). The enterprise-automation framing was kept — no home-automation angle. Length target moved 2200 → 2600 words; the draft lands at 2616 words.

## Notes on `upsert` (#235)

The draft had 4 blocking QC errors, all fixed before import. Root cause of three of them: a stray ```` ```yaml ```` fence wrapping the front-matter, which hid the front-matter, swallowed the opening `> **TL;DR**` blockquote, and produced a non-parsing "YAML block". The fourth was a genuine YAML parse failure — `echo '{"id": 101, ...}'` shell commands broke YAML (the `": ` read as a mapping); replaced with a heredoc block scalar (same output, parses clean). The "613 words vs 1400 target" warning was an artifact of the same fence — the real count is 1278 words, inside range. Anti-pattern stems reworded; the 3 plugin FQCNs verified against the inventory.

## Front-matter hygiene
Fences balanced; metaTitle ≤60 with the ` | Kestra` suffix stripped (the docs template appends it); metaDescription 140–160; no `image:`/`author:`; no unresolved markers; no duplicated headings. Internal links verified live (incl. `/vs/airflow`, `/vs/n8n`, `/vs/prefect`, and the NiFi/event-driven/runbook resource pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
