### PR TITLE
SEO: wire the AI cluster to the ai-orchestration pillar (28 inbound + 9 hub links)

### DIFF
--- a/src/contents/resources/agentic-ai/index.md
+++ b/src/contents/resources/agentic-ai/index.md
@@ -28,6 +28,8 @@ Deploying and governing truly autonomous AI agents in production raises its own 
 
 Agentic AI marks a shift from passive, responsive systems to proactive, goal-driven actors. Instead of only processing inputs and producing outputs, an agentic system plans and executes a sequence of actions to reach a specific objective, adapting its strategy based on feedback from its environment.
 
+Autonomy is what makes agentic AI useful and what makes it hard to operate. Both concerns land on the same foundation: [AI orchestration in production](/resources/ai/ai-orchestration).
+
 ### What makes an AI system "agentic"?
 
 Several characteristics distinguish an agentic AI system. At its core, an agent runs a perception-action loop: it perceives its environment, makes a decision, and takes an action. What makes it "agentic" is the addition of autonomy, memory, and learning.

--- a/src/contents/resources/agentic-orchestration/index.md
+++ b/src/contents/resources/agentic-orchestration/index.md
@@ -60,6 +60,8 @@ Agentic orchestration provides this missing framework. It's the discipline of de
 
 Agentic orchestration represents a significant evolution in automation, moving from simple, task-based scripts to goal-oriented systems. It's the structured practice of managing and coordinating multiple specialized [AI agents](/resources/ai/ai-agent) to achieve outcomes that no single agent could accomplish alone.
 
+Agentic orchestration is the newest layer of a longer-standing practice: [enterprise AI orchestration](/resources/ai/ai-orchestration), which coordinates models, data pipelines and tools whether or not an autonomous agent is involved.
+
 At its core, agentic orchestration is about creating a system where AI agents can collaborate, share context, and execute tasks in a governed, observable manner. This is not just about running a sequence of model calls; it's about building a framework that handles errors, incorporates human feedback, and interacts with external tools and APIs.
 
 This approach is a cornerstone of [AI-native orchestration platforms](/resources/ai/ai-native-orchestration-platform), which are designed from the ground up to manage the complexities of AI-driven processes. These platforms provide the control plane needed to move agentic systems from experimental prototypes to production-grade applications, so every action is auditable, repeatable, and aligned with business objectives.

--- a/src/contents/resources/agentic-workflows/index.md
+++ b/src/contents/resources/agentic-workflows/index.md
@@ -90,6 +90,8 @@ GitHub is a prime example of a platform embracing agentic workflows. Their "GitH
 
 ## Kestra's Approach to Agentic Workflows
 
+Agentic workflows are one workload among several that a control plane has to run, which is why they are usually deployed on the same [AI orchestration platforms](/resources/ai/ai-orchestration) that already handle training, retrieval and inference.
+
 ### Declarative Orchestration for AI Agents
 
 Building reliable agentic workflows requires a robust orchestration layer. Kestra provides this through a declarative, YAML-based approach. Instead of writing complex, imperative code to manage an agent's lifecycle, you define the agent's goals, tools, and constraints in a simple, auditable [flow definition](/docs/workflow-components/flow).

--- a/src/contents/resources/ai-agent-evaluation/index.md
+++ b/src/contents/resources/ai-agent-evaluation/index.md
@@ -75,6 +75,8 @@ Several methodologies have emerged to structure the evaluation process:
 
 As evaluation scenarios become more sophisticated, running them manually becomes untenable. Orchestration is the key to building a scalable, repeatable, and reliable evaluation system. It addresses several critical challenges:
 
+Evaluation runs are themselves workflows, with dependencies, retries and cost ceilings. That places them squarely inside the practice of [orchestrating evaluation across an AI stack](/resources/ai/ai-orchestration).
+
 *   **Automation:** Evaluation often involves a sequence of steps: setting up an environment, running the agent against a dataset, executing an evaluation script, and storing the results. An orchestrator automates this entire pipeline.
 *   **Integration:** A typical evaluation pipeline involves multiple components: the agent itself, LLM providers, evaluation frameworks (like DeepEval or LangChain), data sources, and notification systems. Orchestration unifies these disparate tools into a single, cohesive workflow.
 *   **Lifecycle Management:** It manages the entire lifecycle of an evaluation run, including versioning of agents, datasets, and evaluation logic. This ensures that results are reproducible and comparable over time.

--- a/src/contents/resources/ai-agent/index.md
+++ b/src/contents/resources/ai-agent/index.md
@@ -26,6 +26,8 @@ The rise of Large Language Models (LLMs) has transformed what's possible with au
 
 An AI agent is a software program that can perceive its environment, process that information, and take autonomous actions to achieve specific goals. Unlike a simple script that follows a rigid set of instructions, an agent operates within a perception-action cycle: it senses changes, makes decisions based on its programming and past experiences, and then acts upon its environment.
 
+An agent is one component in a wider system. Making it useful in production means [coordinating models, data and tools](/resources/ai/ai-orchestration) around it, not just improving the agent itself.
+
 This ability to operate autonomously is what sets AI agents apart. They are designed to be proactive and persistent, capable of running complex, long-duration tasks without direct human intervention. This could involve anything from monitoring a system for anomalies to executing a multi-step financial transaction or provisioning cloud infrastructure. The core idea is to delegate not just the "how" but also the "what" and "when" of a task to a system that can reason and react. For a deeper dive into how Kestra implements this, explore our documentation on [AI Agents in Kestra](/docs/ai-tools/ai-agents). Broader patterns around autonomous, goal-driven automation are covered in our guide to [agentic AI](/resources/ai/agentic-ai).
 
 ## Key characteristics of AI agents

--- a/src/contents/resources/ai-code-generation-pipelines/index.md
+++ b/src/contents/resources/ai-code-generation-pipelines/index.md
@@ -134,6 +134,8 @@ The evolution of AI in software development is heading towards more autonomous s
 
 Kestra is uniquely positioned to serve as the backbone for AI code generation pipelines. Its declarative YAML interface makes workflows auditable and version-controllable, which is essential for governing AI-driven processes. As a polyglot platform, Kestra can run any tool or script, regardless of language, providing the flexibility needed to integrate various AI models, linters, and security scanners.
 
+Code generation is one AI workload among many, which is [why teams end up putting every AI workload on the same scheduler](/resources/ai/ai-orchestration) instead of running a separate tool per use case.
+
 With native [AI tools](https://kestra.io/docs/ai-tools) like the AI Copilot and autonomous agents, Kestra is not just an orchestrator but an active participant in the AI-driven development lifecycle. It provides the unified control plane needed to manage these complex workflows, from data ingestion for RAG systems to the final deployment of AI-generated code. This is [why Kestra](https://kestra.io/docs/why-kestra) is a powerful choice for teams looking to build the next generation of software delivery pipelines.
 
 ## Conclusion

--- a/src/contents/resources/ai-code-generation-workflow/index.md
+++ b/src/contents/resources/ai-code-generation-workflow/index.md
@@ -119,6 +119,8 @@ The workflow extends beyond simple code generation. Advanced tools and concepts 
 
 To move from ad-hoc AI usage to a systematic, enterprise-grade process, you need to architect a workflow that prioritizes reliability, quality, and maintainability. This involves establishing clear principles and leveraging the right structural patterns.
 
+Reliability here is not a property of the model but of the system around it — which is [why AI projects stall between the model and production](/resources/ai/ai-orchestration) more often than at the modelling stage.
+
 ### The importance of separating planning from execution
 
 One of the most effective strategies for getting reliable results from AI is to separate the "planning" phase from the "execution" (code generation) phase.

--- a/src/contents/resources/ai-governance-workflows/index.md
+++ b/src/contents/resources/ai-governance-workflows/index.md
@@ -183,6 +183,8 @@ As you scale your AI initiatives, it's crucial to track their impact on business
 
 AI workflows can be broadly categorized into non-agentic and agentic systems, each requiring a tailored governance approach.
 
+Governance is only enforceable where execution is observable, which is why audit trails and approval gates belong to the orchestration layer. See [governed AI orchestration](/resources/ai/ai-orchestration) for how the two fit together.
+
 ### Non-agentic AI workflows
 
 These are traditional, deterministic workflows common in MLOps, such as [ETL for ML](https://kestra.io/resources/data/etl-workflow) and batch inference jobs. Governance for these workflows focuses on data quality, model versioning, and the reproducibility of the [machine learning pipeline](https://kestra.io/resources/ai/what-is-a-machine-learning-pipeline).

--- a/src/contents/resources/ai-native-orchestration-platform/index.md
+++ b/src/contents/resources/ai-native-orchestration-platform/index.md
@@ -31,6 +31,8 @@ This article explores the emerging category of AI-native orchestration platforms
 
 An AI-native orchestration platform is a control plane designed specifically to manage the entire lifecycle of AI and machine learning applications. It goes beyond simple task scheduling to coordinate complex dependencies between data ingestion, model training, validation, deployment, and monitoring.
 
+An AI-native platform is one implementation of [AI orchestration](/resources/ai/ai-orchestration); the discipline itself is broader, and covers how models, pipelines, tools and agents are sequenced across the whole stack.
+
 ### Defining AI Orchestration: Models, Data, and Workflows
 
 AI orchestration involves the automated management of three core components:

--- a/src/contents/resources/ai-orchestration-for-non-technical-teams/index.md
+++ b/src/contents/resources/ai-orchestration-for-non-technical-teams/index.md
@@ -29,6 +29,8 @@ This guide cuts through that complexity, showing how non-technical users can lev
 
 AI orchestration is no longer confined to the domain of data scientists and developers. For non-technical teams, it represents a powerful way to automate processes, make smarter decisions, and boost productivity by coordinating various AI-powered tasks into a cohesive workflow.
 
+The underlying discipline is the same one engineering teams practise: read the full guide to [AI orchestration software](/resources/ai/ai-orchestration) for how models, data and tools are coordinated once a workflow leaves the prototype stage.
+
 ### Defining AI orchestration: a straightforward approach
 
 At its core, AI orchestration is the process of managing and automating a sequence of tasks that involve one or more AI models or agents. Think of it as a conductor leading an orchestra. Each musician (an AI tool) is skilled at a specific task, such as summarizing text, analyzing customer sentiment, or generating images. The conductor (the orchestration platform) ensures they all work together in the right order to produce a final piece—a complete business process.

--- a/src/contents/resources/ai-orchestration/index.md
+++ b/src/contents/resources/ai-orchestration/index.md
@@ -45,6 +45,8 @@ An effective [orchestrator for data, AI, and infrastructure](/resources/data/orc
 
 The term "AI orchestration" is often used broadly, but it's useful to distinguish between the general practice and the more specific discipline of agent orchestration.
 
+The subset that deals specifically with autonomous, goal-driven components is covered in depth in [AI agent orchestration](/resources/ai/ai-agent-orchestration).
+
 ### What is AI orchestration?
 
 AI orchestration is the end-to-end coordination and management of all components in an AI system. This includes the entire lifecycle:
@@ -65,6 +67,8 @@ AI agent orchestration manages how these agents collaborate, share information, 
 ## How AI orchestration works in practice
 
 At its core, an AI orchestration platform acts as the central nervous system for your AI applications, connecting various tools and processes into a cohesive workflow.
+
+Two adjacent disciplines sit inside this picture: [orchestrating the ML lifecycle](/resources/ai/ml-orchestration) on the training side, and [managing what the model actually sees](/resources/ai/context-engineering) on the inference side.
 
 ### Key components of an AI orchestration system
 
@@ -141,6 +145,8 @@ tasks:
 
 When evaluating AI orchestration platforms, several key features are essential for building scalable and maintainable systems.
 
+Tool access deserves its own mention: standardising it through a protocol, as covered in [exposing tools through MCP](/resources/ai/mcp-orchestration), keeps integrations out of individual prompts.
+
 - **Declarative Workflow Definition:** Defining workflows as code, typically in YAML, allows for version control, code reviews, and GitOps-style management. This [YAML-first orchestration](/blogs/yaml-for-workflow-orchestration) approach separates workflow logic from business logic.
 - **Polyglot Execution:** The ability to run tasks written in any language (Python, R, SQL, Bash, etc.) is crucial for heterogeneous AI teams. [Language-agnostic orchestration](/features/code-in-any-language) ensures that the platform doesn't force a specific programming language on your team.
 - **Event-Driven Triggers:** Modern AI applications need to react to real-time events. [Event-driven orchestration](/resources/infrastructure/event-driven-orchestration) enables workflows to be triggered by message queues, webhooks, or file system events.
@@ -152,6 +158,8 @@ When evaluating AI orchestration platforms, several key features are essential f
 ## Comparing top AI orchestration tools and platforms
 
 The market for [AI and data orchestration platforms](/blogs/top-data-orchestration-platforms) is diverse, with tools ranging from general-purpose orchestrators to specialized ML platforms and cloud-native services. Choosing the right one depends on your team's skills, existing infrastructure, and specific use cases.
+
+If your workload is dominated by model calls and retrieval rather than autonomous decision-making, the narrower comparison of [LLM orchestration frameworks](/resources/ai/ai-native-orchestration-platform) is the more useful starting point.
 
 Here is a comparison of some popular [ETL and AI orchestration tools](/resources/data/etl-orchestration-tool-alternatives):
 
@@ -169,6 +177,8 @@ While many platforms exist, a key differentiator is whether the tool is a specia
 
 Kestra is an open-source platform designed to be the [orchestration control plane of the AI era](/blogs/kestra-series-a). It provides a unified solution for orchestrating data, AI, and infrastructure workflows through a simple, declarative YAML interface.
 
+For any step that is irreversible or customer-facing, add [human approval gates](/resources/ai/human-in-the-loop-orchestration) before the action executes rather than after.
+
 With Kestra, you can:
 - **Unify Your Stack:** Use a single platform to coordinate everything from data ingestion and transformation with tools like dbt and Snowflake, to model training with Python scripts, to deploying applications on Kubernetes.
 - **Empower All Teams:** The declarative nature of YAML makes workflows accessible to a broader audience, enabling [AI orchestration for non-technical teams](/resources/ai/ai-orchestration-for-non-technical-teams) to collaborate with engineers.
@@ -180,6 +190,8 @@ Kestra's approach is to provide a flexible, language-agnostic control plane that
 ## The future of AI orchestration: Agents, LLMs, and beyond
 
 The field of AI is evolving rapidly, and orchestration platforms must evolve with it. The rise of [autonomous AI agents](/blogs/introducing-ai-agents) and complex LLM-powered applications is placing new demands on orchestration. The future will require platforms that can manage dynamic, decision-driven workflows and provide robust governance for increasingly autonomous systems.
+
+Two directions are worth following closely: [agentic workflows](/resources/ai/agentic-workflows) as the execution model, and [multi-agent systems](/resources/ai/multi-agent-system) as the coordination problem that follows from it.
 
 Orchestration is no longer just about scheduling static tasks; it's about providing the guardrails, observability, and human oversight for intelligent systems. Platforms that embrace this new reality by integrating features like AI Copilots for workflow generation and native support for agentic patterns will be essential for building the next generation of AI applications.
 

--- a/src/contents/resources/ai-pipeline/index.md
+++ b/src/contents/resources/ai-pipeline/index.md
@@ -65,6 +65,8 @@ Implementing a well-structured AI pipeline moves AI development from an artisana
 
 While the benefits are clear, building and managing AI pipelines presents significant challenges. Teams often struggle with fragmented tools, brittle custom scripts, and a lack of visibility across the data, infrastructure, and ML domains. Kestra provides a unified, declarative control plane to [orchestrate AI workflows](/docs/ai-tools/ai-workflows) and overcome these hurdles.
 
+A single pipeline is straightforward. Running dozens of them alongside inference, evaluation and agents is where [AI orchestration best practices](/resources/ai/ai-orchestration) start to matter.
+
 As [the orchestration control plane of the AI era](/blogs/kestra-series-a), Kestra is designed to manage complex, multi-system pipelines with ease. Here’s how it addresses common challenges:
 
 *   **Declarative YAML Workflows:** AI pipelines are defined as simple, readable YAML files. This makes them easy to version in Git, review with colleagues, and manage like any other piece of code.

--- a/src/contents/resources/context-engineering/index.md
+++ b/src/contents/resources/context-engineering/index.md
@@ -46,6 +46,8 @@ Where a prompt engineer might write, "Based on our latest Q3 report, summarize s
 
 In a production environment, the quality of an AI agent's output is directly tied to the quality of its context. Poor or missing context leads to a host of problems:
 
+Context is assembled by the pipelines that run before the model is called, so reliable context is ultimately a question of [AI orchestration across models and tools](/resources/ai/ai-orchestration) rather than of prompt wording.
+
 -   **Hallucinations:** The LLM invents facts to fill knowledge gaps.
 -   **Irrelevant Responses:** The agent answers based on its general training data, not the specific user need.
 -   **Incorrect Tool Use:** The agent calls the wrong API or provides invalid parameters because it lacks situational awareness.

--- a/src/contents/resources/cron-replacement/index.md
+++ b/src/contents/resources/cron-replacement/index.md
@@ -171,6 +171,6 @@ Whatever you pick, evaluate against the failure modes that made you leave cron: 
 
 ## From Cron to Kestra in Practice
 
-Migrating doesn't mean rewriting everything at once. The typical path: inventory your crontabs, port schedules one-to-one into Kestra Schedule triggers (the cron syntax carries over unchanged), then progressively add what cron never gave you — retries, dependencies, alerting, backfill. Our step-by-step guide covers the full process: [migrate from cron to Kestra](/resources/infrastructure/migrate-from-cron-to-kestra).
+Migrating doesn't mean rewriting everything at once. The typical path: inventory your crontabs, port schedules one-to-one into Kestra Schedule triggers (the cron syntax carries over unchanged), then progressively add what cron never gave you — retries, dependencies, alerting, backfill. Our step-by-step guide covers the full process: [migrate from cron to Kestra](/resources/infrastructure/migrate-from-cron).
 
 Ready to see it on your own jobs? [Get started with Kestra](/get-started) or [book a demo](/demo).

--- a/src/contents/resources/directed-agentic-graphs/index.md
+++ b/src/contents/resources/directed-agentic-graphs/index.md
@@ -45,6 +45,8 @@ An agent's decision-making process often follows a pattern similar to the OODA l
 
 While the autonomy of agents is powerful, it also introduces complexity and non-determinism that can be risky in production environments. A robust orchestration layer is essential to govern, manage, and scale these dynamic workflows.
 
+A graph describes what should happen. Executing it under real failure conditions is [the difference between running a model and operating an AI system](/resources/ai/ai-orchestration).
+
 Orchestration provides critical capabilities that agents alone cannot:
 *   **Governance and Auditability:** An orchestrator tracks every decision made by each agent, every tool called, and all inputs and outputs. This creates an auditable trail, which is crucial for debugging, compliance, and understanding system behavior.
 *   **Reliability and Error Handling:** What happens if an agent hallucinates, a tool's API is down, or a decision loop occurs? An orchestration platform provides mechanisms for retries, fallbacks, timeouts, and alerting, ensuring the overall process is resilient.

--- a/src/contents/resources/fast-mcp/index.md
+++ b/src/contents/resources/fast-mcp/index.md
@@ -117,6 +117,8 @@ Choosing FastMCP over FastAPI for MCP servers means you're using a specialized t
 
 Building an MCP server with FastMCP is a crucial first step, but in a production environment, that server is just one component in a larger system. You need a way to deploy, manage, monitor, and integrate these AI capabilities into broader business processes. This is the role of an orchestration platform like Kestra.
 
+FastMCP exposes the tools; something still has to decide when they run and under what constraints. That is the job of [governing the whole AI stack, not just the agent](/resources/ai/ai-orchestration).
+
 ### Unifying FastMCP Servers within Broader AI Workflows
 
 Kestra acts as a control plane for your entire technical stack, including your FastMCP-powered agents. You can create Kestra workflows that:

--- a/src/contents/resources/how-to-build-an-ai-agent/index.md
+++ b/src/contents/resources/how-to-build-an-ai-agent/index.md
@@ -48,6 +48,8 @@ While ChatGPT can exhibit agent-like behaviors, it is fundamentally an LLM. It l
 
 As agents move from prototypes to production systems, managing their behavior becomes critical. This is where a dedicated orchestration layer is essential for several reasons:
 
+What an agent cannot supply for itself is durable state, retries and an audit trail. Those come from [the control plane above your models](/resources/ai/ai-orchestration).
+
 *   **State Management and Context Preservation**: Agents need persistent memory across interactions. An orchestrator manages this state, ensuring the agent has the right context for each decision without requiring complex custom code.
 *   **Tool Integration and Management**: Securely connecting agents to external systems like APIs, databases, or other Kestra flows is paramount. Orchestration provides a secure, governed way to define and manage these tools.
 *   **Error Handling and Resilience**: What happens when a tool fails or an LLM gives an unexpected response? Orchestration platforms provide automatic retries, fallback mechanisms, and human-in-the-loop approval gates to ensure resilience.

--- a/src/contents/resources/llm-evaluation/index.md
+++ b/src/contents/resources/llm-evaluation/index.md
@@ -139,6 +139,8 @@ The MLOps ecosystem has rapidly evolved to support LLM evaluation. Several open-
 
 Moving from theory to practice requires a systematic approach to building and automating evaluation pipelines. The goal is to create a reliable, repeatable process that integrates seamlessly into your MLOps lifecycle.
 
+Evaluation is only meaningful when it runs on every change, which makes it a scheduling problem as much as a measurement one. See how it fits into [unifying models, pipelines and agents](/resources/ai/ai-orchestration).
+
 ### Setting Up Systematic Evaluation Pipelines
 
 An evaluation pipeline is an automated workflow that executes a series of steps to assess an LLM. By orchestrating this process, you ensure consistency and scalability.

--- a/src/contents/resources/mcp-orchestration/index.md
+++ b/src/contents/resources/mcp-orchestration/index.md
@@ -25,6 +25,8 @@ The landscape of artificial intelligence is rapidly evolving, with AI agents and
 
 Model Context Protocol (MCP) orchestration refers to the use of MCP to enable and manage the interactions between AI agents and a wide array of external tools and services. It solves a fundamental problem in the AI ecosystem: the lack of a common language for different systems to communicate. Without a standard like MCP, integrating a new tool with an AI agent requires custom glue code, making the system brittle and difficult to scale. MCP provides a standardized contract, an "API for AI," that allows any compliant tool to be discoverable and usable by any MCP-aware agent.
 
+MCP standardises how a model reaches a tool. It does not decide when that call runs, what happens when it fails, or who approves it — those belong to [the AI orchestration layer](/resources/ai/ai-orchestration) underneath.
+
 ### What does MCP stand for?
 
 MCP stands for **Model Context Protocol**. The name highlights its core function: providing AI models with the necessary *context* to interact with the outside world. This context includes information about what a tool does, what inputs it requires, and what outputs it produces, all in a format that a language model can understand and act upon.

--- a/src/contents/resources/ml-orchestration/index.md
+++ b/src/contents/resources/ml-orchestration/index.md
@@ -140,6 +140,8 @@ A few things are worth noticing in this workflow:
 
 The terms "ML Orchestration" and "MLOps" are often used interchangeably, but they represent different scopes. MLOps is a broad discipline, while orchestration is a specific, foundational technology within it.
 
+Widen the frame once more and ML orchestration becomes one branch of [AI orchestration](/resources/ai/ai-orchestration), which extends the same scheduling and governance guarantees to inference, retrieval and autonomous agents.
+
 ### Orchestration as a Foundational Layer of MLOps
 MLOps (Machine Learning Operations) is a set of practices that aims to deploy and maintain ML models in production reliably and efficiently. It covers the entire lifecycle, including:
 *   Experiment Tracking (e.g., MLflow, Weights & Biases)

--- a/src/contents/resources/model-deployment/index.md
+++ b/src/contents/resources/model-deployment/index.md
@@ -121,6 +121,8 @@ Deployed models often handle sensitive data, making security paramount. This inc
 
 A robust orchestration platform like Kestra can unify and automate the entire model deployment lifecycle, from data preparation and model training to deployment and monitoring. By defining the entire MLOps workflow as declarative YAML, Kestra ensures reproducibility, version control, and collaboration.
 
+Deployment is one stage in a longer chain that also covers retraining, evaluation and rollback — the reason most teams standardise on a single [enterprise AI orchestration platform](/resources/ai/ai-orchestration).
+
 ```yaml
 id: ml-model-deployment
 namespace: production.mlops

--- a/src/contents/resources/multi-agent-collaboration-evolving-orchestration/index.md
+++ b/src/contents/resources/multi-agent-collaboration-evolving-orchestration/index.md
@@ -27,6 +27,8 @@ This is where evolving orchestration steps in. Far beyond simple task sequencing
 
 ## Understanding multi-agent collaboration and evolving orchestration
 
+Agent collaboration is the visible layer of a deeper question: [how enterprises coordinate models, data pipelines and agents in one place](/resources/ai/ai-orchestration) rather than in a dozen disconnected tools.
+
 ### What does multi-agent orchestration mean?
 
 Multi-agent orchestration is the practice of coordinating multiple, often specialized, [AI agents](https://kestra.io/resources/ai/ai-agent) to achieve a common goal. Unlike single-agent systems that handle a task from start to finish, a [multi-agent system](https://kestra.io/resources/ai/multi-agent-system) breaks down a complex problem into sub-tasks, each handled by an agent best suited for the job.

--- a/src/contents/resources/multi-agent-system/index.md
+++ b/src/contents/resources/multi-agent-system/index.md
@@ -28,6 +28,8 @@ This article will demystify Multi-Agent Systems, exploring their fundamental com
 
 At its core, a Multi-Agent System is a collection of autonomous, interacting computational entities called agents. These agents work within a shared environment to solve problems that are often beyond the scope or capabilities of any single agent. The power of a MAS lies not just in the individual agents, but in their collective behavior and interactions.
 
+A multi-agent system rarely runs in isolation. It sits on top of retrieval, feature and inference pipelines, which is why [AI orchestration for multi-agent systems](/resources/ai/ai-orchestration) has to govern far more than agent-to-agent messaging.
+
 ### Defining agents and their collective intelligence
 
 An agent is more than just a piece of code; it's a computational entity with specific properties that enable it to function autonomously. While the exact definition can vary, most agents exhibit four key characteristics:

--- a/src/contents/resources/prompt-chaining-llm-guide/index.md
+++ b/src/contents/resources/prompt-chaining-llm-guide/index.md
@@ -176,6 +176,8 @@ The technique is model-agnostic and applies to any capable LLM. Common use cases
 
 Building a production-ready prompt chain requires a structured development workflow and the right tooling.
 
+A chain is a small orchestration problem. The same questions — order, failure handling, observability — reappear at scale when [coordinating model calls end to end](/resources/ai/ai-orchestration).
+
 ### Planning your prompt chain workflow
 
 Before writing a single prompt, map out the entire process. A simple flowchart can help visualize the sequence of steps, the data that flows between them, and any conditional logic. For each step, define:

--- a/src/contents/resources/rag-architecture/index.md
+++ b/src/contents/resources/rag-architecture/index.md
@@ -152,6 +152,8 @@ Evaluating a RAG system is a multi-faceted task that benefits from a systematic 
 
 A production-grade RAG system is not a single application but a complex pipeline of interconnected components that must be automated, monitored, and scaled. This is where an orchestration platform like Kestra becomes essential. Leading enterprises like Apple, JPMorgan Chase, and Toyota use Kestra to manage their complex data and AI pipelines at scale.
 
+Retrieval is one workload on a shared control plane. The same scheduling, retry and audit guarantees apply to training and agent execution, which is the scope of [AI orchestration for retrieval workloads](/resources/ai/ai-orchestration).
+
 ### Declarative YAML for RAG Pipeline Definition
 
 Kestra allows you to define your entire [RAG workflow](https://kestra.io/docs/ai-tools/ai-rag-workflows) as a simple, declarative YAML file. This brings GitOps principles to your AI pipelines, enabling version control, code reviews, and automated deployments. You can define every step, from data ingestion and chunking to embedding and indexing, in a single, auditable file.

--- a/src/contents/resources/rag-pipeline/index.md
+++ b/src/contents/resources/rag-pipeline/index.md
@@ -79,6 +79,8 @@ Orchestration concerns vary by type. Naïve RAG needs basic workflow scaffolding
 
 Five components define what a production RAG orchestration layer must handle:
 
+These components are not specific to retrieval. They are the general shape of [the layer that sequences AI workloads](/resources/ai/ai-orchestration), applied to a RAG use case.
+
 - **Data preparation and chunking.** Scheduled or event-driven ingestion of source documents. Chunking strategy choices (fixed-size, semantic, recursive). Quality tests on chunks (length distribution, overlap, deduplication). Source freshness monitoring.
 - **Vector indexing and retrieval.** Embedding generation (batched for efficiency), upsert to the [vector database](/resources/ai/vector-database), index freshness tracking, retrieval quality monitoring (are relevant documents being returned?).
 - **Prompt augmentation and context building.** Token budget management, context-window packing, deduplication of similar retrieved chunks, metadata injection (timestamps, source attribution). This is where "how much context" is decided dynamically.

--- a/src/contents/resources/semantic-search/index.md
+++ b/src/contents/resources/semantic-search/index.md
@@ -122,6 +122,8 @@ The applications of semantic search extend far beyond public web search. Interna
 
 Building and maintaining a semantic search system involves a series of interconnected data pipelines. Kestra is ideally suited to orchestrate this entire lifecycle, from data ingestion to query time.
 
+Index refreshes, embedding jobs and relevance evaluation all run on the same schedule-and-retry foundation, described in full in [Kestra's AI orchestration guide](/resources/ai/ai-orchestration).
+
 ### Building robust data pipelines for embeddings and indexing
 
 A semantic search index is only as good as the data it contains. Kestra can automate the process of keeping your index fresh and accurate. This typically involves:

--- a/src/contents/resources/vector-database/index.md
+++ b/src/contents/resources/vector-database/index.md
@@ -129,6 +129,8 @@ Yes, and this is a major trend. Systems like [OpenSearch](https://kestra.io/plug
 
 ## Orchestrating Vector Database Workflows with Kestra
 
+Embedding, indexing and refresh jobs are pipelines like any other. Running them reliably is part of [how retrieval fits into a wider AI orchestration strategy](/resources/ai/ai-orchestration).
+
 ### Declarative Management of Embedding Pipelines
 
 Vector databases don't exist in a vacuum. They require robust pipelines to ingest data, generate embeddings, and keep the index up-to-date. Kestra excels at this by allowing you to define the entire end-to-end process as a [declarative YAML flow](https://kestra.io/docs/concepts/flow). This approach brings version control, reproducibility, and clarity to your AI [data orchestration](/resources/data/data-orchestration) pipelines, making them as manageable as infrastructure-as-code. With [declarative orchestration](https://kestra.io/features/declarative-data-orchestration), you can reliably manage the lifecycle of your vector data.

--- a/src/contents/resources/what-is-a-machine-learning-pipeline/index.md
+++ b/src/contents/resources/what-is-a-machine-learning-pipeline/index.md
@@ -20,7 +20,6 @@ faq:
   - question: "What are the 4 pillars of ML?"
     answer: "Some perspectives categorize the four pillars of ML as predictions, decisions, discovery, and generation. These represent the core capabilities and applications of machine learning, from forecasting future outcomes to creating new data or insights."
 ---
-```
 
 Building and deploying machine learning models in production is rarely a straightforward task. From raw data to a deployed model, the journey involves numerous complex, interconnected steps that demand precision, reproducibility, and efficient management. Without a structured approach, teams often grapple with inconsistent results, slow deployments, and operational overhead.
 
@@ -173,6 +172,8 @@ As data volumes and model complexity grow, pipelines must scale. This requires t
 ## Unifying and Governing ML Pipelines with Kestra
 
 Machine learning pipelines are fundamental to modern AI, but their complexity demands a powerful and flexible orchestration layer. Kestra provides a unified control plane that addresses the core challenges of building, deploying, and managing ML workflows at scale.
+
+The same unification argument applies well beyond training. It is the basis of [what it takes to run AI workloads reliably in production](/resources/ai/ai-orchestration).
 
 With its declarative YAML interface, Kestra ensures that every pipeline is reproducible, versionable, and auditable. Its polyglot nature allows teams to use the best tool for each task—whether it's Python for model training, SQL for data transformation, or Bash for infrastructure setup—all within a single, cohesive workflow. This versatility is backed by an ecosystem of over 1,400 plugins, enabling seamless integration across your entire stack.
 

--- a/src/contents/resources/what-is-mlops/index.md
+++ b/src/contents/resources/what-is-mlops/index.md
@@ -121,6 +121,8 @@ Finally, it **strengthens governance and risk management**. With a complete audi
 
 At the core of any MLOps practice sits an orchestration engine able to manage the complex dependencies of an [AI pipeline](/resources/ai/ai-pipeline). Kestra is an [AI-native orchestration platform](/resources/ai/ai-native-orchestration-platform) that unifies data, AI, and infrastructure workflows under a single declarative control plane.
 
+Teams that already run MLOps on a single scheduler tend to extend it rather than adopt a second one — a pattern covered in our comparison of [AI orchestration tools](/resources/ai/ai-orchestration).
+
 Kestra's design lines up directly with MLOps principles:
 *   **Declarative Workflows:** ML pipelines are defined in simple, reviewable YAML files, which makes them easy to version, audit, and manage with GitOps practices.
 *   **Language-Agnostic Execution:** MLOps pipelines often span multiple languages and frameworks. Kestra runs Python, R, SQL, Shell scripts, and Docker containers as first-class citizens in the same workflow, removing the need for glue code.


### PR DESCRIPTION
Draft — lots 2 and 3 of the `/resources/ai/` internal-linking plan. Content only: no URL change, no redirect, no component touched. Fully reversible.

Independent of #5290 — different files, no conflict, either can merge first.

## Why

`/resources/ai/ai-orchestration` targets **`ai orchestration`** (1500 US, KD 0, $6 CPC) plus its commercial long tail — `ai orchestration platforms` ($9 CPC) and `best ai orchestration tools` ($8 CPC), which Ahrefs groups under the same `parent_topic`.

It had **exactly one editorial inbound link**. Meanwhile the whole `/resources/ai/` prefix ranks for 3 US keywords and 0 clicks (Ahrefs, 2026-08-06), 2 of them `ai_overview`.

On the four head SERPs the winners hold URL Ratings of **0 to 19** (IBM 6, Domo 0, Zapier 0, Snowflake 0, GitHub 19). They rank on domain authority, not page authority — which is precisely the gap internal linking closes.

## Lot 2 — 28 editorial inbound links

One contextual link per AI page, inside a named H2, never in a footer block. Distribution measured on **editorial links only**:

| type | n | share | target |
|---|---|---|---|
| exact | 5 | 17.9% | ≤ 20% |
| partial | 9 | 32.1% | 25–35% |
| semantic | 8 | 28.6% | 25–35% |
| long/natural | 5 | 17.9% | 15–25% |
| navigational | 1 | 3.6% | ≤ 10% |

27 distinct anchors for 28 links; no exact anchor repeated more than twice.

**Why template links are excluded from that budget**: the `Related resources` block anchors on a 288-character concatenation of tag + title + date + description, so it forms no exact anchor; and it selects the 3 most recent `tag: ai` pages by date, so those 36 links per page rotate away on the next publication. The editorial layer has to stand on its own.

## Lot 3 — 9 outbound hub links from the pillar

The link to `agentic-process-automation` is intentionally omitted — that page does not exist yet.

## Two pre-existing bugs fixed along the way

**`what-is-a-machine-learning-pipeline` had a stray unclosed code fence on the first line of its body.** The entire 2360-word page rendered as a single **28 204-character `<pre>` block with zero headings**. Removing the fence restores 8 H2s and 91 in-content links. It was also silently swallowing one of the lot 2 links.

`cron-replacement` linked to a non-existent slug; corrected.

## ⚠️ Out of scope but worth knowing

**13 other pages have unbalanced code fences.** Measured on the built HTML:

- **4 render with no headings at all**, body in one `<pre>`: `cloud-orchestration-tools`, `legacy-orchestration-migration`, `open-source-orchestration-cost-savings`, `self-service-infrastructure`
- **5 partially damaged**, a `<pre>` swallowing 17–34% of the body: `prefect-alternatives`, `zapier-alternatives`, `microsoft-fabric-alternatives`, `vmware-automation`, `kubernetes-workflow-orchestration`
- 4 harmless

Several are competitive `*-alternatives` pages. Tracked separately.

## Verification

- `astro sync` — all collection entries validate
- `npm run build` — passes (exit 0)
- crawl of the built HTML: **28/28** inbound links render in page content, 18 outbound from the pillar, none inside a code block, no broken internal link in the touched files