### PR TITLE
fix(ci): welcome first-time contributors again

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,40 +1,101 @@
-# A GitHub Action to automatically welcome and encourage first-time contributors
-# https://github.com/marketplace/actions/first-contribution
+# Welcomes first-time contributors when they open their first pull request, and congratulates them once it is merged.
 
 name: Contributor Onboarding
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, closed]
 
 
 permissions: {}
 
 jobs:
   welcome:
+    # GitHub already resolves the author's relationship to the repository, so internal contributors are filtered out without an API lookup.
+    if: ${{ github.event.pull_request.user.type != 'Bot' && !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) && (github.event.action == 'opened' || github.event.pull_request.merged) }}
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      contents: read # reading the author's commit history
+      issues: read # reading the author's issues and pull requests
+      pull-requests: write # commenting and reacting on the pull request
     steps:
-      - uses: plbstl/first-contribution@v4
+      - name: Welcome a first pull request
+        if: github.event.action == 'opened'
+        uses: actions/github-script@v9
         env:
-          GH_PAT_READ_ORG: ${{ secrets.GH_READ_ORG_TOKEN }}
-        with:
-          skip-internal-contributors: true
-          # The action defaults to false, which turns a broken GH_READ_ORG_TOKEN into a green job that silently welcomes nobody.
-          fail-on-error: true
-          pr-opened-msg: |
-            ### Hey @{fc-author} :wave: 
+          # Kept out of the script itself: interpolated there, a backtick or ${ would break out and run as JS.
+          OPENED_MESSAGE: |
+            ### Hey @{author} :wave:
 
             Thanks for raising your first pull request - we really appreciate it! :heart:
 
             Make sure you've checked our [contribution guide](https://kestra.io/docs/contribute-to-kestra/contributing), and don't forget to give us a star! :star:
 
             If you're looking for more issues to contribute to, we'd suggest checking our [curated list of good first issues](https://go.kestra.io/contributing) to see if there's something you find interesting and feel comfortable tackling independently. You can further filter the list by labels to narrow down the results (we recommend `area/backend`, `area/frontend`, or `area/plugin`, depending on your preferences).
-          pr-merged-msg: |
-            ### 🎉 Congrats @{fc-author}!
+        with:
+          script: |
+            const author = context.payload.pull_request.user.login;
+            const issue_number = context.payload.pull_request.number;
+
+            const {data: commits} = await github.rest.repos.listCommits({...context.repo, author, per_page: 1});
+            if (commits.length > 0) {
+              core.info(`@${author} has already committed to this repository. Exiting..`);
+              return;
+            }
+
+            const contributions = await github.paginate(github.rest.issues.listForRepo, {
+              ...context.repo,
+              creator: author,
+              state: 'all',
+              per_page: 100
+            });
+            const pullRequests = contributions.filter(contribution => contribution.pull_request);
+            core.info(`Author's pr_count: ${pullRequests.length}`);
+            if (pullRequests.length > 1) {
+              core.info(`@${author} has opened a pull request before. Exiting..`);
+              return;
+            }
+
+            for (const reaction of ['+1', 'heart', 'hooray', 'rocket', 'eyes']) {
+              await github.rest.reactions.createForIssue({...context.repo, issue_number, content: reaction});
+            }
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number,
+              body: process.env.OPENED_MESSAGE.replaceAll('{author}', author)
+            });
+
+      - name: Congratulate on a first merged pull request
+        if: github.event.action == 'closed'
+        uses: actions/github-script@v9
+        env:
+          MERGED_MESSAGE: |
+            ### 🎉 Congrats @{author}!
 
             Your first pull request has been merged - thanks a lot for your contribution, we really appreciate it! :heart:
 
             If you'd like to keep contributing, feel free to check out our [good first issues](https://go.kestra.io/contributing). And don't forget to give us a star! :star:
-          pr-reactions: +1, heart, hooray, rocket, eyes
+        with:
+          script: |
+            const author = context.payload.pull_request.user.login;
+
+            const contributions = await github.paginate(github.rest.issues.listForRepo, {
+              ...context.repo,
+              creator: author,
+              state: 'closed',
+              per_page: 100
+            });
+            // The pull request that triggered this run is part of the list, so a single merged one means it is the author's first.
+            const merged = contributions.filter(contribution => contribution.pull_request?.merged_at);
+            core.info(`Author's merged_pr_count: ${merged.length}`);
+            if (merged.length > 1) {
+              core.info(`@${author} already had a pull request merged. Exiting..`);
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.payload.pull_request.number,
+              body: process.env.MERGED_MESSAGE.replaceAll('{author}', author)
+            });


### PR DESCRIPTION
## What

Rewrites the contributor onboarding workflow so that it welcomes first-time contributors again, and drops both the `GH_READ_ORG_TOKEN` secret and the third-party action it needed.

## Why

Every external pull request currently fails the `welcome` job — for example [this run](https://github.com/kestra-io/docs/actions/runs/31169046845):

```
Checking if @dependabot[bot] is an org member of `kestra-io`.
Org membership check returned status: 404
Checking if @dependabot[bot] is a collaborator in `kestra-io/docs`.
Collaborator check returned status: 403
##[error]Must have push access to view repository collaborators.
```

With `skip-internal-contributors: true`, `plbstl/first-contribution` checks org membership and then falls back to `GET /repos/{owner}/{repo}/collaborators/{username}`, using the same `GH_READ_ORG_TOKEN` for both. That endpoint requires push access, which a `read:org` token does not have — exactly the scope the action's README tells you to create — so GitHub answers 403. The action only swallows 404s and rethrows anything else, aborting before it can comment. That fallback is reached for every author who is not an org member, which is precisely the audience this workflow exists for. Green runs since then are all org members, who short-circuit at the membership check.

The same failure was happening in `kestra-io/kestra`; the companion pull request is https://github.com/kestra-io/kestra/pull/17996.

## How

- **No token.** GitHub already resolves the author's relationship to the repository and ships it in the `pull_request_target` payload as `author_association`, so `OWNER` / `MEMBER` / `COLLABORATOR` (and bots) are filtered out in the job condition. Verified against real payloads: `MEMBER` for organisation members such as `iitzIrFan`; `FIRST_TIME_CONTRIBUTOR` / `CONTRIBUTOR` / `NONE` for outside contributors.
- **No third-party action.** The remaining logic runs on the built-in `GITHUB_TOKEN` through `actions/github-script`, which the other workflows in this repository already use. That also removes an unpinned third-party action holding `pull-requests: write` inside a `pull_request_target` job. The first-timer check is the same one the action performed — no prior commits, and no earlier pull request — except that it paginates instead of looking at only the author's first 30 issues and pull requests.
- **Congratulations on merge, for real this time.** `pr-merged-msg` was configured but could never fire: the workflow only listened for `opened`, and the action's merged path passes `author` to `issues.listForRepo`, whose parameter is `creator` — so it compared the repository's oldest pull request against the one just merged. The trigger now includes `closed`, and the check counts the author's merged pull requests, verified against real contributors of this repository (`yuri1969` → 96 and `m-t-a97` → 2, so both skipped; a contributor with none becomes 1 on their first merge).
- **Permissions.** Declares what the API calls actually need: `contents: read` for the author's commit history and `issues: read` for their issues and pull requests, next to the existing `pull-requests: write`.

Message wording is unchanged; the `{fc-author}` placeholder became `{author}`, since the `fc-` prefix referred to the action that is no longer used.

## Note for reviewers

`pull_request_target` workflows run the copy of the file on the base branch, so this cannot be exercised from the pull request itself. The first real proof is the next external pull request opened after it lands — worth watching the run log (`Author's pr_count:` / `Author's merged_pr_count:`) that first time.
