### PR TITLE
SEO: agentic cluster — fix rendered frontmatter + scope the agent-orchestration pillar

### DIFF
--- a/src/contents/resources/agentic-orchestration/index.md
+++ b/src/contents/resources/agentic-orchestration/index.md
@@ -6,6 +6,14 @@ metaDescription: "Learn what agentic orchestration is, how it coordinates AI age
 tag: ai
 date: 2026-07-01
 faq:
+  - question: "What is agentic orchestration?"
+    answer: "Agentic orchestration is a structured approach to managing specialized AI agents so they collaborate and complete tasks autonomously. It coordinates agents, governs their actions, and moves data between them to achieve complex organizational goals reliably."
+  - question: "What is an agentic orchestration platform?"
+    answer: "An agentic orchestration platform is a control plane that lets AI agents, automation, machine learning, and people work together. It provides the capabilities to design, run, monitor, and optimize long-running processes end-to-end, with audit trails and access controls for AI initiatives."
+  - question: "What is the difference between agentic workflows and orchestration?"
+    answer: "In agentic systems, workflows are the processes where agents execute tasks. Orchestration defines explicit checkpoints and rules, letting agents do preparatory and analytical work autonomously while keeping human judgment where it is required. This lets people focus on outcomes rather than supervising every step."
+  - question: "What is the difference between orchestration and choreography in agentic AI?"
+    answer: "Orchestration provides a central authority for control, ensuring compliance, governance, and predictable execution across AI agents. Choreography emphasizes decentralized, self-organizing interactions that favor adaptability. A blend of both can create resilient agentic ecosystems tailored to an organization's need for control and autonomy."
   - question: "What is the difference between agentic and orchestration?"
     answer: "'Agentic' refers to the quality of an AI system having autonomous, goal-driven actors (agents). 'Orchestration' refers to the framework that coordinates these agents, along with other systems and people, to achieve a larger business process. Agentic is about the actor; orchestration is about the system managing the actors."
   - question: "What is an orchestrator in agentic AI?"
@@ -26,32 +34,6 @@ faq:
     answer: "Common pitfalls include underestimating the need for governance, giving agents access to too many or poorly defined tools, failing to implement human oversight for critical tasks, and not having adequate monitoring to observe and debug agent behavior. Starting with a strong orchestration platform helps avoid these issues."
 ---
 
-```yaml
----
-title: "Agentic Orchestration: Unifying AI Agents and Workflows"
-description: "Agentic orchestration provides the framework for AI agents to collaborate effectively, tackling complex tasks across diverse domains. Learn how a declarative orchestration platform can bring governance and scalability to your AI workflows."
-metaTitle: "Agentic Orchestration: Unifying AI Agents & Workflows"
-metaDescription: "Learn what agentic orchestration is, how it differs from choreography, and how a declarative platform coordinates AI agents into governed, auditable systems."
-tag: "ai"
-date: 2026-07-01
-slug: "agentic-orchestration"
-faq:
-  - question: "What is agentic orchestration?"
-    answer: "Agentic orchestration is a structured approach to managing specialized AI agents so they collaborate and complete tasks autonomously. It coordinates agents, governs their actions, and moves data between them to achieve complex organizational goals reliably."
-  - question: "What is an agentic orchestration platform?"
-    answer: "An agentic orchestration platform is a control plane that lets AI agents, automation, machine learning, and people work together. It provides the capabilities to design, run, monitor, and optimize long-running processes end-to-end, with audit trails and access controls for AI initiatives."
-  - question: "What is the difference between an agent and an orchestrator?"
-    answer: "An agent is an autonomous unit that reasons, calls tools, and acts toward a goal. An orchestrator is the layer above it that decides which agents run, in what order, with what data, and under what governance. The agent does the work; the orchestrator coordinates and supervises it."
-  - question: "What is the difference between agentic workflows and orchestration?"
-    answer: "In agentic systems, workflows are the processes where agents execute tasks. Orchestration defines explicit checkpoints and rules, letting agents do preparatory and analytical work autonomously while keeping human judgment where it is required. This lets people focus on outcomes rather than supervising every step."
-  - question: "What is the difference between orchestration and choreography in agentic AI?"
-    answer: "Orchestration provides a central authority for control, ensuring compliance, governance, and predictable execution across AI agents. Choreography emphasizes decentralized, self-organizing interactions that favor adaptability. A blend of both can create resilient agentic ecosystems tailored to an organization's need for control and autonomy."
-  - question: "How to build agentic orchestration?"
-    answer: "Building agentic orchestration involves assessment and planning, selecting specialized AI agents, implementing an orchestration framework, assigning agents to tasks, coordinating workflow execution, and managing data sharing and context. Continuous optimization and learning are essential for long-term success."
-  - question: "What exactly is orchestration?"
-    answer: "Orchestration is the coordinated execution of multiple IT automation tasks or processes across various systems, applications, and services. Its purpose is to ensure that complex sequences—deployments, configuration management, and data pipelines—run in the correct order, with proper error handling and dependency management."
----
-```
 The rise of AI agents promises a new level of automation, but their real power lies not in isolated capabilities, but in their ability to collaborate and execute complex, multi-step workflows. Without a central coordinating intelligence, these agents quickly become chaotic, creating new silos and operational blind spots.
 
 Agentic orchestration provides this missing framework. It's the discipline of designing, managing, and monitoring teams of AI agents, making sure they work together across diverse systems—from data pipelines and cloud infrastructure to business logic and human approvals. This article explores how agentic orchestration unifies these disparate elements into a single, auditable control plane, so enterprises can build reliable, scalable AI-powered systems.

--- a/src/contents/resources/ai-agent-orchestration/index.md
+++ b/src/contents/resources/ai-agent-orchestration/index.md
@@ -1,11 +1,10 @@
 ---
-title: "AI Agent Orchestration: Governing Autonomous Workflows in Production"
-description: "Explore AI agent orchestration, the critical discipline for coordinating multiple AI agents to achieve complex goals reliably. Learn how declarative platforms enable scalable, auditable, and human-in-the-loop agentic workflows."
-metaTitle: "AI Agent Orchestration: Governing Autonomous Workflows"
-metaDescription: "Coordinate multiple AI agents in production: manage complex goals and ensure reliability with declarative, auditable human-in-the-loop workflows."
+title: "AI Agent Orchestration: How to Coordinate AI Agents in Production"
+description: "AI agent orchestration coordinates multiple autonomous agents into one reliable system. Learn the four patterns, how agent orchestration differs from single-agent workflows, and what it takes to run agents in production."
+metaTitle: "AI Agent Orchestration: How to Coordinate Agents | Kestra"
+metaDescription: "What AI agent orchestration is, how it differs from single-agent workflows, and the four patterns that keep multi-agent systems reliable in production."
 tag: "ai"
 date: 2026-08-05
-slug: "ai-agent-orchestration"
 faq:
   - question: "What is AI agent orchestration?"
     answer: "AI agent orchestration is the practice of designing, coordinating, and managing multiple specialized AI agents to work collaboratively towards a common objective. It involves defining their roles, communication protocols, execution order, and error handling to ensure reliable and efficient goal achievement in complex environments."
@@ -17,6 +16,10 @@ faq:
     answer: "A typical system includes AI agents (specialized models with tools and memory), an orchestration layer (defining flow, triggers, and dependencies), a tool registry (APIs, databases, scripts), a communication bus, and an observability layer for monitoring and debugging. Human-in-the-loop mechanisms are also vital for oversight."
   - question: "What are common challenges in orchestrating AI agents?"
     answer: "Challenges include managing complex interdependencies, ensuring data consistency across agents, handling unexpected agent behaviors, maintaining security and compliance, and providing clear visibility into multi-agent decision-making. Scalability and cost optimization for LLM calls are also significant concerns."
+  - question: "What is the difference between agent orchestration and AI agent orchestration?"
+    answer: "The two terms are used interchangeably in practice. 'Agent orchestration' is the broader phrasing and can cover non-AI software agents; 'AI agent orchestration' specifies that the coordinated agents are LLM-driven, with tools, memory and goals. Both describe the same discipline: defining how multiple autonomous agents share context, execute in order, and hand off work under a single governed control plane."
+  - question: "Is AI orchestration the same as AI agent orchestration?"
+    answer: "AI orchestration is the broader discipline: coordinating models, data pipelines, tools and agents across an enterprise AI stack. AI agent orchestration is the subset that deals specifically with autonomous agents that plan and act. If your workload is a fixed sequence of model calls, you need AI orchestration; as soon as a component decides its own next step, you need agent orchestration on top of it."
   - question: "Can AI agent orchestration integrate with existing enterprise systems?"
     answer: "Yes, effective AI agent orchestration platforms are designed to integrate seamlessly with existing enterprise systems, including databases, CRM, ERP, cloud services, and custom APIs. This allows agents to leverage current data and trigger actions across the organization, extending automation capabilities without requiring a full system overhaul."
 ---
@@ -35,6 +38,8 @@ AI agent orchestration is the process of coordinating multiple autonomous AI age
 
 An orchestration platform acts as the central nervous system for a [multi-agent system](/resources/ai/multi-agent-system), ensuring that each agent, whether it's designed for data analysis, code generation, or customer interaction, contributes effectively to the overall goal without conflicts or redundancy.
 
+Agent orchestration is one discipline inside the wider practice of [coordinating models, pipelines and tools across an enterprise AI stack](/resources/ai/ai-orchestration). The distinguishing factor is who decides the next step: in a classic AI pipeline the sequence is fixed at design time, while in an agentic one at least one component chooses its own path at runtime. That single difference is what makes the guarantees below — durable state, retries, audit trails, spend ceilings — non-negotiable rather than nice to have.
+
 ### The Shift from Single Agents to Collaborative Systems
 
 Early AI applications often relied on a single agent to perform a task. However, complex real-world problems are rarely solved by a single skill set. A financial forecasting task might require one agent to gather market data, another to perform statistical analysis, a third to generate a report, and a fourth to summarize findings for an executive audience.
@@ -46,6 +51,18 @@ This is where [multi-agent collaboration](/resources/ai/multi-agent-collaboratio
 - **Ensuring Goal Alignment:** Keeping all agents focused on the primary objective, even as they operate with a degree of autonomy.
 
 Without orchestration, a team of powerful AI agents is just a collection of individuals. With it, they become a high-performance, autonomous workforce.
+
+## Agent Orchestration vs. Single-Agent Workflows
+
+A single-agent workflow has one reasoning loop: the agent receives a goal, calls tools until it believes the goal is met, and returns. It is easy to build, easy to reason about, and it degrades predictably — when it fails, there is one place to look.
+
+Agent orchestration changes three things at once, and each introduces a class of failure that single-agent setups never encounter:
+
+1. **Context has to be transferred, not shared.** One agent's conclusion becomes another's premise. If the handoff loses a caveat or a confidence level, the second agent reasons confidently from a distorted input, and nothing in the system flags it.
+2. **Failure stops being local.** A single agent that fails returns an error. An agent inside a chain that fails silently — returning a plausible but wrong answer — propagates that answer downstream, where it is expensive to trace back.
+3. **Cost and latency compound.** Five agents at ten seconds and thirty cents each is a very different operational profile from one agent at the same unit cost, and it scales with every input.
+
+None of these are solved by a better prompt or a stronger model. They are execution problems, which is why they belong to the orchestration layer: explicit contracts between agents, checkpoints where output is validated before it moves on, and a ceiling on how much a single run is allowed to spend.
 
 ## How Kestra Enables Declarative AI Agent Orchestration
 
@@ -80,7 +97,11 @@ tasks:
 
 This declarative approach makes it easy to [build and manage AI agents](/resources/ai/how-to-build-an-ai-agent), turning complex agentic logic into manageable, version-controlled code.
 
-### Orchestration Patterns for Agentic Workflows
+## How to Orchestrate AI Agents: Four Patterns
+
+Almost every production system that orchestrates AI agents is built from four patterns, alone or in combination. Choosing between them is the first design decision, and the one that most affects cost and debuggability.
+
+### Sequential, Parallel, Conditional and Hierarchical Routing
 
 Kestra’s flowable task model supports several key patterns for orchestrating agent interactions:
 


### PR DESCRIPTION
Draft — first two lots of the `/resources/ai/` internal-linking plan. Content only: no URL change, no redirect, no component touched. Fully reversible.

## Context

The `/resources/ai/` prefix ranks for **3 US keywords and 0 clicks** (Ahrefs, 2026-08-06), 2 of them `ai_overview`. 37 pages, ~82k words, no organic footprint. The cluster has no pillar and its internal links are accidental.

Full plan and measurements are in the working doc; this PR is lots 0 and 1.

## Commit 1 — `agentic-orchestration`: remove frontmatter rendered on the page

The body started with a **second, complete frontmatter block wrapped in a ```` ```yaml ```` fence**, so a code block rendered as the first content element right after the H1. Verified live: `curl https://kestra.io/resources/ai/agentic-orchestration.md`. Only page in the repo in this state (checked all 253).

This is the most internally-linked page of the AI cluster (40 editorial inbound links), so the defect sat on the page crawlers and generative engines read first.

The dead block also carried **four FAQ entries that never shipped**, including *"What is agentic orchestration?"* — the page's own primary keyword, absent from the live FAQ schema. Those four are merged into the active frontmatter before the block is dropped; three redundant ones discarded.

FAQ 9 → 13 entries. No URL, tag or title change.

## Commit 2 — `ai-agent-orchestration`: scope it to its own parent topic

Ahrefs groups `ai agent orchestration` (1000) and `agent orchestration` (1000) under a single `parent_topic`, so one page must own both. The broader `ai orchestration` head (1500) stays with `/resources/ai/ai-orchestration`, which already exists and is built for it — this page links **up** to it instead of competing.

- `title` / `description` / `metaTitle` / `metaDescription` rewritten to lead on the primary keyword; `metaTitle` kept at 57 chars to avoid SERP truncation
- drop the no-op `slug` field (not in the collection schema — the id comes from the folder name)
- new H2 *"Agent Orchestration vs. Single-Agent Workflows"* for the secondary head
- the four orchestration patterns promoted from a buried H3 to their own H2, *"How to Orchestrate AI Agents: Four Patterns"*
- contextual upward link to `ai-orchestration` at 12% of the body
- 2 FAQ entries disambiguating agent orchestration from AI orchestration

2040 → 2403 words.

## Verification

- `astro sync` — all 253 collection entries validate against the zod schema
- `npm run build` — full build passes (exit 0)
- rendered HTML checked: no residual code block after the H1, FAQPage schema present (13 questions), all 8 H2s render, outbound links resolve
- script check: tags within the `content.config.ts` enum, no out-of-schema fields, every `/resources/` link points to an existing slug

## Not in this PR

Editorial inbound links to the pillar (lot 2), orphan rescue including `context-engineering` (2900 vol, 0 editorial links), anchor de-concentration, and the `agentic-process-automation` page.