### PR TITLE
SEO: /blueprints title + meta description (workflow templates)

### DIFF
--- a/src/pages/blueprints/index.astro
+++ b/src/pages/blueprints/index.astro
@@ -258,8 +258,9 @@ const categoryList =
 
 const ITEMS = blueprintFaqItems(categoryList)
 
-const title = "Blueprints"
-const description = "Get started with our library of workflows ready to use"
+const title = "Blueprints: Ready-to-Use Workflow Templates"
+const description =
+    "Browse Kestra's library of ready-to-use workflow templates for data pipelines, AI, infrastructure, and business automation. Copy the YAML and run in minutes."
 ---
 
 <Layout {title} {description}>


### PR DESCRIPTION
## What

`/blueprints` metadata now targets **workflow templates**, the term people actually search, instead of only "blueprints".

Single file, two variables in the frontmatter of `src/pages/blueprints/index.astro`:

| | Before | After |
|---|---|---|
| `<title>` | `Blueprints \| Kestra` | `Blueprints: Ready-to-Use Workflow Templates \| Kestra` (54 chars) |
| `description` | `Get started with our library of workflows ready to use` | `Browse Kestra's library of ready-to-use workflow templates for data pipelines, AI, infrastructure, and business automation. Copy the YAML and run in minutes.` (156 chars) |

## Why "Blueprints" still comes first

The word stays in the title, the URL, the H1 and the nav label — the page already has search equity on the brand term, so this adds the generic keyword rather than trading it away.

## Social tags

No overrides needed: `og:title`, `og:description`, `twitter:title`, `twitter:description` and `meta name="title"` all derive from the same two props in `src/components/layout.astro`, and the `| Kestra` suffix is appended there (so the page-level `title` is written without it).

## Verified

`/blueprints` is `prerender = false`, so it is absent from `dist/` and cannot be checked by grepping the build. Verified on the HTML actually served by the dev server instead:

```
<title>Blueprints: Ready-to-Use Workflow Templates | Kestra</title>
<meta name="title" content="Blueprints: Ready-to-Use Workflow Templates | Kestra">
<meta name="description" content="Browse Kestra's library of ready-to-use workflow templates for data pipelines, AI, infrastructure, and business automation. Copy the YAML and run in minutes.">
<meta name="twitter:title" content="Blueprints: Ready-to-Use Workflow Templates | Kestra">
<meta name="twitter:description" content="Browse Kestra's library of ready-to-use workflow templates ...">
<meta property="og:title" content="Blueprints: Ready-to-Use Workflow Templates | Kestra">
<meta property="og:description" content="Browse Kestra's library of ready-to-use workflow templates ...">
```

Unchanged, as intended: URL, H1 (`480+ Blueprints, ready to build.`), nav label, all visible content. No blueprint count in the metadata (no figures without a live source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)