### PR TITLE
fix(resources): let tab clicks navigate so the hero matches the URL

### DIFF
--- a/src/components/common/Tabs.vue
+++ b/src/components/common/Tabs.vue
@@ -8,11 +8,9 @@
                 <a
                     class="tab"
                     :class="{ active: modelValue === slug }"
-                    @click.prevent="
-                        $emit('update:modelValue', slug);
-                    "
+                    @click="select($event, slug)"
                     :href="`${rootHref}/${slug}`"
-                    role="presentation"
+                    :role="navigate ? undefined : 'presentation'"
                 >
                     {{ category }}
                 </a>
@@ -22,15 +20,28 @@
 </template>
 
 <script setup lang="ts">
-    defineProps<{
-        modelValue: string
-        categories: Map<string, string>
-        rootHref: string
+    const props = withDefaults(
+        defineProps<{
+            modelValue: string
+            categories: Map<string, string>
+            rootHref: string
+            // Follow the tab's href instead of filtering in place. Needed when the
+            // target page ships its own copy (h1, subtitle, title, canonical):
+            // a client-side swap would leave those pointing at the current tab.
+            navigate?: boolean
+        }>(),
+        { navigate: false },
+    )
+
+    const emit = defineEmits<{
+        (e: "update:modelValue", value: string): void
     }>()
 
-    defineEmits<{
-        (e: 'update:modelValue', value: string): void
-    }>()
+    const select = (event: MouseEvent, slug: string) => {
+        if (props.navigate) return
+        event.preventDefault()
+        emit("update:modelValue", slug)
+    }
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/resources/ResourceGrid.vue
+++ b/src/components/resources/ResourceGrid.vue
@@ -4,6 +4,7 @@
             v-model="activeTag"
             :categories="resourceTabs"
             root-href="/resources"
+            navigate
             class="m-0 mb-4"
         />
 
@@ -80,14 +81,6 @@
             activeTag.value = newSlug || ALL_RESOURCES
         },
     )
-
-    watch(activeTag, () => {
-        const target =
-            activeTag.value === ALL_RESOURCES
-                ? "/resources"
-                : `/resources/${activeTag.value}`
-        window.history.pushState(null, "", target)
-    })
 
     const showMore = () => {
         visibleCount.value += 9


### PR DESCRIPTION
## The bug

Land on `/resources`, click the **Infrastructure** tab:

| | before | expected |
|---|---|---|
| `location.pathname` | `/resources/infrastructure` | `/resources/infrastructure` |
| `h1` | All Orchestration Resources | Infrastructure Automation Resources |
| hero subtitle | the `$all` one | the infrastructure one |
| `document.title` | `Kestra Resources: Guides for Data, AI…` | `Infrastructure Automation Resources: Terraform…` |
| `link[rel=canonical]` | `/resources` | `/resources/infrastructure` |
| grid + active tab | Infrastructure ✅ | Infrastructure ✅ |

`Tabs.vue` called `preventDefault()` on the anchor and `ResourceGrid.vue` called `window.history.pushState`. The URL changed but no navigation happened, so the hero — a separate island — and the document head kept the copy of whichever page was loaded first. Back/forward were broken the same way: the URL moved, the content did not, because nothing listened for `popstate`.

This predates #5268; the hero copy was identical on all 6 tabs, so nothing looked wrong. Per-tab headings and subtitles made it visible.

## The fix

The tabs are already `<a href="/resources/<tag>">`, so let the browser follow them. `Tabs.vue` gets an opt-in `navigate` prop; `ResourceGrid.vue` sets it and drops the now-dead `pushState` watcher.

- Each tag page serves its own h1, subtitle, title, meta description, canonical and OG tags.
- History works natively, no `popstate` handling needed.
- Cmd/ctrl/middle-click opens the tab in a new browser tab again (`preventDefault` used to swallow it).
- `role="presentation"` is dropped in navigate mode, so the link is exposed to assistive tech as the link it now is.
- `navigate` defaults to `false`, so `BlogGrid.vue` and `videos/[slug].astro` keep in-place filtering.

Trade-off: a tab click is now a page load instead of an instant filter. These pages are prerendered static, so it is cheap. If we want the snap back later, the honest version is Astro's `ClientRouter`, which swaps the head too — not a hand-rolled `pushState`.

## Verified locally

- All 6 resources tabs return 200 with the right h1.
- Clicking Infrastructure from `/resources`: h1, subtitle, title and canonical all switch to the infrastructure page. Back returns to `/resources` with its own h1 and the full 9-card grid.
- `/blogs`: clicking a category still filters in place and pushes `/blogs/$company-news` (unchanged), `role="presentation"` still there. `/videos` renders.
- `oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)