### PR TITLE
seo(resources): add 9 W32 pages (AI orchestration cluster, BPM tools, kafka, data mesh vs fabric, process mining)

### DIFF
--- a/src/contents/resources/ai-agent-evaluation/index.md
+++ b/src/contents/resources/ai-agent-evaluation/index.md
@@ -1,0 +1,172 @@
+---
+title: "AI Agent Evaluation: Metrics, Benchmarks, and Orchestration"
+description: "Understand AI agent evaluation, from defining key metrics to implementing robust testing frameworks. Orchestrate and automate your agent evaluation pipelines with Kestra."
+metaTitle: "AI Agent Evaluation: Metrics & Orchestration"
+metaDescription: "Master AI agent evaluation with practical metrics, frameworks, and tools. Learn how to orchestrate automated testing pipelines for your AI agents with Kestra."
+tag: "ai"
+date: 2026-08-05
+slug: "ai-agent-evaluation"
+faq:
+  - question: "How can an AI agent be evaluated?"
+    answer: "Effective AI agent evaluation involves using representative datasets, simulating real-world scenarios, and testing an agent's reasoning, tool use, and decision-making. Ground truth data, often human-annotated, is crucial for benchmarking the agent's outputs against expected outcomes."
+  - question: "What is an AI agent evaluation analyst?"
+    answer: "An AI Agent Evaluation Analyst is a professional who reviews and benchmarks AI agents in realistic, simulation-based environments. They test an agent's logic, reasoning, and decision-making under structured scenarios, often evaluating task designs for clarity, realism, and effectiveness."
+  - question: "What are the best AI agent evaluation tools?"
+    answer: "Leading AI agent evaluation tools for production teams include Braintrust, Arize Phoenix, Promptfoo, Galileo, and Cosmos. These platforms offer capabilities for dataset management, metric calculation, human-in-the-loop feedback, and integration into existing ML pipelines."
+  - question: "Who are the big 4 AI agents?"
+    answer: "There is no universally agreed-upon 'big 4' of AI agents, as the field is rapidly evolving. However, prominent agent frameworks and models include those from OpenAI (e.g., Assistants API), Anthropic (e.g., Claude with tool use), Google (e.g., Gemini Agents), and open-source projects like LangChain and AutoGPT."
+  - question: "Is ChatGPT an AI agent?"
+    answer: "ChatGPT, in its base form, is primarily a large language model (LLM) designed for conversational interaction. While it can engage in multi-turn dialogues, it lacks true autonomous agency, persistent memory, and the ability to independently use external tools or achieve goals without explicit user prompting. However, specialized versions like OpenAI's Assistants API or custom implementations built on top of ChatGPT can exhibit agentic behaviors."
+  - question: "How do you measure the accuracy of an AI agent?"
+    answer: "Measuring an AI agent's accuracy involves evaluating the correctness and relevance of its outputs against a predefined ground truth or expected behavior. Metrics include task completion rate, correctness of tool calls, factual accuracy of generated text, adherence to constraints, and success in achieving complex goals. Human-in-the-loop evaluation is often critical for nuanced assessments."
+  - question: "What are the challenges in evaluating AI agents?"
+    answer: "Evaluating AI agents presents several challenges, including the dynamic nature of agentic behavior, the difficulty in defining comprehensive ground truth for open-ended tasks, the cost and complexity of simulating real-world environments, and the need to assess not just final outputs but also the reasoning and intermediate steps taken by the agent."
+---
+
+> **TL;DR** — AI agent evaluation is the systematic process of assessing the performance, reliability, and ethical behavior of autonomous AI agents. It goes beyond basic model metrics to test an agent's reasoning, tool use, and decision-making capabilities in dynamic, real-world scenarios, ensuring safe and effective deployment.
+
+Building powerful AI agents is one challenge; ensuring they perform reliably, accurately, and ethically in production is another entirely. Unlike traditional machine learning models, autonomous agents operate dynamically, making decisions, using tools, and adapting to environments. This complexity means standard evaluation metrics often fall short.
+
+To confidently deploy AI agents, teams need robust evaluation frameworks that go beyond basic accuracy scores. This article explores why comprehensive AI agent evaluation is critical, outlines the methodologies and tools available, and demonstrates how Kestra can orchestrate these complex evaluation pipelines to ensure your agents deliver consistent, trustworthy results.
+
+## Why AI Agent Evaluation is Different
+
+Traditional [LLM evaluation](/resources/ai/llm-evaluation) often focuses on static input-output pairs, assessing qualities like fluency, factual accuracy, and relevance. While these are important, they fail to capture the essence of what makes an agent an agent: its ability to act. An [AI agent](/resources/ai/ai-agent) isn't just generating text; it's executing a plan, interacting with tools, and pursuing a goal over multiple steps.
+
+Evaluating an agent requires a shift in perspective:
+*   **From Static to Dynamic:** Instead of a single prompt and response, you must assess a sequence of actions, decisions, and tool interactions.
+*   **From Output to Process:** The final answer is only part of the story. The evaluation must also consider the agent's reasoning process, the efficiency of its plan, and the correctness of its tool calls. Did it arrive at the right answer for the right reasons?
+*   **From Isolated to Integrated:** Agents operate within complex ecosystems of APIs, databases, and other software. Evaluation must account for this interaction, testing how the agent handles API errors, navigates system constraints, and manages uncertainty.
+
+This multi-faceted nature is at the core of [agentic orchestration](/resources/ai/agentic-orchestration), where the focus is on managing these dynamic, goal-oriented processes. Effective evaluation must therefore assess the entire agentic loop: planning, tool use, observation, and adaptation.
+
+## How AI Agent Evaluation Works
+
+A comprehensive evaluation strategy examines an agent's performance across multiple layers of abstraction, from the correctness of individual actions to the successful completion of high-level tasks.
+
+### Defining Evaluation Layers: From Tools to Tasks
+
+Evaluating an agent isn't a single test but a hierarchy of assessments:
+1.  **Tool Use:** Can the agent correctly invoke tools and APIs? Does it provide valid parameters? Can it handle API errors gracefully?
+2.  **Reasoning and Planning:** Does the agent formulate a coherent and efficient plan to achieve its goal? Can it break down a complex task into logical sub-steps?
+3.  **Task Completion:** Can the agent successfully complete the end-to-end task? This is the ultimate measure of its utility.
+
+This layered approach helps pinpoint failures. An agent might fail a task not because its reasoning is flawed, but because it consistently formats an API call incorrectly.
+
+### Core Metrics for Agent Performance
+
+While specific metrics vary by use case, a good evaluation framework typically includes:
+*   **Task Success Rate:** The percentage of tasks the agent completes successfully.
+*   **Correctness:** The accuracy and factual validity of the final output.
+*   **Efficiency:** The resources consumed, such as the number of steps, tool calls, or tokens used.
+*   **Robustness:** The agent's ability to handle unexpected inputs, errors, or environmental changes.
+*   **Safety and Alignment:** The agent's adherence to predefined safety protocols and ethical guidelines.
+*   **Cost:** The monetary cost of the agent's execution, including LLM API calls and tool usage.
+
+### Frameworks and Methodologies for Systematic Assessment
+
+Several methodologies have emerged to structure the evaluation process:
+*   **Human-in-the-Loop (HITL):** Human evaluators review the agent's performance, providing qualitative feedback on the reasoning process and the quality of the final output. This is crucial for nuanced or subjective tasks.
+*   **Model-Based Evaluation:** Using a powerful "judge" LLM (like GPT-4 or Claude 3 Opus) to score an agent's output against a predefined rubric. This can scale evaluation but requires careful calibration.
+*   **Simulation Environments:** Creating sandboxed environments where the agent can interact with mock tools and data. This allows for safe, repeatable testing of complex interactions.
+*   **Trajectory-Based Evaluation:** Analyzing the entire sequence of the agent's thoughts and actions (its "trajectory") rather than just the final result. This is key to understanding *how* an agent works and identifying failure modes in its reasoning. The concept of [Directed Agentic Graphs](/resources/ai/directed-agentic-graphs) provides a formal structure for managing and analyzing these complex trajectories.
+
+## Why AI Agent Evaluation Needs Orchestration
+
+As evaluation scenarios become more sophisticated, running them manually becomes untenable. Orchestration is the key to building a scalable, repeatable, and reliable evaluation system. It addresses several critical challenges:
+
+*   **Automation:** Evaluation often involves a sequence of steps: setting up an environment, running the agent against a dataset, executing an evaluation script, and storing the results. An orchestrator automates this entire pipeline.
+*   **Integration:** A typical evaluation pipeline involves multiple components: the agent itself, LLM providers, evaluation frameworks (like DeepEval or LangChain), data sources, and notification systems. Orchestration unifies these disparate tools into a single, cohesive workflow.
+*   **Lifecycle Management:** It manages the entire lifecycle of an evaluation run, including versioning of agents, datasets, and evaluation logic. This ensures that results are reproducible and comparable over time.
+*   **Scheduling and Triggering:** Evaluations can be triggered on a schedule (e.g., nightly regression tests), on-demand, or in response to events like a new agent model being pushed to a repository. This is a core function of [event-driven orchestration](/resources/infrastructure/event-driven-orchestration).
+*   **Reliability and Alerting:** Orchestration platforms provide built-in error handling, retries, and alerting. If an evaluation run fails, the team is notified immediately, preventing faulty agents from progressing through the development lifecycle.
+*   **Continuous Improvement:** By automating the evaluation feedback loop, orchestration enables a form of [CI/CD orchestration](/resources/infrastructure/ci-cd-orchestration) for AI agents, where every change can be automatically benchmarked, accelerating iteration and improvement.
+
+In essence, orchestration treats agent evaluation as a production-grade data pipeline, bringing engineering rigor to the process of building trustworthy AI.
+
+## Orchestrate AI Agent Evaluation with Kestra: An End-to-End Workflow
+
+Kestra provides a powerful, declarative platform for orchestrating complex AI workflows, including evaluation pipelines. The following example demonstrates a simple flow that runs an AI agent, evaluates its output with a Python script, and sends a Slack notification if the evaluation fails.
+
+```yaml
+id: ai-agent-evaluation-pipeline
+namespace: prod.evaluations
+
+tasks:
+  - id: run_agent
+    type: io.kestra.plugin.ai.agent.AIAgent
+    prompt: "What is the current capital of France and what is the weather there?"
+    temperature: 0.7
+    model: "gpt-4-turbo"
+    # Assumes an OpenAI connection is configured in Kestra
+    
+  - id: evaluate_output
+    type: io.kestra.plugin.scripts.shell.Commands
+    runner: DOCKER
+    docker:
+      image: python:3.11-slim
+    commands:
+      - |
+        pip install -q pytest
+        cat <<'EOF' > test_agent_output.py
+        import os
+        import json
+        import pytest
+
+        def test_capital_and_weather():
+            output_str = os.getenv('AGENT_OUTPUT')
+            assert output_str is not None, "Agent output is missing"
+            
+            # Simple checks for keywords
+            assert "paris" in output_str.lower(), "The capital 'Paris' was not mentioned"
+            assert "weather" in output_str.lower(), "The term 'weather' was not mentioned"
+            assert "°C" in output_str or "°F" in output_str or "celsius" in output_str.lower() or "fahrenheit" in output_str.lower(), "No temperature unit found"
+
+        EOF
+        pytest test_agent_output.py
+    env:
+      AGENT_OUTPUT: "{{ outputs.run_agent.chunks | join(' ') }}"
+
+errors:
+  - id: notify_on_failure
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    payload: |
+      {
+        "text": "AI Agent Evaluation Failed for flow `{{ flow.namespace }}.{{ flow.id }}`\nExecution: `{{ execution.id }}`\nTask: `{{ task.id }}`\nError: Evaluation script failed. Please check the logs."
+      }
+```
+
+This workflow demonstrates a complete, automated evaluation loop. Here are a few things worth noticing:
+*   **Declarative & Reproducible:** The entire evaluation logic is defined in a single YAML file, making it easy to version, review, and reproduce.
+*   **Polyglot Execution:** Kestra seamlessly orchestrates the [AI Agent task](/plugins/plugin-ai/agent/io.kestra.plugin.ai.agent.AIAgent) with a Python evaluation script running in a Docker container via the [Shell Commands plugin](/plugins/plugin-scripts-shell/commands). You can use any language or tool for your evaluation logic.
+*   **Data Flow:** The output from the agent task (`run_agent`) is passed directly as an environment variable to the evaluation task (`evaluate_output`), creating a clean data dependency.
+*   **Built-in Error Handling:** The `errors` block automatically catches any failure in the `evaluate_output` task (e.g., a failed pytest assertion) and triggers a Slack notification, providing immediate feedback.
+
+### Best Practices for Implementing Orchestrated Evaluation
+
+To maximize the value of orchestrated evaluation, consider these best practices:
+*   **Design Robust Scenarios:** Go beyond simple "hello world" tests. Create a diverse evaluation dataset that includes edge cases, adversarial inputs, and scenarios that test the agent's ability to recover from errors.
+*   **Integrate into Your CI/CD Pipeline:** Trigger evaluation workflows automatically whenever a new version of your agent is deployed. This prevents regressions and ensures that only high-quality agents reach production.
+*   **Establish Baselines:** Run evaluations against a stable "baseline" version of your agent. This allows you to quantify the impact of changes and make data-driven decisions about model updates.
+*   **Implement [AI Governance Workflows](/resources/ai/ai-governance-workflows):** Use orchestration to enforce governance rules, such as requiring a successful evaluation and human approval before an agent can be promoted to production.
+
+## Where AI Agent Evaluation Pays Off
+
+Implementing a robust, orchestrated evaluation strategy delivers tangible benefits across the AI development lifecycle:
+*   **Ensuring Safety and Compliance:** Systematically test agents against safety benchmarks and ethical guidelines before they interact with real users or production systems.
+*   **Validating Performance:** Confidently validate that your agent performs as expected across a wide range of inputs and scenarios, reducing the risk of production failures.
+*   **Benchmarking and Improvement:** Objectively compare different agent versions, models, or prompting strategies to drive continuous improvement.
+*   **Accelerating Iteration:** Automate the tedious process of manual testing, allowing your team to iterate faster and focus on building better agents.
+*   **Building Trust and Auditability:** Provide a clear, auditable record of an agent's capabilities and limitations, building trust with stakeholders and meeting regulatory requirements. This is especially critical for complex systems like [RAG architectures](/resources/ai/rag-architecture).
+
+## Related concepts
+
+AI agent evaluation is part of a broader ecosystem of technologies and practices for building and managing sophisticated AI systems.
+*   **[Multi-Agent Systems](/resources/ai/multi-agent-system):** When multiple agents collaborate, evaluation becomes even more complex, requiring assessment of communication, coordination, and emergent group behavior.
+*   **[LLM Evaluation](/resources/ai/llm-evaluation):** The foundation upon which agent evaluation is built, providing the core techniques for assessing the quality of language-based outputs.
+*   **[Agentic Workflows](/resources/ai/agentic-workflows):** The structured processes that agents execute. Evaluating the workflow itself—its efficiency and robustness—is as important as evaluating the agent.
+*   **[MLOps](/resources/ai/what-is-mlops):** Agent evaluation is a key component of a mature MLOps practice, bringing principles of automation, versioning, and continuous integration to AI development.
+*   **[RAG Pipelines](/resources/ai/rag-pipeline):** For agents that use Retrieval-Augmented Generation, evaluation must also cover the performance of the retrieval system and the agent's ability to synthesize retrieved information.
+
+Ready to streamline your AI agent evaluation? [Explore Kestra's AI orchestration capabilities](/ai-automation) and start building reliable, production-grade agents today.

--- a/src/contents/resources/ai-agent-orchestration/index.md
+++ b/src/contents/resources/ai-agent-orchestration/index.md
@@ -1,0 +1,150 @@
+---
+title: "AI Agent Orchestration: Governing Autonomous Workflows in Production"
+description: "Explore AI agent orchestration, the critical discipline for coordinating multiple AI agents to achieve complex goals reliably. Learn how declarative platforms enable scalable, auditable, and human-in-the-loop agentic workflows."
+metaTitle: "AI Agent Orchestration: Governing Autonomous Workflows"
+metaDescription: "Coordinate multiple AI agents in production: manage complex goals and ensure reliability with declarative, auditable human-in-the-loop workflows."
+tag: "ai"
+date: 2026-08-05
+slug: "ai-agent-orchestration"
+faq:
+  - question: "What is AI agent orchestration?"
+    answer: "AI agent orchestration is the practice of designing, coordinating, and managing multiple specialized AI agents to work collaboratively towards a common objective. It involves defining their roles, communication protocols, execution order, and error handling to ensure reliable and efficient goal achievement in complex environments."
+  - question: "Why is orchestration critical for AI agents in production?"
+    answer: "Orchestration is crucial for production AI agents to ensure reliability, scalability, and governance. It provides a framework for error handling, retries, human oversight, and integration with external systems, preventing agent failures from cascading and ensuring that autonomous systems operate within defined boundaries and business rules."
+  - question: "How does Kestra support AI agent orchestration?"
+    answer: "Kestra provides a declarative, YAML-based platform for defining, triggering, and monitoring AI agent workflows. It enables agents to use diverse tools, orchestrates their interactions, and integrates human-in-the-loop approvals, offering full auditability and version control for every agent action and decision."
+  - question: "What are the key components of an AI agent orchestration system?"
+    answer: "A typical system includes AI agents (specialized models with tools and memory), an orchestration layer (defining flow, triggers, and dependencies), a tool registry (APIs, databases, scripts), a communication bus, and an observability layer for monitoring and debugging. Human-in-the-loop mechanisms are also vital for oversight."
+  - question: "What are common challenges in orchestrating AI agents?"
+    answer: "Challenges include managing complex interdependencies, ensuring data consistency across agents, handling unexpected agent behaviors, maintaining security and compliance, and providing clear visibility into multi-agent decision-making. Scalability and cost optimization for LLM calls are also significant concerns."
+  - question: "Can AI agent orchestration integrate with existing enterprise systems?"
+    answer: "Yes, effective AI agent orchestration platforms are designed to integrate seamlessly with existing enterprise systems, including databases, CRM, ERP, cloud services, and custom APIs. This allows agents to leverage current data and trigger actions across the organization, extending automation capabilities without requiring a full system overhaul."
+---
+
+The promise of AI agents to automate complex tasks is vast, but bringing them into production requires more than just building smart agents. It demands a robust system to coordinate their interactions, manage dependencies, and ensure reliable execution. Without effective orchestration, autonomous agents can quickly become chaotic, costly, and difficult to govern.
+
+This guide explores AI agent orchestration – the essential discipline for turning individual agents into a cohesive, goal-oriented system. We'll define its core concepts, examine how it works in practice, and highlight how platforms like Kestra provide the declarative control plane needed to deploy and manage AI agents in enterprise environments.
+
+## Why AI Agent Orchestration is Essential for Production AI
+
+As AI capabilities grow, the focus is shifting from single, monolithic models to dynamic, collaborative systems of specialized agents. This evolution introduces immense power but also significant complexity. AI agent orchestration provides the structure needed to manage this complexity, making agentic AI a viable and reliable enterprise technology.
+
+### Defining AI Agent Orchestration
+
+AI agent orchestration is the process of coordinating multiple autonomous AI agents to work together toward a shared objective. It’s the framework that defines how agents communicate, what tasks they perform, in what order, and how they handle exceptions and failures. This goes beyond simple prompt chaining; it involves managing the entire lifecycle of a multi-agent task, from initiation to completion, with full visibility and control.
+
+An orchestration platform acts as the central nervous system for a [multi-agent system](/resources/ai/multi-agent-system), ensuring that each agent, whether it's designed for data analysis, code generation, or customer interaction, contributes effectively to the overall goal without conflicts or redundancy.
+
+### The Shift from Single Agents to Collaborative Systems
+
+Early AI applications often relied on a single agent to perform a task. However, complex real-world problems are rarely solved by a single skill set. A financial forecasting task might require one agent to gather market data, another to perform statistical analysis, a third to generate a report, and a fourth to summarize findings for an executive audience.
+
+This is where [multi-agent collaboration](/resources/ai/multi-agent-collaboration-evolving-orchestration) becomes critical. Orchestration enables this collaboration by:
+- **Decomposing Complex Tasks:** Breaking down a large goal into smaller, manageable sub-tasks assigned to specialized agents.
+- **Managing Dependencies:** Ensuring that an agent only begins its task after its prerequisite inputs are available from other agents.
+- **Facilitating Communication:** Providing a structured way for agents to exchange information, results, and state.
+- **Ensuring Goal Alignment:** Keeping all agents focused on the primary objective, even as they operate with a degree of autonomy.
+
+Without orchestration, a team of powerful AI agents is just a collection of individuals. With it, they become a high-performance, autonomous workforce.
+
+## How Kestra Enables Declarative AI Agent Orchestration
+
+Kestra provides a declarative, event-driven platform that is uniquely suited for the challenges of AI agent orchestration. By defining workflows in simple YAML, teams can create complex, auditable, and reliable agentic systems that are easy to version, review, and deploy.
+
+### Building Agents with Tools, Memory, and Goals
+
+In Kestra, an [AI agent](/docs/ai-tools/ai-agents) is not just a call to an LLM; it's a configurable task that combines a large language model with memory and a set of tools.
+
+- **Tools:** These are the skills an agent can use to interact with the outside world. A tool could be a simple shell command, a database query, an API call, or even another Kestra flow. This allows you to ground your agents in reality, giving them access to the specific data and systems they need to accomplish their goals.
+- **Memory:** Kestra agents can be configured with memory, allowing them to retain context from previous steps or conversations. This is crucial for multi-step tasks where information must be carried forward.
+- **Goals:** You define the agent's objective using a clear, natural language prompt, guiding its decision-making process.
+
+Here is a simple example of a Kestra flow where an agent uses a tool to get the current date and answers a question based on it:
+
+```yaml
+id: agent-with-date-tool
+namespace: company.team.ai
+
+tasks:
+  - id: ask-question-with-date
+    type: io.kestra.plugin.ai.agent.AIAgent
+    model: "gpt-4"
+    prompt: "What day of the week is it today?"
+    tools:
+      - id: get_current_date
+        type: io.kestra.plugin.core.script.Shell
+        description: "Get the current date."
+        commands:
+          - date
+```
+
+This declarative approach makes it easy to [build and manage AI agents](/resources/ai/how-to-build-an-ai-agent), turning complex agentic logic into manageable, version-controlled code.
+
+### Orchestration Patterns for Agentic Workflows
+
+Kestra’s flowable task model supports several key patterns for orchestrating agent interactions:
+
+- **Sequential:** One agent completes its task, and its output becomes the input for the next agent. This is the simplest pattern for linear, multi-step processes.
+- **Parallel:** Multiple agents run simultaneously to perform independent sub-tasks, with their results aggregated later. This is useful for tasks like gathering data from multiple sources at once.
+- **Conditional:** The workflow branches based on the output of an agent. For example, if an agent detects an anomaly, a different set of agents is triggered for remediation.
+- **Hierarchical:** A "manager" agent decomposes a problem and assigns sub-tasks to "worker" agents. This can be modeled using subflows in Kestra, where a parent flow orchestrates child flows, each representing a specialized agent's work. You can even create sophisticated routing systems with agents, as shown in this [AI agent flow routing blueprint](/blueprints/ai-agent-calling-flows).
+
+### Integrating Human-in-the-Loop for Trust and Control
+
+Full autonomy is not always desirable, especially in critical enterprise processes. Kestra natively supports [human-in-the-loop (HITL) orchestration](/resources/ai/human-in-the-loop-orchestration), allowing you to insert manual approval steps into agentic workflows. An agent can propose an action—like deploying code or sending a customer communication—and the workflow will pause until a human operator reviews and approves it. This builds a crucial layer of trust and safety, ensuring that autonomous systems operate under human oversight.
+
+## Benefits of Orchestrating AI Agents with a Unified Platform
+
+Using a dedicated orchestration platform like Kestra for your agentic workflows provides significant advantages over ad-hoc scripts or embedded framework logic. The benefits extend beyond simple task execution to encompass reliability, scalability, and governance.
+
+### Enhanced Reliability and Error Handling
+
+When an agent fails—due to a hallucination, a faulty tool, or an API timeout—an orchestration platform provides robust error handling. You can configure automatic retries with exponential backoff, define fallback agents, or trigger alert notifications to an on-call team. This resilience is fundamental for production systems and is often missing from pure AI development frameworks. By managing the execution state externally, the orchestrator ensures that workflows can recover from transient failures and proceed to completion.
+
+### Scalability and Resource Optimization for LLM Workloads
+
+Orchestrating agents allows for more intelligent use of resources, particularly expensive LLM calls. For example, you can design workflows where a cheaper, faster model is used for initial data classification, and a more powerful model like GPT-4 is only invoked for complex reasoning tasks. A unified platform provides visibility into execution times and costs, helping you optimize your [AI automation pipelines](/ai-automation) for both performance and budget.
+
+### Auditability and Governance for Autonomous Systems
+
+One of the biggest challenges with autonomous agents is understanding why they made a particular decision. A declarative orchestration platform provides a complete, immutable audit trail for every agentic workflow. Every input, output, tool call, and decision is logged and version-controlled. This transparency is essential for debugging, compliance, and building trust in your AI systems. When you need to know exactly what an agent did and why, the orchestration log provides the ground truth. This is a core component of any serious [AI-native orchestration platform](/resources/ai/ai-native-orchestration-platform).
+
+## Challenges in AI Agent Orchestration and Kestra's Solutions
+
+While powerful, orchestrating AI agents introduces new challenges. A capable orchestration platform must provide solutions to manage complexity, ensure security, and adapt to a rapidly changing ecosystem.
+
+### Managing Complexity and Interdependencies
+
+As the number of agents and their interactions grow, the web of dependencies can become difficult to manage. Kestra's declarative YAML and visual UI help tame this complexity. Workflows are defined as code, allowing for version control, code reviews, and modular design using subflows. The visual topology view makes it easy to understand dependencies at a glance, simplifying both development and troubleshooting.
+
+### Ensuring Security, Compliance, and Data Privacy
+
+Agents often require access to sensitive data and systems. Ensuring they operate securely is paramount. Kestra provides enterprise-grade [workflow orchestration security](/resources/infrastructure/workflow-orchestration-security) features, including secrets management, Role-Based Access Control (RBAC), and audit logs. You can securely store API keys and other credentials, and control which agents have access to which tools and data, ensuring that autonomous processes adhere to your organization's security policies.
+
+### The Evolving Landscape of AI Agent Frameworks
+
+The AI space is moving incredibly fast, with new models and frameworks emerging constantly. An effective orchestration platform must be vendor-agnostic, allowing you to integrate the best tools for the job without being locked into a single ecosystem. Kestra's plugin-based architecture, with over 1,700 integrations, ensures you can connect to any LLM, vector database, or AI service. This flexibility allows you to evolve your AI stack without having to re-architect your core orchestration logic. Kestra's [agent skills](/docs/ai-tools/agent-skills) further extend this by allowing agents to operate Kestra itself, creating powerful self-managing workflows.
+
+## Implementing AI Agent Orchestration in Your Enterprise
+
+Adopting AI agent orchestration is a strategic move that can unlock new levels of automation. A phased, practical approach is key to success.
+
+### Steps for Successful Deployment
+
+1.  **Identify a High-Value Use Case:** Start with a well-defined business problem where agentic automation can provide a clear ROI. Examples include automated incident response, dynamic data analysis reports, or personalized customer onboarding.
+2.  **Define Agent Roles and Tools:** Break down the problem and define the specific roles for each agent. What data will they need? What actions can they take? Implement these as well-scoped tools.
+3.  **Design the Orchestration Flow:** Map out the interactions and dependencies between agents using a declarative workflow. Start simple, perhaps with a sequential flow, and introduce complexity iteratively.
+4.  **Incorporate Human Oversight:** Build in human-in-the-loop approval steps for any critical or irreversible actions.
+5.  **Test, Monitor, and Iterate:** Deploy the workflow in a staging environment. Monitor its performance, cost, and accuracy, and use the insights to refine both the agents and the orchestration logic.
+
+### Real-World Use Cases Across Industries
+
+-   **IT Operations:** An agent detects a performance anomaly from monitoring alerts, another agent queries logs to find the root cause, a third proposes a remediation script, and a human operator approves the fix for execution.
+-   **Financial Services:** A team of agents collaborates to produce a daily market analysis report. One agent pulls stock data, another fetches news sentiment, a third performs technical analysis, and a final agent synthesizes the information into a summary.
+-   **E-commerce:** A customer support agent analyzes an incoming query, determines it's a request for a refund, and triggers a separate workflow where another agent processes the refund in the payment system and updates the CRM.
+
+## Why Kestra is the Control Plane for AI Agent Orchestration
+
+As Kestra CTO Ludovic Dehon states, "AI won't replace the need for orchestration — it will demand more engineering rigor." AI agents are powerful components, but they require a robust control plane to be effective in the enterprise.
+
+Kestra provides this control plane. Its declarative, language-agnostic, and event-driven architecture makes it the ideal platform to govern, scale, and observe agentic workflows. By unifying data, infrastructure, and AI orchestration on a single platform, Kestra ensures that your autonomous systems are not isolated black boxes but are fully integrated, reliable, and auditable components of your modern data stack. Whether you are just beginning to explore [agentic orchestration](/resources/ai/agentic-orchestration) or are looking to scale your existing AI initiatives, Kestra provides the foundation for building production-ready AI solutions.

--- a/src/contents/resources/ai-orchestration/index.md
+++ b/src/contents/resources/ai-orchestration/index.md
@@ -1,0 +1,186 @@
+---
+title: "AI Orchestration: Unifying Data, Models, and Agents for Enterprise AI"
+description: "AI orchestration streamlines complex AI workflows by coordinating models, data pipelines, and intelligent agents. Learn how a declarative platform unifies your enterprise AI strategy."
+metaTitle: "AI Orchestration: Unifying AI Models and Workflows"
+metaDescription: "AI orchestration unifies data, models, and agents for enterprise AI. Declarative platforms optimize complex AI workflows, improving efficiency and scalability."
+tag: ai
+date: 2026-08-05
+slug: ai-orchestration
+faq:
+  - question: What is orchestration in AI?
+    answer: AI orchestration is the coordinated management of various components within an AI system, including machine learning models, data pipelines, infrastructure, and intelligent agents. It ensures these elements work together seamlessly to achieve specific AI-driven objectives, providing end-to-end control, monitoring, and governance.
+  - question: What is an example of AI orchestration?
+    answer: An example of AI orchestration is a RAG (Retrieval Augmented Generation) pipeline. This involves orchestrating data ingestion into a vector database, embedding generation, semantic search, LLM calls, and human-in-the-loop validation, all coordinated to provide accurate, context-aware responses from an AI application.
+  - question: What is the best AI orchestration tool?
+    answer: The "best" AI orchestration tool depends on specific needs. Kestra stands out as an open-source, declarative platform that unifies data, AI, and infrastructure workflows with polyglot execution, strong governance, and native support for AI agents, making it ideal for complex, enterprise-grade AI applications.
+  - question: How does AI agent orchestration differ from general AI orchestration?
+    answer: AI agent orchestration is a specific subset of general AI orchestration focused on coordinating multiple autonomous AI agents to achieve shared goals. General AI orchestration has a broader scope, managing the entire lifecycle of AI systems, including data pipelines, model training, deployment, and monitoring, with or without agents.
+  - question: What are the key benefits of AI orchestration?
+    answer: Key benefits include improved reliability and reproducibility of AI workflows, enhanced visibility and governance across the AI lifecycle, faster deployment of AI models, better resource utilization, and the ability to integrate human oversight for ethical AI development.
+  - question: Can AI orchestration integrate with existing data pipelines?
+    answer: Yes, effective AI orchestration platforms are designed to integrate seamlessly with existing data pipelines and infrastructure. They act as a control plane, coordinating data ingestion, transformation, and movement to feed AI models and process their outputs, often leveraging existing data tools like dbt, Snowflake, or Kafka.
+  - question: How does Kestra support AI orchestration?
+    answer: Kestra supports AI orchestration through declarative YAML workflows, a polyglot execution engine, 1,700+ plugins for diverse AI services and data tools, and native support for AI agents. It provides enterprise-grade features like audit logs, RBAC, and human-in-the-loop capabilities to govern complex AI systems.
+---
+
+The promise of artificial intelligence is immense, but bringing AI models and agents into production at scale often creates new challenges. Fragmented tools, complex data dependencies, and a lack of unified oversight can turn ambitious AI initiatives into operational nightmares. Teams struggle to coordinate data pipelines, train models, deploy inference services, and manage autonomous agents reliably.
+
+AI orchestration provides the missing control plane. It's the practice of unifying the entire lifecycle of AI systems, from data ingestion to model deployment and agent supervision, under a single, auditable, and automated framework. This article explores how AI orchestration simplifies complexity, enhances governance, and accelerates the journey from AI concept to production-ready solution.
+
+## Why unified AI orchestration is essential for enterprise AI
+
+In the rush to adopt AI, many organizations assemble a collection of specialized tools for data preparation, model training, inference, and monitoring. While each tool may be best-in-class for its specific function, the result is often a fragmented and brittle AI stack. This fragmentation creates significant operational overhead, as teams must write and maintain "glue code" to connect disparate systems, manage complex dependencies manually, and troubleshoot failures across multiple platforms.
+
+Without a centralized control plane, visibility into the end-to-end AI lifecycle is lost. It becomes difficult to ensure reproducibility, track data lineage, and enforce governance policies. As AI systems grow in complexity, these challenges multiply, slowing down innovation and increasing operational risk.
+
+A unified approach to AI orchestration addresses these problems directly. By providing a single platform to define, execute, and monitor all AI-related workflows, it delivers:
+- **Reliability and Reproducibility:** Standardized workflows ensure that AI processes run consistently every time, which is critical for compliance and debugging.
+- **Enhanced Governance:** A central point of control makes it easier to implement security policies, manage access, and maintain a complete audit trail of all AI activities.
+- **Faster Time-to-Market:** Automating the end-to-end lifecycle, from data ingestion to model deployment, allows teams to deliver AI-powered features more quickly.
+- **Improved Collaboration:** A shared platform breaks down silos between data, ML, and operations teams, fostering a more collaborative and efficient environment.
+
+An effective [orchestrator for data, AI, and infrastructure](/resources/data/orchestrator) becomes the backbone of a scalable and manageable AI strategy, enabling a wide range of [workflow automation use cases](/use-cases) across the enterprise. This is the core principle behind [AI-native orchestration platforms](/resources/ai/ai-native-orchestration-platform) that are built to handle the unique demands of modern AI.
+
+## Defining AI orchestration vs. AI agent orchestration
+
+The term "AI orchestration" is often used broadly, but it's useful to distinguish between the general practice and the more specific discipline of agent orchestration.
+
+### What is AI orchestration?
+
+AI orchestration is the end-to-end coordination and management of all components in an AI system. This includes the entire lifecycle:
+- **Data Pipelines:** Ingesting, cleaning, transforming, and versioning data for training and inference.
+- **Model Training:** Automating the process of training, validating, and registering machine learning models.
+- **Model Deployment:** Deploying models as inference services with versioning and rollback capabilities.
+- **Inference Workflows:** Triggering model predictions based on events or schedules and processing the results.
+- **Monitoring and Governance:** Tracking model performance, detecting drift, and ensuring compliance with organizational policies.
+
+In essence, AI orchestration provides the framework to build, run, and manage reliable AI applications at scale.
+
+### How AI agent orchestration adds a new layer
+
+[Agentic orchestration](/resources/ai/agentic-orchestration) is a specialized subset of AI orchestration that focuses on coordinating the actions of multiple autonomous AI agents. As AI systems become more sophisticated, they increasingly rely on agents that can reason, plan, and use tools to accomplish complex tasks.
+
+AI agent orchestration manages how these agents collaborate, share information, and work together towards a common objective. This often involves concepts like [Directed Agentic Graphs](/resources/ai/directed-agentic-graphs), where the workflow is not static but evolves based on the decisions made by the agents themselves. Managing these dynamic, multi-agent systems requires a robust orchestration layer that can provide supervision, governance, and observability. Kestra's support for [AI agents](/docs/ai-tools/ai-agents) is designed to address this emerging need, allowing teams to build and govern complex agentic workflows.
+
+## How AI orchestration works in practice
+
+At its core, an AI orchestration platform acts as the central nervous system for your AI applications, connecting various tools and processes into a cohesive workflow.
+
+### Key components of an AI orchestration system
+
+- **Data Pipelines:** Integrations to data sources, warehouses, and streaming platforms to ensure models have access to timely and accurate data.
+- **Model Management:** A registry to store, version, and manage the lifecycle of machine learning models.
+- **Execution Engine:** The core component that runs workflow tasks, managing dependencies, retries, and error handling.
+- **Triggers:** Mechanisms to initiate workflows based on schedules, events (like a new file in S3), or API calls.
+- **Monitoring and Logging:** Tools to provide visibility into workflow performance, track metrics, and debug issues.
+- **Security and Governance:** Features like Role-Based Access Control (RBAC), secrets management, and audit logs.
+- **Human-in-the-Loop:** Capabilities to pause workflows and insert manual approval or validation steps.
+
+### A practical example: Orchestrating a RAG pipeline
+
+A common AI workflow is Retrieval-Augmented Generation (RAG), which enhances Large Language Model (LLM) responses with information from a private knowledge base. A [RAG pipeline orchestration](/resources/ai/rag-pipeline) involves several coordinated steps:
+
+1.  **Data Ingestion:** Extracting data from sources like documents, websites, or databases.
+2.  **Data Processing:** Cleaning and chunking the text into manageable pieces.
+3.  **Embedding Generation:** Using an embedding model to convert text chunks into numerical vectors.
+4.  **Vector Store Indexing:** Loading the vectors into a specialized vector database for efficient searching.
+5.  **Inference:** When a user query arrives, the orchestrator retrieves relevant vectors, passes them to the LLM as context, and returns the augmented response.
+6.  **Validation:** Optionally, a [human-in-the-loop orchestration](/resources/ai/human-in-the-loop-orchestration) step can be included to have a person review and approve sensitive or critical AI-generated responses before they are sent to the end-user.
+
+This entire process can be defined and automated in a single workflow. For instance, a task to query an LLM agent within a RAG pipeline might look like this in Kestra's declarative YAML:
+
+```yaml
+id: rag-pipeline-orchestration
+namespace: company.ai.rag
+
+description: Orchestrates a RAG pipeline from data ingestion to LLM response.
+
+tasks:
+  - id: ingest_data
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      main.py: |
+        import pandas as pd
+        # Simulate data ingestion
+        df = pd.DataFrame({'text': ['Kestra is an orchestration platform.', 'AI agents use tools.']})
+        df.to_csv("ingested_data.csv", index=False)
+    runner:
+      type: io.kestra.plugin.scripts.runner.Process
+    outputFiles:
+      - ingested_data.csv
+
+  - id: generate_embeddings
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      main.py: |
+        import pandas as pd
+        # Simulate embedding generation
+        df = pd.read_csv("ingested_data.csv")
+        df['embedding'] = df['text'].apply(lambda x: [0.1, 0.2] if 'Kestra' in x else [0.3, 0.4])
+        df.to_csv("embeddings.csv", index=False)
+    runner:
+      type: io.kestra.plugin.scripts.runner.Process
+    outputFiles:
+      - embeddings.csv
+    dependsOn:
+      - ingest_data
+
+  - id: query_llm_agent
+    type: io.kestra.plugin.ai.openai.Agent
+    model: gpt-4o
+    prompt: "Based on the text: {{ outputs.ingest_data.outputFiles['ingested_data.csv'] }}, what is Kestra?"
+    tools:
+      - name: web_search
+        description: "Search the web for information."
+    description: "An AI agent queries the LLM based on ingested data."
+    dependsOn:
+      - generate_embeddings
+```
+
+## Key features of modern AI orchestration platforms
+
+When evaluating AI orchestration platforms, several key features are essential for building scalable and maintainable systems.
+
+- **Declarative Workflow Definition:** Defining workflows as code, typically in YAML, allows for version control, code reviews, and GitOps-style management. This [YAML-first orchestration](/blogs/yaml-for-workflow-orchestration) approach separates workflow logic from business logic.
+- **Polyglot Execution:** The ability to run tasks written in any language (Python, R, SQL, Bash, etc.) is crucial for heterogeneous AI teams. [Language-agnostic orchestration](/features/code-in-any-language) ensures that the platform doesn't force a specific programming language on your team.
+- **Event-Driven Triggers:** Modern AI applications need to react to real-time events. [Event-driven orchestration](/resources/infrastructure/event-driven-orchestration) enables workflows to be triggered by message queues, webhooks, or file system events.
+- **Robust Error Handling:** The platform should provide sophisticated mechanisms for retries, timeouts, and conditional error branching to build resilient pipelines.
+- **Extensive Plugin Ecosystem:** A rich library of pre-built integrations for various data sources, AI services, and infrastructure tools accelerates development and reduces the need for custom code.
+- **Observability:** Comprehensive logging, monitoring, and visualization tools are necessary to understand workflow behavior, diagnose issues, and ensure performance.
+- **Security & Governance:** Enterprise-grade features like RBAC, SSO, audit logs, and secrets management are non-negotiable for production AI systems.
+
+## Comparing top AI orchestration tools and platforms
+
+The market for [AI and data orchestration platforms](/blogs/top-data-orchestration-platforms) is diverse, with tools ranging from general-purpose orchestrators to specialized ML platforms and cloud-native services. Choosing the right one depends on your team's skills, existing infrastructure, and specific use cases.
+
+Here is a comparison of some popular [ETL and AI orchestration tools](/resources/data/etl-orchestration-tool-alternatives):
+
+| Feature | Kestra | Prefect | Databricks Workflows | AWS Step Functions |
+|---|---|---|---|---|
+| **Definition Format** | Declarative YAML | Python Code (imperative) | UI / API / Python | JSON (Amazon States Language) |
+| **Language Support** | Polyglot (any language) | Python-first | Python, SQL, Scala, R | Lambda (any language) |
+| **Deployment** | Kubernetes, Docker, Bare Metal | Kubernetes, Docker, Cloud | Databricks Platform Only | AWS Managed Service |
+| **Primary Use Case** | Unified Data, AI, Infra | Python Data & AI Pipelines | Databricks Lakehouse Jobs | AWS Serverless & Microservices |
+| **Governance** | Enterprise-grade RBAC, SSO, Audit Logs | Cloud-based RBAC, Audit Logs | Unity Catalog Integration | AWS IAM Integration |
+
+While many platforms exist, a key differentiator is whether the tool is a specialized component or a true unifying layer. Some organizations may also look for specific [Orchestra alternatives](/resources/data/getorchestra-io-alternatives) to fit their unique stack.
+
+## Implementing AI orchestration with Kestra
+
+Kestra is an open-source platform designed to be the [orchestration control plane of the AI era](/blogs/kestra-series-a). It provides a unified solution for orchestrating data, AI, and infrastructure workflows through a simple, declarative YAML interface.
+
+With Kestra, you can:
+- **Unify Your Stack:** Use a single platform to coordinate everything from data ingestion and transformation with tools like dbt and Snowflake, to model training with Python scripts, to deploying applications on Kubernetes.
+- **Empower All Teams:** The declarative nature of YAML makes workflows accessible to a broader audience, enabling [AI orchestration for non-technical teams](/resources/ai/ai-orchestration-for-non-technical-teams) to collaborate with engineers.
+- **Leverage a Vast Ecosystem:** With over [1,700 plugins](/plugins) for popular AI providers, vector databases, cloud services, and data tools, you can connect your entire stack without writing boilerplate code.
+- **Scale with Confidence:** Kestra's architecture is built for scale, having executed over 2 billion workflows in 2025. The Enterprise Edition provides the governance, security, and support needed for mission-critical AI applications.
+
+Kestra's approach is to provide a flexible, language-agnostic control plane that adapts to your tools and teams, rather than forcing you into a rigid framework. You can [stop writing glue code and start orchestrating](/ai-automation).
+
+## The future of AI orchestration: Agents, LLMs, and beyond
+
+The field of AI is evolving rapidly, and orchestration platforms must evolve with it. The rise of [autonomous AI agents](/blogs/introducing-ai-agents) and complex LLM-powered applications is placing new demands on orchestration. The future will require platforms that can manage dynamic, decision-driven workflows and provide robust governance for increasingly autonomous systems.
+
+Orchestration is no longer just about scheduling static tasks; it's about providing the guardrails, observability, and human oversight for intelligent systems. Platforms that embrace this new reality by integrating features like AI Copilots for workflow generation and native support for agentic patterns will be essential for building the next generation of AI applications.
+
+To learn more about how to build reliable and scalable AI systems, explore our [AI orchestration resources](/resources/ai).

--- a/src/contents/resources/business-process-management-tools/index.md
+++ b/src/contents/resources/business-process-management-tools/index.md
@@ -1,0 +1,161 @@
+---
+title: "Top Business Process Management Tools: A Comprehensive Guide"
+description: "Explore leading business process management (BPM) tools, their core features, and how they drive operational efficiency. Discover alternatives, including Kestra, for unifying your workflows across data, AI, and infrastructure."
+metaTitle: "Business Process Management Tools: Guide & Alternatives"
+metaDescription: "Optimize operations with top Business Process Management (BPM) tools. Explore features, types, and alternatives for unifying workflows across your enterprise."
+tag: "business"
+date: 2026-08-05
+slug: "business-process-management-tools"
+faq:
+  - question: "What are the essential tools used in business processes?"
+    answer: "Essential tools for managing business processes include process modeling software like BPMN tools, workflow automation platforms, business rules engines, and analytics dashboards. These tools facilitate process design, execution, monitoring, and optimization, enabling organizations to streamline operations and improve efficiency."
+  - question: "What are the five pillars of Business Process Management (BPM)?"
+    answer: "The five pillars of BPM are Process Design and Modeling, Process Execution and Automation, Performance Measurement, Process Optimization, and Governance and Compliance. These interconnected stages form a continuous cycle aimed at improving organizational efficiency and effectiveness."
+  - question: "What exactly are Business Process Management (BPM) tools?"
+    answer: "BPM tools are software applications designed to help organizations define, automate, execute, monitor, and optimize business processes. They eliminate repetitive manual work, make information more accessible, and allow employees to focus on high-value tasks, leading to increased customer satisfaction and operational gains."
+  - question: "Which BPM tool is considered the best for enterprise-wide adoption?"
+    answer: "The 'best' BPM tool depends heavily on an organization's specific needs, existing tech stack, and desired level of technical control. While some enterprises favor comprehensive suites like Camunda or Microsoft Power Automate, others prefer flexible, declarative platforms like Kestra for unifying diverse workloads across data, AI, and infrastructure."
+  - question: "Can Kestra be used as a Business Process Management tool?"
+    answer: "Yes, Kestra can serve as a powerful BPM tool, particularly for engineering-led teams and complex, event-driven workflows. Its declarative YAML-based approach allows for flexible process definition, automation across any system (data, AI, infrastructure, business apps), and offers robust monitoring and governance capabilities, including human-in-the-loop approvals."
+  - question: "What are the benefits of using open-source BPM tools?"
+    answer: "Open-source BPM tools offer flexibility, transparency, and often lower initial costs compared to proprietary solutions. They allow for greater customization and avoid vendor lock-in. Kestra, as an open-source platform, extends these benefits to cover a wide range of technical and business process automation needs across different domains."
+---
+
+In an era where operational efficiency can define competitive advantage, organizations are constantly seeking ways to streamline and optimize their internal processes. Business Process Management (BPM) tools have emerged as critical enablers, transforming manual, fragmented workflows into automated, transparent, and agile operations. From customer onboarding to supply chain logistics and IT service management, effective BPM can significantly reduce bottlenecks, improve compliance, and free up human capital for more strategic initiatives.
+
+However, the landscape of BPM tools is diverse, ranging from traditional suites focused on formal process modeling to modern, adaptable platforms that integrate seamlessly with existing technical stacks. This comprehensive guide will explore the core functionalities of Business Process Management tools, delve into the common challenges that lead organizations to seek alternatives, and present a curated list of leading solutions. We'll provide a decision framework to help you choose the right tool for your specific business needs, highlighting how platforms like Kestra offer a declarative, engineering-first approach to unify workflows across data, AI, and infrastructure.
+
+## Understanding Business Process Management (BPM) Tools
+
+### Defining Business Process Management and its Software (BPMS)
+
+Business Process Management (BPM) is a discipline that uses various methods to discover, model, analyze, measure, improve, and optimize business processes. It's a continuous cycle of improvement, not a one-time task. A Business Process Management Suite (BPMS) is the software that supports this discipline. It provides a set of tools to automate and manage processes from end to end.
+
+The goal of a BPMS is to make business operations more effective, efficient, and capable of adapting to an ever-changing environment. By creating a blueprint of business processes, organizations can identify areas for improvement and implement changes in a controlled, measurable way. This structured approach is fundamental to achieving scalable [business process automation](/resources/business/business-process-automation).
+
+### Why BPM Tools are Essential for Modern Organizations
+
+Implementing BPM tools brings tangible benefits that impact both the top and bottom lines. By automating repetitive tasks, organizations can reduce manual errors, lower operational costs, and accelerate process execution times. This efficiency gain allows employees to focus on higher-value activities that require human creativity and critical thinking.
+
+Furthermore, BPM tools enhance visibility and control over business operations. Standardized processes ensure consistency and make it easier to comply with industry regulations and internal policies. The ability to monitor processes in real-time allows managers to identify bottlenecks and make data-driven decisions swiftly. Ultimately, this leads to improved product quality, better customer service, and greater organizational agility.
+
+## Core Features of Effective BPM Software
+
+### Process Modeling and Design for Clarity
+
+The foundation of any BPM tool is its ability to model and visualize business processes. This is typically done through a graphical interface where users can map out tasks, decision points, and the flow of information. Many traditional tools use Business Process Model and Notation (BPMN) as a standard. A clear visual model serves as a common language for both business and technical stakeholders, ensuring everyone understands how the process works.
+
+### Workflow Automation and Orchestration Capabilities
+
+Once a process is designed, the BPM tool automates its execution. This involves routing tasks to the right people or systems, enforcing business rules, and managing deadlines. Effective [workflow management](/resources/infrastructure/workflow-management) capabilities ensure that processes run smoothly without manual intervention. This includes features like task scheduling, parallel execution, and event-driven triggers that can initiate workflows based on real-world events, such as a new customer signing up or an inventory level dropping. An [open-source workflow engine](/resources/infrastructure/open-source-workflow-engine) often provides the flexibility needed to integrate with a wide array of systems.
+
+### Business Rules Management for Dynamic Decisions
+
+Business processes are rarely static; they often involve decisions that change based on specific conditions. A business rules engine allows organizations to define and manage these rules separately from the core process logic. This separation makes it easier to update business policies without having to redesign the entire workflow. For example, a loan approval process might have rules that automatically approve applications below a certain amount, flag others for manual review, and reject those that don't meet specific criteria.
+
+### Performance Monitoring, Analytics, and Optimization
+
+To facilitate continuous improvement, BPM software must provide robust monitoring and analytics capabilities. Dashboards with key performance indicators (KPIs) help track process efficiency, cycle times, and error rates. By analyzing this data, organizations can identify bottlenecks, understand performance trends, and pinpoint areas for optimization. This data-driven feedback loop is what makes BPM a powerful methodology for sustained operational excellence.
+
+## Why Organizations Seek Alternatives to Traditional BPM Tools
+
+While traditional BPM suites offer powerful capabilities, many organizations find them to be rigid, complex, and ill-suited for modern engineering environments. Common reasons for seeking alternatives include:
+
+*   **High Costs and Vendor Lock-in:** Proprietary BPM suites often come with substantial licensing fees and long-term contracts, making it difficult to adapt to changing needs.
+*   **Steep Learning Curves:** Tools centered around complex standards like BPMN can require specialized training, creating a barrier for engineering teams who prefer code-driven approaches.
+*   **Rigidity and Poor Integration:** Many traditional BPM tools struggle to integrate with the diverse, polyglot technology stacks common today. They are not designed for a world of APIs, microservices, and event-driven architectures.
+*   **Lack of Engineering Best Practices:** Visual-only designers often lack support for version control, automated testing, and CI/CD pipelines, clashing with modern GitOps and Infrastructure-as-Code paradigms.
+*   **Inefficiency for Technical Workflows:** BPM tools are often not the right fit for orchestrating data pipelines, infrastructure automation, or complex AI/ML workflows, leading to tool sprawl.
+
+## Top Business Process Management Tools and Alternatives
+
+### 1. Kestra: The Declarative Orchestration Control Plane
+
+Kestra is an open-source, event-driven orchestration platform that unifies data, AI, infrastructure, and business workflows under a single control plane. Instead of relying on visual designers or complex code, Kestra uses declarative YAML files to define workflows. This engineering-first approach brings the benefits of GitOps—versioning, code reviews, and CI/CD—to business process automation.
+
+With a language-agnostic architecture and over 1,700 plugins, Kestra can connect to virtually any system or API. It's designed for scalability and can handle both simple business approvals and complex, high-volume data processing. For instance, Crédit Agricole's IT arm (CAGIP) uses Kestra to manage infrastructure operations across more than 100 clusters, while JPMorgan Chase orchestrates cybersecurity analytics workflows processing billions of rows. Kestra also supports [human-in-the-loop approvals](/docs/use-cases/approval-processes), blending automated tasks with necessary manual oversight.
+
+*   **Best for:** Platform, data, and AI engineering teams seeking a unified, code-driven orchestration platform that spans technical and business processes with robust governance.
+
+### 2. Camunda: The BPMN-Driven Process Orchestrator
+
+Camunda is a universal process orchestrator renowned for its best-in-class support for BPMN and DMN (Decision Model and Notation) standards. It's an excellent choice for organizations that have a mature process modeling practice and require formal, diagram-based definitions for their workflows.
+
+Its strengths lie in orchestrating complex human-task workflows, such as loan applications or insurance claims, where structured approvals and clear process documentation are paramount. However, its BPMN-centric model can feel heavyweight for purely technical or engineering-driven automation, as it's designed primarily for process analysts and business stakeholders.
+
+*   **Best for:** Organizations with formal business processes, heavy human approvals, and existing investment in BPMN modeling. Explore [Camunda alternatives](/resources/infrastructure/camunda-alternatives) for more engineering-focused needs.
+
+### 3. Microsoft Power Automate: The Low-Code Automation for Microsoft Ecosystems
+
+Microsoft Power Automate is a low-code platform designed for business users to automate workflows and processes within the Microsoft 365, Dynamics 365, and Azure ecosystems. Its key strength is its deep integration with Microsoft products, allowing for seamless automation of tasks between applications like Outlook, SharePoint, Teams, and Excel.
+
+Power Automate includes Robotic Process Automation (RPA) capabilities for automating legacy systems and is a strong choice for citizen developers within Microsoft-heavy organizations. Its primary limitation is its Microsoft-centric nature, which can make it less flexible for orchestrating workflows across heterogeneous, multi-cloud environments.
+
+*   **Best for:** Citizen developers and business users in Microsoft-heavy environments needing quick, visual automations and RPA.
+
+### 4. UiPath: The RPA and Hyperautomation Leader
+
+UiPath is a market leader in Robotic Process Automation (RPA) and positions itself as a platform for "hyperautomation"—combining RPA, AI, process mining, and BPM to automate end-to-end business processes. Its strength lies in its powerful software robots that can mimic human actions to interact with legacy systems that lack APIs.
+
+UiPath is a comprehensive, enterprise-grade platform well-suited for large organizations looking to automate repetitive, manual tasks at scale. The main trade-off is its complexity and cost, as it's a heavy-duty solution primarily focused on UI automation rather than backend or [infrastructure orchestration](/infra-automation).
+
+*   **Best for:** Large enterprises with significant legacy systems, repetitive human tasks, and an RPA-first automation strategy. See our list of [UiPath alternatives](/resources/infrastructure/uipath-alternatives) for more options.
+
+### 5. n8n: The Open-Source Workflow Automation for APIs
+
+n8n is an open-source, visual workflow automation tool that is often described as a self-hostable alternative to Zapier. It excels at connecting SaaS applications and APIs, making it a popular choice for developers and ops teams who need to build internal tools and custom integrations quickly.
+
+With a large library of pre-built connectors and a visual, node-based editor, n8n lowers the barrier to creating powerful automations. While excellent for API-driven workflows, it's less suited for high-volume data engineering or complex infrastructure orchestration, and its visual-first approach can be challenging to govern at scale.
+
+*   **Best for:** Ops teams and developers needing quick SaaS API integrations, internal automations, or AI automation prototyping.
+
+### 6. Workato: The Enterprise iPaaS and Business Automation Platform
+
+Workato is an enterprise-grade Integration Platform as a Service (iPaaS) that provides a low-code environment for automating business processes across thousands of applications. It's known for its extensive library of pre-built connectors and "recipes" (workflow templates) that accelerate development.
+
+Workato is a powerful choice for business and IT teams focused on complex application integrations, data synchronization, and enterprise-wide process automation, particularly in a SaaS-heavy environment. As a proprietary, SaaS-first platform, it may be less flexible and more costly for teams that require deep backend control or a self-hosted solution.
+
+*   **Best for:** Business and IT teams focused on complex application integrations and enterprise-wide process automation across SaaS apps.
+
+### 7. ProcessMaker: The Low-Code BPM Suite
+
+ProcessMaker is a low-code BPM and workflow automation platform designed to empower business analysts and non-technical users to design and deploy automated processes. It features an intuitive visual designer and excels at forms-based workflows, human approvals, and document management.
+
+The platform is a strong contender for organizations that prioritize ease of use for business users to automate departmental processes like HR onboarding or expense approvals. Its flexibility may be limited for deep technical integrations or code-heavy automation tasks that require more control than a low-code interface can provide.
+
+*   **Best for:** Organizations prioritizing ease of use for business analysts to design and automate forms-driven processes and human workflows.
+
+## Comparison Table: Business Process Management Tools
+
+| Tool | License | Deployment | Primary Use Case | Key Differentiator | Best For |
+|---|---|---|---|---|---|
+| **Kestra** | Open-Source & Enterprise | Self-Hosted, Cloud | Unified Orchestration (Data, AI, Infra, Business) | Declarative YAML, Language-Agnostic | Engineering-led, cross-domain automation |
+| **Camunda** | Open-Source & Enterprise | Self-Hosted, Cloud | Formal Business Process Automation | Best-in-class BPMN/DMN support | Process analyst-led, human-heavy workflows |
+| **Power Automate** | Commercial | Cloud | Microsoft Ecosystem Automation & RPA | Deep integration with Microsoft 365/Azure | Citizen developers in Microsoft environments |
+| **UiPath** | Commercial | Self-Hosted, Cloud | Robotic Process Automation (RPA) | Enterprise-grade UI automation at scale | RPA-first automation strategies |
+| **n8n** | Open-Source & Commercial | Self-Hosted, Cloud | API & SaaS Integration | Self-hostable, visual node-based editor | Developers and ops teams building API workflows |
+| **Workato** | Commercial | Cloud | Enterprise iPaaS | Thousands of pre-built connectors | Enterprise-wide SaaS application integration |
+| **ProcessMaker** | Open-Source & Commercial | Self-Hosted, Cloud | Low-Code Human Workflows | Intuitive forms and approval designer | Business analysts automating departmental tasks |
+
+## Choosing the Right BPM Tool for Your Business
+
+Selecting the right tool requires matching its capabilities to your team's skills and primary use cases.
+
+*   **For Data Engineering Teams:** Your focus is on reliable, scalable data pipelines. Look for tools like Kestra that offer robust orchestration for the modern [data stack](/data), including dbt, Spark, and cloud data warehouses.
+*   **For Infrastructure & DevOps Teams:** You need automation that aligns with IaC and GitOps principles. A declarative platform like Kestra allows you to manage workflows as code and orchestrate tools like Terraform and Ansible within a unified [infra-automation](/infra-automation) framework.
+*   **For AI & ML Platform Teams:** Your priority is orchestrating complex model training, evaluation, and deployment pipelines. Look for tools that can handle heterogeneous tasks and integrate with the [AI ecosystem](/ai-automation), including LLM providers and vector databases.
+*   **For Business Process Owners & Ops Teams:** Your goal is to quickly automate manual processes. Low-code platforms like Power Automate or ProcessMaker are often a good fit, provided your workflows don't require deep technical integration.
+
+## Future Trends Shaping Business Process Management
+
+The BPM landscape is continuously evolving, driven by advancements in technology.
+
+*   **AI and Machine Learning:** AI is being embedded into BPM tools to enable intelligent process automation, such as predictive analytics for anticipating bottlenecks, natural language processing for understanding unstructured data, and AI-driven decision-making.
+*   **Hyperautomation:** This trend involves combining multiple technologies—including RPA, AI, and BPM—to automate as much of an organization as possible. The goal is to create a seamless, end-to-end automated enterprise.
+*   **Cloud-Native BPM Solutions:** Modern BPM platforms are increasingly built on cloud-native architectures, offering greater scalability, flexibility, and resilience. This reduces the infrastructure burden on organizations and enables them to adapt more quickly to changing demands.
+
+## The Path to Modern Business Process Orchestration
+
+The distinction between business process automation and technical workflow orchestration is blurring. Modern organizations need a single control plane that can manage workflows across all domains—from a simple approval flow to a complex, multi-stage AI pipeline. The future of BPM lies in flexible, declarative, and developer-friendly platforms that empower teams to build, manage, and scale any process, regardless of the underlying technology.
+
+Explore how [Kestra](/) provides a unified platform to orchestrate all your business and technical workflows with the reliability and governance that modern enterprises demand.

--- a/src/contents/resources/case-management-orchestration/index.md
+++ b/src/contents/resources/case-management-orchestration/index.md
@@ -1,0 +1,172 @@
+---
+title: "Case Management Orchestration: Automating Complex Workflows"
+description: "Case management involves coordinating complex processes and services. Explore how declarative orchestration streamlines these workflows, enhancing efficiency and improving outcomes."
+metaTitle: "Case Management Orchestration & Automation"
+metaDescription: "Automate complex case management workflows with declarative orchestration. Kestra streamlines processes in healthcare, legal, and business for efficiency."
+tag: business
+date: 2026-08-05
+slug: "case-management-orchestration"
+faq:
+  - question: "What is meant by case management?"
+    answer: "Case management is a collaborative process that assesses, plans, implements, coordinates, monitors, and evaluates the options and services required to meet an individual's or organization's comprehensive needs. It aims to optimize quality of care and outcomes, often involving complex, unstructured processes across various domains like healthcare, social work, and legal services."
+  - question: "Why would an organization need case management orchestration?"
+    answer: "Organizations need orchestration for case management to automate repetitive tasks, ensure compliance, improve data consistency, and accelerate response times. Orchestration streamlines the coordination of diverse systems and human approvals, reducing manual effort and errors while providing comprehensive audit trails and real-time visibility into case progress."
+  - question: "What degree is needed to be a human case manager?"
+    answer: "While Kestra automates the technical workflows *supporting* case management, the human role of a case manager often requires specific educational backgrounds. Many roles, particularly in healthcare and social work, require a bachelor's or master's degree in fields like nursing, social work, psychology, or a related health/human services discipline. Certifications may also be required."
+  - question: "Can someone be a case manager without a degree?"
+    answer: "Some entry-level positions or roles in specific sectors might allow individuals to work as case managers with relevant experience or certifications, rather than a specific degree. However, the requirements vary significantly by industry, regulatory body, and the complexity of the cases handled. Many professional case management roles require formal education."
+  - question: "What's another word for case management?"
+    answer: "While 'case management' is a widely recognized term, depending on the context, related terms might include 'care coordination,' 'service coordination,' 'workflow management,' 'process management,' or 'client advocacy.' In an automation context, 'workflow orchestration' describes the underlying technical coordination."
+  - question: "How does Kestra support dynamic case management?"
+    answer: "Kestra supports dynamic case management by providing a flexible, event-driven orchestration engine that can adapt to evolving case needs. Its declarative YAML workflows allow for dynamic task generation, conditional logic, and human-in-the-loop approvals, enabling agile responses to unstructured events and ensuring that processes can change as cases progress."
+  - question: "What sectors benefit most from case management orchestration?"
+    answer: "Sectors that benefit most from case management orchestration include healthcare (patient journey coordination), financial services (claims, fraud detection), legal (document processing, client intake), and IT service management (incident resolution, change requests). Any domain with complex, multi-step processes involving diverse systems and human decisions can gain significant efficiencies."
+---
+
+In an era of increasing complexity, organizations across healthcare, legal, finance, and IT face a common challenge: managing intricate, often unstructured processes known as case management. These cases demand meticulous coordination of people, systems, and data, often leading to bottlenecks, errors, and compliance risks if handled manually. The true power of case management lies not just in defining the steps, but in orchestrating the underlying workflows that drive them.
+
+This article explores how declarative orchestration platforms empower organizations to automate the technical backbone of case management. By unifying diverse systems, streamlining human approvals, and providing real-time visibility, modern orchestration transforms case management from a reactive burden into a proactive, efficient, and auditable operation.
+
+## Understanding Case Management in a Modern Enterprise Context
+
+Traditionally viewed through a human-centric lens, case management is evolving. In the enterprise, it represents a dynamic approach to handling complex, non-linear business processes that don't fit into rigid, predefined sequences. This shift requires a robust technical foundation to support adaptive and event-driven operations.
+
+### Defining Case Management: Coordinating Complex Processes
+
+At its core, case management is a collaborative process of assessing, planning, implementing, and monitoring the services and resources required to meet a specific set of needs. Unlike standard business processes that are predictable and repetitive, case management deals with unstructured or semi-structured situations. Each case might follow a unique path, adapting to new information and events as they arise. This adaptability is critical, but it also introduces significant coordination challenges that require a flexible [workflow management](/resources/infrastructure/workflow-management) system.
+
+### Core Principles for Effective Case Management
+
+Effective case management, whether human-led or automated, adheres to several key principles:
+*   **Client-Centricity:** The process revolves around the needs of the "case" (a patient, a customer, a legal matter, an IT incident).
+*   **Goal-Oriented:** Every action is tied to achieving a specific outcome.
+*   **Collaboration:** Multiple stakeholders, systems, and data sources must work in concert.
+*   **Adaptability:** The process must be able to change course based on real-time events and new data.
+*   **Auditability:** Every decision and action must be tracked for compliance, reporting, and process improvement.
+
+In an enterprise setting, these principles translate into technical requirements for a system that can handle dynamic logic, integrate disparate tools, and maintain a complete, auditable record of every action.
+
+## The Challenges of Traditional Case Management
+
+Relying on manual processes, spreadsheets, or disconnected point solutions to manage complex cases creates significant operational friction. As organizations scale, these traditional methods break down, leading to inefficiency, risk, and poor outcomes.
+
+### Manual Coordination: Bottlenecks and Human Error
+
+When case progression depends on manual handoffs—emails, phone calls, or status meetings—bottlenecks are inevitable. A single delayed approval or missed notification can stall an entire process. This reliance on human intervention also introduces a high risk of error. Data entry mistakes, miscommunication, and inconsistent application of business rules can lead to compliance failures, financial losses, and damaged customer trust.
+
+### Siloed Systems and Data Fragmentation
+
+A typical case management process spans multiple systems: a CRM for client data, a financial system for billing, a document management system for records, and various communication platforms. Without a unified orchestration layer, data becomes fragmented and siloed. Teams waste valuable time manually gathering information from different sources, and decisions are often made with an incomplete picture. This lack of a single source of truth hinders collaboration and makes comprehensive reporting nearly impossible.
+
+### Compliance, Auditability, and Reporting Complexities
+
+In regulated industries like finance and healthcare, proving compliance is non-negotiable. Traditional case management approaches make this incredibly difficult. Compiling a complete audit trail from disparate systems is a time-consuming, manual effort. It’s challenging to demonstrate that every step was followed correctly, that all necessary approvals were obtained, and that data was handled securely. Generating accurate, real-time reports on case status, team performance, and overall efficiency is often an exercise in frustration.
+
+## Orchestrating Case Management: Kestra's Declarative Approach
+
+Declarative orchestration provides a powerful solution to these challenges by creating a centralized, automated, and auditable control plane for all case management workflows. Instead of manually pushing a case from one stage to the next, Kestra allows you to define the entire process as code, automating the coordination of every task, system, and human interaction.
+
+### Automating Intake and Initial Assessment with Event-Driven Triggers
+
+Case management begins at intake. Kestra can automate this crucial first step using event-driven triggers. For example, a `Webhook` trigger can instantly launch a workflow when a new claim is submitted via a web form or a new incident is logged in a service desk. This workflow can then perform initial data validation, enrich the case with information from other systems, and route it for assessment based on predefined rules.
+
+```yaml
+id: financial_claim_intake
+namespace: company.team.finance
+
+tasks:
+  - id: validate_claim
+    type: io.kestra.plugin.scripts.python.Script
+    script: |
+      # Python script to validate form data
+      # ...
+
+  - id: check_fraud_score
+    type: io.kestra.plugin.core.http.Request
+    uri: https://api.fraud-detection.service/check
+    method: POST
+    body: "{{ outputs.validate_claim.value }}"
+
+  - id: route_for_review
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ outputs.check_fraud_score.body.score > 0.8 }}"
+    then:
+      - id: flag_for_manual_review
+        type: io.kestra.plugin.notifications.slack.SlackExecution
+        url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+        payload: |
+          {
+            "text": "High-risk claim flagged for manual review: {{ trigger.data.claim_id }}"
+          }
+    else:
+      - id: auto_approve
+        type: io.kestra.plugin.jdbc.postgresql.Query
+        url: "{{ secret('DB_URL') }}"
+        sql: "UPDATE claims SET status = 'Approved' WHERE id = '{{ trigger.data.claim_id }}';"
+```
+
+### Streamlining Planning and Resource Allocation with Dynamic Workflows
+
+Once a case is assessed, Kestra's dynamic task capabilities can automate the planning and implementation phases. Using conditional logic (`If` tasks) and parallel processing (`ForEach` tasks), workflows can adapt to the specific needs of each case. For instance, a legal case workflow could dynamically generate tasks to collect documents from different sources in parallel, while a patient onboarding workflow could trigger different care pathways based on the patient's diagnosis. This ensures that resources are allocated efficiently and that every case follows the optimal path to resolution.
+
+### Ensuring Secure and Auditable Implementation
+
+Security and auditability are built into Kestra's design. By centralizing workflow definitions in version-controlled YAML files, every change to a process is tracked and reviewed. Kestra’s robust [workflow orchestration security](/resources/infrastructure/workflow-orchestration-security) features, including granular access controls and a centralized system for [workflow secret management](/docs/best-practices/secrets-management), ensure that sensitive case data is handled appropriately. Every execution, every decision, and every system interaction is logged automatically, creating an immutable audit trail for compliance and reporting.
+
+## Case Management Across Industries: Real-World Applications
+
+The principles of case management orchestration apply across numerous sectors, delivering tangible benefits by automating complex, domain-specific processes.
+
+### Financial Services: Claims, Fraud Detection, and Compliance
+
+In finance, case management is critical for processes like insurance claims processing, loan origination, and fraud investigations. Kestra can orchestrate these workflows by automating document ingestion and validation, integrating with fraud detection APIs, routing cases for underwriter review, and managing communications with customers. This level of automation accelerates resolution times, reduces operational costs, and ensures a consistent, compliant process for every case. For a deeper look, explore how Kestra enables [financial services workflow automation](/use-cases/financial-services).
+
+### Healthcare: Patient Journeys and Care Coordination
+
+Coordinating patient care involves managing appointments, test results, insurance approvals, and communication between multiple providers. Kestra can serve as the backbone for this process, triggering workflows to schedule follow-ups, notifying care teams of critical lab results, and automating the submission of insurance claims. This ensures a seamless patient journey and frees up clinical staff to focus on patient care rather than administrative tasks.
+
+### Legal Services: Client Intake and Document Processing
+
+Legal case management involves organizing vast amounts of information, from client intake forms and contracts to court filings and evidence. Kestra can automate the entire lifecycle, from triggering a workflow upon new client submission to parsing documents, assigning tasks to paralegals, and scheduling deadlines. This systematic approach ensures that nothing falls through the cracks and provides a complete, organized record for every matter.
+
+### IT Service Management: Incident Response and Change Requests
+
+IT operations rely on case management for incident response, service requests, and change management. Kestra can automate these ITSM workflows by creating tickets in systems like ServiceNow, running diagnostic scripts, escalating issues based on severity, and managing the approval process for infrastructure changes. This leads to faster incident resolution and more reliable, auditable change control.
+
+## Key Features of Kestra for Advanced Case Management Orchestration
+
+Kestra provides a unique combination of features perfectly suited for the dynamic and demanding nature of modern case management.
+
+### Declarative YAML: Version Control and Collaboration
+
+All workflows in Kestra are defined as simple, human-readable YAML files. This declarative, code-based approach brings the benefits of software engineering practices like version control (Git), code reviews, and automated testing to your business processes. It allows technical and business teams to collaborate on workflow design and ensures that every process is documented, repeatable, and easy to maintain.
+
+### Human-in-the-Loop: Approvals and Manual Tasks
+
+Not every step in a case can be fully automated. Kestra natively supports human-in-the-loop workflows with features like `Pause` tasks, which can halt a workflow pending manual approval. This allows you to seamlessly integrate human decision-making and expertise into your automated processes, ensuring that complex or sensitive cases receive the necessary oversight. The platform provides a full guide to [automate manual approval processes](/docs/use-cases/approval-processes).
+
+### Polyglot Task Execution: Integrating Any System or API
+
+Case management requires connecting to a wide array of systems. Kestra's language-agnostic architecture and vast library of over 1,700 plugins allow you to integrate with virtually any tool or API. Whether you need to run a Python script, query a SQL database, call a REST API, or execute a shell command, Kestra can orchestrate it all within a single, unified workflow. This flexibility allows you to [connect to any API and automate everything](/blogs/2024-04-11-http-trigger). For example, companies like [Displayce](/customers/displayce) have used Kestra to unify monitoring and orchestrate expanding data operations.
+
+### Real-Time Visibility and Audit Trails
+
+Kestra provides a centralized UI where you can visualize, monitor, and manage all your case management workflows in real-time. Detailed logs, execution histories, and a comprehensive audit trail for every task provide complete transparency. This visibility is crucial for troubleshooting issues, reporting on performance, and demonstrating compliance to auditors.
+
+## The Future of Case Management: AI and Intelligent Orchestration
+
+The integration of Artificial Intelligence is the next frontier for case management. Kestra is at the forefront of this evolution, enabling organizations to build more intelligent and adaptive workflows.
+
+### Leveraging AI for Automated Insights and Decision Support
+
+By integrating AI and machine learning models into your workflows, you can automate complex decision-making. For example, an AI model could analyze an incoming insurance claim to predict the likelihood of fraud, or parse a customer support ticket to determine its sentiment and priority. Kestra can orchestrate these AI-driven tasks, routing cases based on model outputs and providing a framework for [AI automation](/ai-automation).
+
+### Adaptive Workflows for Dynamic Case Progression
+
+The future of case management is adaptive. With Kestra's agentic AI capabilities, workflows can dynamically adjust their path based on real-time events and AI-driven insights. An agent could monitor a case and proactively initiate remediation steps or gather additional information when needed, creating a truly autonomous and intelligent case management system.
+
+## Choosing Kestra for Your Case Management Needs
+
+Effective case management in the modern enterprise is an orchestration problem. It requires a platform that can unify disparate systems, automate complex logic, integrate human decisions, and provide a complete audit trail.
+
+Kestra's declarative, event-driven, and language-agnostic approach provides the ideal foundation for building scalable and resilient case management solutions. By transforming your processes into version-controlled code, you gain the agility to adapt to changing business needs and the confidence that comes with a secure, auditable, and transparent operation. Kestra serves as the [unified control plane](/infra-automation) to orchestrate your entire ecosystem, from simple IT tasks to the most complex, mission-critical business cases.

--- a/src/contents/resources/context-engineering/index.md
+++ b/src/contents/resources/context-engineering/index.md
@@ -1,0 +1,203 @@
+---
+title: "Context Engineering: Building Reliable AI Agent Workflows"
+description: "Context engineering goes beyond simple prompts to deliver dynamic, relevant information to AI agents. Understand how to design and orchestrate context systems for scalable and governed LLM applications."
+metaTitle: "Context Engineering for AI Agents"
+metaDescription: "Context engineering: retrieve, shape, and inject the right context for accurate LLM answers. Kestra orchestrates reliable AI agent workflows."
+tag: "ai"
+date: 2026-08-05
+slug: "context-engineering"
+faq:
+  - question: "What is a context engineer?"
+    answer: "A context engineer is a specialized role focused on designing, building, and maintaining the dynamic systems that provide AI agents with relevant, up-to-date information and tools. They ensure LLMs have the right context to perform complex tasks reliably and accurately, bridging the gap between data sources, tools, and AI models."
+  - question: "How much do context engineers make?"
+    answer: "Salaries for context engineers vary by experience and location. Entry-level roles typically range from $120K-$150K, while mid-level positions can reach $180K-$240K. Senior and lead contextual AI software engineers can command salaries upwards of $200K-$230K, reflecting the specialized skills required."
+  - question: "What are the four pillars of context engineering?"
+    answer: "The four pillars of context engineering are dynamic information flow, tool integration, memory architecture, and format optimization. These pillars ensure AI systems receive relevant data, can interact with external systems, retain necessary information across interactions, and consume data efficiently for precise and production-ready outputs."
+  - question: "Is context engineering better than prompt engineering?"
+    answer: "Context engineering addresses deeper challenges of reliability, scalability, and governance that prompt engineering alone cannot solve. While prompt engineering is crucial for setting expectations and tone, context engineering builds the dynamic systems that enable complex reasoning, safe tool use, and grounded responses for production AI agents."
+  - question: "Where can I learn context engineering?"
+    answer: "Learning resources for context engineering are emerging, with online courses from universities and platforms offering certificates. Practical experience with LLM frameworks, data retrieval techniques, and workflow orchestration platforms like Kestra is essential for mastering the discipline."
+---
+
+> **TL;DR** — Context engineering is the discipline of designing and maintaining dynamic information systems that provide AI agents with the right data, tools, and memory in the optimal format, ensuring reliable, governed, and scalable LLM applications.
+
+AI agents promise to automate complex tasks, but their real-world reliability often falls short. Static prompts quickly hit limitations when agents need to interact with external data, use tools, or maintain a consistent state across long-running operations. This is where context engineering becomes indispensable.
+
+Context engineering is the systematic discipline of designing, building, and managing the dynamic information an AI agent receives. It’s about ensuring LLMs always have the right data, tools, and memory, in the optimal format, to execute tasks accurately and safely in production environments. This article explores how to operationalize this critical practice.
+
+## How Context Engineering Works: Beyond Static Prompts
+
+Context engineering is the systematic design of everything you feed into an LLM to control its reasoning and output, without retraining the model itself. It treats the context window not as a blank slate for a single prompt, but as a dynamic environment to be populated with precisely the right information at the right time.
+
+This approach moves beyond static, handcrafted instructions. It involves building automated systems that retrieve, filter, format, and inject information into the LLM's context window during inference. This ensures that an AI agent's responses are grounded in relevant, up-to-date data, enabling it to perform complex, multi-step tasks that require external knowledge or interaction with other systems. It directly addresses core LLM limitations like finite token windows, knowledge cutoffs, and the tendency to hallucinate. For an in-depth look at structuring prompts for multi-step tasks, see our guide on [prompt chaining for LLMs](/resources/ai/prompt-chaining-llm-guide).
+
+### Context Engineering vs. Prompt Engineering: A Fundamental Shift
+
+Prompt engineering focuses on crafting the perfect set of instructions to guide an LLM's response for a specific task. It's about setting the tone, defining the persona, and clearly stating the desired output format. While essential, it's a manual and often brittle process.
+
+Context engineering is the architectural layer above prompt engineering. It doesn't replace good prompts; it makes them scalable and reliable.
+
+-   **Prompt Engineering** is about writing the question.
+-   **Context Engineering** is about building the system that provides the answer.
+
+Where a prompt engineer might write, "Based on our latest Q3 report, summarize sales performance," a context engineer builds the automated workflow that fetches the Q3 report from a database, extracts the relevant sales figures, and injects them into the context alongside the prompt. This shift from instruction crafting to system building is what enables truly autonomous and reliable [AI automation](/ai-automation).
+
+## Why Reliable Context is Crucial for Production AI Agents
+
+In a production environment, the quality of an AI agent's output is directly tied to the quality of its context. Poor or missing context leads to a host of problems:
+
+-   **Hallucinations:** The LLM invents facts to fill knowledge gaps.
+-   **Irrelevant Responses:** The agent answers based on its general training data, not the specific user need.
+-   **Incorrect Tool Use:** The agent calls the wrong API or provides invalid parameters because it lacks situational awareness.
+-   **Security Risks:** The agent might leak sensitive data if its context isn't properly filtered and scoped.
+-   **Lack of Auditability:** Without a record of the context provided, it's impossible to debug why an agent made a particular decision.
+
+Effective context engineering mitigates these risks, delivering improved accuracy, grounded decision-making, and the governance necessary for enterprise use.
+
+### The Core Challenges Context Engineering Solves
+
+Context engineering provides a framework for addressing the fundamental operational challenges of working with LLMs at scale:
+
+-   **Relevance:** Filtering vast amounts of information to provide only what is necessary for the task at hand.
+-   **Freshness:** Ensuring the context reflects the most current data, not the LLM's potentially outdated training knowledge.
+-   **Tooling:** Integrating external systems and APIs so agents can take action in the real world.
+-   **Memory:** Managing conversational history and long-term knowledge to maintain state across interactions.
+-   **Cost:** Optimizing token usage by providing concise, relevant context instead of large, unfiltered data dumps.
+
+## The Pillars of Effective Context Engineering
+
+A robust context engineering practice is built on four key pillars that work together to create a reliable information supply chain for AI agents.
+
+### Dynamic Information Flow
+
+This pillar focuses on retrieving real-time data from external sources. Instead of relying on the LLM's static knowledge, the system actively fetches information from databases, APIs, or vector stores. The most common pattern here is Retrieval-Augmented Generation (RAG), where a user query first triggers a search against a knowledge base, and the retrieved documents are then passed to the LLM as context. Building a production-grade [RAG pipeline](/resources/ai/rag-pipeline) is a core task in context engineering.
+
+### Tool Integration and Orchestration
+
+For an AI agent to be useful, it must be able to interact with other systems. This pillar involves providing the agent with a secure and reliable way to use external tools, such as APIs or internal functions. It requires a robust tool registry, a secure execution environment, and an orchestration layer to manage the sequence of tool calls and data handoffs. Orchestration platforms are essential for managing the lifecycle of these integrations, a concept we explore in [automating the plugin SDLC](/blogs/context-engineering-plugins-squad).
+
+### Memory Architecture
+
+Memory enables agents to maintain context across multiple turns of a conversation or even across different sessions. This involves designing systems for both short-term memory (the history of the current conversation) and long-term memory (a persistent knowledge base of user preferences or past interactions). Effective memory management is critical for creating personalized and coherent user experiences.
+
+### Format Optimization
+
+LLMs have limitations on input length (the context window) and are sensitive to the format of the information they receive. This pillar covers the techniques for structuring context in a way that is easily consumable by the model. This includes using formats like JSON or XML for structured data, summarizing long documents, and compressing information to maximize the value of every token.
+
+## Orchestrate Context Engineering with Kestra: A RAG Scenario
+
+A workflow orchestration platform like Kestra is the ideal control plane for implementing context engineering. It allows you to define the entire context retrieval and formatting pipeline as a declarative, version-controlled workflow.
+
+Consider a common RAG scenario: a user asks a question that requires information from an internal knowledge base stored in Elasticsearch. The Kestra flow below automates the entire process of retrieving, formatting, and injecting the context. You can find a similar, more detailed implementation in our [Chat With Your Data blueprint](/blueprints/chat-with-your-data).
+
+```yaml
+id: dynamic_context_rag
+namespace: ai.context.engineering
+
+description: Orchestrates a RAG pipeline to dynamically retrieve context and query an LLM.
+
+inputs:
+  - id: user_query
+    type: STRING
+    description: The user's query for the LLM.
+
+tasks:
+  - id: retrieve_context_from_vector_db
+    type: io.kestra.plugin.elasticsearch.Search
+    description: Retrieve relevant documents from Elasticsearch based on the user query.
+    host: "{{ secret('ELASTICSEARCH_HOST') }}"
+    authentication:
+      type: Basic
+      username: "{{ secret('ELASTICSEARCH_USERNAME') }}"
+      password: "{{ secret('ELASTICSEARCH_PASSWORD') }}"
+    index: "document_index"
+    body: |
+      {
+        "query": {
+          "match": {
+            "content": "{{ inputs.user_query }}"
+          }
+        },
+        "size": 3
+      }
+  - id: format_context
+    type: io.kestra.plugin.scripts.python.Script
+    description: Extract and format the retrieved documents into a coherent context string.
+    beforeCommands:
+      - pip install jq
+    script: |
+      import json
+      retrieved_docs_raw = """{{ outputs.retrieve_context_from_vector_db.hits }}"""
+      retrieved_docs = json.loads(retrieved_docs_raw)
+      
+      context_parts = []
+      for hit in retrieved_docs['hits']:
+          context_parts.append(hit['_source']['content'])
+      
+      formatted_context = "\\n\\n".join(context_parts)
+      print(f"{{'context': formatted_context}}")
+  - id: query_llm_with_context
+    type: io.kestra.plugin.openai.ChatCompletion
+    description: Send the user query and retrieved context to an LLM for a grounded response.
+    # Model can be updated to newer versions as they become available.
+    model: gpt-4o
+    apiSecret: "{{ secret('OPENAI_API_KEY') }}"
+    messages:
+      - role: system
+        content: "You are a helpful assistant. Use the provided context to answer the user's question. If the answer is not in the context, state that you don't know."
+      - role: user
+        content: |
+          Context:
+          {{ outputs.format_context.outputs.context }}
+          
+          Question: {{ inputs.user_query }}
+
+errors:
+  - id: handle_error
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+    description: Send a Slack notification if the workflow fails.
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    payload: |
+      {
+        "text": "Context Engineering flow failed for query: {{ inputs.user_query }}. Error: {{ error.message }}"
+      }
+```
+
+**Worth noticing in this flow:**
+
+-   **Dynamic retrieval**: The `retrieve_context_from_vector_db` task dynamically fetches relevant information based on the user's query, ensuring the LLM always has fresh and specific data.
+-   **Polyglot processing**: A Python script (`format_context`) handles the transformation of raw search results into a clean, LLM-consumable format.
+-   **Grounded responses**: The `query_llm_with_context` task uses the formatted context to provide grounded answers, significantly reducing hallucinations.
+-   **Error handling**: The `handle_error` task demonstrates robust error management, ensuring that failures in context retrieval or LLM interaction are promptly communicated.
+
+## Context Engineering in Practice: Roles and Learning Paths
+
+As the discipline matures, a new specialized role is emerging: the context engineer. This role sits at the intersection of data engineering, software development, and AI/ML. A context engineer is responsible for designing, building, and maintaining the systems that feed AI agents.
+
+### The Rise of the Context Engineer
+
+The shift from prompt engineer to context engineer reflects a broader maturation of the AI industry. Early experiments focused on what could be achieved with clever prompts. Now, the focus is on building reliable, production-grade systems. The context engineer is a type of workflow engineer, focused on the information pipelines that make AI agents work. This evolution is part of a larger trend where engineering disciplines are adapting to a world of automated workflows, as highlighted in the [2026 Data Engineering Trends](/blogs/2026-03-05-data-eng-trends-2026).
+
+### Essential Skills and Learning Resources
+
+Becoming a proficient context engineer requires a diverse skill set:
+
+-   **LLM Frameworks:** Deep understanding of frameworks like LangChain, LlamaIndex, and their underlying principles.
+-   **Data Retrieval:** Expertise in vector databases (e.g., Pinecone, Weaviate), search engines (e.g., Elasticsearch), and traditional databases.
+-   **Workflow Orchestration:** Proficiency with platforms like Kestra to build, schedule, and monitor context pipelines.
+-   **Programming:** Strong skills in a language like Python for data manipulation and API interaction.
+-   **Cloud Platforms:** Familiarity with AWS, GCP, or Azure for deploying and managing the required infrastructure.
+
+Learning paths often involve a combination of online courses and hands-on projects. Building practical applications, such as the RAG pipeline shown above, is one of the best ways to develop these skills.
+
+## Where Context Engineering Pays Off
+
+The principles of context engineering are applicable across numerous domains, turning experimental AI agents into reliable business tools.
+
+-   **Enhanced customer support bots:** Providing real-time, accurate answers from internal knowledge bases and user account data.
+-   **Automated code generation:** Giving coding agents access to a project's specific documentation, codebase, and APIs to write relevant, working code.
+-   **Financial analysis:** Grounding LLMs with up-to-date market data, financial reports, and internal analytics to generate insightful and accurate summaries.
+-   **Cybersecurity analytics:** Orchestrating agents to analyze threat intelligence with relevant context from security logs and vulnerability databases.
+-   **Manufacturing and Automotive:** In complex supply chains, agents can be given context from MES and PLM systems to manage non-conformance reports, as seen in [automotive use cases](/use-cases/automotive).
+
+Ready to build more reliable and scalable AI agent workflows? Explore Kestra's AI orchestration capabilities.

--- a/src/contents/resources/data-mesh-vs-data-fabric/index.md
+++ b/src/contents/resources/data-mesh-vs-data-fabric/index.md
@@ -1,0 +1,210 @@
+---
+title: "Data Mesh vs. Data Fabric: Key Differences and When to Choose Each"
+description: "Data Mesh and Data Fabric are two leading approaches to modern data management. Understand their core distinctions, how they can complement each other, and which strategy best suits your organization's needs for scalable and governed data."
+metaTitle: "Data Mesh vs. Data Fabric: Differences & Use Cases"
+metaDescription: "Explore the core differences between Data Mesh and Data Fabric, how they complement each other, and which approach is best for your data strategy."
+tag: "data"
+date: 2026-08-05
+slug: "data-mesh-vs-data-fabric"
+faq:
+  - question: "What is the difference between data fabric and data mesh?"
+    answer: "Data Fabric is a technology-driven architectural approach focused on unifying data access and integration through intelligent automation. Data Mesh is an organizational and operating model, emphasizing decentralized domain ownership and treating data as products, often enabled by a data fabric's technical capabilities."
+  - question: "What are the 4 pillars of data mesh?"
+    answer: "The four pillars of data mesh are domain-oriented decentralized data ownership, data as a product, a self-serve data infrastructure platform, and federated computational governance. These principles guide its implementation and operational model."
+  - question: "Can data mesh and data fabric be used together?"
+    answer: "Yes, Data Mesh and Data Fabric can be highly complementary. Data Fabric can provide the technical capabilities (like unified data access and governance) that enable the self-serve infrastructure and data product delivery required by a Data Mesh operating model."
+  - question: "What are the disadvantages of data mesh?"
+    answer: "Disadvantages of data mesh include its complexity to implement, particularly for organizations new to decentralized models. It requires significant cultural and organizational change, and a 'one-size-fits-all' solution does not exist, demanding customisation."
+  - question: "Is data mesh obsolete?"
+    answer: "Data mesh is not obsolete but has evolved. While initial implementations faced challenges, its core principles of domain-oriented ownership, data as a product, and federated governance remain highly relevant for decentralized data architectures."
+  - question: "How does Data Fabric simplify data integration?"
+    answer: "Data Fabric simplifies data integration by using AI and machine learning to automate data discovery, ingestion, transformation, and governance. It creates a unified, virtualized view of data from disparate sources, reducing manual effort and improving data accessibility."
+  - question: "Which approach is better for large enterprises, Data Mesh or Data Fabric?"
+    answer: "Neither approach is inherently 'better' for large enterprises; the optimal choice depends on organizational structure, data strategy, and existing infrastructure. Data Mesh suits highly decentralized organizations, while Data Fabric is ideal for complex, distributed data estates needing unified access and automation."
+---
+Modern data architectures are complex, with organizations constantly seeking ways to manage vast, distributed datasets effectively. Two terms frequently surface in these discussions: Data Mesh and Data Fabric. While often mentioned together, they represent distinct philosophies and approaches to data management, leading to confusion about their roles and whether they are mutually exclusive.
+
+This article will clarify the core differences between Data Mesh and Data Fabric, exploring their unique strengths, challenges, and how they can be used in concert. By the end, you'll have a clear understanding of each approach and how to determine which best fits your organization's strategic data goals.
+
+## Understanding Data Mesh and Data Fabric Concepts
+
+Before comparing Data Mesh and Data Fabric, it's essential to define each concept individually. They both aim to solve the challenges of modern data management but from different perspectives.
+
+### What is Data Mesh?
+
+Data Mesh is a socio-technical approach to data architecture that emphasizes decentralization and domain-oriented ownership. It treats data as a product, with each business domain responsible for owning and delivering its data products to the rest of the organization. This model moves away from monolithic data lakes and warehouses managed by a central data team, aiming to solve the scalability and agility bottlenecks that often arise in large, complex organizations.
+
+The core idea is to apply the principles of modern distributed software engineering to the data world. By empowering domain teams who are closest to the data, a [data mesh architecture](/resources/data/data-mesh-architecture) promotes greater accountability, quality, and speed in data delivery. A successful implementation, like the one at [Leroy Merlin France, which increased data production by 900%](/customers/leroy-merlin-france), demonstrates the potential of this approach when supported by the right [data orchestration](/resources/data/data-orchestration) tools.
+
+### What is Data Fabric?
+
+Data Fabric is a technology-centric architectural approach that creates a unified, intelligent, and automated data platform. It focuses on connecting disparate data sources across hybrid and multi-cloud environments, providing a single, consistent layer for data access, governance, and integration. Unlike Data Mesh, which is primarily an operating model, Data Fabric is about the technology that enables seamless data flow.
+
+A Data Fabric uses AI and machine learning to automate metadata management, data discovery, and the generation of data integration pipelines. It provides virtualized data access, meaning data consumers can query and use data without needing to know its physical location or underlying structure. This approach aims to reduce the complexity of data integration and accelerate time-to-insight by providing a cohesive view of an organization's entire data estate. You can explore more concepts in our [data engineering resources](/resources/data).
+
+## Data Mesh vs. Data Fabric: Core Distinctions
+
+While both concepts address the challenges of distributed data, their fundamental differences lie in their approach to ownership, implementation, and focus.
+
+### Decentralization vs. Centralization of Ownership
+
+The most significant distinction is their approach to data ownership. Data Mesh advocates for radical decentralization, distributing the responsibility for data to the business domains that create and understand it best. Each domain team is accountable for the entire lifecycle of its data products.
+
+Data Fabric, in contrast, creates a centralized and unified data access layer. While the data itself remains distributed at its source, the management, governance, and integration logic are centrally managed by the fabric's technology. This provides a single point of control and consistency, which can be beneficial for organizations that prefer a more standardized [data management organization structure](/resources/data/data-management-organization-structure).
+
+### Operating Model vs. Architectural Approach
+
+Data Mesh is fundamentally an organizational and operating model. It requires a cultural shift in how an organization thinks about and manages data. The focus is on people and processes: establishing domain teams, defining data product ownership, and fostering a culture of data stewardship. The technology is an enabler, but the core transformation is socio-technical.
+
+Data Fabric is primarily a technical architecture. It is a set of technologies and services designed to automate and streamline data management tasks. While it impacts processes, its implementation is driven by the selection and integration of tools for data cataloging, metadata management, virtualization, and automated pipeline generation.
+
+### Analytical Data Focus vs. Broader Data Integration
+
+Data Mesh was initially conceived to address the challenges of scaling analytical data and business intelligence. Its "data as a product" principle is tailored for creating high-quality, reliable datasets for analysis, reporting, and machine learning.
+
+Data Fabric has a broader scope. It is designed to handle all types of data, including analytical, operational, and transactional data. Its goal is to provide a comprehensive integration solution that serves a wide range of use cases, from real-time operational applications to large-scale analytics.
+
+### Data Products and Domain Boundaries
+
+Data Mesh places a strong emphasis on the concept of "data products." A data product is more than just data; it is a discoverable, addressable, trustworthy, self-describing, and secure unit of data that is delivered with a clear service-level agreement (SLA). These products are defined and bounded by the business domains that own them, ensuring high contextual quality. Ensuring this level of [data quality](/resources/data/data-quality) is a cornerstone of the mesh philosophy.
+
+Data Fabric does not have the same explicit concept of data products tied to domain ownership. Instead, it focuses on creating a unified data model and providing standardized access patterns to all available data, abstracting away the underlying complexity and domain-specific nuances.
+
+### How Responsibilities are Distributed
+
+In a Data Mesh, domain teams have end-to-end responsibility for their data products, from ingestion and cleaning to serving and lifecycle management. A central platform team provides the self-serve tools, but the data accountability lies with the domains.
+
+In a Data Fabric, responsibilities are more centralized around the technology. A central data or IT team typically manages the fabric itself, overseeing the automation of data integration, governance policy enforcement, and the overall health of the data platform. Domain experts may be involved in defining rules, but the operational burden is largely automated and centrally managed.
+
+## The Four Pillars of Data Mesh
+
+To fully grasp the Data Mesh concept, it's crucial to understand its four founding principles, as defined by Zhamak Dehghani.
+
+### Domain-Oriented Decentralized Data Ownership and Architecture
+
+This pillar advocates for aligning data ownership with the business domains that have the most expertise. Instead of a central team managing a monolithic data lake or warehouse, each domain (e.g., sales, marketing, logistics) is responsible for its own data. This decentralization empowers teams to manage their data assets autonomously, leading to faster decision-making and higher data quality.
+
+### Data as a Product
+
+This principle requires a shift in mindset: data should be treated not as a byproduct of a process but as a valuable product in its own right. Each data product must be discoverable, understandable, trustworthy, and secure. It should have a clear owner, documentation, and defined SLAs, just like any software product. This ensures that data consumers across the organization can confidently find and use the data they need.
+
+### Self-Serve Data Infrastructure Platform
+
+To enable domain teams to build and manage their data products effectively, a central platform team must provide a self-serve data infrastructure. This platform should offer a set of tools and services that abstract away the underlying complexity of data management, allowing domain teams to focus on creating value. This includes capabilities for data storage, processing, governance, and orchestration, often supporting a [language-agnostic approach](/features/code-in-any-language) to cater to diverse team skills.
+
+### Federated Computational Governance
+
+While Data Mesh promotes domain autonomy, it also recognizes the need for global interoperability and security. Federated computational governance establishes a set of global rules and standards (e.g., for data quality, security, privacy) that are enforced across all data products. This model creates a balance between decentralization and standardization, ensuring that the entire mesh operates as a cohesive ecosystem.
+
+## Are Data Mesh and Data Fabric Complementary?
+
+Despite their differences, Data Mesh and Data Fabric are not mutually exclusive. In fact, they can be highly complementary, with each approach reinforcing the other.
+
+### Synergies for Modern Data Management
+
+A Data Fabric can be seen as the technological foundation that enables a Data Mesh operating model. The automated capabilities of a Data Fabric—such as intelligent metadata management, a unified data catalog, and automated governance—can provide the very self-serve infrastructure that the third pillar of Data Mesh requires. For example, a fabric's ability to track [data lineage](/resources/data/data-lineage) automatically can help enforce the governance standards required in a federated model.
+
+### Integrating Both Approaches for Enhanced Data Strategy
+
+An organization can adopt a Data Mesh philosophy for its organizational structure and data ownership model while using a Data Fabric to implement the underlying technical platform. In this scenario:
+-   **Data Mesh** defines the "who" and "why": domain teams own data products to drive business outcomes.
+-   **Data Fabric** provides the "how": a unified platform that automates integration and provides the tools for domain teams to build, deploy, and manage their data products efficiently.
+
+This integrated approach allows an organization to benefit from the agility and scalability of a decentralized model while leveraging the power of automation and unified access provided by a technical fabric.
+
+## Advantages and Disadvantages of Each Approach
+
+Both architectures come with their own set of benefits and challenges that organizations must weigh before adoption.
+
+### Benefits and Challenges of Data Mesh
+
+**Advantages:**
+-   **Increased Agility and Scalability:** Decentralized ownership removes central bottlenecks, allowing teams to innovate and deliver data products faster.
+-   **Higher Data Quality:** Domain teams have deep context and expertise, leading to more accurate and reliable data.
+-   **Clear Accountability:** With clear ownership, it's easier to manage the quality, security, and lifecycle of data products.
+
+**Disadvantages:**
+-   **Organizational Complexity:** Requires a significant cultural and organizational shift, which can be difficult to implement.
+-   **High Initial Investment:** Building a self-serve data platform and upskilling domain teams requires substantial upfront resources.
+-   **Potential for Inconsistency:** Without strong federated governance, there's a risk of creating new data silos or inconsistent standards across domains.
+
+### Benefits and Challenges of Data Fabric
+
+**Advantages:**
+-   **Unified Data Access:** Provides a single, consistent view of all data, regardless of its location or format.
+-   **Increased Automation:** AI-driven automation reduces manual effort in data integration, discovery, and governance.
+-   **Reduced Data Silos:** By connecting disparate data sources, it helps break down silos and improves data sharing.
+
+**Disadvantages:**
+-   **Implementation Complexity:** Integrating diverse data sources and implementing advanced automation can be technically challenging.
+-   **Potential for Vendor Lock-in:** Relying on a single vendor's data fabric solution can create dependencies.
+-   **Governance Challenges:** Automating governance across a complex data landscape requires careful planning and robust policy definition.
+
+## Is Data Mesh Obsolete? Debunking Common Misconceptions
+
+In recent years, some have questioned the viability of Data Mesh, labeling it as overly complex or just a marketing buzzword. However, this view often stems from a misunderstanding of its principles and the challenges of early implementations.
+
+### Evolution and Current Relevance of Data Mesh
+
+Data Mesh is not obsolete; it has evolved. The initial hype may have subsided, but its core principles remain highly relevant for large, decentralized organizations struggling with data scalability. Successful implementations, such as the [Data Mesh at Leroy Merlin](/blogs/2023-08-16-datamesh), show that when properly executed, the model delivers significant value. The industry has learned that a successful Data Mesh requires a strong platform engineering culture and the right orchestration tools to support domain teams.
+
+### When Data Mesh is Still a Powerful Approach
+
+Data Mesh remains a powerful strategy for organizations that fit a specific profile:
+-   **Large and Decentralized:** Companies with multiple autonomous business units or product teams.
+-   **Diverse Data Domains:** Organizations with a wide variety of data sources and use cases that are difficult to manage centrally.
+-   **High Agility Needs:** Businesses operating in fast-moving markets where the ability to quickly develop and iterate on data products is a competitive advantage.
+
+For these organizations, the benefits of domain-driven ownership and scalability often outweigh the implementation complexities.
+
+## Choosing the Right Approach for Your Organization with Kestra
+
+The choice between Data Mesh and Data Fabric—or a combination of both—depends on your organization's unique context. Kestra's declarative orchestration platform is designed to support both models by providing the flexibility and control needed to manage complex data workflows.
+
+### Factors to Consider for Implementation
+
+-   **Organizational Structure:** Is your organization centralized or decentralized? A decentralized structure is a natural fit for Data Mesh.
+-   **Data Volume and Variety:** A highly complex and distributed data landscape may benefit from the unifying capabilities of a Data Fabric.
+-   **Existing Tech Stack:** Evaluate how each approach would integrate with your current tools and infrastructure.
+-   **Cultural Readiness:** Is your organization prepared for the cultural shift required by Data Mesh's decentralized ownership model?
+
+### Kestra's Role in Orchestrating Data Mesh and Data Fabric
+
+Kestra acts as the orchestration control plane that can power either architecture. Its [declarative orchestration](/features/declarative-data-orchestration) model, defined in simple YAML, makes it easy for teams to build, manage, and scale their workflows.
+
+**For Data Mesh:**
+-   Kestra enables domain teams to build and own their [data pipelines](/resources/data/data-pipeline) as code, treating them as data products.
+-   The platform's language-agnostic nature allows each domain to use the best tools for their specific needs (Python, SQL, R, etc.).
+-   Kestra can be a core component of the self-serve infrastructure platform, providing standardized, repeatable patterns for workflow automation.
+
+```yaml
+id: sales-data-product
+namespace: retail.sales
+
+tasks:
+  - id: extract_pos_data
+    type: io.kestra.plugin.jdbc.postgresql.Query
+    sql: "SELECT * FROM raw.point_of_sale WHERE transaction_date = '{{ trigger.date }}';"
+
+  - id: transform_in_python
+    type: io.kestra.plugin.scripts.python.Script
+    script: |
+      # Python code to clean and aggregate sales data
+      # ...
+
+  - id: load_to_snowflake
+    type: io.kestra.plugin.jdbc.snowflake.Query
+    sql: "COPY INTO analytics.daily_sales FROM @kestra_stage/{{ outputs.transform_in_python.uri }};"
+
+triggers:
+  - id: daily_schedule
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 5 * * *"
+```
+
+**For Data Fabric:**
+-   Kestra can automate the complex integration workflows that form the backbone of a Data Fabric.
+-   Its extensive library of plugins allows it to connect to virtually any data source, API, or system, helping to weave the fabric together.
+-   Kestra's event-driven triggers can react to changes in the data landscape in real-time, enabling the dynamic and responsive nature of a Data Fabric.
+
+Whether you are building a decentralized mesh of data products or a unified data fabric, effective orchestration is key. Kestra provides the scalable, flexible, and developer-friendly platform to help you succeed. Explore how Kestra can help you with your [data strategy](/data).

--- a/src/contents/resources/process-mining/index.md
+++ b/src/contents/resources/process-mining/index.md
@@ -1,0 +1,199 @@
+---
+title: "Process Mining: Uncovering and Optimizing Business Workflows"
+description: "Process mining applies data science to event logs, revealing how business processes truly operate. Discover how to identify inefficiencies and drive data-driven improvements."
+metaTitle: "Process Mining: Optimize Business Workflows with Data"
+metaDescription: "Explore process mining to uncover inefficiencies and optimize business workflows. Learn how data-driven insights transform operations and enhance automation."
+tag: "business"
+date: 2026-08-05
+slug: "process-mining"
+faq:
+  - question: "What is process mining?"
+    answer: "Process mining is a data-driven method that uses specialized algorithms on event log data to reveal the actual flow, trends, and patterns of how a business process unfolds. It applies data science to discover, validate, and improve workflows, bridging the gap between theoretical process models and real-world execution."
+  - question: "Does process mining use AI?"
+    answer: "Yes, process mining increasingly leverages AI and machine learning. This 'Process Mining AI' applies advanced analytical techniques to enterprise process data to continuously analyze, predict, and optimize how work actually happens across various systems, enabling more intelligent and proactive process improvements."
+  - question: "What are the three types of process mining?"
+    answer: "The three primary types of process mining are discovery, conformance checking, and enhancement. Discovery automatically builds process models from event logs. Conformance checking compares observed process behavior to a reference model. Enhancement aims to improve existing processes by identifying bottlenecks and deviations."
+  - question: "How does process mining optimize business operations?"
+    answer: "Process mining optimizes business operations by providing objective, data-driven insights into actual process execution. It uncovers bottlenecks, deviations, and inefficiencies that might otherwise go unnoticed. This allows organizations to make informed decisions to streamline workflows, reduce costs, improve compliance, and enhance overall operational performance."
+  - question: "What kind of data is needed for process mining?"
+    answer: "Process mining primarily relies on event log data, which records every step or 'event' within a process. Each event must include a case ID (linking events to a specific process instance), an activity name (what happened), and a timestamp (when it happened). Additional attributes like resources or costs can enrich the analysis."
+  - question: "How does Kestra support process improvement initiatives?"
+    answer: "Kestra enhances process improvement by automating the data extraction required for process mining tools and operationalizing the insights gained. It can orchestrate data pipelines to collect, transform, and deliver event logs, and then automatically trigger or execute the optimized workflows identified by process mining, ensuring continuous improvement and automation."
+---
+
+In today's complex enterprise environments, understanding how business processes actually operate can feel like navigating a maze in the dark. Manual process documentation often falls short, leading to hidden inefficiencies, compliance gaps, and missed optimization opportunities. This is where process mining shines: a powerful data-driven approach that illuminates the true execution paths of your workflows.
+
+By analyzing digital footprints left in IT systems, process mining transforms raw event data into clear, actionable insights. This article will explore what process mining is, why it's critical for modern businesses, how it works, and how orchestration platforms like Kestra can help you operationalize its findings for continuous improvement.
+
+## What is Process Mining? Understanding the Data-Driven Approach
+
+Process mining is an analytical discipline that sits at the intersection of data science and process management. It provides an objective, evidence-based view of how your business processes function in reality, rather than how you think they do.
+
+### Defining process mining: from event logs to insights
+
+At its core, process mining uses specialized algorithms to analyze event log data from information systems like ERPs, CRMs, and custom applications. These event logs contain digital footprints of every step taken within a process. By reconstructing these steps, process mining creates a dynamic, visual model of the entire workflow.
+
+The foundational data elements required are:
+*   **Case ID:** A unique identifier that links all events belonging to a single process instance (e.g., an order number, a customer ID, an insurance claim number).
+*   **Activity Name:** A description of the specific step that occurred (e.g., "Invoice Received," "Approve Purchase Order," "Ship Goods").
+*   **Timestamp:** The exact time and date the activity took place.
+
+With these three data points, process mining tools can visualize the end-to-end process, including all variations, bottlenecks, and deviations.
+
+### The core concept: bridging theoretical models and real-world execution
+
+Many organizations have documented process models, often created using standards like [BPMN (Business Process Model and Notation)](/resources/business/bpmn). However, these models are often static, outdated, or represent an idealized "happy path" that doesn't reflect the complexities of daily operations.
+
+Process mining bridges this gap. It doesn't rely on interviews or workshops to map a process; it uses the actual data generated by your systems. This creates a "digital twin" of your operations, revealing the true "as-is" process. This data-driven approach removes subjectivity and provides a single source of truth for process analysis and improvement, forming a key part of any robust [business process automation](/resources/business/business-process-automation) strategy.
+
+## Why Process Mining Matters for Business Optimization
+
+Process mining moves beyond simple reporting and analytics to provide deep, actionable insights into operational performance. It helps organizations understand the "why" behind their process metrics, enabling targeted and effective improvements.
+
+### Key benefits: enhancing efficiency, compliance, and cost reduction
+
+By visualizing the actual flow of work, organizations can pinpoint specific areas of waste and inefficiency. The key benefits include:
+
+*   **Identifying Bottlenecks:** Discover where work gets stuck, causing delays and increasing cycle times. For example, identifying an approval step that consistently takes days instead of hours.
+*   **Uncovering Deviations:** See where employees or systems deviate from the standard operating procedure. This is critical for ensuring compliance and reducing operational risk.
+*   **Optimizing Resource Allocation:** Understand how teams and systems are utilized, allowing for better workload balancing and resource management.
+*   **Reducing Operational Costs:** By streamlining processes and eliminating redundant steps, organizations can significantly lower the cost of execution.
+*   **Improving Customer Experience:** Faster, more consistent processes directly translate to better service and higher customer satisfaction.
+
+### Common use cases: examples across industries
+
+Process mining is applicable to virtually any structured business process. Common use cases include:
+
+*   **Procure-to-Pay (P2P):** Analyzing the entire procurement lifecycle to identify delays in purchase order approvals, invoice processing, and payments.
+*   **Order-to-Cash (O2C):** Mapping the customer journey from order placement to payment receipt to find opportunities to accelerate cash flow and improve order fulfillment.
+*   **IT Service Management (ITSM):** Optimizing incident resolution and service request fulfillment by analyzing ticket data from platforms like ServiceNow. This is a core component of effective [IT process automation](/resources/infrastructure/it-process-automation).
+*   **Customer Onboarding:** Streamlining the steps involved in bringing a new customer on board to reduce churn and improve initial satisfaction.
+*   **Loan Application Processing:** In banking, analyzing the loan approval process to ensure compliance with regulations and reduce time-to-decision.
+
+### Does process mining use AI? The evolving role of advanced analytics and predictive capabilities
+
+Yes, modern process mining platforms increasingly incorporate Artificial Intelligence (AI) and machine learning. AI enhances traditional process mining by:
+
+*   **Predictive Analysis:** Forecasting potential bottlenecks or compliance issues before they occur.
+*   **Root Cause Analysis:** Automatically identifying the most likely causes of process deviations or inefficiencies.
+*   **Prescriptive Recommendations:** Suggesting specific actions to improve a process based on historical data.
+*   **Automated Discovery:** Using natural language processing (NLP) to extract process data from unstructured sources like emails or support tickets.
+
+This fusion of AI and process mining enables a more proactive and intelligent approach to continuous process improvement.
+
+## How Process Mining Works: Methodology and Data Analysis
+
+Implementing a process mining initiative involves a structured methodology that transforms raw data into strategic insights. The quality and availability of event log data are central to its success.
+
+### The critical role of event log data preparation and extraction
+
+The first and most crucial step is gathering the necessary data. This data often resides in multiple systems—an ERP for financial steps, a CRM for customer interactions, and a logistics system for shipping. A robust [data orchestration](/resources/data/data-orchestration) strategy is essential to extract, combine, and clean this data.
+
+Data preparation involves:
+*   **Extraction:** Pulling event logs from various source systems using APIs, database queries, or file exports.
+*   **Transformation:** Standardizing data formats, especially timestamps, and ensuring the case ID is consistent across all systems.
+*   **Correlation:** Stitching together event logs from different sources to create a single, unified view of the end-to-end process.
+*   **Loading:** Loading the prepared data into the process mining tool for analysis.
+
+### Step-by-step implementation: from data collection to insight generation
+
+A typical process mining project follows these steps:
+
+1.  **Define Scope:** Clearly identify the business process to be analyzed and the key questions you want to answer.
+2.  **Data Extraction:** Collect the relevant event log data from all associated IT systems.
+3.  **Data Transformation & Loading:** Prepare and load the data into the process mining software.
+4.  **Process Discovery:** The tool automatically generates a visual model of the "as-is" process.
+5.  **Analysis & Insight Generation:** Analysts explore the process model, identify bottlenecks, check for conformance, and perform root cause analysis.
+6.  **Action & Improvement:** Based on the insights, the business implements changes to the process. This could involve training, system changes, or automation.
+7.  **Monitoring:** Continuously monitor the process to measure the impact of the changes and identify new optimization opportunities.
+
+## Exploring Process Mining Techniques: Discovery, Conformance, and Enhancement
+
+Process mining is not a single technique but a collection of methods, each serving a different analytical purpose. The three primary types are discovery, conformance, and enhancement.
+
+### Process discovery: automatically mapping the 'as-is' process
+
+This is the most common type of process mining. It takes raw event log data as input and produces a process model without any prior information. The resulting model is a direct representation of what actually happened. It visualizes all paths, including common routes, rare exceptions, and rework loops, providing an unbiased view of the process.
+
+### Conformance checking: identifying deviations from desired processes
+
+Conformance checking compares the real-world process, as revealed by event logs, against a pre-defined reference model (the "to-be" or "should-be" process). This technique is invaluable for compliance and auditing. It highlights where and how often the actual process deviates from the prescribed standard, helping to identify policy violations, fraudulent activity, or areas where the standard process is impractical.
+
+### Process enhancement: optimizing for performance and compliance
+
+Enhancement aims to improve an existing process model using information from the event logs. It can enrich a model with performance data, such as showing the average time taken for each step or the cost associated with different paths. It can also identify the root causes of problems like bottlenecks or deviations, providing the data needed to redesign the process for better performance.
+
+## Choosing Process Mining Tools and Solutions
+
+The market for process mining software has grown significantly, with a range of vendors offering specialized platforms. Selecting the right tool depends on your organization's specific needs, scale, and technical maturity.
+
+### Key criteria for selecting the right process mining platform
+
+When evaluating tools, consider the following criteria:
+
+*   **Data Connectivity:** How easily can the tool connect to your source systems (e.g., SAP, Salesforce, Oracle)? Does it have pre-built connectors?
+*   **Scalability:** Can the platform handle the volume of event data your processes generate, especially for large-scale enterprise workflows?
+*   **Analytical Capabilities:** Does it support all three types of process mining? Does it offer advanced features like AI-driven root cause analysis or predictive monitoring?
+*   **Visualization and Usability:** Is the interface intuitive for business analysts and process owners, not just data scientists?
+*   **Integration:** How well does it integrate with other platforms, such as BI tools for reporting or orchestration platforms for automation?
+
+### Does Palantir do process mining? Exploring specialized and integrated solutions
+
+Yes, platforms like Palantir Foundry offer process mining capabilities as part of a broader data analytics and operations platform. This represents a trend where process mining is not just a standalone tool but an integrated feature within larger enterprise software suites. Other major vendors like SAP, ServiceNow, and Microsoft have also integrated process mining into their ecosystems.
+
+The choice between a best-of-breed specialized tool (like Celonis or UiPath Process Mining) and an integrated solution depends on your strategy. A specialized tool may offer deeper process-specific features, while an integrated solution can provide a more seamless connection to the underlying data and operational systems.
+
+## Common Challenges and Best Practices for Successful Initiatives
+
+While process mining is powerful, successful implementation requires careful planning and execution. Awareness of common pitfalls can help ensure a positive return on investment.
+
+### Overcoming data quality and integration obstacles
+
+The most common challenge is data-related. Issues include:
+*   **Data Availability:** Event logs may not be recorded for all process steps, especially manual ones.
+*   **Data Quality:** Inconsistent or missing data (e.g., incorrect timestamps, missing case IDs) can skew the analysis.
+*   **Data Correlation:** Tying together events from multiple systems can be complex if there isn't a common identifier.
+
+A solid data management strategy, including clear policies for [data storage](/docs/concepts/storage) and processing, is a prerequisite for effective process mining.
+
+### Best practices for effective process mining implementation and sustained value
+
+To maximize the impact of your process mining efforts, follow these best practices:
+
+*   **Start with a Clear Business Question:** Don't just "mine for gold." Start with a specific problem to solve, such as "Why are our customer support ticket resolution times so high?"
+*   **Ensure Stakeholder Buy-In:** Involve process owners and IT teams from the beginning to ensure access to data and support for implementing changes.
+*   **Combine Quantitative and Qualitative Analysis:** Use the insights from process mining to guide conversations with the people who execute the process daily. They can provide context that the data alone cannot.
+*   **Think Beyond One-Time Analysis:** Treat process mining as a continuous monitoring and improvement discipline, not a one-off project.
+
+## Orchestrating Process Mining Insights with Kestra
+
+Discovering an inefficiency is only the first step. The real value is realized when you operationalize that insight to create a better, more automated process. This is where an orchestration platform like Kestra becomes a critical partner to process mining tools.
+
+### Automating event log extraction and data preparation for process mining tools
+
+Process mining relies on a steady stream of high-quality data. Kestra can automate the entire data pipeline required to feed your process mining software. You can build declarative workflows using a variety of [ETL pipeline tools](/resources/data/etl-pipeline-tools) to:
+*   Schedule regular data extractions from databases, APIs, and file systems.
+*   Transform and clean the data to ensure it meets the required format.
+*   Load the prepared event logs into your process mining platform's storage layer (e.g., an S3 bucket or a database).
+
+This ensures your analysis is always based on fresh, accurate data without manual intervention.
+
+### Operationalizing process improvements with declarative, event-driven workflows
+
+Once process mining identifies an opportunity for improvement—such as a manual step that can be automated or a new approval rule—Kestra can execute the new, optimized process. With declarative, event-driven workflows, you can:
+*   Automate tasks that were previously manual, such as sending notifications, updating systems, or running scripts.
+*   Implement complex business logic and [approval processes](/docs/use-cases/approval-processes) directly in code.
+*   Trigger workflows based on real-time business events, ensuring that the optimized process runs consistently every time.
+
+You can get started quickly by exploring [business process blueprints](/blueprints/business-processes) that show how to model and automate common operational tasks.
+
+### Integrating Kestra with existing process mining tools for end-to-end automation
+
+Kestra acts as the execution engine that turns insights into action. By connecting your process mining tool's findings to Kestra's orchestration capabilities, you create a closed loop of continuous improvement:
+
+1.  **Mine:** Use your process mining tool to analyze data and identify an inefficiency.
+2.  **Model:** Design the new, improved workflow as a declarative YAML file in Kestra.
+3.  **Automate:** Deploy the Kestra workflow to automate the process, from data handling with tools like [DuckDB](/orchestration/duckdb) to complex integrations.
+4.  **Monitor:** Kestra provides detailed logs and metrics, which become new event data that feeds back into your process mining tool, allowing you to measure the impact of your changes.
+
+By bridging the gap between analysis and execution, you can transform your [infrastructure automation](/infra-automation) and business operations into a data-driven, continuously improving system. Explore more [business process resources](/resources/business) to see how orchestration can drive efficiency across your organization.

--- a/src/contents/resources/what-is-kafka/index.md
+++ b/src/contents/resources/what-is-kafka/index.md
@@ -1,0 +1,146 @@
+---
+title: "What Is Apache Kafka? Architecture, Concepts & Orchestration"
+description: "Apache Kafka is a distributed event streaming platform. Learn its core components, how it works, and common use cases for real-time data. Discover how Kestra orchestrates Kafka pipelines."
+metaTitle: "What Is Apache Kafka? Architecture & Orchestration"
+metaDescription: "Learn what Apache Kafka is, how its brokers, topics and partitions work, and how Kestra orchestrates producers and consumers in event-driven pipelines."
+tag: "data"
+date: 2026-08-05
+slug: "what-is-kafka"
+faq:
+  - question: "What is Apache Kafka and why is it used?"
+    answer: "Apache Kafka is an open-source distributed event streaming platform designed for building real-time data pipelines and streaming applications. It's used for its high-throughput, fault-tolerant, and scalable nature, enabling organizations to process massive volumes of events for analytics, logging, and operational data."
+  - question: "What does Kafka mean?"
+    answer: "Kafka is a project name chosen by its creators at LinkedIn, inspired by the author Franz Kafka. It doesn't have a direct technical acronym or meaning within the context of data streaming, but it has become synonymous with distributed event streaming."
+  - question: "Is Kafka backend or frontend?"
+    answer: "Kafka operates primarily in the backend, serving as a foundational layer for data ingestion, processing, and distribution between various backend systems and applications. While frontend applications might interact with systems that use Kafka, Kafka itself is a core infrastructure component."
+  - question: "What is Kafka vs Spark?"
+    answer: "Kafka is an event streaming platform for real-time data ingestion and storage, acting as a publish-subscribe messaging system. Apache Spark is a powerful distributed processing engine for large-scale data analytics, both batch and streaming. They are often used together, with Kafka feeding data to Spark for processing."
+  - question: "Do Netflix use Kafka?"
+    answer: "Yes, Netflix is a prominent user of Apache Kafka. They leverage Kafka extensively for real-time monitoring, event processing, and data ingestion across their vast microservices architecture, handling trillions of events daily for critical operational and analytical workloads."
+  - question: "Why is LinkedIn replacing Kafka?"
+    answer: "LinkedIn, the creator of Kafka, is not replacing Kafka. In fact, they remain one of its largest users and primary contributors. Any claims of replacement are likely misunderstandings or refer to specific internal projects that might complement or extend Kafka's capabilities, rather than replacing the core platform."
+  - question: "What are the core components of Apache Kafka?"
+    answer: "The core components of Kafka include Producers (applications that publish events), Consumers (applications that subscribe to and process events), Brokers (servers that store events), Topics (categories where events are stored), and Zookeeper (or Kraft, for managing broker metadata)."
+---
+
+> **TL;DR** — Apache Kafka is an open-source distributed event streaming platform for real-time data pipelines and applications, designed for high-throughput, fault-tolerant ingestion, storage, and processing of event streams.
+
+In today's event-driven architectures, the ability to handle streams of data in real time is paramount. From user activity logs to IoT sensor readings, organizations generate a continuous flow of information that needs to be ingested, processed, and acted upon without delay. This constant deluge of data presents both immense opportunities and significant challenges for traditional batch processing systems. Apache Kafka emerged as a solution to this problem, designed from the ground up to be a distributed, fault-tolerant, and high-throughput platform for handling event streams.
+
+## How Apache Kafka Works: Producers, Brokers, and Consumers
+
+Kafka's power lies in its simple yet robust architecture. It functions as a distributed, append-only log, allowing multiple applications to publish (write) and subscribe to (read) streams of records in a scalable and reliable manner.
+
+### Core Components of Kafka
+
+-   **Producers**: Applications that publish streams of records to one or more Kafka topics.
+-   **Consumers**: Applications that subscribe to topics and process the stream of records published to them. Consumers read records in the order they were produced.
+-   **Brokers**: The servers that make up a Kafka cluster. Each broker stores data and serves client requests. Brokers manage data replication and partition distribution.
+-   **Topics**: A category or feed name to which records are published. Topics in Kafka are multi-subscriber; that is, a topic can have zero, one, or many consumers that subscribe to the data written to it.
+-   **Partitions**: Each topic is split into one or more partitions. Partitions allow for parallel processing by splitting the data for a topic across multiple brokers. This is a key mechanism for Kafka's scalability.
+-   **Offset**: A unique, sequential ID given to each record within a partition. Consumers track their position in a partition using this offset, allowing them to read messages from a specific point.
+-   **ZooKeeper/Kraft**: Historically, ZooKeeper was used for managing and coordinating Kafka brokers. More recent versions can use Kafka's own quorum controller, Kraft, to remove the ZooKeeper dependency, simplifying the [deployment architecture](/docs/architecture/deployment-architecture).
+
+### The Distributed Architecture
+
+Kafka achieves high availability and durability through its distributed nature. A Kafka cluster consists of one or more brokers. Topics are partitioned, and these partitions are distributed across the brokers in the cluster. For fault tolerance, each partition can be replicated across multiple brokers.
+
+One broker acts as the "leader" for a given partition, handling all read and write requests. Other brokers act as "followers," passively replicating the leader's data. If the leader fails, one of the followers is automatically promoted to become the new leader, ensuring continuous availability. This model provides strong guarantees for message durability and fault tolerance, making Kafka a reliable choice for critical [event-driven orchestration](/resources/infrastructure/event-driven-orchestration).
+
+## Why Streaming Data Needs Orchestration
+
+While Kafka provides a powerful foundation for streaming data, building production-grade pipelines requires more than just a message bus. Effective orchestration is crucial to manage the complexity and ensure reliability.
+
+-   **End-to-End Integrity**: Orchestration ensures that messages are not just consumed but are fully processed, transformed, and loaded into downstream systems with guaranteed semantics (e.g., exactly-once processing).
+-   **Complex Dependencies**: Real-world pipelines involve multiple steps. An orchestrator manages the dependencies between Kafka consumers, data transformation jobs, database writes, and API calls.
+-   **Robust Error Handling**: What happens when a consumer fails? An orchestration platform implements sophisticated retry mechanisms, such as [exponential backoff](/resources/infrastructure/exponential-backoff), and routes failed messages to a [dead-letter queue](/resources/infrastructure/dead-letter-queue) for analysis without halting the entire pipeline.
+-   **Monitoring and Alerting**: Orchestration provides centralized visibility into the health of your streaming pipelines. It automates monitoring, sends alerts on failures, and can trigger operational runbooks.
+-   **Data Quality and Governance**: An orchestrator can enforce [data quality](/resources/data/data-quality) checks on incoming streams and manage schema evolution, ensuring that your [data observability](/resources/data/data-observability) is maintained as your systems evolve.
+
+## Orchestrate Kafka with Kestra: A Real-time Data Pipeline Scenario
+
+Using Kafka effectively in a production environment involves coordinating consumers, producers, and the business logic that processes the data. Kestra allows you to define and manage this entire workflow declaratively in YAML.
+
+Consider a scenario where you consume user activity events from a Kafka topic, filter out low-value events using a Python script, and then publish the enriched events to a separate topic for downstream analytics.
+
+```yaml
+id: kafka-event-processing
+namespace: company.team.analytics
+
+tasks:
+  - id: consume_events
+    type: io.kestra.plugin.kafka.Consume
+    properties:
+      bootstrap.servers: "{{ secret('KAFKA_BOOTSTRAP_SERVERS') }}"
+      security.protocol: "SASL_SSL"
+      sasl.mechanism: "PLAIN"
+      sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username='{{ secret('KAFKA_USERNAME') }}' password='{{ secret('KAFKA_PASSWORD') }}';"
+    topic: user_activity_raw
+    maxRecords: 500
+    keyDeserializer: STRING
+    valueDeserializer: JSON
+
+  - id: filter_and_enrich
+    type: io.kestra.plugin.scripts.python.Script
+    inputFiles:
+      data.json: "{{ outputs.consume_events.uri }}"
+    script: |
+      import json
+      import sys
+
+      with open('data.json', 'r') as f:
+        records = [json.loads(line) for line in f]
+
+      processed_records = []
+      for record in records:
+        # Example: filter for 'purchase' events and add a timestamp
+        if record.get('event_type') == 'purchase':
+          record['processed_at'] = "{{ now() | date('iso') }}"
+          processed_records.append(record)
+
+      # Write processed records to a new file for the next task
+      with open('processed_data.json', 'w') as f:
+        for record in processed_records:
+          f.write(json.dumps(record) + '\n')
+
+  - id: produce_enriched_events
+    type: io.kestra.plugin.kafka.Produce
+    properties:
+      bootstrap.servers: "{{ secret('KAFKA_BOOTSTRAP_SERVERS') }}"
+      security.protocol: "SASL_SSL"
+      sasl.mechanism: "PLAIN"
+      sasl.jaas.config: "org.apache.kafka.common.security.plain.PlainLoginModule required username='{{ secret('KAFKA_USERNAME') }}' password='{{ secret('KAFKA_PASSWORD') }}';"
+    topic: user_activity_enriched
+    from: "{{ outputs.filter_and_enrich.outputFiles['processed_data.json'] }}"
+    keySerializer: STRING
+    valueSerializer: JSON
+```
+
+A few things are worth noticing in this flow:
+
+-   **Declarative Definition**: The entire pipeline, from consuming to producing, is defined in a single, version-controllable YAML file.
+-   **Polyglot Processing**: A Kafka consumer task, written in Java, seamlessly passes data to a Python script for custom business logic.
+-   **State Management**: Kestra handles passing the data between tasks via internal storage, abstracting away the complexity of file management.
+-   **Secrets Management**: Credentials are not hardcoded; they are securely accessed using Kestra's secret management system.
+-   **Built-in Error Handling**: If any task fails, Kestra's built-in retry and error handling mechanisms can be configured to manage the failure gracefully.
+
+This declarative approach simplifies [Kafka orchestration](/orchestration/kafka), making complex streaming pipelines easier to build, maintain, and scale.
+
+## Where Kafka Stream Orchestration Pays Off
+
+Integrating Kafka with a robust orchestration platform unlocks numerous high-value use cases across an organization:
+
+-   **Real-time Analytics**: Feed cleaned and transformed data from Kafka streams directly into real-time dashboards and analytical systems.
+-   **Event Sourcing**: Use Kafka as the system of record for events in a microservices architecture, with an orchestrator managing the complex interactions between services.
+-   **Log Aggregation**: Ingest logs from thousands of services, process them in real-time to detect anomalies, and forward them to long-term storage or monitoring systems.
+-   **Change Data Capture (CDC)**: Stream database changes into Kafka and orchestrate the process of replicating those changes to data warehouses, search indexes, or other systems. See how to build [CDC pipelines](/resources/data/change-data-capture).
+-   **IoT Data Ingestion**: Handle massive streams of data from IoT devices, orchestrating filtering, aggregation, and alerting based on real-time sensor readings.
+
+## Related Concepts
+
+-   [Kafka Connect: Data Streaming & Orchestration](/resources/data/kafka-connect)
+-   [Kafka Streams: Real-Time Processing Explained](/resources/data/kafka-streams)
+-   [Kinesis vs. Kafka: Streaming Platform Comparison](/resources/data/kinesis-vs-kafka)
+-   [Pub/Sub vs. Kafka: Event Streaming Platform Comparison](/resources/data/pubsub-vs-kafka)
+-   [What is Data Ingestion?](/resources/data/what-is-data-ingestion)
+-   [What Is Data Orchestration?](/resources/data/data-orchestration)


### PR DESCRIPTION
## Summary

Imports 9 W32 SEO drafts from `vfanucci/kestra-seo` (#311–#319) into the resources hub.

| Page | Type | URL | Source |
|------|------|-----|--------|
| AI Agent Evaluation | concept | `/resources/ai/ai-agent-evaluation` | #311 |
| AI Orchestration | concept | `/resources/ai/ai-orchestration` | #312 |
| Business Process Management Tools | listicle | `/resources/business/business-process-management-tools` | #313 |
| Context Engineering | concept | `/resources/ai/context-engineering` | #314 |
| What Is Kafka | concept | `/resources/data/what-is-kafka` | #315 |
| AI Agent Orchestration | concept | `/resources/ai/ai-agent-orchestration` | #316 |
| Case Management Orchestration | concept | `/resources/business/case-management-orchestration` | #317 |
| Data Mesh vs Data Fabric | standard | `/resources/data/data-mesh-vs-data-fabric` | #318 |
| Process Mining | standard | `/resources/business/process-mining` | #319 |

No slug collisions.

## Fixes applied on import

- **ai-orchestration (#312)** had **no `date` field at all** in its front-matter — added, otherwise the page renders without a publish date. (Same defect previously hit `workflow-observability`.)
- Publish `date` set to the **real publication date (`2026-08-05`)** on all 9 pages. Two outlines also shipped a literal `date: YYYY-MM-DD` placeholder upstream (`what-is-kafka`, `data-mesh-vs-data-fabric`) — fixed at the outline stage.
- **ai-agent-orchestration (#316)**: metaDescription 177 → 145 chars.
- metaTitle ≤ 60 with the ` | Kestra` suffix stripped (the docs template appends it); fences balanced; no `image:`/`author:`; no unresolved markers; no duplicated headings.
- Concept-page plugin FQCNs verified against `context/plugin-classes.txt`. Several invented classes were corrected upstream at the outline stage: `ai.agent.aiagent` → `AIAgent`, `kafka.consume/produce` → `Consume/Produce`, `elasticsearch.rest.Search` → `elasticsearch.Search`, `openai.chat.ChatCompletion` → `openai.ChatCompletion`, `notifications.slack.SlackSend` → `SlackIncomingWebhook`, plus a fictitious `core.flow.Continue` task removed and its error handling moved into a root-level `errors:` block.

## ⚠️ Cannibalisation watch — the AI-orchestration cluster is getting crowded

`ai-orchestration` (#312) and `ai-agent-orchestration` (#316) land next to several live pages on adjacent intents: `ai-native-orchestration-platform`, `agentic-orchestration`, `agentic-ai`, `ai-agent`, `ml-orchestration`, `mcp-orchestration`, `directed-agentic-graphs`, `ai-orchestration-for-non-technical-teams`. Worth a canonical / internal-link pass to make the hierarchy explicit (which page is the hub, which are the spokes) before this grows further.

Similarly, `business-process-management-tools` (#313) sits next to the live `business-process-automation`, and `process-mining` (#319) next to `it-process-automation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
