### PR TITLE
seo(resources): add 7 W33 pages (airflow operators, kafka acks, databricks clusters, step functions, ADF, cloud run, enterprise scheduler)

### DIFF
--- a/src/contents/resources/adf-pipeline-explained/index.md
+++ b/src/contents/resources/adf-pipeline-explained/index.md
@@ -1,0 +1,185 @@
+---
+title: "ADF Pipeline Explained: Concepts, Capabilities, and Orchestration with Kestra"
+description: "An Azure Data Factory (ADF) pipeline orchestrates data movement and transformation in the Azure cloud. Learn its core concepts, how it facilitates ETL, and how Kestra can extend its capabilities for hybrid and multi-cloud environments."
+metaTitle: "ADF Pipeline: Concepts, ETL, and Cross-Cloud Orchestration"
+metaDescription: "Understand Azure Data Factory (ADF) pipelines, their role in cloud ETL, and how to unify ADF orchestration with the rest of your data stack using Kestra."
+tag: data
+date: 2026-08-11
+slug: adf-pipeline-explained
+faq:
+  - question: "What is a pipeline in Azure Data Factory (ADF)?"
+    answer: "In Azure Data Factory, a pipeline is a logical grouping of activities that together perform a unit of work. These activities define the actions to be performed on data, such as copying data, transforming it, or invoking other processes. Pipelines enable the orchestration of complex data integration and transformation workflows."
+  - question: "Is Azure Data Factory (ADF) an ETL tool?"
+    answer: "Yes, Azure Data Factory (ADF) is primarily a cloud-based ETL (Extract, Transform, Load) and ELT (Extract, Load, Transform) tool. It provides a serverless platform to visually create, schedule, and monitor data integration workflows, connecting to various data sources and destinations within and outside the Azure ecosystem."
+  - question: "Is ADF better than SSIS for modern data integration?"
+    answer: "ADF is generally considered better than SSIS for modern cloud-native data integration due to its serverless architecture, scalability, and deep integration with Azure services. SSIS remains strong for on-premises ETL, but ADF offers greater flexibility for hybrid and multi-cloud strategies, though both can complement each other."
+  - question: "What is the difference between ADF pipelines and Microsoft Fabric Data Pipelines?"
+    answer: "ADF pipelines are a standalone Azure service, while Microsoft Fabric Data Pipelines are an integrated experience within the broader Microsoft Fabric platform. Fabric Data Pipelines offer a more unified UI and tighter integration with other Fabric components like OneLake and Power BI, making them ideal for organizations fully invested in the Fabric ecosystem."
+  - question: "What is the purpose of Azure Data Factory?"
+    answer: "The purpose of Azure Data Factory is to provide a fully managed, scalable, and serverless data integration service in the Azure cloud. It enables organizations to build, schedule, and monitor data pipelines that ingest, transform, and load data from diverse sources into various destinations for analytics and reporting."
+  - question: "Can Kestra orchestrate Azure Data Factory pipelines?"
+    answer: "Yes, Kestra can orchestrate Azure Data Factory pipelines. Kestra's language-agnostic and event-driven engine can trigger ADF pipelines via the Azure CLI or REST API, monitor their execution, and integrate them into broader, cross-cloud, or hybrid workflows. This allows for a unified orchestration layer across your entire stack."
+  - question: "How does Kestra enhance ADF pipelines in hybrid environments?"
+    answer: "In hybrid environments, Kestra enhances ADF pipelines by providing a central control plane that can coordinate ADF with on-premises systems, other cloud providers, and custom applications. This allows for end-to-end visibility, advanced error handling, and declarative GitOps practices across heterogeneous data landscapes."
+---
+
+> **TL;DR** — An Azure Data Factory (ADF) pipeline is a logical grouping of activities that automates data movement and transformation processes within the Azure cloud. It acts as the core component for building ETL/ELT workflows, connecting various data sources to destinations.
+
+Azure Data Factory (ADF) pipelines are the backbone of many cloud-native data strategies, enabling organizations to move and transform data within the Azure ecosystem. While powerful for Azure-centric workloads, managing complex dependencies, diverse technologies, and hybrid cloud scenarios with a single cloud provider's tool can introduce operational overhead.
+
+This article demystifies ADF pipelines, explaining their core components and how they facilitate ETL. We'll explore their capabilities and limitations, and then demonstrate how Kestra can provide a unified, declarative orchestration layer to coordinate ADF pipelines alongside your entire data, AI, and infrastructure stack, even across hybrid and multi-cloud environments.
+
+## How ADF Pipelines Work: Core Concepts
+
+An ADF pipeline is a workflow composed of one or more activities that perform a specific task. To understand how they function, it's essential to grasp their core components:
+
+*   **Pipeline:** The top-level resource that logically groups a set of activities. It defines the workflow's structure and execution flow.
+*   **Activities:** These are the individual processing steps within a pipeline. Common activities include `Copy Data` for moving data between stores, `Data Flow` for visual data transformation, `Stored Procedure` for invoking database logic, and `Web Activity` for calling REST APIs.
+*   **Datasets:** A named view of data that points to or references the data you want to use in your activities as inputs or outputs. Datasets define the structure of the data within the connected data stores.
+*   **Linked Services:** Similar to connection strings, linked services define the connection information needed for Data Factory to connect to external resources. This could be an Azure Blob Storage account, an on-premises SQL Server, or a SaaS application.
+*   **Triggers:** These initiate the execution of a pipeline. ADF supports several trigger types, including `Schedule` for time-based execution, `Tumbling Window` for processing time-sliced data, and `Event-based` triggers that respond to events like file arrival in Azure Blob Storage.
+
+These components work together to create a cohesive [data pipeline](/resources/data/data-pipeline). A trigger fires, executing a pipeline. The pipeline runs its activities in a defined sequence, using linked services to connect to datasets that represent the source and destination of the data.
+
+## Why ADF Pipelines Need Robust Orchestration
+
+While ADF is a capable tool for Azure-native data integration, production environments often demand orchestration capabilities that span beyond a single cloud service. Relying solely on ADF's internal scheduler can create challenges:
+
+*   **Complex Dependencies:** Real-world workflows often involve dependencies on services outside of Azure, such as on-premises databases, other cloud providers, or third-party SaaS applications. Managing these cross-platform dependencies within ADF can be complex.
+*   **Error Recovery and Alerting:** While ADF has retry mechanisms, implementing sophisticated, multi-step error recovery logic that involves external systems requires a more powerful orchestration layer.
+*   **End-to-End Visibility:** Gaining a unified view of a workflow that includes an ADF pipeline, a dbt transformation, and a notification to a Slack channel is difficult without a central orchestrator.
+*   **Hybrid and Multi-Cloud Scenarios:** Organizations often operate in hybrid or multi-cloud environments. An orchestration tool locked into a single cloud ecosystem limits flexibility and increases operational complexity.
+*   **CI/CD and GitOps:** Implementing robust [CI/CD practices](/resources/infrastructure/ci-cd-pipeline) for data pipelines requires a declarative, version-controlled approach to workflow definitions, which is where a platform like Kestra excels. You can manage your [data pipelines as code](/docs/version-control-cicd) and integrate them into your existing DevOps toolchain.
+
+## Orchestrate ADF Pipelines with Kestra: An End-to-End Example
+
+Kestra acts as a universal control plane that can trigger, monitor, and manage ADF pipelines as part of a larger, technology-agnostic workflow. Instead of being limited to Azure's ecosystem, you can coordinate ADF with any tool or service that has an API or CLI.
+
+The following Kestra flow demonstrates how to trigger an ADF pipeline, poll for its completion status, and send a Slack notification based on the outcome. This entire process is defined in a single, declarative YAML file.
+
+### Orchestrating ADF with the Azure CLI in Kestra
+
+One of the most flexible ways to interact with Azure services is through the Azure CLI. Kestra's `Commands` task can execute any shell command within a containerized environment, providing a universal interface to manage services like ADF. This approach allows you to leverage your existing knowledge of the Azure CLI and integrate it seamlessly into a governed, observable workflow.
+
+```yaml
+id: trigger-and-monitor-adf-pipeline
+namespace: prod.azure
+description: Triggers an Azure Data Factory pipeline, polls for its status, and sends notifications.
+
+tasks:
+  - id: install-azure-cli
+    type: io.kestra.plugin.scripts.shell.Commands
+    description: "Ensure Azure CLI is available in the runner environment"
+    runner: DOCKER
+    docker:
+      image: mcr.microsoft.com/azure-cli:latest
+    commands:
+      - az --version
+
+  - id: trigger-adf-pipeline
+    type: io.kestra.plugin.scripts.shell.Commands
+    description: "Start the ADF pipeline run and capture the run ID"
+    runner: DOCKER
+    docker:
+      image: mcr.microsoft.com/azure-cli:latest
+    env:
+      AZURE_CLIENT_ID: "{{ secret('AZURE_CLIENT_ID') }}"
+      AZURE_CLIENT_SECRET: "{{ secret('AZURE_CLIENT_SECRET') }}"
+      AZURE_TENANT_ID: "{{ secret('AZURE_TENANT_ID') }}"
+    commands:
+      - az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID
+      - |
+        run_id=$(az datafactory pipeline create-run \
+          --factory-name "YourADFName" \
+          --name "YourPipelineName" \
+          --resource-group "YourResourceGroup" \
+          --query "runId" -o tsv)
+        echo "::> runId: $run_id"
+
+  - id: poll-pipeline-status
+    type: io.kestra.plugin.scripts.shell.Commands
+    description: "Poll the ADF pipeline run status until it completes"
+    runner: DOCKER
+    docker:
+      image: mcr.microsoft.com/azure-cli:latest
+    env:
+      AZURE_CLIENT_ID: "{{ secret('AZURE_CLIENT_ID') }}"
+      AZURE_CLIENT_SECRET: "{{ secret('AZURE_CLIENT_SECRET') }}"
+      AZURE_TENANT_ID: "{{ secret('AZURE_TENANT_ID') }}"
+    retry:
+      type: constant
+      maxAttempts: 20
+      interval: PT1M
+    commands:
+      - az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID
+      - |
+        status=$(az datafactory pipeline-run show \
+          --factory-name "YourADFName" \
+          --resource-group "YourResourceGroup" \
+          --run-id "{{ outputs['trigger-adf-pipeline'].vars.runId }}" \
+          --query "status" -o tsv)
+        
+        if [ "$status" == "Succeeded" ]; then
+          echo "Pipeline Succeeded"
+          exit 0
+        elif [ "$status" == "InProgress" ] || [ "$status" == "Queued" ]; then
+          echo "Pipeline still running with status: $status"
+          exit 1
+        else
+          echo "Pipeline failed with status: $status"
+          exit 2
+        fi
+  
+  - id: success-notification
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    payload: |
+      {
+        "text": "ADF Pipeline `{{ flow.namespace }}.{{ flow.id }}` completed successfully. Execution ID: `{{ execution.id }}`"
+      }
+
+errors:
+  - id: failure-notification
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    payload: |
+      {
+        "text": "ADF Pipeline `{{ flow.namespace }}.{{ flow.id }}` failed on task `{{ taskrun.taskId }}`. Execution ID: `{{ execution.id }}`"
+      }
+```
+
+What makes this Kestra workflow powerful:
+*   **Declarative & Version-Controlled:** The entire end-to-end process is defined in a single YAML file, which can be stored in Git, reviewed, and versioned like any other piece of code.
+*   **Stateful Retries:** The `retry` block on the polling task automatically handles the waiting logic, making the workflow resilient to long-running ADF jobs without complex scripting.
+*   **Unified Notifications:** Success and failure notifications are built into the workflow, providing immediate feedback without requiring separate monitoring configurations in Azure.
+*   **Cross-System Coordination:** This flow could easily be extended to include tasks that run before or after the ADF pipeline, such as triggering a dbt Cloud job, loading data from an S3 bucket, or updating a Salesforce record.
+
+## ADF vs. Microsoft Fabric Data Pipelines: Key Differences
+
+With the launch of Microsoft Fabric, a common question is how ADF pipelines differ from the new [Fabric Data Pipelines](/orchestration/microsoft-fabric). While they share a similar purpose, their context and integration are distinct.
+
+ADF is a standalone, mature Azure service focused purely on data integration and ETL. It's a versatile tool designed to connect a wide array of data sources and destinations.
+
+In contrast, Fabric Data Pipelines are an integrated component of the broader Microsoft Fabric platform. Fabric aims to be an all-in-one analytics solution, unifying data engineering, data science, and business intelligence. Fabric pipelines are designed to work seamlessly with other Fabric components like OneLake, Notebooks, and Power BI. For organizations fully committed to the Microsoft Fabric ecosystem, its pipelines offer a more cohesive user experience. For those needing a more flexible, standalone data integration service that connects to a heterogeneous stack, ADF remains a strong choice. You can find more on [Microsoft Fabric alternatives here](/resources/data/microsoft-fabric-alternatives).
+
+## When Kestra Extends ADF for Hybrid and Multi-Cloud Workflows
+
+The true power of a universal orchestrator like Kestra becomes apparent in complex enterprise environments. While ADF excels within its Azure boundaries, Kestra provides the control plane to manage workflows that cross those boundaries.
+
+Consider these scenarios where Kestra extends ADF's capabilities:
+*   **Hybrid Cloud:** An on-premises SQL Server database needs to be ingested into Azure Synapse via an ADF pipeline. Kestra can orchestrate the entire flow, first running a script on the on-premises server to prepare the data, then triggering the ADF pipeline, and finally launching a validation check.
+*   **Multi-Cloud:** A workflow might start by pulling data from Google Cloud Storage, processing it with an ADF pipeline, and then loading the results into a Snowflake warehouse running on AWS. Kestra can manage this entire multi-cloud process from a single point of control.
+*   **Beyond ETL:** Data pipelines are often part of a larger business process. Kestra can [orchestrate ADF](/orchestration/azure) as part of an [infrastructure automation](/infra-automation) workflow that also involves provisioning resources with Terraform or running Ansible playbooks.
+
+By using Kestra, you are not replacing ADF; you are elevating it. ADF handles the Azure-native data movement, while Kestra provides the overarching orchestration, observability, and governance across your entire technology stack.
+
+## Related Concepts
+
+*   [Best ETL Pipeline Tools for Data Engineering](/resources/data/etl-pipeline-tools)
+*   [SSIS Replacements: Modern ETL & Orchestration](/resources/data/ssis-replacement)
+*   [Top Free ETL Tools 2026: Open Source & Kestra Alternatives](/resources/data/free-etl-tools)
+*   [DataStage Migration: Strategies & Modern Cloud ETL](/resources/data/migrate-datastage)
+*   [Top Matillion Alternatives for Data Integration](/resources/data/matillion-alternatives)
+*   [Talend Alternatives: Top Data Integration Tools (2026)](/resources/data/talend-alternatives)
+
+Explore Kestra's capabilities for [unified data orchestration](/data).

--- a/src/contents/resources/airflow-operators/index.md
+++ b/src/contents/resources/airflow-operators/index.md
@@ -1,0 +1,174 @@
+---
+title: "Airflow Operators Explained: Core Concepts, Limitations, and Alternatives"
+description: "Understand Airflow operators as the building blocks of DAGs, explore common types, and examine their limitations. Discover how Kestra offers a declarative, language-agnostic approach to task definition."
+metaTitle: "Airflow Operators: Concepts, Limitations, and Alternatives"
+metaDescription: "Airflow operators are DAG building blocks. Understand their function, types, and limitations. Explore Kestra, a declarative, language-agnostic alternative."
+tag: data
+date: 2026-08-11
+slug: airflow-operators
+faq:
+  - question: "What is an Airflow operator?"
+    answer: "An Airflow operator is a class that encapsulates a single, atomic unit of work within an Airflow Directed Acyclic Graph (DAG). Operators define the specific action that a task in your workflow will perform, such as running a Python function, executing a Bash command, or querying a database. They are the fundamental building blocks for constructing data pipelines."
+  - question: "What are the main types of Airflow operators?"
+    answer: "Airflow operators fall into several categories, including action operators (like PythonOperator, BashOperator for executing code), transfer operators (for moving data between systems), and sensor operators (for waiting on external events or data). Provider packages extend these with specialized operators for various services like AWS, Google Cloud, or database systems."
+  - question: "How do Airflow operators differ from Kestra's tasks?"
+    answer: "Airflow operators are primarily Python-based, requiring Python code for task definition and often for custom logic. Kestra's tasks are defined declaratively in YAML, supporting polyglot execution (Python, Bash, SQL, Docker, etc.) directly without code wrappers. Kestra's plugin system integrates external services similarly to Airflow's providers, but with a YAML-first approach."
+  - question: "What are the limitations of Airflow operators?"
+    answer: "The primary limitations of Airflow operators include their tight coupling to Python, which can introduce boilerplate for non-Python tasks and a steeper learning curve for non-Python developers. Custom operators require Python development skills, and managing dependencies across many operators can increase operational complexity and debugging challenges."
+  - question: "Can Kestra orchestrate Airflow DAGs?"
+    answer: "Yes, Kestra can orchestrate Airflow DAGs by using its dedicated Airflow plugin. This allows Kestra to trigger and monitor Airflow DAG runs from within a Kestra workflow, treating Airflow DAGs as just another task. This enables hybrid orchestration strategies where Kestra can manage broader workflows while leveraging existing Airflow investments."
+  - question: "When should I consider an alternative to Airflow operators?"
+    answer: "Consider alternatives if your team works with multiple programming languages, struggles with Airflow's operational complexity, or needs a more declarative and infrastructure-agnostic approach. If you require seamless orchestration across data, infrastructure, and AI domains, or prefer GitOps-native workflow management, alternatives like Kestra may offer a better fit."
+---
+
+Airflow operators are the foundational components of any data pipeline built with Apache Airflow. They define the specific actions tasks perform, from running Python scripts to interacting with external APIs. While powerful, Airflow's operator-centric design, heavily rooted in Python, can introduce complexities for polyglot teams and those seeking a more declarative approach to orchestration.
+
+This article will explain what Airflow operators are, explore their common types, and discuss their strengths and limitations. We will then introduce Kestra's declarative, language-agnostic approach to task definition as a compelling alternative, especially for teams looking to unify data, AI, and infrastructure workflows under a single control plane.
+
+## What are Airflow Operators and Why They Are Central to Airflow DAGs?
+
+In the Airflow ecosystem, everything revolves around the Directed Acyclic Graph (DAG), which defines the structure and dependencies of your workflow. But the DAG only describes the "how" and "when." The "what"—the actual work performed at each step—is defined by operators.
+
+### Defining the building blocks of Airflow workflows
+
+An Airflow operator is a Python class that acts as a template for a single, atomic unit of work. Think of it as a blueprint for a specific action. The main components of the system are:
+
+- **Operator:** The class definition itself (e.g., `BashOperator`, `PythonOperator`). It defines the logic and parameters required for a type of action.
+- **Task:** An instantiated object of an operator class within a DAG. When you write `my_task = BashOperator(...)`, you are creating a task. It represents a specific instance of that action in your workflow.
+- **DAG:** The collection of tasks and their dependencies, defining the overall workflow structure.
+
+Operators are the core building blocks. You assemble various tasks (instances of operators) into a DAG to create a complete data pipeline. This modular approach allows for reusable components but also tightly couples the workflow definition to Python code.
+
+## Exploring Common Airflow Operators and Their Functions
+
+Airflow's strength lies in its extensive library of operators, which are organized into core functionalities and provider packages for third-party services.
+
+### Core operators: `PythonOperator` and `BashOperator` for executing code
+
+These are the most fundamental operators, allowing you to run arbitrary code.
+
+The `BashOperator` executes a shell command. It's useful for running scripts, command-line tools, or simple system commands.
+
+```python
+from airflow.operators.bash import BashOperator
+
+# A task that prints the current date
+print_date_task = BashOperator(
+    task_id='print_current_date',
+    bash_command='date'
+)
+```
+
+The `PythonOperator` executes a Python callable (a function). This is the standard way to run custom Python logic within an Airflow DAG.
+
+```python
+from airflow.operators.python import PythonOperator
+
+def my_python_function():
+    print("Executing Python logic from an Airflow operator!")
+
+# A task that calls the Python function
+python_logic_task = PythonOperator(
+    task_id='run_python_logic',
+    python_callable=my_python_function
+)
+```
+
+### Provider-specific operators: `HttpOperator`, `SQLExecuteQueryOperator`, and others
+
+Provider packages extend Airflow's capabilities to interact with hundreds of external systems. For example:
+
+- **`HttpOperator`:** Sends an HTTP request to an API endpoint.
+- **`SQLExecuteQueryOperator`:** Executes a SQL query against a configured database connection.
+- **`S3KeySensor`:** A type of sensor that waits for a specific key to appear in an Amazon S3 bucket.
+- **`DockerOperator`:** Executes a command inside a Docker container.
+
+Each of these operators encapsulates the logic needed to connect to and interact with its respective service, abstracting away the low-level details from the DAG author.
+
+### Understanding different operator categories (sensors, transfers, hooks)
+
+Operators generally fall into a few key categories:
+
+- **Action Operators:** Perform an action, like the `BashOperator` or `PythonOperator`.
+- **Sensor Operators:** Wait for a certain condition to be met before succeeding. They poll for a state, file, or event. The `S3KeySensor` is a classic example.
+- **Transfer Operators:** Move data from a source to a destination system.
+- **Hooks:** While not operators themselves, hooks are low-level interfaces that operators use to interact with external platforms (e.g., `PostgresHook`, `S3Hook`). They manage connections and API clients.
+
+## Limitations and Challenges of Airflow's Operator-Centric Design
+
+While the operator model is powerful, its deep integration with Python creates several challenges that become more pronounced as teams and systems scale.
+
+**1. Python Coupling and Boilerplate:**
+Every task, even one that just runs a simple shell command or SQL query, must be defined within a Python script. This introduces boilerplate and requires a Python development environment for all workflow authors. For non-Python tasks, the operator often acts as a thin wrapper, adding a layer of complexity without providing significant value. For teams that want to orchestrate more than just Python scripts, this can be a major limitation.
+
+**2. Operational Complexity of Custom Operators:**
+If a pre-built operator doesn't exist for your use case, you must create a custom one. This requires deep knowledge of Airflow's internal APIs and Python's object-oriented programming. Developing, testing, and maintaining custom operators adds significant operational overhead compared to using a system with more direct, declarative task definitions.
+
+**3. Debugging Challenges:**
+When a task fails, you are often debugging multiple layers: the operator's code, the underlying hook, the external system, and your own DAG logic. Tracing errors through these layers of Python abstraction can be time-consuming and complex.
+
+**4. Dependency Management:**
+Each provider package and custom operator can have its own set of Python dependencies. Managing these dependencies across an entire Airflow environment to avoid conflicts is a well-known operational pain point, often requiring custom Docker images or virtual environments.
+
+**5. Barrier to Entry for Polyglot Teams:**
+For teams with expertise in SQL, shell scripting, R, or other languages, the Python-first approach creates a barrier. They must either learn Python and the Airflow framework or rely on data engineers to translate their logic into DAGs. This slows down development and limits the accessibility of the orchestration platform. For a deeper dive into this topic, see our analysis on [data orchestration beyond analytics and ETL](/blogs/data-orchestration-beyond-analytics).
+
+## Kestra's Declarative Approach to Task Definition
+
+In contrast to Airflow's code-centric model, [Kestra is an open-source orchestration platform](/), that uses a declarative, YAML-based approach. Workflows are defined as simple configuration files, making them easy to read, write, and manage, especially for teams with diverse technical backgrounds.
+
+This approach decouples the orchestration logic from the execution logic. Instead of writing Python code to instantiate an operator, you define a task with its type and properties directly in YAML.
+
+Kestra supports language-agnostic execution out of the box. You can run Python, Bash, Node.js, R, SQL, and Docker containers as first-class citizens without writing Python wrappers. The platform's extensive plugin ecosystem, with over 1700+ plugins, provides integrations for a vast array of tools and services.
+
+Here is an example of a Kestra workflow that runs a Python script and a subsequent Bash command:
+
+```yaml
+id: python-and-bash-example
+namespace: dev.team
+
+tasks:
+  - id: run-python-script
+    type: io.kestra.plugin.scripts.python.Script
+    script: |
+      from kestra import Kestra
+      import pandas as pd
+      
+      # Your Python logic here
+      print("Running a Python script in Kestra")
+      
+      # Pass data to the next task
+      Kestra.outputs({'message': 'Data processed successfully'})
+
+  - id: run-bash-command
+    type: io.kestra.plugin.scripts.shell.Commands
+    commands:
+      - echo "The Python script said: {{ outputs['run-python-script'].message }}"
+```
+
+This YAML file is the entire workflow definition. It's versionable in Git, reviewable in a pull request, and understandable by both technical and non-technical stakeholders. Variables and outputs are passed between tasks using a simple templating syntax based on [Pebble expressions](/docs/expressions/syntax).
+
+## Orchestrating Airflow DAGs with Kestra for Unified Workflows
+
+Migrating from an established tool is a significant undertaking. For teams with a large investment in Airflow, Kestra offers a path for gradual adoption and hybrid orchestration. Using the dedicated [Kestra Airflow plugin](/plugins/plugin-airflow), you can trigger and monitor Airflow DAGs directly from a Kestra workflow.
+
+The [`TriggerDagRun` task](/plugins/plugin-airflow/io.kestra.plugin.airflow.dags.triggerdagrun) allows Kestra to act as an orchestrator of orchestrators. This is particularly useful when you need to coordinate Airflow pipelines with tasks that run on different systems or involve infrastructure automation, AI model interactions, or business processes—domains where Kestra's declarative model excels. You can find a ready-to-use example in our [Airflow Trigger DAG blueprint](/blueprints/airflow-trigger-dag).
+
+## When to Consider Airflow Operator Alternatives for Modern Orchestration
+
+While Airflow is a mature and powerful tool, several scenarios warrant considering an alternative like Kestra:
+
+- **Polyglot Environments:** If your team uses a mix of languages (Python, SQL, R, shell), a language-agnostic platform reduces friction and empowers everyone to build their own workflows.
+- **GitOps and IaC Practices:** Declarative YAML workflows are a natural fit for GitOps. They can be versioned, reviewed, and deployed just like infrastructure code.
+- **Cross-Domain Orchestration:** If you need to orchestrate workflows that span data engineering, infrastructure provisioning (Terraform/Ansible), and AI/ML pipelines, a unified platform provides better visibility and control.
+- **Reducing Operational Overhead:** For teams looking to minimize the complexity of managing dependencies, custom code, and the orchestration platform itself, a simpler, declarative model can significantly lower the total cost of ownership.
+
+The data ecosystem is constantly evolving. With the recent [end of life for Airflow 2](/blogs/2026-04-06-airflow-2-end-of-life) and the release of [Airflow 3](/blogs/airflow-3-vs-airflow-2), many teams are taking the opportunity to evaluate if their current tool still meets their needs. For a comprehensive overview, explore our guide to [Airflow alternatives](/resources/data/airflow-alternatives).
+
+## The Future of Task Orchestration: Beyond Operator-Specific Implementations
+
+The trend in modern orchestration is moving towards more flexible, declarative, and unified platforms. The limitations of single-language, code-heavy frameworks are becoming more apparent as the scope of automation expands beyond traditional ETL.
+
+Platforms like Kestra represent this shift by abstracting away the implementation details of tasks from the orchestration logic. By providing a common declarative language (YAML) to define workflows, they enable seamless coordination across disparate tools, languages, and teams. This approach not only simplifies development and reduces maintenance but also democratizes the ability to build, manage, and monitor complex automated processes.
+
+As organizations continue to break down silos between data, operations, and business teams, the need for a central control plane that can speak every team's language will only grow. This is the future of orchestration—a future that is declarative, language-agnostic, and universally accessible. Explore our [data engineering resources](/resources/data) to learn more about building modern data platforms with [declarative orchestration](/data).

--- a/src/contents/resources/cloud-run-jobs/index.md
+++ b/src/contents/resources/cloud-run-jobs/index.md
@@ -1,0 +1,167 @@
+---
+title: "Cloud Run Jobs: Serverless Batch Processing on Google Cloud"
+description: "Google Cloud Run Jobs provide a serverless environment for batch processing. Learn to orchestrate them with Kestra for scheduling, event-driven triggers, and integration across your data and infrastructure workflows."
+metaTitle: "Orchestrate Cloud Run Jobs for Serverless Batch on GCP"
+metaDescription: "Orchestrate Google Cloud Run Jobs for serverless batch processing with Kestra's declarative YAML. Use event-driven triggers, GCS, and dbt Cloud integration."
+tag: "infrastructure"
+date: 2026-08-11
+slug: "cloud-run-jobs"
+faq:
+  - question: "What is a Google Cloud Run Job?"
+    answer: "Google Cloud Run Jobs provide a fully managed serverless platform for running containerized batch tasks that execute to completion. Unlike Cloud Run services, jobs do not respond to HTTP requests and are designed for discrete, often parallel, workloads like data processing, report generation, or ML inference. They abstract away infrastructure management, allowing developers to focus on application logic."
+  - question: "How do Cloud Run Jobs differ from Cloud Run Services?"
+    answer: "Cloud Run Services are designed for long-running, request-driven applications that respond to HTTP requests, such as web services or APIs. Cloud Run Jobs, conversely, are for batch processing and run-to-completion tasks that do not serve HTTP traffic. Services scale based on demand, while jobs execute a defined task and then terminate, making them suitable for asynchronous, non-interactive workloads."
+  - question: "How can I trigger a Google Cloud Run Job?"
+    answer: "Cloud Run Jobs can be triggered manually via the Google Cloud Console or `gcloud` CLI. For automated orchestration, Kestra can trigger Cloud Run Jobs based on schedules (cron), events (like new files in GCS), or as part of larger multi-step workflows, providing robust error handling and monitoring for the entire process."
+  - question: "How long can a Google Cloud Run Job run for?"
+    answer: "A Google Cloud Run Job can run for up to 24 hours. This generous timeout allows for the execution of long-running batch processes, complex data transformations, or extensive computational tasks. Developers should design their jobs to be idempotent and handle potential restarts gracefully within this timeframe."
+  - question: "Are Cloud Run Jobs still in demand for modern cloud architectures?"
+    answer: "Yes, Cloud Run Jobs remain highly relevant and in demand. As organizations increasingly adopt serverless and event-driven architectures, Cloud Run Jobs offer a cost-effective and scalable solution for batch processing without the operational overhead of managing VMs or Kubernetes clusters. They are particularly valuable for data pipelines, ML inference, and backend automation."
+  - question: "Who owns and manages Google Cloud Run?"
+    answer: "Google Cloud Run is a fully managed service provided by Google Cloud. Google handles all the underlying infrastructure management, including scaling, patching, and security updates. This allows developers and platform engineers to focus solely on their containerized applications and job logic, rather than on server administration."
+---
+> **TL;DR** — Cloud Run Jobs are a serverless execution environment on Google Cloud for running containerized batch, parallel, and run-to-completion tasks without managing underlying infrastructure. They are ideal for discrete, asynchronous workloads that don't serve HTTP requests.
+
+Managing batch processing at scale often involves a trade-off: either accept the operational overhead of virtual machines and Kubernetes clusters, or compromise on flexibility with highly constrained serverless functions. Google Cloud Run Jobs offer a compelling third path, providing a serverless environment to run containerized, run-to-completion tasks without managing the underlying infrastructure.
+
+However, even serverless jobs require orchestration. Coordinating Cloud Run Jobs with other services, handling dependencies, managing retries, and providing end-to-end observability can quickly become complex. This article explores how Kestra's declarative platform elevates Cloud Run Jobs from isolated tasks to integrated, production-ready workflows.
+
+## How Cloud Run Jobs simplify serverless batch processing
+
+Cloud Run Jobs are a core component of Google Cloud's serverless offering, designed specifically for executing containerized applications that run for a finite period and then exit. Unlike traditional server-based batch processing, which requires provisioning, configuring, and managing servers, Cloud Run Jobs abstract away all infrastructure concerns. You provide a container image, and Google Cloud handles the rest—from provisioning resources to scaling and termination.
+
+This model is ideal for workloads such as:
+- Data processing and transformation (ETL/ELT)
+- Report generation
+- Machine learning inference
+- Database migrations
+- Any run-to-completion task that can be containerized.
+
+Each job execution creates one or more independent container instances, or "tasks," which can run in parallel. This makes it a powerful tool for high-throughput, parallelizable batch workloads.
+
+### Cloud Run Jobs vs. Cloud Run Services: Understanding the Difference
+
+It's crucial to distinguish Cloud Run Jobs from their sibling, Cloud Run Services. While both run containers in a serverless environment, they serve fundamentally different purposes.
+
+| Feature | Cloud Run Jobs | Cloud Run Services |
+|---|---|---|
+| **Primary Use Case** | Batch processing, run-to-completion tasks | Web services, APIs, request-driven apps |
+| **Request Handling** | Does not serve HTTP requests | Serves HTTP/S, gRPC, WebSocket requests |
+| **Lifecycle** | Runs until the task is complete, then terminates | Always on, scales to zero when idle |
+| **Invocation** | Manual execution, schedulers, event triggers | HTTP requests |
+| **Execution Timeout** | Up to 24 hours | Up to 60 minutes per request |
+| **Scaling** | Runs a configured number of parallel tasks | Scales based on incoming traffic |
+
+In short, use a **Service** when you need to respond to real-time requests from users or other systems. Use a **Job** when you need to perform a discrete, asynchronous task that runs in the background.
+
+## Why batch jobs on Google Cloud need robust orchestration
+
+While Cloud Run Jobs provide an excellent execution environment, they are not a complete orchestration solution. A production-grade workflow requires more than just the ability to run a container. Key orchestration capabilities needed include:
+
+- **Advanced Scheduling and Triggering:** Beyond simple cron schedules, you need to trigger jobs based on external events, such as a new file arriving in a Google Cloud Storage (GCS) bucket or the completion of another process.
+- **Dependency Management:** Real-world pipelines involve multiple steps. A job might depend on the successful completion of a data ingestion task and, in turn, trigger a data transformation job.
+- **Error Handling and Retries:** What happens if a job fails? A robust orchestrator provides configurable retry policies with exponential backoff, dead-letter queues, and conditional error branching to ensure reliability.
+- **Parameterization and Dynamic Execution:** Workflows often need to pass data between tasks, such as passing a filename from a GCS trigger to a Cloud Run Job.
+- **End-to-End Observability:** You need a single pane of glass to monitor the entire workflow, not just individual job executions. This includes centralized logging, execution history, and alerting on failures.
+- **Cross-Service Integration:** Batch jobs rarely live in isolation. They need to interact with other services like BigQuery, Dataproc, dbt Cloud, or even systems in a [multi-cloud environment](/resources/infrastructure/multi-cloud-orchestration).
+
+Without an orchestration layer, you are left to build this complex logic yourself using a combination of Cloud Functions, Eventarc, and custom scripts—a solution that is often brittle and difficult to maintain.
+
+## Orchestrate Cloud Run Jobs with Kestra: Event-Driven Container Execution
+
+Kestra provides a declarative control plane to manage Cloud Run Jobs as part of larger, more complex workflows. Instead of writing imperative glue code, you define the entire pipeline in a simple YAML file. Kestra treats the Cloud Run Job as a task within a larger flow, handling all the scheduling, triggering, and state management.
+
+A key feature is Kestra's [Google Cloud Run Task Runner](/docs/task-runners/types/google-cloudrun-task-runner), an Enterprise Edition feature that allows any Kestra task to execute as a transient Cloud Run Job. This provides serverless, containerized execution for any script or command without requiring a dedicated worker fleet.
+
+The following example demonstrates an event-driven workflow. It triggers when a new CSV file is uploaded to GCS, uses the Cloud Run Task Runner to process that file with a Python script, and then triggers a dbt Cloud job to update downstream models.
+
+```yaml
+id: gcs-to-cloudrun-to-dbt
+namespace: io.kestra.gcp.examples
+
+description: |
+  This workflow automates a common data pipeline pattern:
+  1. Triggers when a new CSV file is uploaded to a GCS bucket.
+  2. Runs a Python script as a serverless Cloud Run Job to process the file.
+  3. Triggers a dbt Cloud job to update downstream data models.
+
+tasks:
+  - id: python-processing
+    type: io.kestra.plugin.scripts.python.Script
+    description: "Processes the input CSV file using a Python script."
+    containerImage: python:3.11-slim
+    beforeCommands:
+      - pip install pandas
+    script: |
+      import pandas as pd
+      df = pd.read_csv("{{ inputs.dataFile }}")
+      # Example processing: add a new column
+      df['processed_at'] = pd.Timestamp.now()
+      df.to_csv("processed_data.csv", index=False)
+    inputFiles:
+      dataFile: "{{ trigger.uri }}"
+    outputFiles:
+      - processed_data.csv
+    taskRunner:
+      type: io.kestra.plugin.ee.gcp.runner.CloudRun
+      projectId: "{{ secret('GCP_PROJECT_ID') }}"
+      region: "us-central1"
+      serviceAccount: "{{ secret('GCP_SA_EMAIL') }}"
+
+  - id: trigger-dbt-cloud
+    type: io.kestra.plugin.dbt.cloud.TriggerRun
+    description: "Triggers a dbt Cloud job to update downstream models."
+    accountId: "{{ secret('DBT_ACCOUNT_ID') }}"
+    jobId: "{{ secret('DBT_JOB_ID') }}"
+    token: "{{ secret('DBT_API_TOKEN') }}"
+    wait: true # Wait for the dbt job to complete
+
+triggers:
+  - id: watch-for-new-csv
+    type: io.kestra.plugin.gcp.gcs.Trigger
+    bucket: "your-landing-zone-bucket"
+    prefix: "incoming/"
+    interval: "PT1M"
+```
+
+A few things are worth noticing in this flow:
+- **Declarative & Event-Driven:** The entire logic is defined in one YAML file. The `gcs.Trigger` automatically polls the bucket and starts a new flow execution for each new file.
+- **Serverless Task Execution:** The Python script runs inside a container as a Cloud Run Job, managed by Kestra's `CloudRun` task runner. Kestra handles the creation, execution, and cleanup of the job, providing a truly serverless experience.
+- **Seamless Integration:** The workflow seamlessly integrates GCS, a custom Python script, and dbt Cloud. Kestra acts as the universal orchestrator connecting these disparate services.
+- **Data Context Passing:** The GCS trigger automatically passes the URI of the new file (`{{ trigger.uri }}`) to the Python script task, maintaining data context throughout the flow.
+
+### Choosing the Right Task Runner for Google Cloud: Cloud Run vs. Batch
+
+Kestra offers multiple [Task Runner Types](/docs/task-runners/types) for executing workloads on Google Cloud, primarily the `Google Cloud Run Task Runner` and the `Google Batch Task Runner`.
+
+- **Use the Cloud Run Task Runner for:**
+  - Short-to-medium duration tasks (up to 24 hours).
+  - Workloads that benefit from rapid startup times.
+  - General-purpose containerized scripts and applications.
+- **Use the Google Batch Task Runner for:**
+  - Long-running, compute-intensive workloads.
+  - High-performance computing (HPC), AI/ML training, and large-scale data processing.
+  - Tasks requiring specific VM configurations, such as GPUs or large memory allocations.
+
+For most general-purpose batch processing and data pipeline tasks, the Cloud Run Task Runner offers a cost-effective and low-overhead solution.
+
+## Where Cloud Run Jobs accelerate data and AI workflows
+
+The combination of Cloud Run Jobs and a robust orchestrator like Kestra unlocks numerous use cases across data, AI, and infrastructure domains:
+
+- **ETL/ELT Data Transformations:** Run containerized data transformation scripts (Python, R, etc.) on a schedule or triggered by new data arrivals.
+- **Scheduled Report Generation:** Periodically run a job to query a database like BigQuery, generate a report, and upload it to GCS or send it via email.
+- **ML Inference Batch Predictions:** Load a trained model into a container and run a job to generate predictions on a new batch of data.
+- **Backend Asynchronous Processing:** Offload long-running tasks from a web service, such as video transcoding or image processing, to a Cloud Run Job.
+- **Modernizing Cron Jobs:** Replace fragile cron jobs running on a single VM with reliable, observable, and scalable serverless containers.
+
+## Related concepts for modern GCP orchestration
+
+Building production-grade systems on Google Cloud involves orchestrating a variety of services. Understanding how Cloud Run Jobs fit within this ecosystem is key.
+
+- **[Google Cloud Storage (GCS)](/orchestration/gcs):** Often the starting point for data pipelines, with GCS events triggering Cloud Run Jobs.
+- **[dbt Cloud Orchestration](/orchestration/dbt-cloud):** Coordinate dbt Cloud jobs with upstream data loading processes handled by Cloud Run.
+- **[Google Cloud Scheduler](/resources/infrastructure/google-cloud-scheduler):** While a basic scheduling tool, it highlights the need for more advanced, workflow-aware scheduling provided by an orchestrator.
+- **[Deploying on GKE](/docs/installation/kubernetes-gcp-gke):** For teams managing their own infrastructure, Kestra can be deployed on GKE to orchestrate both on-cluster and serverless workloads like Cloud Run Jobs.
+
+Ready to build your first orchestrated Cloud Run Job? Explore Kestra's blueprints to get started quickly.

--- a/src/contents/resources/databricks-cluster-types/index.md
+++ b/src/contents/resources/databricks-cluster-types/index.md
@@ -1,0 +1,164 @@
+---
+title: "Databricks Cluster Types: A Guide to Orchestrating Compute for Data & AI"
+description: "Understand the different Databricks cluster types, including all-purpose, job, and serverless compute. Learn how to optimize their use for diverse data and AI workloads with Kestra's declarative orchestration."
+metaTitle: "Databricks Cluster Types: Orchestrating Compute"
+metaDescription: "Explore Databricks cluster types—all-purpose, job, and serverless. Learn how to choose the right compute for your data and AI workloads with Kestra."
+tag: "data"
+date: 2026-08-11
+slug: "databricks-cluster-types"
+faq:
+  - question: "What is a Databricks cluster?"
+    answer: "A Databricks cluster is a collection of compute resources (VMs) and configurations on which you run data engineering, data science, and machine learning workloads. It consists of a driver node, worker nodes, and a high-speed network, all managed by Databricks for distributed processing."
+  - question: "What are the components of a Databricks cluster?"
+    answer: "Key components include a driver node, which manages the cluster and runs the Spark driver; worker nodes, which execute tasks in parallel; and a cluster file system for data storage. The Databricks Runtime (DBR) provides the software environment, including Spark, libraries, and other optimizations."
+  - question: "What are the three layers of Databricks?"
+    answer: "Databricks operates on three architectural layers: the Lakehouse Platform (data storage, governance), the Databricks Runtime (Spark, MLflow, Delta Lake), and the Compute Layer (clusters, SQL warehouses). This layered approach provides a unified platform for data, analytics, and AI."
+  - question: "What is a job cluster vs. interactive cluster in Databricks?"
+    answer: "An interactive (all-purpose) cluster is designed for collaborative data exploration and development, staying active even when idle. A job cluster is optimized for automated, non-interactive workloads, provisioning on demand and terminating upon job completion to save costs, making it ideal for production pipelines."
+  - question: "How to choose a Databricks cluster?"
+    answer: "Choosing a cluster depends on your workload: interactive clusters for development, job clusters for automated production, and SQL warehouses for BI/analytics. Consider factors like cost, performance, data volume, and the need for auto-scaling or specific instance types. Optimize for auto liquid clustering and Spark/SQL efficiency."
+  - question: "What are the 7 pillars of Databricks?"
+    answer: "The 7 pillars of Databricks, aligning with well-architected principles, are Cost Optimization, Performance Efficiency, Reliability, Operational Excellence, Security, Data Governance, and Sustainability. These guide the assessment and optimization of Databricks environments for robust and efficient operations."
+---
+
+> **TL;DR** — Databricks clusters are scalable compute environments for data and AI workloads, composed of driver and worker nodes. Types like all-purpose, job, and serverless are optimized for specific use cases, impacting cost and performance. Orchestration manages their lifecycle for efficiency.
+
+If you're managing data pipelines or AI training jobs on Databricks, you've likely encountered the challenge of optimizing your compute resources. The right cluster type can accelerate development, cut costs, and ensure reliability, while the wrong choice can lead to wasted spend and operational bottlenecks. This article provides a comprehensive overview of Databricks cluster types and demonstrates how Kestra brings declarative control to their dynamic lifecycle.
+
+## How Databricks Clusters Work: Anatomy of Distributed Compute
+
+At its core, a Databricks cluster is a set of virtual machines configured to work together for distributed data processing. Understanding its components is key to leveraging its power effectively.
+
+### Core Components: Driver, Workers, and Storage
+
+Every Databricks cluster consists of three main parts:
+- **Driver Node**: The central coordinator. It runs the main function of your application, maintains the SparkContext, and orchestrates the execution of tasks on the worker nodes.
+- **Worker Nodes**: The workhorses of the cluster. These nodes execute the individual tasks assigned by the driver, processing data in parallel. The number of worker nodes determines the level of parallelism and the overall processing power of the cluster.
+- **Storage**: Databricks clusters typically interact with cloud storage systems like AWS S3, Azure Blob Storage, or Google Cloud Storage. The Databricks File System (DBFS) provides a unified abstraction layer over these storage backends.
+
+### The Databricks Runtime and its Layers
+
+The Databricks Runtime (DBR) is the software environment that runs on the cluster nodes. It includes Apache Spark and adds numerous components and updates that substantially improve performance, reliability, and security. The DBR is optimized for cloud environments and includes features like Photon, a high-performance query engine, and integrations with tools like Delta Lake and MLflow. This runtime sits on top of the compute layer, providing a robust foundation for building and running data and AI applications, including those using the [Apache Spark plugin](/plugins/plugin-spark). Governance across these layers is often managed through the [Databricks Unity Catalog](/resources/data/databricks-unity-catalog).
+
+## Key Databricks Cluster Types Explained for Data & AI Workloads
+
+Databricks offers several cluster types, each tailored for different scenarios. Choosing the correct one is crucial for both performance and cost-efficiency.
+
+### All-Purpose (Interactive) Clusters: For Development and Exploration
+
+All-Purpose clusters are designed for interactive analysis and collaborative development in notebooks. They can be shared by multiple users and remain active even when not running commands, allowing for quick iteration. While excellent for data science and ad-hoc queries, their "always-on" nature can lead to high costs if left unmanaged.
+
+### Job Clusters: Optimized for Automated Workflows
+
+Job clusters are purpose-built for running automated, non-interactive workloads, such as scheduled ETL jobs or model training pipelines. A job cluster is created for a specific job run and automatically terminates when the job completes. This just-in-time provisioning makes them significantly more cost-effective for production workflows, as you only pay for compute when it's actively being used. This is the ideal model for an [on-demand Databricks cluster](/blueprints/on-demand-cluster-job) in a production pipeline.
+
+### Serverless Compute: On-Demand Scaling Without Infrastructure Management
+
+Serverless compute abstracts away the underlying infrastructure, allowing you to run workloads without managing cluster configurations. Databricks handles the provisioning, scaling, and management of resources automatically. This model offers instant startup times and simplifies operations, making it a good choice for workloads with unpredictable or bursty traffic patterns.
+
+### SQL Warehouses: Dedicated for Analytics and BI
+
+SQL Warehouses are specialized compute resources optimized for running SQL queries and powering BI tools like Tableau or Power BI. They provide a high-performance, cost-effective engine for analytics on the Lakehouse, separating BI workloads from data engineering and data science compute. This separation ensures that an ad-hoc analytics query doesn't interfere with a critical production pipeline, a key consideration in a [Databricks vs. Snowflake](/resources/data/databricks-vs-snowflake) architecture.
+
+## Why Databricks Cluster Lifecycle Needs Orchestration
+
+Simply choosing a cluster type isn't enough. Managing the lifecycle of these clusters—when they start, what they run, and when they stop—is where the real operational efficiency is gained. This is where orchestration becomes critical.
+
+- **Dynamic Provisioning and Termination**: Manually starting and stopping clusters is inefficient and prone to error. Orchestration automates this process, ensuring compute is active only when needed, which is the single most effective way to control costs.
+- **Automated Job Submission and Monitoring**: An orchestration tool can submit jobs to the correct cluster, monitor their progress, and capture logs and outputs in a centralized location.
+- **Error Handling and Retries**: Production pipelines need resilience. Orchestration platforms provide built-in mechanisms for retries, error branching, and alerting, so a transient failure doesn't derail your entire workflow.
+- **Integration into Broader Workflows**: Databricks jobs are often just one step in a larger process. Orchestration connects these jobs with upstream data ingestion tasks and downstream actions, providing end-to-end visibility and control. Effective [data orchestration](/resources/data/data-orchestration) is key to [simplifying Databricks workflow management with Kestra](/blogs/kestra-over-databricks-workflows).
+
+## Orchestrate Databricks Clusters with Kestra: Dynamic Provisioning & Cleanup
+
+Kestra's declarative, YAML-based approach allows you to define the entire lifecycle of a Databricks cluster as code. This makes your infrastructure repeatable, version-controlled, and easy to audit.
+
+The following flow demonstrates how to create a Databricks cluster on-demand, submit a notebook job, and then automatically terminate the cluster upon completion, ensuring no resources are left idle.
+
+```yaml
+id: databricks-dynamic-cluster-management
+namespace: company.team.production
+
+tasks:
+  - id: create_cluster
+    type: io.kestra.plugin.databricks.cluster.CreateCluster
+    clusterName: "kestra-on-demand-cluster"
+    sparkVersion: "14.3.x-scala2.12"
+    nodeTypeId: "i3.xlarge"
+    autoterminationMinutes: 60
+    numWorkers: 2
+    awsAttributes:
+      instanceProfileArn: "{{ secret('DATABRICKS_INSTANCE_PROFILE') }}"
+      availability: ON_DEMAND
+
+  - id: submit_job
+    type: io.kestra.plugin.databricks.job.SubmitRun
+    runName: "daily-data-processing"
+    existingClusterId: "{{ outputs.create_cluster.cluster_id }}"
+    notebookTask:
+      notebookPath: "/Users/user@company.com/DailyProcessing"
+
+  - id: delete_cluster
+    type: io.kestra.plugin.databricks.cluster.DeleteCluster
+    clusterId: "{{ outputs.create_cluster.cluster_id }}"
+    
+triggers:
+  - id: daily_schedule
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 5 * * *"
+
+errors:
+  - id: send_failure_alert
+    type: io.kestra.plugin.notifications.slack.SlackExecution
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    channel: "#data-alerts"
+```
+
+A few things are worth noticing in this workflow:
+- **Declarative Infrastructure**: The cluster's configuration is defined directly in the YAML, making it versionable and auditable through Git.
+- **Automated Lifecycle**: The `CreateCluster` and `DeleteCluster` tasks wrap the job submission, guaranteeing that compute resources are provisioned just-in-time and torn down immediately after use.
+- **Dynamic Task Chaining**: The `clusterId` output from the `create_cluster` task is passed directly to the `submit_job` and `delete_cluster` tasks, creating a seamless and dynamic dependency chain.
+- **Centralized Control**: This entire process is managed from a single orchestration platform, providing a unified view of your Databracks compute and job status alongside all other data operations. Kestra's [Databricks plugin](/plugins/plugin-databricks) simplifies this integration, reflecting the strong [Databricks & Kestra partnership](/blogs/2024-03-07-databricks-partnership).
+
+## Choosing the Right Databricks Cluster Strategy
+
+Developing an effective cluster strategy involves more than just picking between job and all-purpose clusters. It requires a nuanced approach based on workload characteristics and performance goals.
+
+### Matching Cluster Types to Workload Patterns
+
+- **Development/Ad-Hoc Analysis**: Use All-Purpose clusters. Consider setting aggressive auto-termination policies to prevent runaway costs.
+- **Production ETL/ML Pipelines**: Always use Job clusters. Their ephemeral nature is ideal for automated, scheduled workflows and offers the best cost efficiency.
+- **BI and SQL Analytics**: Use SQL Warehouses. This isolates analytics workloads and provides optimized performance for SQL queries.
+- **Variable/Unpredictable Workloads**: Serverless compute is a strong candidate, as it removes the need for capacity planning and manual scaling.
+
+For teams exploring options, reviewing [Databricks Alternatives](/resources/data/databricks-alternatives) and specifically [Databricks Workflows Alternatives](/resources/data/databricks-workflows-alternatives) can provide additional context on different orchestration patterns.
+
+### Optimizing Instance Types for Performance and Cost
+
+The virtual machine (instance) type you choose for your driver and worker nodes has a significant impact.
+- **General Purpose**: A balanced choice for a wide range of workloads.
+- **Memory-Optimized**: Ideal for jobs that perform memory-intensive operations, such as large shuffles or aggregations, which can prevent data from spilling to disk.
+- **Compute-Optimized**: Best for CPU-intensive tasks, like complex transformations or machine learning algorithms.
+
+## Optimizing Databricks Cluster Costs and Performance with Kestra
+
+Beyond lifecycle management, an orchestration tool like Kestra can enforce best practices for cost and performance at scale.
+
+### Auto-scaling and Cluster Pools for Efficiency
+
+Databricks allows clusters to auto-scale worker nodes based on workload demands. Cluster pools maintain a set of idle, ready-to-use instances, reducing cluster start times. Kestra can programmatically manage these settings, applying standardized policies across all your automated workflows to ensure consistent efficiency.
+
+### Monitoring and Governance with Integrated Workflows
+
+By centralizing Databricks operations within Kestra, you gain a single point of control for monitoring and governance. You can build workflows that check for idle clusters, enforce tagging policies for cost allocation, or trigger alerts based on job duration or failure rates. This level of [workflow governance](/resources/infrastructure/workflow-governance) is detailed in our [Kestra Administrator Guide](/docs/administrator-guide).
+
+## Related Concepts
+
+- [ETL Workflow: Definition, Types & Automation](/resources/data/etl-workflow)
+- [Data Pipeline: Definition, Architecture, and Examples](/resources/data/data-pipeline)
+- [What is Data Ingestion? Types, Challenges & Best Practices](/resources/data/what-is-data-ingestion)
+- [dbt Tests Explained: Types, Benefits & Best Practices](/resources/data/dbt-tests-explained)
+- [What is a Machine Learning Pipeline?](/resources/ai/what-is-a-machine-learning-pipeline)
+- [Data Orchestration: A Comprehensive Guide](/resources/data/data-orchestration)
+
+Explore Kestra's capabilities for [declarative data orchestration](/data) and streamline your data and AI workflows today.

--- a/src/contents/resources/enterprise-job-scheduler/index.md
+++ b/src/contents/resources/enterprise-job-scheduler/index.md
@@ -1,0 +1,171 @@
+---
+title: "Enterprise Job Scheduler: Modernizing Workload Automation"
+description: "Explore enterprise job schedulers, from core functions to advanced features. Learn how modern platforms like Kestra unify automation across data, AI, and infrastructure with declarative workflows."
+metaTitle: "Enterprise Job Scheduler: Modernizing Workload Automation"
+metaDescription: "Automate complex IT tasks and data pipelines. Discover how a modern enterprise job scheduler ensures reliability and efficiency across your entire organization."
+tag: infrastructure
+date: 2026-08-11
+slug: "enterprise-job-scheduler"
+faq:
+  - question: "What is an enterprise scheduler?"
+    answer: "An enterprise job scheduler is a sophisticated software solution designed to automate, manage, and monitor complex IT processes and workflows across an entire organization. It goes beyond simple task scheduling to handle dependencies, error recovery, and integrations across diverse systems."
+  - question: "What does a job scheduler do?"
+    answer: "A job scheduler automates the execution of tasks based on predefined schedules or events. In an enterprise context, it ensures that jobs run in the correct sequence, handles retries on failure, manages resources, and provides centralized visibility into execution status."
+  - question: "What is the best job scheduling tool?"
+    answer: "The 'best' job scheduling tool depends on your organization's specific needs. Modern solutions prioritize declarative workflows, polyglot execution, and deep integration across data, AI, and infrastructure. Evaluating factors like scalability, governance, and developer experience is key."
+  - question: "How does job scheduling work?"
+    answer: "Job scheduling works by defining tasks and their dependencies, triggers (like time or events), and execution environments. The scheduler then monitors these conditions and executes tasks automatically, often with built-in error handling and logging for operational oversight."
+  - question: "Is a scheduler a hard job to implement?"
+    answer: "Implementing a basic scheduler can be straightforward, but deploying and managing an enterprise-grade job scheduler can be complex. It requires careful planning for integrations, scalability, security, and operational overhead, especially for legacy systems."
+  - question: "Which enterprise job scheduling software is the best?"
+    answer: "Leading enterprise job scheduling software offers robust features for workload automation, event-driven execution, and cross-platform integration. Solutions that provide declarative configuration, comprehensive observability, and support for diverse technical stacks often stand out."
+---
+
+For many organizations, critical IT operations still rely on a patchwork of cron jobs, manual scripts, or outdated schedulers like Windows Task Scheduler. This fragmented approach often leads to dependency nightmares, debugging headaches, and a lack of visibility, turning routine automation into a constant firefighting exercise.
+
+Modern enterprise demands more than simple task execution. It requires a sophisticated platform that can orchestrate complex workflows across diverse systems, from data pipelines and cloud infrastructure to AI models and business processes. This article explores how a true enterprise job scheduler provides the control plane needed to automate, govern, and scale your organization's most critical operations.
+
+## What an Enterprise Job Scheduler Is (and Isn't)
+
+At its core, an enterprise job scheduler is the automation backbone of an organization. It's a centralized platform responsible for executing, managing, and monitoring workloads across the entire IT landscape. But to truly understand its value, it's important to distinguish it from more basic tools that often share the "scheduler" name.
+
+### Defining Enterprise Job Scheduling Software
+
+An [enterprise job scheduling software](/resources/infrastructure/job-scheduling-software) is a solution that automates and orchestrates business-critical processes. Unlike simple schedulers that run tasks at a specific time, an enterprise-grade platform manages complex dependencies, handles failures gracefully, and provides a single pane of glass for all automated operations.
+
+These platforms are designed for scale, reliability, and security. They integrate with a wide array of applications, databases, and infrastructure components, allowing teams to build end-to-end workflows that might start with a data ingestion task, trigger an infrastructure change, and end with a business notification.
+
+### The Evolution from Simple Schedulers to Orchestrators
+
+Many teams start their automation journey with basic tools. A developer might set up a cron job to run a nightly script. An operations team might use Windows Task Scheduler to handle routine maintenance. For a while, this works. But as the number of jobs grows and their interdependencies become more complex, this approach breaks down.
+
+This is the critical point where organizations realize they need more than a collection of individual schedulers. They need a system that understands the entire workflow.
+
+The limitations of simple schedulers include:
+- **No Dependency Management:** Cron has no built-in way to say, "Only run Job B after Job A succeeds." This leads to brittle, custom-coded logic or, worse, timing-based assumptions that fail unpredictably.
+- **Limited Error Handling:** If a cron job fails, it often fails silently. An enterprise platform provides robust error handling, including automatic retries, alternative execution paths, and immediate alerting.
+- **Lack of Visibility:** Managing hundreds of cron jobs across dozens of servers creates a black box. There's no central place to see what's running, what failed, and why.
+- **Scalability Issues:** Simple schedulers are not designed to manage thousands of concurrent tasks across a distributed environment.
+
+A modern [job scheduler](/resources/infrastructure/job-scheduler) is, in practice, an orchestrator. It doesn't just trigger jobs; it directs the entire symphony of automated processes, making it a crucial component for any organization looking to move beyond basic, fragile automation. For teams stuck managing a web of cron jobs, a modern [cron replacement](/resources/infrastructure/cron-replacement) offers a path to a more reliable and scalable architecture.
+
+## Key Capabilities of Modern Enterprise Job Schedulers
+
+The features that define a modern enterprise job scheduler are built to address the challenges of complexity, scale, and collaboration in today's IT environments. They go far beyond simple time-based execution to provide a comprehensive platform for workload automation.
+
+### Declarative Workflow Definition and Version Control
+
+Legacy schedulers often rely on proprietary GUIs or complex XML configurations to define jobs. This makes workflows opaque, difficult to version, and hard to integrate into modern DevOps practices.
+
+A modern approach uses a declarative, human-readable format like YAML. Instead of scripting the step-by-step "how," teams define the desired end state—the "what." This has several key advantages:
+- **Readability:** Both technical and non-technical stakeholders can understand the workflow logic.
+- **Version Control:** Workflows are treated as code. They can be stored in Git, reviewed through pull requests, and rolled back easily.
+- **Collaboration:** Data engineers, platform engineers, and developers can collaborate on the same workflow definitions using tools they already know.
+
+### Event-Driven Automation and Flexible Triggers
+
+While time-based scheduling remains important, modern operations are increasingly event-driven. An enterprise scheduler must be able to react to a wide variety of triggers beyond a simple cron expression. This includes:
+- **API Calls (Webhooks):** Start a workflow when an external system sends an HTTP request.
+- **File Arrivals:** Trigger a process when a new file lands in an S3 bucket or FTP server.
+- **Database Changes:** Initiate a workflow in response to a new row in a database table.
+- **Message Queues:** Consume messages from systems like Kafka or RabbitMQ to kick off tasks.
+- **Workflow Completions:** Chain workflows together, creating complex, multi-stage processes.
+
+This flexibility allows for the creation of responsive, real-time systems and is a core tenet of [event-driven orchestration](/resources/infrastructure/event-driven-orchestration).
+
+### Seamless Integration with Diverse Systems (Data, Infra, AI)
+
+An enterprise is a collection of diverse technologies. A scheduler that only works with one part of the stack—like only running shell scripts or only connecting to a specific database—creates silos. A true enterprise scheduler acts as a universal translator, with a rich ecosystem of plugins and connectors for:
+- **Cloud Services:** AWS, Google Cloud, Microsoft Azure.
+- **Databases:** PostgreSQL, Snowflake, BigQuery, Oracle.
+- **Data Tools:** dbt, Spark, Airbyte.
+- **Infrastructure as Code:** Terraform, Ansible.
+- **AI/ML Platforms:** OpenAI, Anthropic, Hugging Face.
+- **Business Applications:** Salesforce, SAP, ServiceNow.
+
+### Scalability, High Availability, and Reliability for Critical Workloads
+
+Enterprise workloads are mission-critical; the scheduler cannot be a single point of failure. Modern platforms are architected for resilience and scale. Key features include:
+- **High Availability (HA):** A clustered architecture ensures that if one node fails, another takes over seamlessly.
+- **Horizontal Scaling:** The ability to add more worker nodes to handle increasing loads without performance degradation.
+- **Concurrency Control:** Policies to manage how many jobs can run simultaneously, preventing resource contention.
+- **Fault Tolerance:** Built-in retry logic with exponential backoff and dead-letter queues to handle transient failures.
+
+Properly [sizing and scaling the infrastructure](/docs/performance/sizing-and-scaling-infrastructure) is crucial for meeting performance SLAs, and modern schedulers provide the tools and architecture to do so effectively. For more details on achieving this, refer to the documentation on enterprise [scalability](/docs/enterprise/scalability).
+
+### Centralized Governance, Security, and Observability
+
+When you centralize automation, you also need to centralize control. Enterprise-grade [governance](/docs/enterprise/governance) features are non-negotiable.
+- **Role-Based Access Control (RBAC):** Fine-grained permissions to control who can view, create, edit, and execute workflows.
+- **Secrets Management:** Secure integration with vaults like HashiCorp Vault, AWS Secrets Manager, or Azure Key Vault to avoid hardcoding credentials.
+- **Audit Logs:** A complete, immutable record of all actions taken within the platform for compliance and security investigations.
+- **Observability:** Centralized logs, real-time metrics, and visual dashboards to monitor the health of all workflows and quickly diagnose issues.
+
+## Choosing the Right Enterprise Job Scheduler for Your Organization
+
+Selecting an enterprise job scheduler is a significant architectural decision. The right choice can accelerate innovation and improve reliability, while the wrong one can introduce technical debt and operational friction.
+
+### Evaluating Total Cost of Ownership (TCO) Beyond Licensing
+
+The sticker price of a commercial license is just one part of the equation. A comprehensive TCO analysis should include:
+- **Operational Overhead:** How much time will your team spend installing, configuring, upgrading, and maintaining the scheduler itself?
+- **Developer Productivity:** How quickly can developers build and deploy new workflows? A steep learning curve or clunky interface can be a major hidden cost.
+- **Infrastructure Costs:** What are the underlying hardware or cloud resource requirements?
+- **Migration Costs:** The effort required to move existing jobs from legacy systems to the new platform.
+
+Comparing [open-source vs. paid](/docs/oss-vs-paid) solutions requires looking at these factors. A free open-source tool might have a higher TCO if it requires significant engineering effort to operate at scale.
+
+### Assessing Flexibility for Hybrid and Multi-Cloud Environments
+
+Vendor lock-in is a serious risk. An ideal enterprise scheduler should be platform-agnostic, capable of running wherever your workloads are. This includes on-premises data centers, multiple public clouds, and edge locations. A solution that is tightly coupled to a single cloud provider's ecosystem can limit future flexibility. Look for platforms that offer robust support for [self-hosted workflow orchestration](/resources/infrastructure/self-hosted-workflow-orchestration) and can be deployed consistently across different environments using technologies like Docker and Kubernetes.
+
+### Prioritizing Developer Experience and Team Adoption
+
+A powerful tool that developers refuse to use is shelfware. The best scheduler is one that fits naturally into existing engineering workflows.
+- **Ease of Use:** Is the interface intuitive? Can new users become productive quickly?
+- **API and SDKs:** Does the platform offer a comprehensive API and SDKs in languages your team uses?
+- **Documentation and Community:** Is the documentation clear and complete? Is there an active community for support and shared knowledge?
+- **Debugging and Testing:** How easy is it to test workflows locally and troubleshoot failures in production?
+
+Adoption is often smoother when the platform's architecture aligns with modern best practices, such as the [three-layer architecture](/blogs/enterprise-three-layer-architecture) used by many teams to structure their orchestration at scale.
+
+## How Kestra Modernizes Enterprise Job Scheduling
+
+Kestra is an open-source platform designed to address the shortcomings of legacy schedulers and the complexity of modern IT environments. It serves as a universal orchestration layer that unifies job scheduling across all technical domains.
+
+### YAML-Defined Workflows for GitOps and Collaboration
+
+All workflows in Kestra are defined as simple, declarative YAML files. This code-centric approach allows teams to manage their automation with the same rigor and tools they use for application and infrastructure code. Workflows are versioned in Git, reviewed via pull requests, and deployed through CI/CD pipelines, creating a fully auditable and collaborative process.
+
+### Polyglot Execution Across Data, AI, and Infrastructure
+
+Kestra is language-agnostic. A single workflow can seamlessly combine a Python script, a SQL query, a shell command, and a Docker container. With a library of over 1,700 plugins, Kestra integrates natively with the tools your teams already use, whether for [data engineering](/data), [infrastructure automation](/infra-automation), or [AI pipelines](/ai-automation). This eliminates the need for multiple, domain-specific schedulers and breaks down technology silos.
+
+### A Unified Control Plane for All Workloads
+
+Instead of having one scheduler for data pipelines, another for IT automation, and a third for CI/CD, Kestra provides a single control plane. This centralized view improves visibility, simplifies governance, and enables the creation of powerful cross-functional workflows that automate entire business processes from end to end.
+
+### Enterprise-Grade Governance and Scalability
+
+Kestra is built for mission-critical use cases. The [Enterprise Edition](/enterprise) adds features essential for large organizations, including:
+- **Multi-Tenancy:** Isolate workflows, users, and resources between different teams or projects.
+- **Advanced Security:** SSO, RBAC, and Audit Logs for comprehensive security and compliance.
+- **High-Performance Architecture:** Worker Groups and a distributed architecture allow Kestra to scale to millions of workflow executions.
+
+For a deeper dive into these capabilities, explore the [Kestra Enterprise documentation](/docs/enterprise).
+
+## From Job Scheduling to Full Workload Automation: A Unified Approach
+
+The conversation around enterprise job scheduling is evolving. While the term "scheduler" is still common, modern platforms deliver capabilities that fall under the broader umbrella of workload automation and orchestration.
+
+### The Overlap and the Critical Distinction
+
+A job scheduler's primary concern is *when* a job runs. A workload automation platform is concerned with the entire lifecycle of a business process—*what* tasks need to run, in *what order*, with *what data*, how to *handle exceptions*, and how to *provide visibility* to all stakeholders.
+
+While all workload automation platforms include a scheduler, not all schedulers provide true workload automation. The key distinction lies in the ability to manage complex, end-to-end processes rather than just isolated tasks.
+
+### Why Modern Workload Automation Demands More Than Scheduling
+
+In a modern enterprise, value is created through interconnected digital processes. A data pipeline is not just a series of scheduled SQL queries; it's a process that involves ingestion, transformation, quality checks, and loading, often triggered by an external event. Automating infrastructure is not just running a script; it's a workflow that includes a pull request, an approval step, provisioning via Terraform, and a notification in Slack.
+
+Legacy [batch scheduling platforms](/resources/infrastructure/batch-scheduling-platform-alternatives) and simple [open-source job schedulers](/resources/infrastructure/open-source-job-scheduler) often struggle to manage this complexity. A truly modern platform unifies these disparate tasks into a cohesive, observable, and reliable whole. It provides the control plane necessary to not only schedule jobs but to orchestrate the full spectrum of business-critical operations, as explored in the broader [scheduling platform landscape](/blogs/2023-10-17-schedulers-landscape).

--- a/src/contents/resources/kafka-acks/index.md
+++ b/src/contents/resources/kafka-acks/index.md
@@ -1,0 +1,163 @@
+---
+title: "Kafka Acks Explained: Balancing Durability and Throughput"
+description: "Kafka acknowledgments (acks) are crucial for producer reliability. Understand how acks=0, acks=1, and acks=all impact data durability, performance, and availability in your Kafka workflows."
+metaTitle: "Kafka Acks Explained: Durability, Performance, Throughput"
+metaDescription: "Kafka acks (0, 1, all) balance durability, throughput, and latency. Understand how producer acknowledgments work and configure them reliably."
+tag: data
+date: 2026-08-11
+slug: "kafka-acks"
+faq:
+  - question: "What are ACKs in Kafka?"
+    answer: "ACKs (acknowledgments) in Kafka refer to the setting that dictates how many Kafka brokers must acknowledge a message before the producer considers the write successful. This configuration is critical for balancing data durability, ensuring messages are not lost, with the performance and latency of message production."
+  - question: "Does Kafka have an ACK?"
+    answer: "Yes, Kafka producers use the 'acks' property to configure acknowledgment behavior. This setting determines if and how the producer waits for confirmation that messages have been successfully written to the Kafka cluster's brokers, directly influencing data safety and write performance."
+  - question: "What is the Acks property in Kafka?"
+    answer: "The 'acks' property in a Kafka producer's configuration specifies the level of acknowledgment required from Kafka brokers. It can be set to 0 (no acknowledgment), 1 (leader acknowledgment), or 'all' (full in-sync replica acknowledgment), each offering a different trade-off between durability and throughput."
+  - question: "How does Kafka ACK work?"
+    answer: "Kafka ACK works by having the producer send messages and then wait for a specified number of acknowledgments from the broker(s) before proceeding. Depending on the 'acks' setting (0, 1, or 'all'), the producer either doesn't wait, waits for the leader, or waits for all in-sync replicas to confirm the message write."
+  - question: "Which one is better, Kafka or RabbitMQ?"
+    answer: "Kafka and RabbitMQ serve different primary use cases. Kafka is generally better for high-throughput, fault-tolerant streaming data, while RabbitMQ excels at flexible message routing and complex queueing patterns. The 'better' choice depends on your specific application requirements for messaging and event streaming. For a detailed comparison, see our guide on RabbitMQ vs. Kafka."
+---
+
+> **TL;DR** — Kafka acknowledgments (acks) are a producer configuration that determines the level of durability for messages sent to a Kafka cluster, directly impacting throughput, latency, and data loss risk.
+
+Reliably delivering data in a distributed streaming system like Kafka is a constant balancing act. Producers need to send messages quickly, but they also need assurance that those messages won't disappear. This tension between speed and safety is where Kafka's acknowledgment mechanism, known as `acks`, becomes critical.
+
+Understanding and configuring `acks` correctly is fundamental for any Kafka deployment. This article will demystify Kafka acks, explaining how the different settings (`0`, `1`, `all`) directly impact your data's durability, the performance of your producers, and the overall availability of your message delivery.
+
+## How Kafka Acks Work: Balancing Durability and Throughput
+
+The `acks` setting is a producer-side configuration that determines how many acknowledgments the producer requires from broker replicas before considering a message successfully sent. Before diving into the `acks` values, it's essential to understand two core concepts from [Apache Kafka's architecture](/resources/data/what-is-kafka):
+
+*   **Leader Replica**: For each topic partition, one broker acts as the "leader." All producer writes and consumer reads for that partition go through the leader.
+*   **In-Sync Replicas (ISR)**: These are follower replicas that are fully caught up with the leader's log. They serve as hot standbys, ready to take over as leader if the current leader fails.
+
+The `acks` setting leverages this leader/follower model to provide tunable durability guarantees. It's a fundamental concept in any [message queue](/resources/infrastructure/message-queue) system that offers replication.
+
+### Acks=0: The "Fire and Forget" Approach
+
+When a producer's `acks` are set to `0`, it sends the message to the leader broker and immediately considers it successful without waiting for any acknowledgment.
+
+*   **Durability**: Lowest. Data can be lost if the leader broker fails before it has a chance to write the message to its log or replicate it. The producer will never know the message was dropped.
+*   **Performance**: Highest throughput and lowest latency. The producer doesn't wait for any network round-trip from the broker, allowing it to send messages as fast as the network allows.
+*   **Use Case**: Best for non-critical data where some loss is acceptable, such as metrics collection, logging, or IoT sensor data where occasional gaps are tolerated.
+
+### Acks=1: Leader Acknowledgment for a Balance
+
+With `acks=1`, the producer sends a message and waits for an acknowledgment from the leader replica only. The leader responds as soon as it writes the message to its local log, without waiting for follower replicas to confirm they have copied it. This is the default setting in Kafka.
+
+*   **Durability**: Moderate. The message is confirmed to be on at least one broker (the leader). However, data loss can still occur if the leader fails immediately after acknowledging the message but before any followers have replicated it.
+*   **Performance**: A good balance between throughput and durability. It introduces some latency due to the network round-trip for the leader's acknowledgment but is significantly more reliable than `acks=0`.
+*   **Use Case**: Suitable for many common scenarios where a small risk of data loss in specific failure modes is acceptable, such as general application event tracking or analytics pipelines.
+
+### Acks=all (-1): Ensuring Maximum Durability
+
+Setting `acks` to `all` (or its equivalent, `-1`) provides the strongest available durability guarantee. The producer waits for the leader to receive acknowledgments from all brokers in the current in-sync replica (ISR) set.
+
+*   **Durability**: Highest. As long as at least one in-sync replica remains online, the message will not be lost. This setting works in tandem with the broker-side configuration `min.insync.replicas`. If you set `min.insync.replicas=2` and `acks=all`, the producer will only receive a successful acknowledgment if the message is written to the leader and at least one follower.
+*   **Performance**: Lowest throughput and highest latency of the three settings. The producer must wait for the message to be replicated across the network to follower brokers and for their acknowledgments to return.
+*   **Use Case**: Essential for critical data where no loss can be tolerated, such as financial transactions, e-commerce orders, or audit trail events.
+
+## Why Reliable Acknowledgments Need Orchestration
+
+Simply setting `acks=all` is not enough to guarantee end-to-end reliability. In a production environment, managing Kafka producers involves more than just a single configuration parameter. This is where an orchestration platform becomes essential for several reasons:
+
+*   **Dynamic Configuration**: Different data streams have different criticality. An orchestration platform can manage multiple producer flows, applying `acks=all` for financial data and `acks=1` for application logs, all within a governed framework.
+*   **Automated Error Handling**: What happens when a producer with `acks=all` fails due to an insufficient number of in-sync replicas? An orchestration layer can automatically trigger alerts, retry the message with an exponential backoff strategy, or route it to a dead-letter queue for manual inspection.
+*   **Observability and Auditing**: An orchestration platform provides a centralized view of all producer activity. It logs every success and failure, making it easy to audit delivery guarantees and troubleshoot issues without parsing scattered producer logs.
+*   **Simplified Management**: Orchestration allows you to manage `acks` declaratively alongside other critical Kafka settings like idempotence and transactions. This configuration-as-code approach simplifies maintenance and ensures consistency across environments.
+
+## Orchestrate Kafka Producer Acks with Kestra: Ensuring Delivery Guarantees
+
+With Kestra, you can [orchestrate Kafka](/orchestration/kafka) workflows declaratively, ensuring that producer settings like `acks` are explicitly defined, version-controlled, and consistently applied.
+
+The following flow demonstrates producing a message to a Kafka topic with `acks` set to `all` for maximum durability. If the produce task fails for any reason (e.g., brokers are unavailable or `min.insync.replicas` is not met), an error-handling task is triggered to log the failure for immediate investigation.
+
+```yaml
+id: kafka-guaranteed-delivery
+namespace: company.team.production
+
+inputs:
+  - id: message_key
+    type: STRING
+    defaults: "order-12345"
+  - id: message_value
+    type: STRING
+    defaults: '{"orderId": "12345", "amount": 99.99, "status": "CONFIRMED"}'
+
+tasks:
+  - id: produce-message
+    type: io.kestra.plugin.kafka.Produce
+    description: Produce a critical message with the highest durability guarantee.
+    brokers: "{{ secret('KAFKA_BROKERS') }}"
+    topic: critical_orders
+    acks: all
+    key: "{{ inputs.message_key }}"
+    value: "{{ inputs.message_value }}"
+
+  - id: log-success
+    type: io.kestra.plugin.core.log.Log
+    message: "Message produced successfully to Kafka topic {{ outputs['produce-message'].topic }} with acks=all."
+    level: INFO
+
+errors:
+  - id: handle-failure
+    type: io.kestra.plugin.core.log.Log
+    message: "Failed to produce message to Kafka. Exception: {{ error.message }}"
+    level: ERROR
+```
+
+Here’s what this declarative flow accomplishes:
+
+*   **Explicit Durability**: The `acks: all` setting is clearly defined in the YAML, leaving no room for ambiguity. This is version-controlled in Git and auditable.
+*   **Robust Error Handling**: The `errors` block provides a clean, built-in mechanism for handling failures. Instead of complex `try/catch` logic in producer code, the platform manages exceptions.
+*   **Secret Management**: Broker connection strings are securely managed via Kestra's secret management, not hardcoded in scripts.
+*   **Plugin-Based Simplicity**: The entire operation is handled by the official Kestra [Apache Kafka plugin](/plugins/plugin-kafka), abstracting away the boilerplate of Kafka client libraries.
+
+### Choosing Between Batch and Realtime Kafka Triggers
+
+When consuming messages, Kestra offers two primary mechanisms: the `Trigger` for batch processing and the `RealtimeTrigger` for streaming.
+
+*   **`Trigger`**: Polls the topic on a schedule (e.g., every minute) and processes all new messages in a single batch execution. This is ideal for periodic data loads and analytics.
+*   **`RealtimeTrigger`**: Maintains a persistent connection and processes each message as it arrives, triggering a new flow execution for every message. This is suited for low-latency, event-driven applications.
+
+The choice of consumer model can influence your producer `acks` strategy. For example, a realtime pipeline processing financial transactions will almost certainly require `acks=all` on the producer side to prevent data loss.
+
+## Advanced Considerations for Kafka Producer Reliability
+
+### Idempotence and Transactional Producers with Acks
+
+Even with `acks=all`, network issues can cause a producer to retry sending a message that was already successfully committed, leading to duplicate records. Kafka addresses this with two features:
+
+*   **Idempotent Producer**: By setting `enable.idempotence=true`, the producer attaches a sequence number to each message. The broker tracks these numbers and discards any duplicates, guaranteeing exactly-once delivery per producer session. Enabling idempotence requires `acks` to be set to `all`.
+*   **Transactional Producer**: Transactions extend idempotence across multiple partitions and topics. They allow you to group a series of produce and consume operations into a single atomic unit. This is the gold standard for exactly-once semantics in stream processing applications. Transactions also require `acks=all`.
+
+For advanced use cases, refer to Kestra's documentation on [Enterprise and Advanced Configuration](/docs/configuration/enterprise-and-advanced).
+
+### Troubleshooting Acks-Related Issues
+
+When using stricter `acks` settings, you might encounter issues like:
+*   **`TimeoutException`**: The producer did not receive acknowledgments within the configured `request.timeout.ms`. This can happen if the cluster is under heavy load or if there are network issues.
+*   **`NotEnoughReplicasException`**: The number of available in-sync replicas is less than what is required by `min.insync.replicas`, preventing the producer from getting the required acknowledgments.
+*   **`LeaderNotAvailableException`**: The leader for the partition is temporarily unavailable, often during a leadership election.
+
+Debugging these often involves checking broker health, network connectivity between clients and brokers, and ensuring your topic's replication factor is appropriate for your `acks` and `min.insync.replicas` settings.
+
+## Where Kafka Acks Pay Off
+
+Configuring the right `acks` setting is crucial across various domains:
+*   **Financial Services**: For processing payments, trades, and other transactions, `acks=all` is non-negotiable to prevent data loss.
+*   **Real-Time Analytics**: Ingesting user activity for real-time dashboards often uses `acks=1` to balance data freshness with reliability.
+*   **IoT Data Ingestion**: Collecting high-volume sensor data might use `acks=0` or `acks=1`, as losing a few data points is often acceptable for the sake of performance.
+*   **Auditing and Compliance**: Systems that require a verifiable audit trail of events must use `acks=all` to ensure every message is durably stored.
+
+## Related concepts
+
+*   [Message Queue: A Guide to Asynchronous Communication](/resources/infrastructure/message-queue)
+*   [Orchestrate Kafka with Kestra](/orchestration/kafka)
+*   [What Is Apache Kafka? Architecture & Orchestration](/resources/data/what-is-kafka)
+*   [Apache Kafka Plugin for Kestra](/plugins/plugin-kafka)
+*   [RabbitMQ vs Kafka: Messaging and Event Streaming Comparison](/resources/data/rabbitmq-vs-kafka)
+*   [Enterprise & Advanced Configuration in Kestra](/docs/configuration/enterprise-and-advanced)
+
+Ready to simplify your Kafka operations and ensure data delivery? Explore how Kestra can orchestrate your event-driven workflows.

--- a/src/contents/resources/step-functions-limits/index.md
+++ b/src/contents/resources/step-functions-limits/index.md
@@ -1,0 +1,149 @@
+---
+title: "AWS Step Functions Limits: Overcoming Workflow Constraints"
+description: "Understand the common limitations of AWS Step Functions, from payload size to execution history. Explore practical strategies and best practices to design robust, scalable serverless workflows."
+metaTitle: "AWS Step Functions Limits: Overcoming Workflow Constraints"
+metaDescription: "Navigate AWS Step Functions limits, including payload and concurrency. Learn expert strategies to build resilient and scalable serverless workflows."
+tag: "infrastructure"
+date: 2026-08-11
+slug: "step-functions-limits"
+faq:
+  - question: "Do AWS Step Functions have limits?"
+    answer: "Yes, AWS Step Functions impose several limits, including a strict 256KB payload size for state transitions, a maximum of 25,000 events in an execution's history, and various quotas for concurrent executions and state machine resources. These are designed to ensure service stability but require careful workflow design."
+  - question: "What are the main limitations of AWS Step Functions?"
+    answer: "Key limitations include the 256KB payload size, which can be challenging for workflows handling large datasets, and the 25,000 event history limit, which can impact long-running or complex workflows. Additionally, concurrent execution quotas and specific throughput limitations for Express and Standard workflows can affect scalability."
+  - question: "How long can an AWS Step Function run?"
+    answer: "Standard AWS Step Functions workflows can run for up to one year and manage up to 25,000 events. Express Workflows, designed for high-volume, short-duration tasks, have a maximum duration of five minutes. These limits dictate the types of long-running processes suitable for each workflow type."
+  - question: "How can you overcome the 256KB payload limit in Step Functions?"
+    answer: "To exceed the 256KB payload limit, a common strategy is to offload larger data to external storage like Amazon S3. Instead of passing the full payload, the workflow passes a reference (e.g., an S3 URI). Tasks then retrieve data from S3 and store results back to S3, keeping inter-state payloads small."
+  - question: "When should you avoid using AWS Step Functions?"
+    answer: "Step Functions might not be the ideal choice for extremely high-throughput, low-latency data streaming where even Express Workflows introduce too much overhead. It's also less suited for workflows that are purely infrastructure provisioning (where IaC tools excel) or those requiring deep custom code logic that is better managed within a dedicated application."
+---
+
+AWS Step Functions offer a powerful way to orchestrate serverless applications, visually defining workflows that span multiple AWS services. However, like any cloud service, they come with specific limits and quotas designed to maintain service stability and manage resource consumption. Understanding these constraints is not just about avoiding errors; it's about designing resilient, scalable, and cost-effective solutions.
+
+This guide delves into the most critical AWS Step Functions limits, from payload size restrictions to execution history and concurrency. We'll explore practical strategies for navigating these boundaries, best practices for optimizing your workflows, and when to consider alternative orchestration approaches for complex, cross-domain automation needs.
+
+## Understanding AWS Step Functions and Their Core Purpose
+
+Before diving into the limits, it's essential to understand what Step Functions are designed for. They are a serverless orchestration service that lets you coordinate multiple AWS services into a single, cohesive workflow.
+
+### What are AWS Step Functions?
+
+At their core, AWS Step Functions are state machines. You define a series of steps, or "states," that your application should execute. Each state can perform a specific task, such as invoking an AWS Lambda function, running a job on AWS Batch, or interacting with other AWS services. The state machine manages the flow of data between these steps, handles errors, and provides a visual representation of the workflow's progress.
+
+This model is ideal for building complex, event-driven applications, automating business processes, and managing [data orchestration](/resources/data/data-orchestration) tasks within the AWS ecosystem.
+
+### Why Navigating Step Functions Limits is Critical for Scalability
+
+AWS implements service quotas (limits) to protect both the customer and the service itself. For the customer, these limits prevent runaway executions from generating unexpected costs. For AWS, they ensure service availability and prevent any single customer's workload from degrading performance for others.
+
+Ignoring these limits during the design phase can lead to critical failures in production. A workflow that performs perfectly with small test data might abruptly fail when faced with real-world payloads. A process that runs for months might suddenly hit an execution history limit. Proactively designing around these constraints is the key to building applications that are not just functional, but also scalable and reliable. Many teams look for the [top data orchestration platforms](/blogs/top-data-orchestration-platforms) to find solutions that align with their scalability needs from the start.
+
+## Key AWS Step Functions Limits and Quotas to Know
+
+Step Functions have several quotas, some of which are "hard" (cannot be changed) and some "soft" (can be increased upon request). Here are the most important ones to be aware of.
+
+### Payload Size Restrictions: The 256KB Constraint
+
+One of the most frequently encountered limits is the 256KB maximum payload size. This applies to the data passed as input to an execution, the data passed between states, and the final output of a state machine. This size includes the entire JSON structure, not just the values. For applications processing large files or complex data objects, this can be a significant constraint.
+
+### Execution Event History Limits: Managing Workflow Traceability
+
+Each execution of a state machine generates a detailed history of events. This includes every state transition, task start, task completion, and retry attempt. Standard Workflows have a hard limit of 25,000 entries in this event history. For long-running workflows or those with many iterative steps (like loops), this limit can be reached before the workflow completes, causing the execution to fail. You can monitor the progress and history of each [flow execution](/docs/workflow-components/execution) to stay ahead of this limit.
+
+### Concurrent Execution Limits: Scaling Your Workflows
+
+AWS places a soft quota on the number of concurrent state machine executions per account and region. While this limit can be increased, sudden spikes in traffic can lead to throttling, where new execution requests are rejected. Understanding this limit is crucial for designing systems that can handle variable loads without dropping requests.
+
+### State Machine and Activity Quotas
+
+There's a limit on the number of state machines and activities you can register in your AWS account per region. As of early 2024, this default quota was increased from 10,000 to 100,000, providing ample room for most use cases. However, for large enterprises or SaaS providers using a multi-tenant architecture, it's still a number to track.
+
+### Throughput Limitations for Express and Standard Workflows
+
+Step Functions offer two workflow types with different performance characteristics:
+*   **Standard Workflows**: Designed for long-running, durable workflows. They have lower throughput for starting executions.
+*   **Express Workflows**: Optimized for high-volume, short-duration event processing. They can handle a much higher rate of new executions but have their own set of limitations, such as a shorter maximum duration.
+
+### How Long Can an AWS Step Function Run?
+
+The maximum duration of a workflow depends on its type:
+*   **Standard Workflows**: Can run for a maximum of **one year**. This makes them suitable for long-running business processes, such as order fulfillment or compliance workflows.
+*   **Express Workflows**: Have a maximum duration of **five minutes**. This is aligned with their use case for high-throughput, synchronous tasks like microservice orchestration. This duration is significantly shorter than the maximum [AWS Lambda timeout](/resources/infrastructure/aws-lambda-timeout), which is 15 minutes.
+
+## Strategies to Overcome Step Functions Limitations
+
+While these limits may seem restrictive, AWS and the developer community have established effective patterns for working around them.
+
+### Bypassing the 256KB Payload Limit with External Storage
+
+The most common solution for the payload size limit is the "Claim Check" pattern. Instead of passing large data directly between states, you store it in an external location like Amazon S3.
+
+1.  A task (e.g., a Lambda function) receives or generates a large payload.
+2.  It uploads this payload to an S3 bucket.
+3.  It then passes a small JSON object containing the S3 bucket name and object key (the "claim check") to the next state.
+4.  Subsequent tasks use this reference to download the data from S3, process it, and upload the results back to S3, passing a new claim check forward.
+
+This pattern keeps the state machine's internal payload minimal, effectively bypassing the 256KB limit. Managing access to this data often involves using [secrets](/docs/how-to-guides/secrets) for credentials and permissions.
+
+### Optimizing Execution History for Long-Running Workflows
+
+To avoid hitting the 25,000 event history limit, you can break down a large workflow into smaller, nested workflows.
+*   **Child Workflows**: A parent state machine can start the execution of a child state machine. Each child workflow has its own independent 25,000 event history limit. This is an effective way to modularize complex processes.
+*   **Distributed Map State**: For large-scale parallel processing, the Distributed Map state is a powerful feature. It can iterate over millions of items in a dataset (e.g., objects in an S3 bucket) and launch a child workflow for each item. This pattern contains the event history within each child execution, preventing the parent from exceeding its limit.
+
+### Designing for High Concurrency and Dynamic Scaling
+
+To handle high concurrency and avoid throttling, you can decouple your execution triggers from the state machine itself.
+*   **Buffering with SQS**: Instead of directly starting a Step Function execution for every incoming event, send the events to an Amazon SQS queue. A separate Lambda function can then poll this queue and start executions at a controlled rate, smoothing out traffic spikes.
+*   **Requesting Quota Increases**: For predictable high-load scenarios, you can request an increase for the concurrent execution quota through the AWS Service Quotas console.
+*   **Implement Retries**: Ensure your application logic can handle throttling errors by implementing [retry strategies](/docs/workflow-components/retries) with exponential backoff.
+
+### Adjusting Quotas and Monitoring Utilization
+
+Proactive monitoring is key. Use Amazon CloudWatch to track metrics like `ExecutionsStarted`, `ExecutionsThrottled`, and `ExecutionsFailed`. Set up alarms to notify your team when you are approaching a service quota, giving you time to request an increase or adjust your architecture. You can also define flow [inputs](/docs/workflow-components/inputs) to control batch sizes and other parameters that affect resource consumption.
+
+## Advanced Best Practices for Resilient Step Functions Workflows
+
+Beyond specific workarounds, building resilient systems with Step Functions involves a strategic approach to workflow design.
+
+### Architecting Workflows to Mitigate Common Limits
+
+*   **Decompose Monoliths**: Avoid creating single, monolithic state machines that try to do everything. Break down complex business processes into smaller, independent, and reusable state machines.
+*   **Favor Idempotency**: Design your tasks to be idempotent, meaning they can be run multiple times with the same input and produce the same result. This makes your workflows more resilient to transient failures and retries.
+
+### Implementing Robust Monitoring and Alerting
+
+Go beyond basic quota monitoring. Use CloudWatch Logs Insights to query your execution logs for patterns that might indicate performance issues or design flaws. Set up alerts for specific error types or unusually long state transitions to catch problems before they impact users.
+
+### When Step Functions Might Not Be the Optimal Choice
+
+Step Functions are a versatile tool, but they aren't the right fit for every problem. It's important to recognize scenarios where another approach might be better:
+*   **High-Volume Streaming**: For real-time data processing with very low latency requirements, services like Amazon Kinesis or Apache Kafka are often more suitable.
+*   **Complex Custom Logic**: If your workflow is dominated by complex, custom code rather than service coordination, it might be simpler to manage that logic within a single application or container.
+*   **Multi-Cloud or Hybrid Orchestration**: By design, Step Functions are tightly integrated with the AWS ecosystem. If your workflows need to span multiple clouds or on-premise systems, a vendor-agnostic orchestrator may be a better choice. For a comparison, see these [AWS Step Functions alternatives](/resources/infrastructure/aws-step-functions-alternatives).
+*   **Simple Scheduled Tasks**: For basic scheduling needs, a modern [cron replacement](/resources/infrastructure/cron-replacement) might be a more straightforward solution.
+
+## Kestra: A Declarative Alternative for Broader Orchestration Needs
+
+When the limitations of a single-vendor, serverless-focused tool become a bottleneck, platforms like Kestra offer a different approach. Kestra is an open-source, declarative orchestration platform designed for complex, cross-domain workflows.
+
+### Overcoming AWS-Specific Constraints with a Vendor-Agnostic Platform
+
+Unlike Step Functions, Kestra is not tied to any specific cloud provider. It provides a single control plane to orchestrate tasks across AWS, Google Cloud, Azure, on-premise servers, and SaaS applications. This allows you to build workflows that seamlessly integrate your entire tech stack, not just your AWS services. This is a core reason [why teams choose Kestra](/docs/why-kestra) for their infrastructure automation needs.
+
+### Declarative YAML for Complex, Polyglot Workflows
+
+Kestra workflows are defined in simple, human-readable YAML. This declarative approach makes it easy to version control, review, and collaborate on workflows as part of a GitOps practice. It supports a wide range of task types out of the box, allowing you to run Python scripts, shell commands, SQL queries, and containerized applications as first-class citizens within the same workflow.
+
+### Unified Orchestration Across Data, AI, and Infrastructure
+
+While Step Functions excel at serverless application coordination, Kestra is built to be a universal orchestrator. You can use the same platform to manage everything from [creating a data pipeline](/resources/data/create-data-pipeline) and running dbt models to provisioning infrastructure with Terraform and orchestrating complex AI agent workflows. This unified approach reduces tool sprawl and provides consistent visibility and governance across all your automated processes.
+
+## Conclusion
+
+AWS Step Functions are an invaluable tool for building and managing serverless applications within the AWS ecosystem. Understanding their limits on payload size, execution history, and concurrency is fundamental to designing robust and scalable systems. By applying patterns like the Claim Check for large payloads and decomposing complex processes into nested workflows, you can effectively work within these constraints.
+
+However, as your orchestration needs grow to span multiple clouds, on-premise systems, or diverse technical domains, the limitations of a cloud-specific service can become a challenge. In these scenarios, a vendor-agnostic, declarative platform like Kestra provides the flexibility and power to orchestrate your entire stack from a single, unified control plane.
+
+To explore more guides on data, AI, and infrastructure automation, browse our full collection of [Kestra resources](/resources).


### PR DESCRIPTION
## Summary

Imports 7 W33 SEO drafts from `vfanucci/kestra-seo` (#322–#328) into the resources hub.

| Page | Type | URL | Source |
|------|------|-----|--------|
| Airflow Operators | concept | `/resources/data/airflow-operators` | #322 |
| Kafka Acks | concept | `/resources/data/kafka-acks` | #323 |
| Databricks Cluster Types | concept | `/resources/data/databricks-cluster-types` | #324 |
| Step Functions Limits | concept | `/resources/infrastructure/step-functions-limits` | #325 |
| ADF Pipeline Explained | concept | `/resources/data/adf-pipeline-explained` | #326 |
| Cloud Run Jobs | concept | `/resources/infrastructure/cloud-run-jobs` | #327 |
| Enterprise Job Scheduler | concept | `/resources/infrastructure/enterprise-job-scheduler` | #328 |

No slug collisions. Note: #326 ships with the slug `adf-pipeline-explained` (not `adf-pipeline`).

## Front-matter hygiene

All 7 pages: publish `date` set to the **real publication date (`2026-08-11`)**; metaTitle ≤ 60 with the ` | Kestra` suffix stripped (the docs template appends it); metaDescription 140–160; fences balanced; no `image:`/`author:`; no unresolved markers; no duplicated headings.

Upstream outline fixes worth noting (all corrected before the drafts were generated):

- **cloud-run-jobs**: the outline used `io.kestra.plugin.ee.gcp.cloudrun.Run`, which does not exist — Cloud Run is a **task runner** in Kestra (`io.kestra.plugin.ee.gcp.runner.CloudRun`, EE), not a task type. The example now runs a shell `Commands` task on that task runner. Its `description` also started with a banned opener.
- **adf-pipeline**: `io.kestra.plugin.azure.datafactory` is a package, not a class → `.CreateRun`; `SlackSimpleMessage` → `SlackIncomingWebhook`.
- **databricks-cluster-types** / **kafka-acks**: FQCN casing fixed (`createcluster`/`deletecluster`/`submitrun` → `CreateCluster`/`DeleteCluster`/`SubmitRun`; `kafka.produce`/`trigger`/`realtimetrigger` → `Produce`/`Trigger`/`RealtimeTrigger`; `core.log.Logger` → `core.log.Log`).
- Several outlines shipped either a literal `date: YYYY-MM-DD` placeholder or no `date` field at all — filled in.

All plugin FQCNs verified against `context/plugin-classes.txt`.

## ⚠️ Cannibalisation watch

**`enterprise-job-scheduler` (#328)** lands on an intent already covered by five live pages: `job-scheduler`, `job-scheduling-software`, `open-source-job-scheduler`, `batch-scheduling-platform-alternatives`, `infrastructure-orchestration-vs-job-scheduling`. This is the crowded cluster we flagged earlier — worth deciding which page is the hub before adding more.

Lower-risk but adjacent: `step-functions-limits` next to the live `aws-step-functions-alternatives`; `kafka-acks` joins the Kafka cluster (`what-is-kafka`, `kafka-connect`, `kafka-streams`, `kinesis-vs-kafka`, `pubsub-vs-kafka`, `rabbitmq-vs-kafka`); `databricks-cluster-types` joins the Databricks cluster (4 live pages). Those three are narrow technical sub-topics, so they read as complements rather than duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
