### PR TITLE
seo(resources): add dbt-on-airflow-vs-kestra page

### DIFF
--- a/src/contents/resources/dbt-on-airflow-vs-kestra/index.md
+++ b/src/contents/resources/dbt-on-airflow-vs-kestra/index.md
@@ -1,0 +1,197 @@
+---
+title: "Running dbt on Airflow vs Kestra: A Head-to-Head Comparison"
+description: "Data teams need robust orchestration for dbt. Compare Airflow and Kestra's approaches to managing dbt projects, from workflow definition to operational complexity, to find the best fit for your stack."
+metaTitle: "dbt on Airflow vs Kestra: Orchestration Comparison"
+metaDescription: "Compare dbt orchestration on Airflow vs Kestra: analyze workflow definition, scalability, and operational overhead for your production data pipelines."
+tag: "data"
+date: 2026-08-13
+slug: "dbt-on-airflow-vs-kestra"
+faq:
+  - question: "Why is orchestration important for dbt projects?"
+    answer: "Orchestration for dbt ensures models run in the correct order, handles dependencies, manages scheduling, and provides robust error handling and observability. Without it, dbt runs can be isolated, difficult to monitor, and prone to failures in complex data pipelines."
+  - question: "What are the main differences in workflow definition between Airflow and Kestra for dbt?"
+    answer: "Airflow defines dbt workflows using Python DAGs, often requiring custom operators or `BashOperator` wrappers. Kestra uses declarative YAML, allowing dbt commands to be defined directly as tasks, leading to more readable, versionable, and polyglot workflows."
+  - question: "How does Kestra handle dbt environments and dependencies?"
+    answer: "Kestra's declarative YAML and containerization capabilities simplify dbt environment management. Each dbt task can specify its own Docker image or Python environment, ensuring isolated and reproducible runs. Dependencies are managed implicitly through the flow's task sequence or explicitly using Kestra's flow control tasks."
+  - question: "Can Kestra orchestrate dbt alongside other tools?"
+    answer: "Yes, Kestra is designed for polyglot, cross-domain orchestration. It can easily integrate dbt with data ingestion tools like Airbyte, data warehouses like Snowflake or BigQuery, and even infrastructure or AI tasks, all within a single, unified workflow definition."
+  - question: "Is it difficult to migrate dbt projects from Airflow to Kestra?"
+    answer: "Migrating dbt projects from Airflow to Kestra typically involves translating Python DAGs into Kestra's declarative YAML flows. Kestra's native dbt plugin and `Bash` or `Python` tasks simplify this transition, often reducing boilerplate code and improving readability. The process is streamlined by Kestra's explicit task definitions."
+  - question: "Which tool offers better observability for dbt pipelines?"
+    answer: "Both tools offer observability. Airflow provides a UI for DAG runs and logs. Kestra offers a comprehensive UI with real-time execution graphs, detailed task logs, and built-in metrics, giving granular visibility into each dbt task's status, inputs, and outputs for faster debugging."
+  - question: "When should I consider Airflow for dbt orchestration?"
+    answer: "Airflow is a strong choice if your team is already heavily invested in the Python ecosystem, has extensive Airflow expertise, and primarily deals with Python-centric data engineering workloads. Its vast operator ecosystem can be beneficial for specific integrations."
+---
+Orchestrating dbt (data build tool) projects effectively is crucial for maintaining reliable data pipelines. As data stacks grow in complexity, choosing the right orchestrator—one that seamlessly integrates dbt while offering robust control, scalability, and observability—becomes a strategic decision. Apache Airflow has long been a default for many data teams, but modern alternatives like Kestra offer a fresh perspective with declarative approaches and broader capabilities.
+
+This article delves into how Airflow and Kestra approach dbt orchestration, comparing their strengths, operational models, and ideal use cases. Understanding their core differences will help you make an informed choice for your data team's specific needs.
+
+## The Crucial Role of Orchestration for dbt
+
+dbt has become the standard for transformation in the modern data stack, allowing teams to turn raw data into tested, trusted datasets for analytics. However, dbt only handles the "T" (transform) in ELT. It doesn't manage when your models run, what happens if they fail, or how they connect to upstream ingestion tools and downstream applications. This is where orchestration comes in.
+
+Effective orchestration for dbt is not just about scheduling `dbt run`. It involves:
+*   **Dependency Management:** Ensuring data is loaded and ready before transformations begin.
+*   **Scheduling:** Running models on a fixed schedule, or in response to events like new data arriving.
+*   **Error Handling and Retries:** Automatically managing failures and retrying steps without manual intervention.
+*   **Environment Management:** Isolating development, staging, and production runs with the correct configurations and dependencies.
+*   **Observability:** Providing clear visibility into run history, logs, and performance for faster debugging.
+
+Without a dedicated orchestrator, teams often fall back on cron jobs and shell scripts, leading to a brittle, unmanageable system. For a more detailed look at dbt workflows, you can check out how to [orchestrate dbt workflows in Kestra](/docs/use-cases/dbt) or see an example of an [end-to-end data pipeline](/blogs/2023-06-26-end-to-end-data-orchestration).
+
+## Airflow for dbt Orchestration: The Pythonic Path
+
+Apache Airflow is a mature, widely adopted orchestrator that defines workflows as Python code in Directed Acyclic Graphs (DAGs). Its deep roots in the Python data ecosystem make it a common choice for dbt orchestration.
+
+### How Airflow Integrates with dbt
+
+There are several common patterns for running dbt jobs in Airflow:
+*   **`BashOperator`:** The simplest method is to wrap dbt CLI commands in a `BashOperator`. This is straightforward but can become cumbersome for managing environments and passing dynamic parameters.
+*   **`dbt-airflow` Provider:** The official provider offers operators like `DbtRunOperator` and `DbtTestOperator`, providing a more structured way to invoke dbt commands.
+*   **Custom Python Operators:** Teams often write their own Python functions to interact with dbt Core or the dbt Cloud API, offering maximum flexibility at the cost of higher maintenance.
+
+Regardless of the method, the core principle is the same: dbt commands are triggered from within a Python-defined DAG.
+
+### Advantages for dbt Teams
+
+For teams already standardized on Python, Airflow offers several benefits:
+*   **Python Familiarity:** Defining data pipelines in the same language used for data analysis and scripting feels natural.
+*   **Large Ecosystem:** Airflow boasts a massive library of community-contributed operators for integrating with hundreds of other tools.
+*   **Mature and Battle-Tested:** Having been around for years, Airflow is a known quantity with extensive documentation and community support.
+
+### Operational Complexities and Limitations
+
+Despite its popularity, orchestrating dbt with Airflow introduces significant operational challenges:
+*   **Python Boilerplate:** Every dbt task must be wrapped in Python code, leading to verbose and often repetitive DAG files. This makes simple dbt runs more complex than they need to be.
+*   **Environment Isolation:** Managing Python virtual environments to avoid dependency conflicts between different DAGs and tasks is a persistent struggle.
+*   **Debugging:** When a dbt model fails, debugging requires tracing the error from dbt's logs back through the Airflow operator and the underlying Python environment, complicating root cause analysis.
+*   **Operational Overhead:** Running Airflow in production requires managing a complex architecture of schedulers, workers, and a metadata database, which can be a full-time job. Even with the updates in [Airflow 3 vs Airflow 2](/blogs/airflow-3-vs-airflow-2), this core complexity remains, leading many to seek [enterprise Airflow alternatives](/blogs/enterprise-airflow-alternatives).
+
+## Kestra for dbt Orchestration: Declarative and Unified
+
+Kestra is a modern orchestration platform that uses declarative YAML to define workflows. This language-agnostic approach fundamentally changes how teams orchestrate dbt, moving away from Python-centric DAGs to a more direct and readable format.
+
+### How Kestra Streamlines dbt Workflows
+
+Kestra integrates with dbt through its native `dbt` plugin, which directly exposes dbt CLI commands as tasks. Instead of writing Python code to call `dbt run`, you simply define a task in YAML:
+
+```yaml
+- id: dbt_run
+  type: io.kestra.plugin.dbt.cli.Build
+  commands:
+    - dbt build --select my_model
+```
+
+This declarative model is combined with first-class support for containerization, allowing each dbt project to run in its own isolated environment with specific dependencies, all defined within the same workflow file.
+
+### Key Benefits of a Declarative Approach
+
+Using YAML to define dbt workflows offers several advantages over Python DAGs:
+*   **Readability and Simplicity:** Workflows are easier to read and understand, even for non-Python developers. What you see in the YAML is what gets executed.
+*   **Version Control and GitOps:** YAML files are perfectly suited for Git. Changes are easily auditable through diffs, enabling robust GitOps practices for your data pipelines.
+*   **Reduced Boilerplate:** By defining tasks directly, Kestra eliminates the need for Python wrapper code, making workflows more concise and maintainable.
+*   **Simplified Environment Management:** Containerized task runners mean no more conflicting dependencies. Each dbt project can use its own Docker image, ensuring consistency from local development to production.
+
+### Orchestrate dbt with Kestra: An Example Pipeline
+
+Here is a complete Kestra flow that loads new data from a Postgres database, sets up a dbt environment, runs a specific dbt model, and sends success or failure notifications.
+
+```yaml
+id: postgres-to-dbt-reporting
+namespace: company.team.analytics
+
+tasks:
+  - id: initial-data-load
+    type: io.kestra.plugin.jdbc.postgresql.Query
+    description: Load new data from the raw_data table.
+    url: jdbc:postgresql://host.docker.internal:5432/postgres
+    username: "{{ secret('POSTGRES_USER') }}"
+    password: "{{ secret('POSTGRES_PASSWORD') }}"
+    sql: "SELECT * FROM raw_data WHERE loaded_at > '{{ trigger.date }}'"
+    store: true
+
+  - id: dbt-setup-env
+    type: io.kestra.plugin.scripts.shell.Commands
+    description: Install dbt dependencies.
+    commands:
+      - pip install dbt-postgres
+      - dbt deps
+
+  - id: dbt-run-build
+    type: io.kestra.plugin.dbt.cli.Build
+    description: Run the dbt build command for a specific model.
+    commands:
+      - dbt build --select my_model
+
+  - id: notify-success
+    type: io.kestra.plugin.core.log.Log
+    description: Log a success message.
+    message: "dbt build completed successfully for my_model."
+    level: INFO
+
+errors:
+  - id: notify-failure
+    type: io.kestra.plugin.core.log.Log
+    description: Log a failure message on error.
+    message: |
+      dbt build failed for my_model.
+      Error: {{ error.message }}
+    level: ERROR
+
+triggers:
+  - id: daily-schedule
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 8 * * 1-5"
+```
+This example showcases a few key benefits of orchestrating dbt with Kestra:
+*   **Clear Dependencies:** The sequence of tasks is explicit and easy to follow. The `dbt-run-build` task only starts after the data load and environment setup are complete.
+*   **Integrated Error Handling:** The `errors` block provides a clean, built-in way to handle failures without complex `try/except` logic in Python.
+*   **Polyglot by Nature:** The workflow seamlessly combines a SQL query, a shell command, and a dbt command. This flexibility is central to Kestra's design, making it easy to [orchestrate dbt jobs](/blogs/2024-04-02-dbt-kestra) alongside any other tool in your stack.
+*   **Declarative Scheduling:** The trigger is defined as part of the workflow, keeping all logic in one place.
+
+For teams exploring transformation tools beyond dbt, Kestra's approach is equally applicable to alternatives like [dbt or SQLMesh](/blogs/2024-02-28-dbt-or-sqlmesh).
+
+## dbt on Airflow vs. Kestra: A Head-to-Head Comparison
+
+| Feature                 | Apache Airflow                                        | Kestra                                                     |
+| ----------------------- | ----------------------------------------------------- | ---------------------------------------------------------- |
+| **Workflow Definition** | Python DAGs                                           | Declarative YAML                                           |
+| **Language Support**    | Python-centric; other languages via operators         | Polyglot (Python, SQL, Shell, R, Node.js, etc.)            |
+| **Operational Complexity** | High (Scheduler, Worker, Metadata DB management)      | Lower (Single binary deployment option)                    |
+| **Scalability**         | Horizontal scaling with Celery/Kubernetes Executor    | Built-in horizontal scaling with Kafka/Pulsar              |
+| **Observability**       | UI for DAG runs, logs, task instances                 | UI with real-time graph, detailed logs, outputs, metrics   |
+| **Ecosystem & Plugins** | Vast ecosystem of Python-based operators              | 1,700+ plugins across data, infra, AI, and business tools  |
+| **Learning Curve**      | Steep, requires Python and Airflow-specific knowledge | Approachable for engineers familiar with YAML and CI/CD    |
+| **GitOps & Versioning** | Possible with external tooling and best practices     | Native, as YAML files are inherently version-controllable  |
+| **Event-Driven**        | Supported via Sensors and deferrable operators        | Native support for event-driven triggers (Webhook, Kafka)  |
+
+This table highlights a fundamental philosophical difference. Airflow provides a powerful but complex Python framework, while Kestra offers a more accessible, language-agnostic platform. For a broader look at orchestrators, you can explore other [Kestra vs. Alternatives](/vs).
+
+## When to Choose Airflow for dbt Orchestration
+
+Airflow remains a solid choice in specific contexts:
+*   **Deep Python Investment:** If your data team lives and breathes Python and has built extensive tooling around it, the learning curve for Airflow is lower.
+*   **Existing Airflow Infrastructure:** For organizations with a mature, well-maintained Airflow deployment, adding another dbt DAG is the path of least resistance.
+*   **Complex Dynamic DAGs:** If your dbt workflows require complex, dynamically generated structures based on Python logic, Airflow’s code-based nature can be an advantage.
+
+## When to Choose Kestra for dbt Orchestration
+
+Kestra is a better fit for modern data teams facing different challenges:
+*   **Declarative & GitOps-Native:** Teams that want to manage their data pipelines like infrastructure-as-code will benefit from Kestra's YAML-first approach.
+*   **Polyglot Environments:** When dbt is just one piece of a puzzle that includes tools written in Go, Java, R, or simple shell scripts, Kestra's language-agnosticism shines.
+*   **Cross-Domain Orchestration:** For use cases that extend beyond analytics, such as coordinating dbt runs with infrastructure provisioning (Terraform) or business applications, Kestra provides a single control plane. This is why it’s considered a powerful [IT automation platform](/resources/infrastructure/it-automation-platform).
+*   **Reduced Operational Burden:** Teams looking to spend more time building data products and less time managing their orchestrator will find Kestra's simpler architecture appealing. It's built to empower [data engineers](/use-cases/data-engineers) to focus on value.
+
+## Beyond Airflow and Kestra: Other dbt Orchestration Approaches
+
+While this article focuses on Airflow and Kestra, other tools also offer dbt orchestration:
+*   **Dagster:** An asset-centric orchestrator that provides strong data lineage and a software engineering focus. Its dbt integration is excellent for teams who think in terms of data assets rather than tasks.
+*   **Prefect:** A modern, Python-native orchestrator that emphasizes a great developer experience for Python users. It's a strong alternative for teams who want to stick with Python but desire a more flexible and dynamic model than Airflow.
+
+## Making an Informed Choice for Your dbt Data Stack
+
+Choosing between Airflow and Kestra for dbt orchestration comes down to your team's priorities.
+
+If your organization is deeply rooted in the Python ecosystem and has the operational capacity to manage Airflow's complexity, it remains a viable option.
+
+However, if your goal is to build a more maintainable, scalable, and collaborative data platform where dbt coexists with a diverse set of tools, Kestra's declarative, polyglot, and unified approach offers a compelling modern alternative. It reduces boilerplate, simplifies operations, and aligns with modern DevOps and GitOps practices, allowing your team to move faster and more reliably.


### PR DESCRIPTION
## Summary

Imports the ready draft `dbt-on-airflow-vs-kestra` from `vfanucci/kestra-seo#334` into the resources hub.

| Page | Type | URL | Source |
|------|------|-----|--------|
| dbt on Airflow vs Kestra | concept | `/resources/data/dbt-on-airflow-vs-kestra` | kestra-seo#334 |

New slug; no collision.

## Front-matter hygiene

Publish `date` set to the **real publication date (`2026-08-13`)**; metaTitle 50 chars with no ` | Kestra` suffix (the docs template appends it); metaDescription 150; fences balanced; no `image:`/`author:`; no unresolved markers; no duplicated headings. Body is 1,725 words.

Upstream outline fixes applied before the draft was generated:

- `io.kestra.plugin.dbt.cli.commands.Build` → `io.kestra.plugin.dbt.cli.Build` (there is no `.commands.` segment)
- `io.kestra.plugin.core.log.Logger` → `io.kestra.plugin.core.log.Log`
- `date:` was the literal `YYYY-MM-DD` placeholder → filled in
- metaDescription trimmed into the 140–160 range

All plugin FQCNs verified against `context/plugin-classes.txt`: `dbt.cli.Build`, `core.log.Log`, `core.trigger.Schedule`, `jdbc.postgresql.Query`, `scripts.shell.Commands`.

## Note on the superseded version

An older take on the same topic exists as `vfanucci/kestra-seo#55` (May 2026, slug `running-dbt-airflow-vs-kestra`). It was **not** used: its outline was emitted twice, was missing `## Length target` and `## YAML example plan`, and carried an invalid `tag: "Data Orchestration"`. #334 is the clean regeneration and the one imported here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
