### PR TITLE
docs(how-to-guides): add Kubernetes Prometheus scraping section

### DIFF
--- a/src/contents/docs/15.how-to-guides/monitoring/index.md
+++ b/src/contents/docs/15.how-to-guides/monitoring/index.md
@@ -65,6 +65,114 @@ You can now go to `http://localhost:9090/graph` and try out visualizing some met
 
 ![promql_graph](./promql_graph.png)
 
+## Scraping Kestra on Kubernetes
+
+The setup above uses `static_configs` with a single hardcoded target, which suits a single Kestra instance running locally. It does not translate to [Kubernetes](../../02.installation/03.kubernetes/index.md): pod IP addresses change whenever a pod restarts or is rescheduled, and a distributed deployment runs many pods to scrape rather than one.
+
+Use Kubernetes service discovery instead. Prometheus resolves its targets from the Kubernetes API and updates them as pods come and go, so pod churn is handled for you.
+
+You do not need to create a Service to scrape Kestra. Prometheus discovers and scrapes the pods directly.
+
+:::alert{type="warning"}
+Avoid pointing Prometheus at a Service `ClusterIP`. A `ClusterIP` load-balances, so each scrape reaches one arbitrary pod while reporting under a single target identity. Counters then appear to jump backwards between scrapes, and no series can be attributed to a specific pod.
+:::
+
+### Enable the metrics endpoint
+
+The Helm chart renders `configurations.application` into a single ConfigMap that every component mounts, so enabling the endpoint once covers the webserver, executor, scheduler, indexer, worker, and every worker group:
+
+```yaml
+configurations:
+  application:
+    endpoints:
+      metrics:
+        enabled: true
+      prometheus:
+        enabled: true
+        sensitive: false
+    micronaut:
+      metrics:
+        enabled: true
+        export:
+          prometheus:
+            enabled: true
+            step: PT1M
+```
+
+Every Kestra pod already declares port 8081 as a named container port called `management`, so no additional port configuration is required.
+
+:::alert{type="info"}
+Metrics are served on port 8081, not the 8080 UI port. Requesting `/prometheus` on port 8080 returns a redirect.
+:::
+
+### Discover pods with annotations
+
+If you run Prometheus yourself with a `kubernetes_sd_configs` scrape job, annotate the pods so your existing annotation-based job picks them up. Setting this under `common` applies it to every component, including all worker groups:
+
+```yaml
+common:
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8081"
+    prometheus.io/path: "/prometheus"
+```
+
+### Discover pods with a PodMonitor
+
+If you use the Prometheus Operator, a single `PodMonitor` covers every Kestra component. Add it through the chart's `extraManifests`:
+
+```yaml
+extraManifests:
+  - |
+    apiVersion: monitoring.coreos.com/v1
+    kind: PodMonitor
+    metadata:
+      name: {{ include "kestra.fullname" . }}
+      labels:
+        {{- include "kestra.labels" . | nindent 4 }}
+    spec:
+      selector:
+        matchLabels:
+          {{- include "kestra.selectorLabels" . | nindent 6 }}
+      podMetricsEndpoints:
+        - port: management
+          path: /prometheus
+          interval: 30s
+      podTargetLabels:
+        - app.kubernetes.io/component
+        - kestra.io/worker-group
+```
+
+`podMetricsEndpoints.port` refers to the named `management` container port, so it stays correct regardless of how the port is configured. `podTargetLabels` promotes the listed pod labels onto the scraped metrics, which is what lets you filter by component and by worker group in PromQL.
+
+:::alert{type="info"}
+Entries in `extraManifests` are rendered as Helm templates. When writing one as a YAML block scalar, the `nindent` value must match the indentation of the surrounding literal keys after YAML strips the block indent. A mismatch fails with a `did not find expected key` error.
+:::
+
+### Distinguishing worker groups
+
+Kestra's metrics payload does not include a worker group tag, so worker group identity has to come from Kubernetes pod labels. The Helm chart does not add a per-group label automatically, so declare one for the worker deployment and for each worker group:
+
+```yaml
+deployments:
+  worker:
+    enabled: true
+    podLabels:
+      kestra.io/worker-group: default
+
+workerGroups:
+  gpu:
+    enabled: true
+    podLabels:
+      kestra.io/worker-group: gpu
+```
+
+Together with `podTargetLabels` in the `PodMonitor` above, this makes each worker group separately queryable. Without it, every worker pod carries the same labels and its metrics cannot be attributed to a group.
+
+:::alert{type="info"}
+`podLabels` and `podAnnotations` are supported per component and per worker group, not only under `common`.
+:::
+
 ## Setting up Grafana
 
 Let us now move on to setting up Grafana. You start by installing Grafana using docker via the following command:


### PR DESCRIPTION
Closes #5320

## What

Adds a `## Scraping Kestra on Kubernetes` section to the Grafana and Prometheus how-to guide, between the existing Docker walkthrough and the Grafana setup.

## Why

The guide only covered a single-instance Docker Compose setup, and the scrape config it teaches is:

```yaml
static_configs:
  - targets: ["<kestra-host-ip-address>:8081"]
```

A single hardcoded target is the one approach that does not work on Kubernetes, where pod IPs change on restart and a distributed deployment has many pods to scrape. Nothing elsewhere in the docs fills the gap: `02.installation/03.kubernetes/index.md` has no mention of `prometheus`, `monitoring`, `metric`, or `8081`, and `10.administrator-guide/03.monitoring/index.md` documents metric names and a Grafana dashboard but no scrape configuration.

In practice this leads users to conclude they need a Service per worker group and then scrape its ClusterIP, which silently produces broken data rather than an error.

## What the section covers

- **Enabling the metrics endpoint.** Notes that `configurations.application` renders into a single ConfigMap mounted by all components, so this is a one-time setting rather than per-component.
- **Pod discovery via annotations**, for users running their own Prometheus with a `kubernetes_sd_configs` job.
- **Pod discovery via `PodMonitor`**, for Prometheus Operator users. One `PodMonitor` covers every component and needs no Service.
- **Distinguishing worker groups.** Kestra's metrics payload carries no worker group tag, so group identity has to come from pod labels. The chart does not add one automatically today, so the section shows declaring it via `podLabels` and promoting it with `podTargetLabels`.
- **A warning against scraping a Service ClusterIP**, explaining that it load-balances across pods and makes counters appear to jump backwards.
- **A note that metrics are on 8081, not 8080** (8080 returns a redirect for `/prometheus`).
- **A note on the `extraManifests` block-scalar `nindent` trap**, which fails with an opaque `did not find expected key` error.

## Verification

Every YAML snippet in the new section was extracted from the rendered markdown and applied verbatim to `helm template` against the published charts `1.3.22` and `1.3.30`. Both render successfully, and the output was checked to confirm:

- the `PodMonitor` renders as valid YAML with the expected selector and `podTargetLabels`
- the scrape annotations reach every component pod including worker groups
- the `kestra.io/worker-group` labels appear on the worker and worker-group pods
- the prometheus endpoint config lands in the shared ConfigMap

## Scope notes

- Deliberately does not document the `ServiceMonitor` route. `PodMonitor` covers the Operator case without requiring a Service, and keeping one recommended path avoids reintroducing the Service-based confusion this section exists to correct.
- The manual `podLabels` step becomes unnecessary once kestra-io/kestra#18100 lands, at which point this section can be simplified.
- Branched from `main`. This page has no changes on `docs/2.0.0-release`, so there is no conflict with the 2.0 docs work.
