### PR TITLE
feat(seo): block AI crawlers on versioned docs paths

### DIFF
--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -3,13 +3,54 @@ export const prerender = false
 import type { APIRoute } from "astro"
 import * as envField from "astro:env/server"
 
-export const GET: APIRoute = async () => {
-const disabled = import.meta.env.DEV || envField.PREVIEW
-    const result = `# indexing ${disabled ? "disabled" : "enabled"}
+/**
+ * Crawlers that build training corpora or AI search indexes. They ignore
+ * `noindex` (meta and header alike) and honour robots.txt only, so it is the
+ * single lever we have over them.
+ *
+ * User-triggered fetchers (`ChatGPT-User`, `Perplexity-User`) are deliberately
+ * absent: those are a person explicitly asking about the page in front of them,
+ * including on a version they actually run.
+ */
+const AI_CRAWLERS = [
+    "GPTBot",
+    "OAI-SearchBot",
+    "ClaudeBot",
+    "anthropic-ai",
+    "PerplexityBot",
+    "Google-Extended",
+    "Applebot-Extended",
+    "CCBot",
+    "Bytespider",
+    "meta-externalagent",
+]
 
-User-agent: *
-Disallow: ${disabled ? "*" : "/slack"}
-${disabled ? "" : `Disallow: /t/
+/**
+ * Docs of past releases live under version-shaped prefixes (`/docs/1.3/...`,
+ * plus the `.md` variant of every one of them). They already carry `noindex` +
+ * `X-Robots-Tag`, which keeps them out of Google — but that does nothing for the
+ * crawlers above, and the `.md` passthrough hands them clean markdown of
+ * superseded documentation. Blocked so assistants don't answer old-version
+ * behaviour as if it were current, which is not correctable after the fact.
+ *
+ * robots.txt has no character classes, so the version shape is enumerated as
+ * `/docs/<digit>.` prefixes. That matches `/docs/1.3/...` and `/docs/1.3/x.md`;
+ * no real docs slug starts with a digit followed by a dot.
+ *
+ * Deliberately NOT added to the `User-agent: *` group: Googlebot has to keep
+ * crawling these URLs to see the `noindex` we want it to obey.
+ */
+const VERSIONED_DOCS_DISALLOW = Array.from(
+    { length: 10 },
+    (_, digit) => `Disallow: /docs/${digit}.`,
+).join("\n")
+
+export const GET: APIRoute = async () => {
+    const disabled = import.meta.env.DEV || envField.PREVIEW
+
+    // Shared by every group. A crawler with its own group ignores `User-agent: *`
+    // entirely, so these have to be repeated there rather than inherited.
+    const commonRules = `Disallow: /t/
 Disallow: /flags/
 # Block faceted /blueprints navigation (crawler trap: combinatorial
 # ?tags=/?tools=/?page=/?size=/?sort= permutations, incl. the old ?clid= bug).
@@ -28,8 +69,27 @@ Disallow: /cdn-cgi/
 Disallow: /*?q=
 Disallow: /*?search=
 Disallow: /*?ref=
-Disallow: /*?utm_
-`}${disabled ? "" : "Sitemap: https://kestra.io/sitemap/index.xml"}`
+Disallow: /*?utm_`
+
+    const aiCrawlerGroup = `${AI_CRAWLERS.map((ua) => `User-agent: ${ua}`).join("\n")}
+Disallow: /slack
+${commonRules}
+# Documentation of past releases — see VERSIONED_DOCS_DISALLOW in robots.txt.ts
+${VERSIONED_DOCS_DISALLOW}`
+
+    const result = `# indexing ${disabled ? "disabled" : "enabled"}
+
+User-agent: *
+Disallow: ${disabled ? "*" : "/slack"}
+${
+        disabled
+            ? ""
+            : `${commonRules}
+
+${aiCrawlerGroup}
+
+`
+    }${disabled ? "" : "Sitemap: https://kestra.io/sitemap/index.xml"}`
 
     return new Response(result, {
         headers: {


### PR DESCRIPTION
Companion to #4929. Opened as a draft: it is only worth merging if the versioned docs ship, and the version floor there is still open (see below).

## Why

#4929 serves past releases at `/docs/{major.minor}/...` and gives every versioned response `<meta name="robots" content="noindex, follow">` plus an `X-Robots-Tag: noindex` header, and keeps them out of the sitemap. That settles Google.

It does nothing for the AI crawlers. `GPTBot`, `ClaudeBot`, `PerplexityBot` and friends ignore `noindex` — meta and header alike — and honour robots.txt only. And #4929 keeps the "append `.md` to any `/docs/*` URL" convention on versioned pages, so what we would be offering them is clean markdown of superseded documentation, in the format they ingest best.

The failure mode is the reason for the draft: once an assistant answers 1.3 behaviour as if it were current, we cannot correct it. There is no recrawl to request, no cache to purge — we wait for a training cycle. A Google-side mistake is reversible in days; this one is not.

## What

A group for the training and AI-search crawlers, disallowing the version-shaped prefixes:

```
User-agent: GPTBot
User-agent: OAI-SearchBot
User-agent: ClaudeBot
...
Disallow: /docs/0.
Disallow: /docs/1.
...
Disallow: /docs/9.
```

Three deliberate choices:

- **Not added to `User-agent: *`.** Googlebot has to keep crawling those URLs to see the `noindex` we want it to obey. Blocking it in robots.txt would strand them as URL-only entries instead.
- **`commonRules` extracted and repeated in the new group.** A crawler with its own group ignores `User-agent: *` entirely, so without this the AI crawlers would silently lose the existing blueprints-facet, `/t/` and tracking-parameter rules. Verified byte-identical to the current production `*` group — 14 directives, no regression.
- **`ChatGPT-User` and `Perplexity-User` are left out.** Those are user-triggered fetches: someone explicitly asking about the page in front of them, quite possibly on the version they run. Blocking them costs a real user something and protects nothing.

The enumerated `/docs/<digit>.` prefixes stand in for a character class robots.txt does not have. It matches `/docs/1.3/tutorial/inputs` and `/docs/1.3/tutorial/inputs.md`; no docs slug starts with a digit followed by a dot (checked against the 489 URLs in the live docs sitemap).

## Verification

Rendered both branches of the route locally:

- **enabled** — `*` group unchanged, new AI group present with the 10 versioned prefixes
- **disabled** (dev/preview) — still just `User-agent: * / Disallow: *`, AI group not emitted, everything already blocked

`Allow`/`Disallow` directives of the `*` group diffed against `https://kestra.io/robots.txt`: identical.

## Open question, and why this is a draft

The version floor in #4929 is `>= 0.19` in `versionedDocs.ts`, which against the current `/v1/versions` payload resolves to 10 versions — 1.3 down to 0.19, about 4,000 URLs. AJ mentioned only 1.3 and 2.0 in practice; that is not what the filter does today. This PR is correct either way (the prefixes cover any version), but if the floor is raised to 1.3 the scope it protects shrinks to ~490 URLs and the whole question gets much smaller.

Also worth pairing with #4929: a test asserting the `noindex` meta and the `X-Robots-Tag` header on versioned responses. Neither is covered by the 126 tests there today, and they are the only thing standing between us and a few thousand near-duplicate pages in the index if a refactor or a caching layer drops the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
