### PR TITLE
fix(ai): remove double line breaks in Search AI responses ref: #5304

### DIFF
--- a/src/components/ai/AiChatDialog.vue
+++ b/src/components/ai/AiChatDialog.vue
@@ -602,6 +602,10 @@
                 gap: 0.5rem;
             }
 
+            &.message-user .bubble {
+                white-space: pre-line;
+            }
+
             .avatar {
                 flex-shrink: 0;
 
@@ -622,7 +626,6 @@
                 background: var(--ks-background-body);
                 border: $block-border;
                 color: var(--ks-content-primary);
-                white-space: pre-line;
                 max-width: calc(100% - 48px);
                 position: relative;
 


### PR DESCRIPTION
fixes: https://github.com/kestra-io/docs/issues/5304

---

ref img: 
<img width="592" height="744" alt="Screenshot 2026-08-10 at 10 53 40 AM" src="https://github.com/user-attachments/assets/c62d6ae6-2067-4ad3-9a03-a50e074645a0" />

---