### PR TITLE
Pin /vs H1 to static 'Kestra vs. Alternatives'

### DIFF
--- a/src/pages/vs/index.astro
+++ b/src/pages/vs/index.astro
@@ -31,8 +31,6 @@ const entries = vsEntries
         category: entry.data.category,
         monogram: monogramMap[entry.id] ?? "",
         shortDescription: entry.data.shortDescription,
-        color: entry.data.brandColor.color,
-        gradient: entry.data.brandColor.gradient ?? "",
     }))
 
 const faqItems = [
@@ -82,23 +80,12 @@ const faqItems = [
                                     { active: i === 0 },
                                 ]}
                                 set:html={entry.monogram}
-                                data-name={entry.competitorName}
-                                data-color={entry.color}
-                                data-gradient={entry.gradient}
                             />
                         ))
                     }
                 </div>
             </div>
-            <h1>
-                Kestra vs. <span
-                    id="hero-name"
-                    style={entries[0].gradient
-                        ? `background: ${entries[0].gradient}; -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;`
-                        : `color: ${entries[0].color}`}
-                    >{entries[0].competitorName}</span
-                >
-            </h1>
+            <h1>Kestra vs. Alternatives</h1>
             <p>
                 See how Kestra compares to other orchestration and automation
                 tools
@@ -241,44 +228,15 @@ const faqItems = [
 
             // Hero carousel
             var carousel = document.getElementById("hero-carousel")
-            var heroName = document.getElementById("hero-name")
-            if (carousel && heroName) {
+            if (carousel) {
                 var items = carousel.querySelectorAll(".carousel-item")
                 var current = 0
                 var total = items.length
 
-                function updateHeroName(item) {
-                    heroName.textContent = item.getAttribute("data-name") || ""
-                    var color = item.getAttribute("data-color") || "#8465ff"
-                    var gradient = item.getAttribute("data-gradient") || ""
-                    if (gradient) {
-                        heroName.style.background = gradient
-                        heroName.style.setProperty(
-                            "-webkit-background-clip",
-                            "text",
-                        )
-                        heroName.style.webkitTextFillColor = "transparent"
-                        heroName.style.backgroundClip = "text"
-                        heroName.style.color = ""
-                    } else {
-                        heroName.style.background = ""
-                        heroName.style.setProperty("-webkit-background-clip", "")
-                        heroName.style.webkitTextFillColor = ""
-                        heroName.style.backgroundClip = ""
-                        heroName.style.color = color
-                    }
-                }
-
                 window.__vsCarouselTimer = setInterval(function () {
                     items[current].classList.remove("active")
-                    heroName.style.opacity = "0"
-                    heroName.style.transition = "opacity 0.2s ease"
-                    setTimeout(function () {
-                        current = (current + 1) % total
-                        items[current].classList.add("active")
-                        updateHeroName(items[current])
-                        heroName.style.opacity = "1"
-                    }, 200)
+                    current = (current + 1) % total
+                    items[current].classList.add("active")
                 }, 2000)
             }
         }
@@ -376,10 +334,6 @@ const faqItems = [
                 font-weight: 600;
                 color: var(--ks-content-primary);
                 margin-bottom: 0.5rem;
-
-                span {
-                    color: var(--ks-border-active);
-                }
             }
 
             p {


### PR DESCRIPTION
## Why

Per the **homepage refresh doc, Chapter 1b (Compare nav entry risks)**: the `/vs` H1 must be pinned before `/vs` enters the site navigation.

The `/vs` hub rendered a rotating H1 with the vendor name cycling client-side. Verified live on 18 Aug 2026: the raw HTML shipped `Kestra vs. Airflow` as the page H1, while the `<title>` is `Kestra vs. Alternatives | Kestra`. Once `/vs` is linked sitewide that creates two problems:

- **SEO inconsistency** — a sitewide-linked page whose H1 doesn't match its title, and whose crawled H1 depends on which vendor happened to be first in the collection.
- **Messaging risk** — standing decision that `Kestra vs. Prefect` must not render as a heading anywhere.

## What changed

Single file, `src/pages/vs/index.astro`:

- The `<h1>` is now the static string `Kestra vs. Alternatives`, matching the `<title>`.
- The hero logo carousel is **kept** as a purely decorative rotation — vendor monograms only, no vendor text in any heading.
- Removed the now-dead plumbing that existed only to colour the rotating H1 span: the `data-name` / `data-color` / `data-gradient` attributes, the `updateHeroName()` fade logic, the `brandColor` fields on the hub's entry mapping, and the `h1 span` colour rule.

Not touched: the page URL, the comparison card grid, the FAQ, and every `/vs/<vendor>` subpage.

## Verification

Served HTML from the dev server for `/vs`:

- exactly **1** `<h1>`, text `Kestra vs. Alternatives`
- `<title>` = `Kestra vs. Alternatives | Kestra`
- scanned all 19 headings (`h1`–`h6`) against a vendor-name list → **0** vendor names in any heading tag
- no console errors; the logo carousel still advances (verified index moving across 38 items)

🤖 Generated with [Claude Code](https://claude.com/claude-code)