### PR TITLE
seo(resources): add alteryx-alternatives + fivetran-alternatives pages

### DIFF
--- a/src/contents/resources/alteryx-alternatives/index.md
+++ b/src/contents/resources/alteryx-alternatives/index.md
@@ -1,0 +1,162 @@
+---
+title: "Best Alteryx Alternatives for Data Prep & Workflow Automation in 2026"
+description: "Compare the top Alteryx alternatives for data preparation, workflow automation, and analytics. Find the right cloud-native or open-source tool for your data stack."
+metaTitle: "Top Alteryx Alternatives & Competitors for 2026"
+metaDescription: "Looking for Alteryx alternatives? Compare top data prep, workflow automation, and cloud analytics tools on pricing, scalability, and architecture."
+tag: data
+date: 2026-08-17
+slug: alteryx-alternatives
+faq:
+  - question: "What are the top alternatives to Alteryx?"
+    answer: "The leading alternatives to Alteryx include Kestra for declarative workflow orchestration, KNIME for visual data prep, Databricks and Snowflake for cloud-native analytics, dbt for analytics engineering, and n8n for low-code automation."
+  - question: "Why are teams migrating away from Alteryx?"
+    answer: "Many data teams seek Alteryx alternatives due to rising licensing costs (such as the mandatory 'One bundle' pricing push), hardware constraints of local desktop Designer licenses, and the need for cloud-native scalability and GitOps integration."
+  - question: "Is KNIME a free alternative to Alteryx?"
+    answer: "Yes, KNIME Analytics Platform is free and open-source, offering a visual node-based workflow canvas similar to Alteryx Designer, making it the most direct desktop-based visual alternative."
+  - question: "Can Kestra replace Alteryx for data workflows?"
+    answer: "Kestra replaces Alteryx for heavy workflow automation, data pipeline orchestration, and cross-system integrations. Unlike Alteryx's desktop focus, Kestra runs declaratively in YAML on Kubernetes, Docker, or on-premises infrastructure with full GitOps support."
+  - question: "Which is better for big data, Alteryx or Databricks?"
+    answer: "Databricks is significantly better for massive scale and distributed big data processing, leveraging cloud compute and Spark clusters, whereas Alteryx Designer is fundamentally constrained by single-machine memory limits unless paired with server add-ons."
+  - question: "Are there open-source alternatives to Alteryx?"
+    answer: "Yes, open-source tools like Kestra, KNIME (Analytics Platform), and dbt Core provide powerful alternatives without proprietary vendor lock-in or per-seat pricing penalties."
+---
+
+Alteryx transformed desktop data preparation, giving analysts a visual drag-and-drop canvas to clean, blend, and analyze data without writing code from scratch. But as data volumes have exploded and architectures have shifted to the cloud, many engineering and analytics teams are hitting roadblocks. 
+
+Rising licensing costs—particularly enforced transitions to bundled pricing models—combined with the memory limits of local desktop Designer licenses, are forcing data leaders to reevaluate their tooling. 
+
+The leading alternatives to Alteryx include Kestra, KNIME, Databricks, Snowflake, dbt, and n8n—each suited to different workflows, budgets, and engineering requirements.
+
+## Why data teams are looking for Alteryx alternatives
+
+Alteryx Designer remains popular for ad-hoc data blending and desktop analytics, but three structural pressures drive teams to seek alternatives.
+
+### Licensing pressures and the "One bundle" push
+
+Enterprise budgeting cycles face friction when vendors shift packaging models. Recent commercial changes, such as mandatory pushes toward bundled subscription tiers, have increased software expenditures for organizations that only utilize a subset of Alteryx capabilities. Teams paying per-seat licenses for dormant modules look for modular or open-source alternatives that scale linearly with infrastructure rather than headcount.
+
+### The limits of desktop-bound data prep in a cloud-first era
+
+Alteryx Designer is fundamentally architected as a desktop application. While Server and Cloud expansions exist, heavy data prep workflows running locally on individual laptops suffer from hardware constraints. When datasets grow beyond local memory limits, processing grinds to a halt. Modern data stacks process terabytes directly inside cloud data warehouses or distributed clusters, rendering local desktop extraction inefficient and costly.
+
+### Moving from rigid local files to version-controlled workflows
+
+Workflows built in proprietary desktop canvases are difficult to integrate into standard software engineering practices. Code review, continuous integration, automated testing, and Git-based rollbacks are challenging when workflow definitions are locked in binary or proprietary file formats. Engineering teams require declarative, text-based definitions that integrate seamlessly into existing CI/CD pipelines.
+
+## How we evaluated these Alteryx alternatives
+
+We evaluated each alternative on deployment model, license, scalability, learning curve, and integration ecosystem. The primary criteria emphasize whether a tool operates as a local desktop application, a cloud-native data platform, a code-first transformation engine, or a declarative orchestration control plane.
+
+---
+
+## 1. Kestra: The declarative workflow orchestration alternative
+
+Kestra is an open-source, declarative workflow orchestration platform that unifies data pipelines, infrastructure automation, and API integrations under a single control plane. Rather than restricting data prep to a local desktop GUI, Kestra executes tasks via a scalable backend defined entirely in YAML.
+
+- **Best for:** Engineering-led teams needing scalable workflow orchestration across data, infrastructure, and external APIs with full GitOps support.
+- **Core strengths:** 
+  - **Declarative YAML:** Workflows are version-controlled, diffable, and reviewable in Git.
+  - **Polyglot execution:** Run Python, SQL, shell scripts, and containerized tasks natively without writing glue code.
+  - **Event-driven architecture:** Trigger pipelines via schedules, webhooks, or downstream data events rather than manual execution.
+- **How it compares to Alteryx:** While Alteryx focuses on desktop data blending for analysts, Kestra acts as the underlying execution engine for enterprise data operations, handling millions of daily workflow runs on Kubernetes or on-premises infrastructure.
+
+For more details on data workflow patterns, explore [Declarative Orchestration for Modern Data Engineers](/data) and browse the [Data Engineering Resources Hub](/resources/data).
+
+---
+
+## 2. KNIME Analytics Platform: The closest visual desktop alternative
+
+KNIME Analytics Platform is an open-source, node-based visual workflow environment designed for data preparation, blending, and machine learning. 
+
+- **Best for:** Analysts and data scientists who prefer a visual drag-and-drop canvas similar to Alteryx Designer without paying proprietary licensing fees.
+- **Core strengths:**
+  - **Visual node-based canvas:** Build complex data flows by connecting functional nodes without writing code.
+  - **Free open-source core:** The desktop application is free to use, making it an accessible migration path for budget-constrained teams.
+  - **Extensive extensions:** Built-in support for text mining, time series analysis, and database connectors.
+- **Honest trade-off:** Like Alteryx, KNIME Analytics Platform is primarily client-side software. Scaling team collaboration and scheduled production execution requires KNIME Server or Hub, which reintroduces enterprise licensing costs.
+
+---
+
+## 3. Databricks and Snowflake: Cloud-native data and lakehouse platforms
+
+Databricks and Snowflake are enterprise cloud data platforms that handle massive-scale storage, data preparation, and transformation directly inside the cloud data warehouse or lakehouse.
+
+- **Best for:** Enterprise data teams processing massive datasets that exceed single-machine memory limits.
+- **Core strengths:**
+  - **Cloud-native scalability:** Compute scales independently of storage, allowing teams to process petabytes of data using distributed clusters.
+  - **SQL and Spark integration:** Native execution engines eliminate the need to extract data to a local machine for processing.
+  - **Unified governance:** Built-in security, cataloging, and collaboration features (such as Unity Catalog).
+- **Honest trade-off:** These platforms require SQL and programming expertise. They replace the data transformation and storage layer rather than serving as lightweight desktop analytics tools.
+
+---
+
+## 4. Tableau and Power BI: BI and visualization platforms with data prep
+
+Tableau (with Tableau Prep Builder) and Microsoft Power BI (with Power Query) combine business intelligence dashboards with built-in data preparation capabilities.
+
+- **Best for:** Organizations whose primary deliverable is executive reporting, dashboards, and self-service business intelligence.
+- **Core strengths:**
+  - **Integrated prep and viz:** Clean and transform data right inside the analytics ecosystem before visualizing it.
+  - **Familiar enterprise footprint:** Most organizations already license Microsoft 365 or Salesforce/Tableau, avoiding new vendor approval hurdles.
+  - **Strong semantic layers:** Define business metrics once and reuse them across reports.
+- **Honest trade-off:** These tools are optimized for reporting and visualization. They lack the heavy workflow orchestration, multi-system automation, and API integration capabilities required for complex data engineering pipelines.
+
+---
+
+## 5. dbt (Data Build Tool): The analytics engineering standard
+
+dbt is a transformation workflow that lets analytics engineers transform data in their warehouse by writing modular SQL SELECT statements combined with version control and automated testing.
+
+- **Best for:** Analytics engineers working inside cloud data warehouses who want a code-first, test-driven transformation workflow.
+- **Core strengths:**
+  - **Modular SQL transformations:** Break complex monolithic queries into manageable, reusable models.
+  - **Built-in documentation and testing:** Automatically generate lineage graphs and assert data quality constraints.
+  - **Git integration:** Full version control, staging environments, and CI/CD pipelines out of the box.
+- **Honest trade-off:** dbt handles transformations inside the warehouse (`T` in ELT) but requires an external orchestrator to handle data ingestion, API calls, and non-SQL tasks.
+
+---
+
+## 6. n8n and Windmill: Low-code workflow and process automation
+
+n8n and Windmill are developer-friendly workflow automation tools designed for connecting APIs, handling webhooks, and orchestrating operational processes.
+
+- **Best for:** Connecting SaaS applications, automating internal operations, and triggering actions via webhooks.
+- **Core strengths:**
+  - **Rich integration library:** Hundreds of pre-built connectors for popular business apps and developer tools.
+  - **Self-hosted flexibility:** Run securely on your own infrastructure with open-source core options.
+  - **Developer-friendly scripting:** Easily insert custom JavaScript or Python steps into automation flows.
+- **Honest trade-off:** While excellent for operational automation and API choreography, they are not optimized for heavy analytical data processing or petabyte-scale data warehousing.
+
+For a deeper look at workflow automation alternatives, see the guide on [Top 10 n8n Alternatives for Workflow Automation](/resources/infrastructure/n8n-alternatives).
+
+---
+
+## Comparison table: Alteryx vs top alternatives
+
+| Tool | License | Deployment | Primary Use Case | Scalability | Best For | Pricing Model | Position vs Kestra |
+|---|---|---|---|---|---|---|---|
+| **Kestra** | Open Source (Apache 2.0) / EE | Cloud / K8s / On-Prem | Declarative Orchestration & ETL | High (Distributed) | Platform & Data Engineers | Subscription (EE) / Free (OSS) | Orchestration control plane; coordinates tasks across data, infra, and APIs. |
+| **KNIME** | Open Source / Proprietary | Desktop / Server | Visual Data Prep & ML | Medium (Client-side) | Business Analysts | Free desktop, paid server | Desktop visual canvas vs. code-adjacent declarative YAML engine. |
+| **Databricks** | Commercial SaaS | Cloud (Multi-cloud) | Lakehouse Analytics & Spark | Very High | Enterprise Data Teams | Consumption-based | Cloud data platform; Kestra can orchestrate Databricks jobs via API. |
+| **Snowflake** | Commercial SaaS | Cloud (Multi-cloud) | Cloud Data Warehousing | Very High | Enterprise Analytics | Consumption-based | Cloud data warehouse; Kestra coordinates queries and data loading. |
+| **dbt Core** | Open Source (Apache 2.0) | Cloud / Warehouse | Analytics Engineering | High (Warehouse compute) | Analytics Engineers | Free CLI, paid Cloud | Transformation-only tool; Kestra orchestrates dbt models alongside ingestion. |
+| **n8n** | Fair-code / Commercial | Self-hosted / Cloud | App Integration & Webhooks | Medium | Operations Teams | Per-user / execution | SaaS automation vs. enterprise-grade infrastructure and data orchestration. |
+
+---
+
+## How to choose the right Alteryx alternative for your stack
+
+Selecting the right alternative depends on your team's technical background, infrastructure constraints, and primary goals.
+
+### For data engineering & platform teams
+If your team is moving away from desktop tools toward automated, reliable data pipelines, prioritize code-first and declarative systems. Pairing cloud data warehouses with a robust orchestrator eliminates manual bottlenecks. For teams migrating from legacy orchestrators or exploring modern architectures, review the analysis on [Airflow Alternatives: Top Workflow Orchestrators](/resources/data/airflow-alternatives) and [Top Dagster Alternatives for Data Orchestration](/resources/data/dagster-alternatives).
+
+### For business analysts & data prep users
+If analysts rely heavily on visual canvas interfaces and want to avoid heavy coding, KNIME Analytics Platform offers the closest desktop-based visual experience without proprietary licensing penalties.
+
+### For enterprise IT and public sector compliance
+Organizations with strict regulatory requirements, air-gapped environments, or complex security mandates need tools that support on-premise deployment, role-based access control, and robust audit logs. For examples of secure, auditable automation in government and regulated sectors, review the [Government & Public Sector Workflow Automation Use Case](/use-cases/public-services).
+
+## Conclusion
+
+Transitioning away from Alteryx depends on what your team values most. If you need a free visual desktop tool, KNIME serves as a direct substitute. If you need massive scale, cloud data platforms like Databricks and Snowflake are essential. However, if your goal is to escape rigid desktop silos, eliminate rising bundle costs, and manage data pipelines through declarative, version-controlled workflows, adopting an orchestration platform like Kestra provides the scalability and flexibility required for modern data architecture.

--- a/src/contents/resources/fivetran-alternatives/index.md
+++ b/src/contents/resources/fivetran-alternatives/index.md
@@ -1,0 +1,136 @@
+---
+title: "Best Fivetran Alternatives in 2026: Compare Top Data Integration Tools"
+description: "Compare the top Fivetran alternatives for data integration and replication. Explore open-source and managed tools, pricing models, and how orchestration unifies your data stack."
+metaTitle: "Best Fivetran Alternatives in 2026: Compare Top Tools"
+metaDescription: "Looking for Fivetran alternatives? Compare top data integration tools like Airbyte, Hevo, and open-source orchestration platforms for your data stack."
+tag: "data"
+date: 2026-08-17
+slug: "fivetran-alternatives"
+faq:
+  - question: "Why are data teams looking for Fivetran alternatives?"
+    answer: "Many businesses seek Fivetran alternatives due to its usage-based pricing model, which can lead to unexpected cost spikes as data volumes grow. Other common reasons include limited customization for complex transformations, black-box error handling, and the need for self-hosted or air-gapped deployments."
+  - question: "Is Airbyte cheaper than Fivetran?"
+    answer: "Airbyte offers a generous open-source self-hosted edition that eliminates per-row fees, making it significantly cheaper for teams with engineering capacity to manage infrastructure. However, Airbyte Cloud uses a consumption pricing model comparable to Fivetran."
+  - question: "Can Kestra replace Fivetran?"
+    answer: "Kestra is a declarative orchestration platform rather than a pure connector tool, but it integrates natively with ingestion tools like Airbyte, Fivetran, and dbt. It allows data teams to orchestrate data movement, testing, and reverse ETL in a single control plane without separate scheduling tools."
+  - question: "What is the best open-source alternative to Fivetran?"
+    answer: "Airbyte is widely considered the leading open-source alternative to Fivetran due to its extensive connector library and flexible deployment models. For teams wanting deep workflow orchestration alongside ingestion, Kestra and Apache NiFi serve as powerful open-source alternatives."
+  - question: "Why is Fivetran so expensive for large datasets?"
+    answer: "Fivetran charges based on monthly active rows (MAR). As companies scale their data ingestion across multiple SaaS applications and databases, row counts multiply rapidly, causing subscription costs to scale non-linearly compared to fixed-infrastructure alternatives."
+  - question: "How do managed Fivetran alternatives compare on ease of use?"
+    answer: "Managed alternatives like Hevo Data and Stitch offer zero-config setup experiences similar to Fivetran. They require minimal data engineering overhead, whereas open-source alternatives demand more setup time in exchange for lower costs and full data ownership."
+---
+
+Fivetran revolutionized data ingestion by replacing fragile, home-grown ETL scripts with reliable, out-of-the-box connectors. But as data volumes scale, so does the invoice. For many engineering teams, Fivetran’s monthly active row (MAR) pricing model turns routine data growth into an unpredictable budget hurdle. 
+
+Whether you need predictable infrastructure costs, tighter control over sensitive data in air-gapped environments, or an architecture that unifies ingestion with downstream transformation and orchestration, finding the right alternative matters. The leading alternatives to Fivetran in 2026 include Kestra, Airbyte, Hevo Data, Estuary, Stitch, Matillion, and cloud-native services—each suited to different workloads such as real-time replication, zero-infrastructure SaaS management, and declarative data pipeline orchestration.
+
+## Why data teams look for Fivetran alternatives
+
+Fivetran established itself as an industry standard by abstracting away the operational headache of maintaining API integrations. However, data engineering teams frequently encounter specific constraints as their pipelines mature:
+
+1. **The Monthly Active Row (MAR) Pricing Trap:** Fivetran bills based on the volume of rows synced each month. High-frequency updates, large historical backfills, or high-volume event logs can cause subscription costs to spike exponentially without a proportional increase in business value.
+2. **Black-Box Error Handling:** When a sync fails due to an unexpected schema change or API rate limit, troubleshooting often requires digging through opaque error messages or waiting on vendor support. Teams with strict SLA requirements need granular visibility and programmatic retry logic.
+3. **Limited Data Transformation Flexibility:** While Fivetran handles extraction and loading efficiently, transformations often require external tools like dbt. For teams managing complex multi-step pipelines, separating ingestion from orchestration introduces friction.
+4. **Data Residency and Security Constraints:** Regulated industries operating in hybrid or air-gapped environments often cannot route sensitive customer data through managed public cloud SaaS pipelines without strict local control.
+
+As discussed in our analysis on [why data integration will never be fully solved](/blogs/2023-10-11-why-ingestion-will-never-be-solved), automated connectors are only one piece of a broader data architecture. Selecting the right alternative requires balancing operational overhead against financial control.
+
+## What to look for in a data integration tool
+
+Before committing to a migration, evaluate potential replacements against the core requirements of your data stack. Understanding [what is data integration](/resources/data/what-is-data-ingestion) and pipeline design helps clarify these evaluation axes:
+
+- **Connector Breadth and Quality:** Does the tool support your specific mix of SaaS applications, databases, and message queues? Are connectors robust against schema drift and API updates?
+- **Deployment Model:** Do you require a fully managed SaaS solution, or do you need self-hosted infrastructure to maintain compliance and avoid per-row penalties?
+- **Total Cost of Ownership (TCO):** Weigh subscription licensing against the engineering hours required to maintain self-hosted open-source alternatives.
+- **Orchestration Capabilities:** Can the tool trigger downstream transformations, handle conditional logic, and coordinate retries across your entire data lifecycle?
+
+## How we evaluated these alternatives
+
+We evaluated each alternative on pricing transparency, deployment flexibility, maintenance overhead, and orchestration capabilities. The selection below balances managed SaaS solutions designed for rapid deployment against open-source platforms and orchestration control planes built for high-scale, cost-sensitive engineering teams.
+
+## The 7 best Fivetran alternatives in 2026
+
+### 1. Kestra (The Unified Orchestration Control Plane)
+
+Kestra is an open-source, declarative orchestration platform that unifies data, AI, and infrastructure workflows. Rather than functioning merely as a point-to-point connector tool, Kestra coordinates ingestion tools like Airbyte and Fivetran, executes dbt models, and triggers reverse ETL processes within a single declarative YAML-based control plane.
+
+- **Best for:** Engineering teams seeking a centralized control plane to eliminate script sprawl and orchestrate ingestion alongside downstream data quality checks and transformations.
+- **Key Differentiator:** Language-agnostic execution engine with 1,700+ plugins. Kestra lets you trigger syncs, monitor data pipelines, and handle failures without relying on separate scheduling tools.
+- **Trade-off:** Requires writing declarative YAML configurations rather than using a pure point-and-click SaaS wizard.
+- **Learn more:** Compare how Kestra pairs with transformation engines via our guide on the [Fivetran + dbt merger and fusion engine](/resources/data/fivetran-dbt-merger-fusion-engine), or explore [Matillion alternatives](/resources/data/matillion-alternatives) for broader integration architectures.
+
+### 2. Airbyte (Open-Source Data Integration)
+
+Airbyte is the leading open-source alternative to Fivetran, offering over 300 pre-built connectors for databases, SaaS applications, and data warehouses. It is available as a self-hosted community edition and a managed cloud service.
+
+- **Best for:** Data teams with Kubernetes infrastructure and the engineering capacity to self-host, eliminating per-row fees entirely.
+- **Key Differentiator:** Massive open-source connector catalog with a flexible CDK (Connector Development Kit) for building custom integrations quickly.
+- **Trade-off:** Self-hosting requires allocating DevOps resources for cluster maintenance, monitoring, and scaling worker nodes.
+- **Learn more:** Read our comprehensive guide on [Airbyte orchestration](/resources/data/airbyte-orchestration) for implementation patterns.
+
+### 3. Hevo Data (No-Code Automated Pipelines)
+
+Hevo Data is a fully managed, zero-data-loss ELT platform designed for real-time data replication from databases and SaaS applications to cloud warehouses.
+
+- **Best for:** Analytics teams that want a managed SaaS experience similar to Fivetran with automated schema management and straightforward pricing.
+- **Key Differentiator:** Real-time data streaming capabilities with automatic schema mapping and active alert monitoring.
+- **Trade-off:** Like Fivetran, subscription costs scale with data volume, making it subject to similar budget pressures at high scale.
+
+### 4. Estuary (Real-Time Data Streaming & Replication)
+
+Estuary is built on the Flux streaming engine, designed specifically for low-latency change data capture (CDC) and real-time data ingestion.
+
+- **Best for:** Teams requiring sub-second data replication across databases and event streams.
+- **Key Differentiator:** Streaming-first architecture that handles both batch ELT and real-time pub/sub pipelines with high throughput.
+- **Trade-off:** Steeper learning curve for engineers accustomed to traditional batch ETL models.
+
+### 5. Stitch (Simple Managed Replication)
+
+Stitch is a lightweight, managed cloud ETL service tailored for data teams that need straightforward replication without heavy configuration overhead.
+
+- **Best for:** Early-stage startups and mid-market teams looking for a simple, out-of-the-box data sync utility.
+- **Key Differentiator:** Simplicity of setup and straightforward interface focused entirely on moving data to a warehouse.
+- **Trade-off:** Limited transformation capabilities and less flexibility for complex enterprise architectures.
+
+### 6. Matillion (Cloud-Native Data ETL & Transformation)
+
+Matillion is a cloud data integration platform emphasizing push-down transformations within cloud data warehouses like Snowflake, BigQuery, and Databricks.
+
+- **Best for:** Data engineering teams utilizing cloud data warehouses who want to combine extraction with heavy in-database transformations.
+- **Key Differentiator:** Visual low-code designer combined with robust code-based orchestration options.
+- **Trade-off:** Pricing and complexity are tailored toward enterprise data teams rather than lightweight ingestion tasks.
+
+### 7. AWS Glue & Native Cloud Services
+
+AWS Glue, Azure Data Factory, and Google Cloud Data Fusion provide native ETL and integration services tightly integrated into their respective cloud ecosystems.
+
+- **Best for:** Organizations operating entirely within a single cloud provider's ecosystem who want native security and IAM management.
+- **Key Differentiator:** Zero additional vendor procurement required if you are already deeply embedded in AWS, Azure, or GCP.
+- **Trade-off:** Vendor lock-in and steep learning curves for managing serverless spark jobs or complex data factory pipelines.
+
+## Comparison table: Fivetran vs top alternatives
+
+| Tool Name | License Model | Deployment Options | Connector Count | Pricing Structure | Best Fit |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **Kestra** | Open Source (Apache 2.0) / Enterprise | Self-Hosted, Cloud, K8s | 1,700+ plugins | Infrastructure & deployment based | Unified orchestration across data, AI, and infra |
+| **Airbyte** | Open Source / Commercial Cloud | Self-Hosted, Cloud | 300+ | Free self-hosted / Consumption-based cloud | Open-source data replication and custom connectors |
+| **Hevo Data** | Commercial SaaS | Managed Cloud | 150+ | Consumption / Event-based | Zero-maintenance managed database replication |
+| **Estuary** | Commercial SaaS | Managed Cloud | 50+ | Throughput-based | Real-time streaming and high-frequency CDC |
+| **Stitch** | Commercial SaaS | Managed Cloud | 100+ | Volume-based | Lightweight, straightforward cloud replication |
+| **Matillion** | Commercial SaaS | Cloud (SaaS / BYOC) | 100+ | Compute / Usage-based | Push-down cloud warehouse transformations |
+| **AWS Glue** | Cloud Native | AWS Managed | Varies | Serverless DPU-hour billing | Single-cloud AWS data integration |
+
+## How to choose the right alternative for your stack
+
+Selecting the optimal Fivetran alternative depends heavily on your team's engineering capacity and architectural scope:
+
+- **For Data Engineering Teams:** If your primary bottleneck is managing transformation dependencies alongside ingestion, adopt a unified orchestration approach. Using [declarative orchestration for modern data engineers](/data) lets you coordinate ingestion tools like Airbyte alongside dbt and SQL transformations without brittle cron schedules.
+- **For Platform & Infrastructure Engineers:** If your goal is avoiding per-row SaaS billing entirely, self-hosting Airbyte on Kubernetes provides full control over data movement and eliminates unexpected subscription invoices.
+- **For Budget-Conscious Startups:** Managed alternatives with transparent entry tiers or open-source tools deployed via Docker Compose offer a reliable path to avoid early-stage infrastructure complexity.
+
+## Conclusion & next steps
+
+Fivetran remains a reliable choice for teams prioritizing zero-maintenance SaaS connectors over cost predictability. However, as data volumes scale and architectures demand tighter integration between ingestion, transformation, and orchestration, exploring alternatives is essential. 
+
+If your team is ready to move beyond rigid subscription models and take control of your entire data pipeline, explore Kestra's open-source platform and container-native plugins to unify your data stack today.

--- a/src/contents/resources/fivetran-alternatives/index.md
+++ b/src/contents/resources/fivetran-alternatives/index.md
@@ -61,51 +61,51 @@ Kestra is an open-source, declarative orchestration platform rather than a pure 
 
 ### 2. Airbyte (Open-Source Data Integration)
 
-Airbyte is the leading open-source alternative to Fivetran, offering a massive library of over 300 pre-built connectors for databases, APIs, and file storage. 
+Airbyte is the reference open-source alternative to Fivetran, with a connector library well past 300 sources and destinations. Its real differentiator is the escape hatch: because the platform and most connectors are open source, a connector that does not exist yet is something your team can build with the connector development kit rather than a support ticket you wait on. You can run it entirely on your own infrastructure — which is often the deciding factor for regulated workloads that cannot route payloads through a multi-tenant cloud.
 
-- **Best for:** Organizations with engineering capacity to manage their own infrastructure who want to eliminate per-row data fees.
-- **Key advantage:** Dual deployment model. You can self-host Airbyte on Kubernetes or Docker for free, retaining full ownership of your data pipelines, or use Airbyte Cloud for managed execution.
-- **Honest limitation:** Self-hosting Airbyte introduces operational overhead. Managing worker nodes, upgrading container versions, and troubleshooting replication failures falls entirely on your platform engineering team.
+- **Best for:** Engineering teams that want connector coverage close to Fivetran's without the per-row bill, and organisations whose compliance posture requires self-hosting.
+- **Key advantage:** Two deployment models from one codebase — free self-hosted, or managed Cloud with consumption pricing — plus the ability to fork or author connectors when coverage falls short.
+- **Honest limitation:** Connector quality varies between the certified set and community contributions, so validate the specific sources you depend on. Self-hosting also means you own the operational burden: Kubernetes, upgrades, and monitoring are now your problem, which is precisely the cost Fivetran's premium removes.
 
 ### 3. Hevo Data (No-Code Automated Pipelines)
 
-Hevo Data is a fully managed, zero-data-loss ELT platform designed for rapid deployment without writing custom code.
+Hevo occupies the same managed, zero-maintenance niche as Fivetran, and most teams evaluate it as a like-for-like swap rather than an architectural change. It handles schema drift automatically, supports lightweight in-flight transformations for teams that do not want a separate modelling layer for simple cleanups, and leans on responsive support as part of the product rather than an upsell.
 
-- **Best for:** BI and analytics teams that need managed pipelines and cannot spare dedicated data engineers for maintenance.
-- **Key advantage:** Automated schema management and real-time data replication with built-in data transformation capabilities.
-- **Honest limitation:** Like Fivetran, Hevo operates on a consumption-based pricing model. As data volumes scale, subscription costs increase accordingly.
+- **Best for:** Teams that liked the Fivetran operating model but not its invoice, and data teams without the headcount to run integration infrastructure themselves.
+- **Key advantage:** Genuinely no-code setup with automatic schema handling, so a non-specialist can stand up a reliable pipeline and keep it running.
+- **Honest limitation:** It is SaaS-only, so self-hosted and air-gapped requirements rule it out entirely. Its event-based pricing can also surprise you in the same way MAR does: a frequently-updated operational table generates far more billable events than its row count suggests, so model your highest-churn table before switching.
 
 ### 4. Estuary (Real-Time Data Streaming & Replication)
 
-Estuary Flow is built on a streaming architecture using Flux, offering exceptionally low-latency Change Data Capture (CDC) and data replication.
+Estuary Flow approaches integration from a streaming angle rather than a scheduled-batch one. Instead of running syncs every fifteen minutes or every hour, it reads the database write-ahead log continuously, so the destination trails the source by seconds. The same pipeline handles the historical backfill and the ongoing tail, which removes the usual seam between "load the past" and "keep up with the present" that batch ELT tools force you to manage separately.
 
-- **Best for:** Teams requiring sub-second data streaming from operational databases into cloud data warehouses.
-- **Key advantage:** Real-time processing guarantees and high throughput for event-driven architectures.
-- **Honest limitation:** Steeper learning curve compared to traditional batch-oriented ELT tools, especially when configuring custom derivations.
+- **Best for:** Teams that need sub-second replication from operational databases into a warehouse or lake, and event-driven use cases where a fifteen-minute sync window is already too slow.
+- **Key advantage:** Continuous CDC with backfill and streaming unified in one pipeline, plus in-flight transformations (derivations) so you can reshape data before it lands rather than after.
+- **Honest limitation:** A smaller connector catalogue than the established ELT vendors, and a steeper learning curve — derivations and streaming semantics ask more of the team than configuring a batch sync. Throughput-based pricing also makes forecasting harder if your event volume is spiky.
 
 ### 5. Stitch (Simple Managed Replication)
 
-Stitch is a lightweight, developer-focused managed replication tool designed for straightforward analytics stacks.
+Stitch is the most deliberately minimal option on this list: point it at a source, pick a destination, set a replication frequency. Its lasting contribution to the ecosystem is Singer, the open-source tap-and-target specification it originated, which means a Stitch pipeline is conceptually portable — a Singer tap you rely on can be run outside Stitch if you ever move. Stitch now sits inside the Talend product family under Qlik, which shapes how you should read its roadmap.
 
-- **Best for:** Small to mid-sized teams looking for a straightforward, managed alternative to enterprise ELT platforms.
-- **Key advantage:** Minimalist interface with fast setup times for standard SaaS sources and cloud warehouses.
-- **Honest limitation:** Less robust customization and advanced transformation options compared to Fivetran or Hevo.
+- **Best for:** Small to mid-sized teams that want managed replication for standard SaaS and database sources without operating a platform, and teams already comfortable with the Singer ecosystem.
+- **Key advantage:** Very fast setup and a small surface area to learn, with volume-based pricing that stays predictable for stable, moderate row counts.
+- **Honest limitation:** No transformation layer and limited support for advanced CDC scenarios, so complex pipelines need a separate orchestrator and modelling tool. Connector development has also moved more slowly than at the newer open-source projects, so verify that your specific sources are actively maintained before committing.
 
 ### 6. Matillion (Cloud-Native Data ETL & Transformation)
 
-Matillion is an enterprise data integration platform focused on push-down transformation inside cloud data warehouses like Snowflake, Databricks, and BigQuery.
+Matillion inverts the usual ELT cost model. Rather than processing data on the vendor's infrastructure, it pushes transformation logic down into the warehouse — Snowflake, Databricks, BigQuery or Redshift — so the heavy lifting runs on compute you already pay for. That makes it attractive to teams whose warehouse is unambiguously the centre of gravity, and it pairs a visual canvas with code components so analytics engineers and less technical contributors can work in the same project.
 
-- **Best for:** Analytics engineering teams that want to execute heavy transformations directly inside their data warehouse.
-- **Key advantage:** Visual and code-based authoring environments optimized for cloud warehouse compute.
-- **Honest limitation:** Can become expensive and complex when managing large multi-cloud deployments.
+- **Best for:** Analytics engineering teams standardised on one cloud warehouse who want transformation and orchestration in a single visual tool.
+- **Key advantage:** Push-down execution keeps data inside the warehouse boundary, which simplifies both performance tuning and governance reviews.
+- **Honest limitation:** The push-down model presumes a warehouse destination, so it fits awkwardly when your target is object storage or a lakehouse. Costs do not disappear either — they move onto the warehouse bill, where they are easy to under-forecast — and multi-cloud estates add real configuration overhead.
 
 ### 7. AWS Glue & Native Cloud Services
 
-AWS Glue, Azure Data Factory, and Google Cloud Dataflow offer native data integration capabilities tightly coupled to specific hyperscaler ecosystems.
+AWS Glue, Azure Data Factory and Google Cloud Dataflow are the integration services each hyperscaler ships with its own platform. The appeal is less about features than about friction: identity, networking and billing are already solved, data never leaves the provider's boundary, and procurement is a line item on an existing contract rather than a new vendor review — often the fastest path to approval in a large enterprise.
 
-- **Best for:** Enterprises committed entirely to a single cloud provider (AWS, Azure, or GCP).
-- **Key advantage:** Deep security integration, IAM role management, and zero egress friction within the same cloud network.
-- **Honest limitation:** Vendor lock-in. Migrating pipelines away from native cloud services if your infrastructure strategy changes is notoriously difficult.
+- **Best for:** Enterprises committed to a single cloud, and teams whose blocking constraint is security review or procurement rather than connector coverage.
+- **Key advantage:** Native IAM and VPC integration, no cross-cloud egress, and consumption billing folded into the existing cloud spend.
+- **Honest limitation:** Lock-in is the whole trade. Pipelines written against Glue or Data Factory do not port to another cloud without a rewrite, so a change of infrastructure strategy becomes a migration project. SaaS connector coverage is also thinner than the dedicated ELT vendors', and the developer experience assumes comfort with the provider's compute model — Spark, in Glue's case.
 
 ## Comparison table: Fivetran vs top alternatives
 

--- a/src/contents/resources/fivetran-alternatives/index.md
+++ b/src/contents/resources/fivetran-alternatives/index.md
@@ -4,7 +4,7 @@ description: "Compare the top Fivetran alternatives for data integration and rep
 metaTitle: "Best Fivetran Alternatives in 2026: Compare Top Tools"
 metaDescription: "Looking for Fivetran alternatives? Compare top data integration tools like Airbyte, Hevo, and open-source orchestration platforms for your data stack."
 tag: "data"
-date: 2026-08-17
+date: 2026-08-18
 slug: "fivetran-alternatives"
 faq:
   - question: "Why are data teams looking for Fivetran alternatives?"
@@ -23,114 +23,112 @@ faq:
 
 Fivetran revolutionized data ingestion by replacing fragile, home-grown ETL scripts with reliable, out-of-the-box connectors. But as data volumes scale, so does the invoice. For many engineering teams, Fivetran’s monthly active row (MAR) pricing model turns routine data growth into an unpredictable budget hurdle. 
 
-Whether you need predictable infrastructure costs, tighter control over sensitive data in air-gapped environments, or an architecture that unifies ingestion with downstream transformation and orchestration, finding the right alternative matters. The leading alternatives to Fivetran in 2026 include Kestra, Airbyte, Hevo Data, Estuary, Stitch, Matillion, and cloud-native services—each suited to different workloads such as real-time replication, zero-infrastructure SaaS management, and declarative data pipeline orchestration.
+Whether you need predictable infrastructure costs, tighter control over sensitive data in air-gapped environments, or an architecture that unifies ingestion with downstream transformation and orchestration, finding the right alternative matters. This guide examines the leading Fivetran alternatives across open-source connectors, managed SaaS platforms, and unified workflow control planes.
 
 ## Why data teams look for Fivetran alternatives
 
-Fivetran established itself as an industry standard by abstracting away the operational headache of maintaining API integrations. However, data engineering teams frequently encounter specific constraints as their pipelines mature:
+Fivetran popularized zero-maintenance ELT. You configure a source, connect a destination, and let the tool handle schema drift, retries, and API rate limits. For early-stage startups, that convenience is worth the premium. However, as data operations mature, several architectural and financial pain points emerge.
 
-1. **The Monthly Active Row (MAR) Pricing Trap:** Fivetran bills based on the volume of rows synced each month. High-frequency updates, large historical backfills, or high-volume event logs can cause subscription costs to spike exponentially without a proportional increase in business value.
-2. **Black-Box Error Handling:** When a sync fails due to an unexpected schema change or API rate limit, troubleshooting often requires digging through opaque error messages or waiting on vendor support. Teams with strict SLA requirements need granular visibility and programmatic retry logic.
-3. **Limited Data Transformation Flexibility:** While Fivetran handles extraction and loading efficiently, transformations often require external tools like dbt. For teams managing complex multi-step pipelines, separating ingestion from orchestration introduces friction.
-4. **Data Residency and Security Constraints:** Regulated industries operating in hybrid or air-gapped environments often cannot route sensitive customer data through managed public cloud SaaS pipelines without strict local control.
+The most common catalyst for evaluating alternatives is the MAR pricing model. When transaction tables update frequently, or when streaming event logs generate massive row volumes, Fivetran bills scale non-linearly. A single high-volume operational database table can push an organization into a much higher pricing tier overnight. Beyond cost, data teams frequently encounter limitations with black-box error handling. When a sync fails due to an unexpected upstream API change, debugging often requires waiting on vendor support rather than inspecting execution logs directly. 
 
-As discussed in our analysis on [why data integration will never be fully solved](/blogs/2023-10-11-why-ingestion-will-never-be-solved), automated connectors are only one piece of a broader data architecture. Selecting the right alternative requires balancing operational overhead against financial control.
+A second catalyst is structural rather than technical. With Fivetran and dbt Labs now under one roof, ingestion and transformation are converging into a single commercial platform. That consolidation is convenient if you intend to buy the whole stack, but it narrows your options if you would rather keep the transformation layer independent — or simply avoid concentrating ingestion, modelling and scheduling with one vendor. We unpack what the combined roadmap means for existing pipelines in our analysis of the [Fivetran and dbt merger and fusion engine](/resources/data/fivetran-dbt-merger-fusion-engine).
+
+Furthermore, strict data residency requirements in regulated sectors rule out managed SaaS tools that process sensitive payloads through multi-tenant cloud infrastructure. For a deeper technical dive into these trade-offs, read our analysis on [why data integration will never be fully solved](/blogs/2023-10-11-why-ingestion-will-never-be-solved).
 
 ## What to look for in a data integration tool
 
-Before committing to a migration, evaluate potential replacements against the core requirements of your data stack. Understanding [what is data integration](/resources/data/what-is-data-ingestion) and pipeline design helps clarify these evaluation axes:
+Selecting the right data movement platform requires evaluating several operational dimensions beyond simple connector counts. 
 
-- **Connector Breadth and Quality:** Does the tool support your specific mix of SaaS applications, databases, and message queues? Are connectors robust against schema drift and API updates?
-- **Deployment Model:** Do you require a fully managed SaaS solution, or do you need self-hosted infrastructure to maintain compliance and avoid per-row penalties?
-- **Total Cost of Ownership (TCO):** Weigh subscription licensing against the engineering hours required to maintain self-hosted open-source alternatives.
-- **Orchestration Capabilities:** Can the tool trigger downstream transformations, handle conditional logic, and coordinate retries across your entire data lifecycle?
+First, consider **schema drift handling**. Databases evolve. Columns are added, renamed, or dropped. A robust integration tool should handle these changes automatically without breaking downstream data models or requiring manual pipeline reconfigurations.
+
+Second, evaluate **incremental sync reliability**. Full table reloads are inefficient for large datasets. Look for tools that support native Change Data Capture (CDC) via database transaction logs or reliable cursor-based incremental extraction. 
+
+Third, examine **deployment flexibility**. Managed SaaS tools minimize operational overhead, but self-hosted open-source alternatives provide absolute data sovereignty and predictable fixed infrastructure costs. Finally, consider how ingestion connects to the rest of your data stack. Moving data into a cloud warehouse is only half the battle; those syncs must trigger downstream transformations, data quality tests, and reverse ETL processes without brittle cron scheduling. For foundational principles on building resilient ingestion layers, review our guide on [what is data integration](/resources/data/what-is-data-ingestion).
 
 ## How we evaluated these alternatives
 
-We evaluated each alternative on pricing transparency, deployment flexibility, maintenance overhead, and orchestration capabilities. The selection below balances managed SaaS solutions designed for rapid deployment against open-source platforms and orchestration control planes built for high-scale, cost-sensitive engineering teams.
+We evaluated each alternative on pricing transparency, deployment flexibility (SaaS vs. self-hosted), maintenance overhead, and orchestration capabilities. The selection below balances open-source projects that eliminate per-row fees against fully managed SaaS platforms designed to minimize engineering toil.
 
 ## The 7 best Fivetran alternatives in 2026
 
 ### 1. Kestra (The Unified Orchestration Control Plane)
 
-Kestra is an open-source, declarative orchestration platform that unifies data, AI, and infrastructure workflows. Rather than functioning merely as a point-to-point connector tool, Kestra coordinates ingestion tools like Airbyte and Fivetran, executes dbt models, and triggers reverse ETL processes within a single declarative YAML-based control plane.
+Kestra is an open-source, declarative orchestration platform rather than a pure point-to-point connector tool. Instead of treating data ingestion as an isolated black box, Kestra provides a unified control plane that coordinates ingestion tools (such as Airbyte or Fivetran), dbt transformations, and reverse ETL in declarative YAML.
 
-- **Best for:** Engineering teams seeking a centralized control plane to eliminate script sprawl and orchestrate ingestion alongside downstream data quality checks and transformations.
-- **Key Differentiator:** Language-agnostic execution engine with 1,700+ plugins. Kestra lets you trigger syncs, monitor data pipelines, and handle failures without relying on separate scheduling tools.
-- **Trade-off:** Requires writing declarative YAML configurations rather than using a pure point-and-click SaaS wizard.
-- **Learn more:** Compare how Kestra pairs with transformation engines via our guide on the [Fivetran + dbt merger and fusion engine](/resources/data/fivetran-dbt-merger-fusion-engine), or explore [Matillion alternatives](/resources/data/matillion-alternatives) for broader integration architectures.
+- **Best for:** Engineering teams seeking to unify data ingestion, infrastructure automation, and reverse ETL under a single orchestrator.
+- **Key advantage:** Language-agnostic execution. You can trigger Airbyte syncs, execute Python scripts, run dbt CLI models, and send Slack alerts within a single workflow. As explored in our [Matillion alternatives comparison](/resources/data/matillion-alternatives), modern data stacks require orchestration that extends beyond simple SQL push-down.
+- **Honest limitation:** Kestra is an orchestrator and workflow engine, not a proprietary connector repository. While it includes extensive plugin support for databases and APIs, teams needing thousands of pre-built SaaS connectors often pair Kestra with an ingestion tool like Airbyte, as detailed in our guide on the [Fivetran and dbt merger & fusion engine](/resources/data/fivetran-dbt-merger-fusion-engine).
 
 ### 2. Airbyte (Open-Source Data Integration)
 
-Airbyte is the leading open-source alternative to Fivetran, offering over 300 pre-built connectors for databases, SaaS applications, and data warehouses. It is available as a self-hosted community edition and a managed cloud service.
+Airbyte is the leading open-source alternative to Fivetran, offering a massive library of over 300 pre-built connectors for databases, APIs, and file storage. 
 
-- **Best for:** Data teams with Kubernetes infrastructure and the engineering capacity to self-host, eliminating per-row fees entirely.
-- **Key Differentiator:** Massive open-source connector catalog with a flexible CDK (Connector Development Kit) for building custom integrations quickly.
-- **Trade-off:** Self-hosting requires allocating DevOps resources for cluster maintenance, monitoring, and scaling worker nodes.
-- **Learn more:** Read our comprehensive guide on [Airbyte orchestration](/resources/data/airbyte-orchestration) for implementation patterns.
+- **Best for:** Organizations with engineering capacity to manage their own infrastructure who want to eliminate per-row data fees.
+- **Key advantage:** Dual deployment model. You can self-host Airbyte on Kubernetes or Docker for free, retaining full ownership of your data pipelines, or use Airbyte Cloud for managed execution.
+- **Honest limitation:** Self-hosting Airbyte introduces operational overhead. Managing worker nodes, upgrading container versions, and troubleshooting replication failures falls entirely on your platform engineering team.
 
 ### 3. Hevo Data (No-Code Automated Pipelines)
 
-Hevo Data is a fully managed, zero-data-loss ELT platform designed for real-time data replication from databases and SaaS applications to cloud warehouses.
+Hevo Data is a fully managed, zero-data-loss ELT platform designed for rapid deployment without writing custom code.
 
-- **Best for:** Analytics teams that want a managed SaaS experience similar to Fivetran with automated schema management and straightforward pricing.
-- **Key Differentiator:** Real-time data streaming capabilities with automatic schema mapping and active alert monitoring.
-- **Trade-off:** Like Fivetran, subscription costs scale with data volume, making it subject to similar budget pressures at high scale.
+- **Best for:** BI and analytics teams that need managed pipelines and cannot spare dedicated data engineers for maintenance.
+- **Key advantage:** Automated schema management and real-time data replication with built-in data transformation capabilities.
+- **Honest limitation:** Like Fivetran, Hevo operates on a consumption-based pricing model. As data volumes scale, subscription costs increase accordingly.
 
 ### 4. Estuary (Real-Time Data Streaming & Replication)
 
-Estuary is built on the Flux streaming engine, designed specifically for low-latency change data capture (CDC) and real-time data ingestion.
+Estuary Flow is built on a streaming architecture using Flux, offering exceptionally low-latency Change Data Capture (CDC) and data replication.
 
-- **Best for:** Teams requiring sub-second data replication across databases and event streams.
-- **Key Differentiator:** Streaming-first architecture that handles both batch ELT and real-time pub/sub pipelines with high throughput.
-- **Trade-off:** Steeper learning curve for engineers accustomed to traditional batch ETL models.
+- **Best for:** Teams requiring sub-second data streaming from operational databases into cloud data warehouses.
+- **Key advantage:** Real-time processing guarantees and high throughput for event-driven architectures.
+- **Honest limitation:** Steeper learning curve compared to traditional batch-oriented ELT tools, especially when configuring custom derivations.
 
 ### 5. Stitch (Simple Managed Replication)
 
-Stitch is a lightweight, managed cloud ETL service tailored for data teams that need straightforward replication without heavy configuration overhead.
+Stitch is a lightweight, developer-focused managed replication tool designed for straightforward analytics stacks.
 
-- **Best for:** Early-stage startups and mid-market teams looking for a simple, out-of-the-box data sync utility.
-- **Key Differentiator:** Simplicity of setup and straightforward interface focused entirely on moving data to a warehouse.
-- **Trade-off:** Limited transformation capabilities and less flexibility for complex enterprise architectures.
+- **Best for:** Small to mid-sized teams looking for a straightforward, managed alternative to enterprise ELT platforms.
+- **Key advantage:** Minimalist interface with fast setup times for standard SaaS sources and cloud warehouses.
+- **Honest limitation:** Less robust customization and advanced transformation options compared to Fivetran or Hevo.
 
 ### 6. Matillion (Cloud-Native Data ETL & Transformation)
 
-Matillion is a cloud data integration platform emphasizing push-down transformations within cloud data warehouses like Snowflake, BigQuery, and Databricks.
+Matillion is an enterprise data integration platform focused on push-down transformation inside cloud data warehouses like Snowflake, Databricks, and BigQuery.
 
-- **Best for:** Data engineering teams utilizing cloud data warehouses who want to combine extraction with heavy in-database transformations.
-- **Key Differentiator:** Visual low-code designer combined with robust code-based orchestration options.
-- **Trade-off:** Pricing and complexity are tailored toward enterprise data teams rather than lightweight ingestion tasks.
+- **Best for:** Analytics engineering teams that want to execute heavy transformations directly inside their data warehouse.
+- **Key advantage:** Visual and code-based authoring environments optimized for cloud warehouse compute.
+- **Honest limitation:** Can become expensive and complex when managing large multi-cloud deployments.
 
 ### 7. AWS Glue & Native Cloud Services
 
-AWS Glue, Azure Data Factory, and Google Cloud Data Fusion provide native ETL and integration services tightly integrated into their respective cloud ecosystems.
+AWS Glue, Azure Data Factory, and Google Cloud Dataflow offer native data integration capabilities tightly coupled to specific hyperscaler ecosystems.
 
-- **Best for:** Organizations operating entirely within a single cloud provider's ecosystem who want native security and IAM management.
-- **Key Differentiator:** Zero additional vendor procurement required if you are already deeply embedded in AWS, Azure, or GCP.
-- **Trade-off:** Vendor lock-in and steep learning curves for managing serverless spark jobs or complex data factory pipelines.
+- **Best for:** Enterprises committed entirely to a single cloud provider (AWS, Azure, or GCP).
+- **Key advantage:** Deep security integration, IAM role management, and zero egress friction within the same cloud network.
+- **Honest limitation:** Vendor lock-in. Migrating pipelines away from native cloud services if your infrastructure strategy changes is notoriously difficult.
 
 ## Comparison table: Fivetran vs top alternatives
 
-| Tool Name | License Model | Deployment Options | Connector Count | Pricing Structure | Best Fit |
-| :--- | :--- | :--- | :--- | :--- | :--- |
-| **Kestra** | Open Source (Apache 2.0) / Enterprise | Self-Hosted, Cloud, K8s | 1,700+ plugins | Infrastructure & deployment based | Unified orchestration across data, AI, and infra |
-| **Airbyte** | Open Source / Commercial Cloud | Self-Hosted, Cloud | 300+ | Free self-hosted / Consumption-based cloud | Open-source data replication and custom connectors |
-| **Hevo Data** | Commercial SaaS | Managed Cloud | 150+ | Consumption / Event-based | Zero-maintenance managed database replication |
-| **Estuary** | Commercial SaaS | Managed Cloud | 50+ | Throughput-based | Real-time streaming and high-frequency CDC |
-| **Stitch** | Commercial SaaS | Managed Cloud | 100+ | Volume-based | Lightweight, straightforward cloud replication |
-| **Matillion** | Commercial SaaS | Cloud (SaaS / BYOC) | 100+ | Compute / Usage-based | Push-down cloud warehouse transformations |
-| **AWS Glue** | Cloud Native | AWS Managed | Varies | Serverless DPU-hour billing | Single-cloud AWS data integration |
+| Tool | License Model | Deployment Options | Connector Count | Pricing Structure | Best Fit |
+|---|---|---|---|---|---|
+| **Kestra** | Open-source (Apache 2.0) + EE | Self-hosted, K8s, Cloud | 1,700+ plugins | Flat instance-based / SaaS | Unified workflow & data orchestration |
+| **Airbyte** | Open-source (MIT/BSL) + Cloud | Self-hosted or SaaS | 300+ | Free self-hosted / Consumption cloud | Open-source data integration |
+| **Hevo Data** | Proprietary SaaS | Managed SaaS | 150+ | Volume-based SaaS | Zero-maintenance managed ELT |
+| **Estuary** | Proprietary / Source-available | Managed SaaS | 100+ | Usage-based streaming | Real-time CDC & streaming |
+| **Stitch** | Proprietary SaaS | Managed SaaS | 100+ | Volume-based SaaS | Simple analytics replication |
+| **Matillion** | Proprietary | SaaS & Virtual Appliance | 100+ | Consumption / credits | Cloud warehouse push-down ETL |
+| **AWS Glue** | Proprietary | Cloud Native (AWS) | Varies by service | DPU-hour consumption | AWS-locked enterprise pipelines |
 
 ## How to choose the right alternative for your stack
 
-Selecting the optimal Fivetran alternative depends heavily on your team's engineering capacity and architectural scope:
+Selecting the optimal Fivetran alternative depends on your team's composition, infrastructure strategy, and budget constraints.
 
-- **For Data Engineering Teams:** If your primary bottleneck is managing transformation dependencies alongside ingestion, adopt a unified orchestration approach. Using [declarative orchestration for modern data engineers](/data) lets you coordinate ingestion tools like Airbyte alongside dbt and SQL transformations without brittle cron schedules.
-- **For Platform & Infrastructure Engineers:** If your goal is avoiding per-row SaaS billing entirely, self-hosting Airbyte on Kubernetes provides full control over data movement and eliminates unexpected subscription invoices.
-- **For Budget-Conscious Startups:** Managed alternatives with transparent entry tiers or open-source tools deployed via Docker Compose offer a reliable path to avoid early-stage infrastructure complexity.
+- **For data engineering teams** managing complex workflows across multiple tools, combining an ingestion engine like Airbyte with a declarative orchestrator like Kestra provides maximum flexibility. You retain complete control over your code, eliminate per-row pricing penalties, and coordinate data movement alongside reverse ETL and infrastructure tasks. Explore our core platform capabilities on our [declarative orchestration for data engineers](/data) page.
+- **For platform engineers** prioritizing data sovereignty and fixed infrastructure costs, self-hosting Airbyte on Kubernetes offers an open-source path that avoids usage-based billing.
+- **For resource-constrained teams** with zero engineering overhead to spare, managed SaaS options like Hevo Data or Stitch deliver immediate out-of-the-box replication without infrastructure maintenance.
 
 ## Conclusion & next steps
 
-Fivetran remains a reliable choice for teams prioritizing zero-maintenance SaaS connectors over cost predictability. However, as data volumes scale and architectures demand tighter integration between ingestion, transformation, and orchestration, exploring alternatives is essential. 
+Fivetran remains a reliable choice for teams willing to trade budget predictability for zero-maintenance convenience. However, as data volumes expand, transitioning to open-source tools like Airbyte or unifying your ingestion, transformation, and reverse ETL with an orchestration control plane like Kestra provides superior cost efficiency and architectural control. 
 
-If your team is ready to move beyond rigid subscription models and take control of your entire data pipeline, explore Kestra's open-source platform and container-native plugins to unify your data stack today.
+To see how declarative orchestration coordinates your entire data stack, explore the [Kestra documentation](/docs) or deploy your first workflow with our open-source release.


### PR DESCRIPTION
## Summary

Imports 2 ready drafts from `vfanucci/kestra-seo` into the resources hub.

| Page | Type | URL | Source |
|------|------|-----|--------|
| Alteryx Alternatives | listicle | `/resources/data/alteryx-alternatives` | #340 |
| Fivetran Alternatives | listicle | `/resources/data/fivetran-alternatives` | #341 |

Both are new slugs; no collisions.

## Front-matter hygiene

Publish `date` set to the **real publication date (`2026-08-17`)**; metaTitle ≤ 60 with the ` | Kestra` suffix stripped (the docs template appends it); metaDescription 140–160; no `image:`/`author:`; no unresolved markers; no duplicated headings; fences balanced.

Internal links verified live (all 200): `/data`, `/resources/data`, `/resources/data/airflow-alternatives`, `/resources/data/dagster-alternatives`, `/resources/infrastructure/n8n-alternatives`, `/use-cases/public-services`, `/resources/data/airbyte-orchestration`, `/resources/data/fivetran-dbt-merger-fusion-engine`, `/resources/data/matillion-alternatives`, `/resources/data/what-is-data-ingestion`, `/blogs/2023-10-11-why-ingestion-will-never-be-solved`.

Both pages mesh into the existing data-alternatives cluster, which is what we want — `fivetran-alternatives` in particular links to the Fivetran/dbt merger page and to `matillion-alternatives`.

## Not included: kestra-seo#342 (tray-ai-alternatives)

`#342` was **deliberately left out**. It regenerates a page that is already live (`/resources/ai/tray-ai-alternatives`, shipped 2026-07-02 via #5062) and the new draft is weaker than what is in production on every axis measured:

| | Live page | #342 |
|---|---|---|
| Words (excl. code) | 2,461 | 1,941 (−21%) |
| Named customers | Amdocs, Gravitee | none |
| Internal links | 7 (incl. 3 sibling cluster pages) | 3, one of which is a self-reference → 2 usable |
| Runnable YAML example | 0 | 0 |

Publishing it would degrade a page that GSC shows holding positions 1–4 on AI-surface queries. Left for a follow-up once the outline is consolidated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
