### PR TITLE
fix(seo): noindex archived plugin version pages

### DIFF
--- a/src/pages/plugins/[...slug].astro
+++ b/src/pages/plugins/[...slug].astro
@@ -340,7 +340,7 @@ const pluginSchema = pluginType
       }
 ---
 
-<Layout title={headingTitle} description={headingDescription} image={ogImage}>
+<Layout title={headingTitle} description={headingDescription} image={ogImage} noindex={versionState.isArchived}>
     <Fragment slot="head">
         {/* This decorative background on .plugin-details is the page's LCP
             image, but as a CSS background it is only discovered once the


### PR DESCRIPTION
## Problem

Archived plugin version pages are served as fully indexable near-duplicates of the latest page.

Verified live:
- `/plugins/plugin-aws/v2.8.1` → `robots: index, follow` + **self-referencing canonical**, identical `<title>`/description to the latest page.
- Same for archived **task/trigger sub-pages**, e.g. `/plugins/plugin-aws/v2.8.1/io.kestra.plugin.aws.s3.upload`.

With per-version URLs multiplied across ~2.4k plugin pages, this is a large **index-bloat + duplicate-content** risk — and it grows with every release as the 2.0 version history accumulates.

What's already fine (left untouched): the sitemap excludes versioned URLs, and the *latest* version's twin (`/vX.Y.Z` == latest) 301-redirects to the clean URL via `isLatestRequested`.

## Fix

One line in `src/pages/plugins/[...slug].astro` — pass `noindex={versionState.isArchived}` to `<Layout>`.

- `versionState.isArchived` is `true` for any non-latest version URL and **all its task/trigger sub-pages** (they share this SSR render path), `false` for the latest → one flag covers the whole archived surface.
- The Layout already emits exactly `noindex, follow` when `noindex` is set (`src/components/layout.astro`), so no layout change is needed.
- Latest + its twin 301 earlier, so they never reach this render path — no side effects.

## Deliberately NOT changed

- **Canonical** stays self-referencing. `noindex` + a canonical pointing to a *different* URL are contradictory signals; `noindex` alone is the clean, decisive one here.
- **robots.txt** unchanged — archived pages must stay crawlable so Google can see the `noindex` (blocking them would freeze the current index bloat instead of clearing it).

## Result

Archived versions drop out of the index as Google recrawls them, while remaining fully accessible and deep-linkable for users. No impact on latest pages, sitemap, or robots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)