### PR TITLE
Update SetupSteps.astro

### DIFF
--- a/src/components/get-started/SetupSteps.astro
+++ b/src/components/get-started/SetupSteps.astro
@@ -14,12 +14,12 @@ const dockerCommandUnix = `docker run --pull=always --rm -it -p 8080:8080 --user
   -v /tmp:/tmp \\
   kestra/kestra:latest server local`
 
-const dockerCommandWindows = `docker run --pull=always --rm -it -p 8080:8080 --user=root ^
-  --name kestra ^
-  -v kestra_data:/app/storage ^
-  -v kestra_db:/app/data ^
-  -v /var/run/docker.sock:/var/run/docker.sock ^
-  -v /tmp:/tmp ^
+const dockerCommandWindows = `docker run --pull=always --rm -it -p 8080:8080 --user=root \`
+  --name kestra \`
+  -v kestra_data:/app/storage \`
+  -v kestra_db:/app/data \`
+  -v /var/run/docker.sock:/var/run/docker.sock \`
+  -v /tmp:/tmp \`
   kestra/kestra:latest server local`
 ---
 


### PR DESCRIPTION
A suggested revision for the windows code snippet on the kestra [getting started page](https://kestra.io/get-started).

When typing the command into a Windows Powershell, the caret symbols (^) cannot be used. They have to be replaced with backtick symbols (`). The backtick allows for a multi-line command to be read by powersell.