### PR TITLE
fix(ci): fail the contributor onboarding workflow when the welcome action errors

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -21,6 +21,8 @@ jobs:
           GH_PAT_READ_ORG: ${{ secrets.GH_READ_ORG_TOKEN }}
         with:
           skip-internal-contributors: true
+          # The action defaults to false, which turns a broken GH_READ_ORG_TOKEN into a green job that silently welcomes nobody.
+          fail-on-error: true
           pr-opened-msg: |
             ### Hey @{fc-author} :wave: 
 


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestra/issues/17940.

The Contributor Onboarding workflow has been reporting ✅ while welcoming nobody.

## What

Set `fail-on-error: true` on the `plbstl/first-contribution` step so an error surfaces as a red check instead of a green one.

## Why

`fail-on-error` defaults to `false`. In that mode the action catches every error and calls `core.error()` rather than `core.setFailed()`, so the step still exits 0.

Because we pass `skip-internal-contributors: true`, the very first thing the action does is an org-membership check — and `is_internal_contributor()` only swallows a `404`; anything else is re-thrown. So an invalid `GH_READ_ORG_TOKEN` aborts the action *before* it can react or comment, and the job still goes green.

That is the current state. Recent runs fail identically:

```
Checking if @<author> is an org member of `kestra-io`.
Org membership check returned status: 401
##[error]Bad credentials - https://docs.github.com/rest
```

## What this does *not* fix

The credential itself — `GH_READ_ORG_TOKEN` is an org-level secret whose PAT has expired or been revoked, and an org admin still needs to rotate it. This PR only ensures we find out immediately next time, rather than weeks later.

## Companion PR

https://github.com/kestra-io/kestra/pull/17939 — same one-line change, same failure.
