### PR TITLE
Build-time live counters: plugins + GitHub stars (fixes 0+ and count drift)

### DIFF
--- a/src/components/common/SchemaSoftwareApplication.astro
+++ b/src/components/common/SchemaSoftwareApplication.astro
@@ -1,4 +1,6 @@
 ---
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
 interface Props {
     id?: string
     name?: string
@@ -9,6 +11,8 @@ interface Props {
 }
 
 const { id, name, description, url, isVariantOf, featureList } = Astro.props
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const canonicalUrl =
     url ?? new URL(Astro.url.pathname, Astro.site ?? "https://kestra.io").toString().replace(/\/$/, "")
@@ -21,7 +25,7 @@ const schema: Record<string, unknown> = {
     "url": canonicalUrl,
     "description":
         description ??
-        "Open-source workflow orchestration platform for data pipelines, infrastructure automation, and AI workflows. YAML-native, language-agnostic, 1400+ plugins.",
+        `Open-source workflow orchestration platform for data pipelines, infrastructure automation, and AI workflows. YAML-native, language-agnostic, ${totalPlugins}+ plugins.`,
     "applicationCategory": "DeveloperApplication",
     "applicationSubCategory": "Workflow Orchestration",
     "operatingSystem": "Linux, macOS, Windows",

--- a/src/components/enterprise/Dashboard.vue
+++ b/src/components/enterprise/Dashboard.vue
@@ -61,8 +61,10 @@
     import Plus from 'vue-material-design-icons/PlusThick.vue';
     import CheckBold from 'vue-material-design-icons/CheckBold.vue';
 
-    import { usePluginsCount } from '~/composables/usePluginsCount';
-    const { totalPlugins } = usePluginsCount();
+    // Comes in from the Astro page, resolved at build time. Fetching it here
+    // (as usePluginsCount does) left "0+ Plugins" in the static HTML, since the
+    // fetch only resolves after hydration.
+    const props = defineProps<{ totalPlugins: string }>();
 
     const COLUMNS = [
         {
@@ -102,7 +104,7 @@
 
     const BOTTOM_FEATURES = computed(() => [
         "Declarative Workflow",
-        `${totalPlugins.value} Plugins`,
+        `${props.totalPlugins} Plugins`,
         "Event Driven & Scheduling",
         "Everything From the UI",
         "Business Logic In Any Language",

--- a/src/components/enterprise/Hero.vue
+++ b/src/components/enterprise/Hero.vue
@@ -20,7 +20,7 @@
                     />
                 </div>
             </div>
-            <Dashboard />
+            <Dashboard :total-plugins="totalPlugins" />
             <div class="logos-wrap">
                 <div class="logos">
                     <div
@@ -43,6 +43,9 @@
 <script setup lang="ts">
     import Link from '~/components/common/Link.vue';
     import Dashboard from '~/components/enterprise/Dashboard.vue';
+
+    defineProps<{ totalPlugins: string }>();
+
     import fortune500Logo from '~/components/enterprise/assets/fortune500.svg';
 
     const logos = import.meta.glob("/src/components/enterprise/assets/logos/*.svg", { eager: true });

--- a/src/components/features/core/EveryPlugin.astro
+++ b/src/components/features/core/EveryPlugin.astro
@@ -2,7 +2,7 @@
 import TaskIcon from "~/components/common/TaskIcon.vue"
 import { Icon } from "astro-icon/components"
 import { $fetchApiCached } from "~/utils/fetch"
-import { calculateTotalPlugins } from "~/composables/usePluginsCount"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
 import KestraIcon from "~/components/icons/KestraIcon.vue"
 import { randomSortFunction } from "~/utils/random"
 
@@ -12,7 +12,7 @@ let plugins: {
     name: string
     link: string
 }[] = []
-let totalPlugins = "0+"
+const totalPlugins = `${await fetchTotalPluginsCount()}+`
 
 try {
     const excluded =
@@ -32,9 +32,6 @@ try {
         .sort(randomSortFunction)
         .slice(0, 20)
 
-    const subgroupsData = await $fetchApiCached("/plugins/subgroups")
-    const count = calculateTotalPlugins(subgroupsData)
-    totalPlugins = `${Math.floor(count / 100) * 100}+`
 } catch (e) {
     console.error("Failed to fetch plugins", e)
 }

--- a/src/components/layout.astro
+++ b/src/components/layout.astro
@@ -16,6 +16,7 @@ import { getRandomAiQuestions } from "~/utils/aiQuestions"
 import annoncesData from "~/contents/annonces/annonces.yml?raw"
 import YAML from "yaml"
 import { DISABLE_USAL, PREVIEW } from "astro:env/server"
+import { getStarCountFormatted } from "~/data/counts"
 
 const parsedAnnonces = YAML.parse(annoncesData ?? "[]")
 
@@ -39,6 +40,9 @@ interface Props {
 }
 
 const props = Astro.props
+
+// Rendered into the header server-side; the client component only refreshes it.
+const stars = await getStarCountFormatted()
 
 const currentUrl = Astro.url
 currentUrl.pathname = currentUrl.pathname.endsWith("/")
@@ -271,7 +275,7 @@ const organizationSchema = {
             : undefined}
         class={hasAnnounce ? "has-annonces" : ""}
     >
-        <Header client:load transition:persist />
+        <Header client:load transition:persist {stars} />
         <Search randomAiQuestions={randomAiQuestions} client:load />
         {
             hasAnnounce ? (

--- a/src/components/layout/FeaturePlugins.astro
+++ b/src/components/layout/FeaturePlugins.astro
@@ -1,7 +1,5 @@
 ---
-import { $fetchApiCached } from "~/utils/fetch"
-import { calculateTotalPlugins } from "~/composables/usePluginsCount"
-import type { Plugin } from "~/utils/plugins/plugin"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
 
 interface Props {
     content: {
@@ -30,8 +28,7 @@ const PLUGINS = [
     { src: "/icons/io.kestra.plugin.github-white.svg", alt: "GitHub" },
 ]
 
-const pluginGroups = await $fetchApiCached<Plugin[]>("/plugins/subgroups")
-const totalPlugins = Math.floor(calculateTotalPlugins(pluginGroups) / 100) * 100
+const totalPlugins = await fetchTotalPluginsCount()
 const displayDescription = content.description.replace(
     "{count}",
     `${totalPlugins}+`,

--- a/src/components/layout/GithubButton.vue
+++ b/src/components/layout/GithubButton.vue
@@ -10,7 +10,12 @@
                 <span class="star-text">Star</span>
             </div>
             <div class="right-part">
-                <LayoutGithubStargazer v-if="onClient" @api-error="hasError = true" />
+                <LayoutGithubStargazer
+                    v-if="onClient"
+                    :initial="stars"
+                    @api-error="hasError = true"
+                />
+                <span v-else-if="stars">{{ stars }}</span>
                 <span v-else class="placeholder"></span>
             </div>
         </a>
@@ -28,7 +33,10 @@
         onClient.value = true
     })
 
-    withDefaults(defineProps<{ small?: boolean }>(), { small: false })
+    // `stars` is resolved at build time and rendered server-side, so crawlers
+    // and AI assistants see the figure without executing JS. The client
+    // component still refreshes it after hydration.
+    const { stars } = defineProps<{ small?: boolean; stars?: string }>()
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/layout/GithubStargazer.client.vue
+++ b/src/components/layout/GithubStargazer.client.vue
@@ -8,7 +8,11 @@
     import { ref, onMounted } from "vue"
 
     const emit = defineEmits(["apiError"])
-    const stargazersText = ref<string | undefined>(undefined)
+    const props = defineProps<{ initial?: string }>()
+
+    // Starts from the build-time value so there is no placeholder flash, and no
+    // empty slot for a crawler to read.
+    const stargazersText = ref<string | undefined>(props.initial)
 
     onMounted(async () => {
         try {
@@ -17,7 +21,9 @@
                 response.stargazers,
             )
         } catch (error) {
-            emit("apiError")
+            // With a build-time value already on screen, a failed refresh is not
+            // worth hiding the button for.
+            if (!props.initial) emit("apiError")
         }
     })
 </script>

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -77,6 +77,7 @@
                 </a>
                 <GithubButton
                     :small="true"
+                    :stars="props.stars"
                     class="d-none d-lg-inline-block"
                 />
                 <a
@@ -728,6 +729,8 @@
     const props = defineProps<{
         scrolled?: boolean
         transparentHeader?: boolean
+        /** Star count resolved at build time, so it is in the static HTML. */
+        stars?: string
     }>()
 
     const isOpen = ref(false)

--- a/src/components/onezero/AiCopilot.vue
+++ b/src/components/onezero/AiCopilot.vue
@@ -98,10 +98,11 @@
     import GamepadSquare from "vue-material-design-icons/GamepadSquare.vue"
     import TimerCheck from "vue-material-design-icons/TimerCheck.vue"
     import SpiderWeb from "vue-material-design-icons/SpiderWeb.vue"
-    import { usePluginsCount } from "~/composables/usePluginsCount"
     import { computed } from "vue"
 
-    const { totalPlugins } = usePluginsCount()
+    // Resolved at build time by the Astro page. usePluginsCount fetches after
+    // hydration, which shipped "0+ Plugins & Safe Upgrades" in the static HTML.
+    const props = defineProps<{ totalPlugins: string }>()
 
     const AI_BLOCKS_1 = [
         {
@@ -134,7 +135,7 @@
             height: 656,
         },
         {
-            title: `${totalPlugins.value} Plugins & Safe Upgrades`,
+            title: `${props.totalPlugins} Plugins & Safe Upgrades`,
             description:
                 "Our extensive ecosystem spans data, AI, and infrastructure. Plugin Versioning allows you to pin and run multiple versions simultaneously for safer, more controlled rollouts.",
             imgSrc: "/landing/onezero/PluginsUpgrade.png",

--- a/src/components/onezero/Header.vue
+++ b/src/components/onezero/Header.vue
@@ -58,14 +58,15 @@
 
 <script setup lang="ts">
     import { computed } from "vue"
-    import { usePluginsCount } from "~/composables/usePluginsCount"
 
-    const { totalPlugins } = usePluginsCount()
+    // Resolved at build time by the Astro page. usePluginsCount fetches after
+    // hydration, which shipped "0+ Plugins" in the static HTML.
+    const props = defineProps<{ totalPlugins: string }>()
 
     const HIGHLIGHTS = computed(() => [
         { title: "LTS Release" },
         { title: "Apache 2.0 License" },
-        { title: `${totalPlugins.value} Plugins` },
+        { title: `${props.totalPlugins} Plugins` },
         { title: "Deploy anywhere" },
     ])
 

--- a/src/components/price/Header.astro
+++ b/src/components/price/Header.astro
@@ -1,5 +1,6 @@
 ---
 import Squared from "~/components/layout/Squared.vue"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
 import LogoCarousel from "~/components/common/LogoCarousel.astro"
 
 import Plus from "vue-material-design-icons/Plus.vue"
@@ -10,6 +11,8 @@ import awsSVG from "~/assets/enterprise/aws.svg?raw"
 import azureSVG from "~/assets/enterprise/azure.svg?raw"
 import googleSVG from "~/assets/enterprise/google.svg?raw"
 import homeRoofSVG from "~/assets/enterprise/home-roof.svg?raw"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const ENTERPRISE_FEATURES = {
     "Access & Governance": [
@@ -49,7 +52,7 @@ const ENTERPRISE_EXTRAS = [
 
 const OS_FEATURES = [
     "Declarative Workflows",
-    "1,200+ Plugins",
+    `${totalPlugins}+ Plugins`,
     "Event-Driven Scheduling",
     "Business Logic in Any Language",
     "Everything as Code & From the UI",

--- a/src/components/price/PlanTable.astro
+++ b/src/components/price/PlanTable.astro
@@ -1,12 +1,9 @@
 ---
 import { Icon } from "astro-icon/components"
-import { calculateTotalPlugins } from "~/composables/usePluginsCount"
-import { $fetchApiCached } from "~/utils/fetch"
-import { type Plugin } from "~/utils/plugins/plugin"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
 import { PLANS, getSections, SHARED_FEATURES, SUPPORT_PLANS, SUPPORT_ROWS } from "./pricingData"
 
-const pluginGroups = await $fetchApiCached<Plugin[]>("/plugins/subgroups")
-const totalPlugins = Math.floor(calculateTotalPlugins(pluginGroups) / 100) * 100
+const totalPlugins = await fetchTotalPluginsCount()
 const SECTIONS = getSections(totalPlugins)
 ---
 

--- a/src/composables/usePluginsCount.ts
+++ b/src/composables/usePluginsCount.ts
@@ -2,6 +2,7 @@ import type { Plugin, PluginElement } from "~/utils/plugins/plugin"
 import { isEntryAPluginElementPredicate } from "~/utils/plugins/plugin"
 import { computed, ref, type Ref } from "vue"
 import { $fetchApiCached } from "~/utils/fetch.ts"
+import FALLBACK from "~/data/counts.fallback.json"
 
 export function calculateTotalPlugins(plugins: Plugin[]): number {
     const classes = new Set<string>()
@@ -30,8 +31,13 @@ export function usePluginsCount(pluginsRef?: Ref<Plugin[]>) {
     }
 
     const totalPlugins = computed(() => {
-        if (!plugins.value) return "0+"
-        const count = calculateTotalPlugins(plugins.value)
+        // Before the fetch resolves there is nothing to count. Fall back to the
+        // committed value rather than rendering a zero: this computed used to
+        // return "0+", which is how "0+ Plugins" reached /enterprise and /1-0.
+        // Prefer ~/data/counts in anything rendered server-side.
+        const count = plugins.value?.length
+            ? calculateTotalPlugins(plugins.value)
+            : FALLBACK.plugins
         const rounded = Math.floor(count / 100) * 100
         return `${rounded}+`
     })

--- a/src/data/counts.fallback.json
+++ b/src/data/counts.fallback.json
@@ -1,0 +1,7 @@
+{
+    "_comment": "Last known-good counters. Used only when a build-time fetch fails, so the site never ships a zeroed placeholder. Values verified against the live APIs on the updatedAt date.",
+    "updatedAt": "2026-08-18",
+    "plugins": 1906,
+    "blueprints": 488,
+    "stars": 27849
+}

--- a/src/data/counts.ts
+++ b/src/data/counts.ts
@@ -1,0 +1,164 @@
+import { DISABLE_GITHUB } from "astro:env/server"
+import { $fetchApiCached, $fetchCached } from "~/utils/fetch"
+import { calculateTotalPlugins } from "~/composables/usePluginsCount"
+import type { Plugin } from "~/utils/plugins/plugin"
+import FALLBACK from "./counts.fallback.json"
+
+/**
+ * Live counters for the figures the site publishes.
+ *
+ * Two rules drive this module:
+ *
+ * 1. No figure ships without a live source, so each count is fetched while the
+ *    page is rendered and inlined into the HTML. Fetching from the browser is
+ *    not an option: crawlers and AI assistants do not reliably execute JS, and
+ *    the number is exactly what we want them to read.
+ * 2. A count we could not verify must never reach a visitor. A failed fetch
+ *    falls back to the committed value in counts.fallback.json; a fetched but
+ *    implausible plugin count fails the build instead of shipping. That second
+ *    rule is what stops "0+ Plugins" from going out again.
+ *
+ * Each counter is fetched and memoised independently, so a page pays only for
+ * the figures it actually renders — /plugins/subgroups is a ~3.4 MB payload and
+ * has no business being pulled in by pages that just show a star count.
+ */
+
+/**
+ * Below these floors, a fetched value is not a smaller Kestra, it is a broken
+ * response.
+ *
+ * The plugin floor is enforced: api.kestra.io is our own infrastructure and a
+ * bad answer there is a bug we want to hear about loudly. The star floor only
+ * warns, because api.github.com is third-party and rate-limits anonymous
+ * callers at 60 requests/hour per IP — a throttled CI runner must not be able
+ * to block a deploy.
+ */
+const MIN_PLUGINS = 1_000
+const MIN_STARS = 10_000
+const MIN_BLUEPRINTS = 100
+
+/** Round down, never up: the displayed figure carries a "+", so flooring is
+ * what keeps the claim true between builds as the real count drifts. */
+function floorTo(value: number, step: number): number {
+    return Math.floor(value / step) * step
+}
+
+function usingFallback(what: string, value: number, extra = ""): void {
+    console.warn(
+        `[counts] using committed fallback ${what} (${value}, as of ${FALLBACK.updatedAt}).${extra}`,
+    )
+}
+
+/** Resolve once per process and share; without this each of the ~30 /vs pages
+ * would refetch, since $fetchApiCached only sets Cloudflare cache hints and
+ * does not cache in-process. */
+function memoise<T>(resolver: () => Promise<T>): () => Promise<T> {
+    let pending: Promise<T> | undefined
+    return () => (pending ??= resolver())
+}
+
+const resolvePlugins = memoise(async () => {
+    let fetched: number | null = null
+
+    try {
+        const groups = await $fetchApiCached<Plugin[]>("/plugins/subgroups")
+        fetched = calculateTotalPlugins(groups)
+    } catch (error) {
+        console.error("[counts] plugin count fetch failed:", error)
+    }
+
+    if (fetched === null) usingFallback("plugin count", FALLBACK.plugins)
+
+    return {
+        count: fetched ?? FALLBACK.plugins,
+        // Flagged rather than thrown here, so only the consumers that publish
+        // the figure refuse it. Throwing from the shared resolver would also
+        // take down on-demand pages that merely read a different counter.
+        suspect: fetched !== null && fetched < MIN_PLUGINS,
+        fetched,
+    }
+})
+
+const resolveBlueprints = memoise(async () => {
+    let fetched: number | null = null
+
+    try {
+        const { total } = await $fetchApiCached<{ total: number }>(
+            "/blueprints/versions/latest?size=1&page=1",
+        )
+        fetched = total ?? null
+    } catch (error) {
+        console.error("[counts] blueprint count fetch failed:", error)
+    }
+
+    if (fetched === null) {
+        usingFallback("blueprint count", FALLBACK.blueprints)
+    } else if (fetched < MIN_BLUEPRINTS) {
+        console.warn(
+            `[counts] blueprint count came back as ${fetched}, below the ${MIN_BLUEPRINTS} floor. Check api.kestra.io.`,
+        )
+    }
+
+    return fetched ?? FALLBACK.blueprints
+})
+
+const resolveStars = memoise(async () => {
+    let fetched: number | null = null
+
+    if (!DISABLE_GITHUB) {
+        try {
+            const repo = await $fetchCached<{ stargazers_count: number }>(
+                "https://api.github.com/repos/kestra-io/kestra",
+                { headers: { "User-Agent": "request" } },
+            )
+            fetched = repo.stargazers_count ?? null
+        } catch (error) {
+            console.error("[counts] star count fetch failed:", error)
+        }
+    }
+
+    if (fetched === null) {
+        usingFallback(
+            "star count",
+            FALLBACK.stars,
+            DISABLE_GITHUB ? " DISABLE_GITHUB is set." : "",
+        )
+    } else if (fetched < MIN_STARS) {
+        console.warn(
+            `[counts] star count came back as ${fetched}, below the ${MIN_STARS} floor. Using it anyway; check api.github.com.`,
+        )
+    }
+
+    return fetched ?? FALLBACK.stars
+})
+
+/**
+ * Plugin count floored to the hundred, without the trailing "+", e.g. "1900".
+ *
+ * Throws when the API answered with an implausible count. Every page that
+ * publishes a plugin figure is prerendered, so this fails the build — which is
+ * the point: "0+ Plugins" reached production because nothing refused it.
+ */
+export async function getPluginCountRounded(): Promise<string> {
+    const { count, suspect } = await resolvePlugins()
+
+    if (suspect) {
+        throw new Error(
+            `[counts] plugin count came back as ${count}, below the ${MIN_PLUGINS} floor. ` +
+                `Refusing to build rather than publish it: this is the failure mode that ` +
+                `shipped "0+ Plugins" to /enterprise. Check https://api.kestra.io/v1/plugins/subgroups.`,
+        )
+    }
+
+    return `${floorTo(count, 100)}`
+}
+
+/** Blueprint count floored to the ten, without the trailing "+", e.g. "480". */
+export async function getBlueprintCountRounded(): Promise<string> {
+    return `${floorTo(await resolveBlueprints(), 10)}`
+}
+
+/** Stargazers on kestra-io/kestra, thousands-separated, e.g. "27,849". */
+export async function getStarCountFormatted(): Promise<string> {
+    return Intl.NumberFormat("en-US").format(await resolveStars())
+}

--- a/src/pages/1-0.astro
+++ b/src/pages/1-0.astro
@@ -1,11 +1,14 @@
 ---
 import Layout from "~/components/layout.astro"
 import Header from "~/components/onezero/Header.vue"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
 import Info from "~/components/onezero/Info.vue"
 import AiCopilot from "~/components/onezero/AiCopilot.vue"
 import Orchestration from "~/components/onezero/Orchestration.astro"
 import Unified from "~/components/onezero/Unified.vue"
 import Answers from "~/components/onezero/Answers.vue"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const title =
     "Introducing Kestra 1.0: The Declarative Agentic Orchestration Platform."
@@ -14,9 +17,9 @@ const description =
 ---
 
 <Layout {title} {description} headerTheme="lightText">
-    <Header client:load />
+    <Header client:load totalPlugins={`${totalPlugins}+`} />
     <Info client:visible />
-    <AiCopilot client:visible />
+    <AiCopilot client:visible totalPlugins={`${totalPlugins}+`} />
     <Orchestration />
     <Unified client:visible />
     <Answers client:visible />

--- a/src/pages/enterprise/index.astro
+++ b/src/pages/enterprise/index.astro
@@ -12,6 +12,9 @@ import PluginsBlock from "~/components/common/PluginsBlock.astro"
 import Capabilities from "~/components/enterprise/Capabilities.vue"
 import StatsHeader from "~/components/enterprise/StatsHeader.astro"
 import CustomerQuotes from "~/components/common/CustomerQuotes.astro"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
+
+const totalPlugins = await fetchTotalPluginsCount()
 
 const title = "Get More Out of Your Data With the Enterprise Edition"
 const description =
@@ -79,7 +82,7 @@ const items = [
         />
         <SchemaFAQ items={items} />
     </Fragment>
-    <Hero client:load />
+    <Hero client:load totalPlugins={`${totalPlugins}+`} />
     <div class="enterprise">
         <ScrollSpy client:load />
     </div>

--- a/src/pages/features/code-in-any-language/index.astro
+++ b/src/pages/features/code-in-any-language/index.astro
@@ -1,7 +1,5 @@
 ---
-import { $fetchApiCached } from "~/utils/fetch"
-import type { Plugin } from "~/utils/plugins/plugin"
-import { calculateTotalPlugins } from "~/composables/usePluginsCount"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
 
 import Layout from "~/components/layout.astro"
 import TopHero from "~/components/layout/TopHero.astro"
@@ -21,8 +19,7 @@ import pythonImg from "~/assets/landing/features/code-in-any-lang/python.webp"
 import rImg from "~/assets/landing/features/code-in-any-lang/r.webp"
 import juliaImg from "~/assets/landing/features/code-in-any-lang/julia.webp"
 
-const pluginGroups = await $fetchApiCached<Plugin[]>("/plugins/subgroups")
-const totalPlugins = Math.floor(calculateTotalPlugins(pluginGroups) / 100) * 100
+const totalPlugins = await fetchTotalPluginsCount()
 
 const title = "Language Agnostic Orchestration"
 const description =

--- a/src/pages/features/code-in-any-language/julia.astro
+++ b/src/pages/features/code-in-any-language/julia.astro
@@ -1,7 +1,5 @@
 ---
-import type { Plugin } from "~/utils/plugins/plugin"
-import { $fetchApiCached } from "~/utils/fetch"
-import { calculateTotalPlugins } from "~/composables/usePluginsCount"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
 
 import Layout from "~/components/layout.astro"
 import Link from "~/components/common/Link.astro"
@@ -19,8 +17,7 @@ import anyLanguage1 from "~/assets/landing/features/code-in-any-lang/python/any-
 import anyLanguage2 from "~/assets/landing/features/code-in-any-lang/julia/any-language-2.webp"
 import anyLanguage3 from "~/assets/landing/features/code-in-any-lang/julia/any-language-3.webp"
 
-const pluginGroups = await $fetchApiCached<Plugin[]>("/plugins/subgroups")
-const totalPlugins = Math.floor(calculateTotalPlugins(pluginGroups) / 100) * 100
+const totalPlugins = await fetchTotalPluginsCount()
 
 const title = "Julia Orchestration"
 const description =

--- a/src/pages/features/code-in-any-language/python.astro
+++ b/src/pages/features/code-in-any-language/python.astro
@@ -1,7 +1,5 @@
 ---
-import type { Plugin } from "~/utils/plugins/plugin"
-import { $fetchApiCached } from "~/utils/fetch"
-import { calculateTotalPlugins } from "~/composables/usePluginsCount"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
 
 import Layout from "~/components/layout.astro"
 import Link from "~/components/common/Link.astro"
@@ -19,8 +17,7 @@ import anyLanguage1 from "~/assets/landing/features/code-in-any-lang/python/any-
 import anyLanguage2 from "~/assets/landing/features/code-in-any-lang/python/any-language-2.webp"
 import anyLanguage3 from "~/assets/landing/features/code-in-any-lang/python/any-language-3.webp"
 
-const pluginGroups = await $fetchApiCached<Plugin[]>("/plugins/subgroups")
-const totalPlugins = Math.floor(calculateTotalPlugins(pluginGroups) / 100) * 100
+const totalPlugins = await fetchTotalPluginsCount()
 
 const title = "Python Orchestration"
 const description =

--- a/src/pages/features/code-in-any-language/r.astro
+++ b/src/pages/features/code-in-any-language/r.astro
@@ -1,7 +1,5 @@
 ---
-import type { Plugin } from "~/utils/plugins/plugin"
-import { $fetchApiCached } from "~/utils/fetch"
-import { calculateTotalPlugins } from "~/composables/usePluginsCount"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
 
 import Layout from "~/components/layout.astro"
 import Link from "~/components/common/Link.astro"
@@ -19,8 +17,7 @@ import anyLanguage1 from "~/assets/landing/features/code-in-any-lang/python/any-
 import anyLanguage2 from "~/assets/landing/features/code-in-any-lang/r/any-language-2.webp"
 import anyLanguage3 from "~/assets/landing/features/code-in-any-lang/r/any-language-3.webp"
 
-const pluginGroups = await $fetchApiCached<Plugin[]>("/plugins/subgroups")
-const totalPlugins = Math.floor(calculateTotalPlugins(pluginGroups) / 100) * 100
+const totalPlugins = await fetchTotalPluginsCount()
 
 const title = "R Orchestration"
 const description =

--- a/src/pages/overview.astro
+++ b/src/pages/overview.astro
@@ -6,12 +6,9 @@ import SeeHow from "~/components/common/SeeHow.astro"
 import StickySteps from "~/components/layout/StickySteps.vue"
 import FeatureSections from "~/components/overview/FeatureSections.astro"
 
-import { calculateTotalPlugins } from "~/composables/usePluginsCount"
-import { $fetchApiCached } from "~/utils/fetch"
-import type { Plugin } from "~/utils/plugins/plugin"
+import { fetchTotalPluginsCount } from "~/utils/plugins/pluginCount"
 
-const pluginGroups = await $fetchApiCached<Plugin[]>("/plugins/subgroups")
-const totalPlugins = `${Math.floor(calculateTotalPlugins(pluginGroups) / 100) * 100}+`
+const totalPlugins = `${await fetchTotalPluginsCount()}+`
 
 const title = "Kestra Platform Overview"
 const description =

--- a/src/utils/blueprints/blueprintCount.ts
+++ b/src/utils/blueprints/blueprintCount.ts
@@ -1,14 +1,12 @@
-import { $fetchApiCached } from "~/utils/fetch"
+import { getBlueprintCountRounded } from "~/data/counts"
 
+/**
+ * Blueprint count floored to the ten, without the trailing "+", e.g. "480".
+ *
+ * This used to return a zero when the fetch failed, which rendered the hero
+ * headline with a zeroed count — the same failure mode as the plugin count.
+ * It now falls back to the committed value in ~/data/counts.
+ */
 export async function fetchTotalBlueprintsCount(): Promise<string> {
-    try {
-        const { total = 0 } = await $fetchApiCached<{ total: number }>(
-            "/blueprints/versions/latest?size=1&page=1",
-        )
-        const rounded = Math.floor(total / 10) * 10
-        return `${rounded}`
-    } catch (e) {
-        console.error("Failed to fetch blueprints count:", e)
-        return "0"
-    }
+    return await getBlueprintCountRounded()
 }

--- a/src/utils/plugins/pluginCount.ts
+++ b/src/utils/plugins/pluginCount.ts
@@ -1,15 +1,12 @@
-import { $fetchApiCached } from "~/utils/fetch";
-import type { Plugin } from "./plugin";
-import { calculateTotalPlugins } from "~/composables/usePluginsCount";
+import { getPluginCountRounded } from "~/data/counts"
 
+/**
+ * Plugin count floored to the hundred, without the trailing "+", e.g. "1900".
+ * Call sites add the "+" themselves.
+ *
+ * Kept as a thin wrapper so existing pages keep working; the fetch, the
+ * fallback and the build-time assertion all live in ~/data/counts.
+ */
 export async function fetchTotalPluginsCount(): Promise<string> {
-    try {
-        const pluginGroups = await $fetchApiCached<Plugin[]>("/plugins/subgroups");
-        const count = calculateTotalPlugins(pluginGroups);
-        const rounded = Math.floor(count / 100) * 100;
-        return `${rounded}`;
-    } catch (e) {
-        console.error("Failed to fetch plugins count:", e);
-        return "0";
-    }
+    return await getPluginCountRounded()
 }


### PR DESCRIPTION
Draft — two points below need a call from the team before this is ready.

## The bug

`/enterprise` and `/1-0` shipped **`0+ Plugins`** in their static HTML. Confirmed live on 18 Aug 2026 (`curl https://kestra.io/enterprise` returns both `0+ Plugins` and `1900+ Plugins` on the same page).

The cause is not a failed fetch. `usePluginsCount()` fetches from a `.then()` on the **client**; `Dashboard.vue` (via `Hero.vue`, `client:load`) renders server-side while the ref is still `[]`, and the computed returns the literal `"0+"`. So it shipped on **every** build, with the API perfectly healthy — a guarded fetch or a fallback alone would not have fixed it. The fix is to stop fetching in the component and pass the value down from the Astro page.

`/1-0` had the same bug twice: `onezero/Header.vue` and `AiCopilot.vue` (`0+ Plugins & Safe Upgrades`).

## What this adds

`src/data/counts.ts` resolves each published figure while the page renders and inlines it into the HTML:

- **Committed fallback** — `src/data/counts.fallback.json` covers a failed fetch, so a network blip can no longer zero a published figure.
- **Build assertion** — a fetched-but-implausible plugin count throws rather than ships. It lives on the plugin accessor, not the shared resolver, so a bad plugin response cannot 500 on-demand pages (`/blueprints`) that only read a different counter.
- **Asymmetric floors** — plugins fail hard (`api.kestra.io` is ours and must answer); stars only warn. `api.github.com` rate-limits anonymous callers at 60/hour per IP, and `DISABLE_GITHUB` is deliberately set in `update-linux-snapshots.yml` — neither should be able to block a deploy.
- **Independent memos** — `/plugins/subgroups` is a ~3.4 MB payload; a page showing only a star count must not pull it.

Seven files had reimplemented `Math.floor(calculateTotalPlugins(...) / 100) * 100` with their own unguarded fetch, and `EveryPlugin.astro` defaulted to `"0+"` on failure. They now share the module, which also drops the per-page refetch.

The star count is rendered **server-side** in the header for the first time (the client component becomes a refresher), which also removes one `/api/github` request per page view.

## ⚠️ Point 1 for the team: the counting method

The brief asked for "total sub-plugins across all groups" and flagged that it yields 1,884 against a site claiming 1900+. Both numbers are real, they are just different methods:

| Method | Result | Display |
|---|---|---|
| Distinct plugin classes — **what the site already does** | **1,906** | `1900+` |
| Sum of the 9 element arrays — the brief's method | **1,884** | `1800+` |
| Sum of all 12 element arrays (incl. `aliases`, `appBlocks`, `dataFiltersKPI`) | 1,908 | `1900+` |

So `1900+` was **not** a hardcoded stale figure — `grep -rE "1,?900" src/pages src/components src/utils` returns nothing. It is already live and already true. Adopting the brief's method would have **lowered** a correct public claim to `1800+`.

**This PR keeps the existing method** (per @vfanucci). If the team prefers the stricter count, it is a one-line change in `getPluginCountRounded`.

Rounding stays **down**, never up: the figure carries a `+`, so flooring is what keeps the claim true as the real count drifts between builds.

## ⚠️ Point 2 for the team: editorial copy is not in this PR

The brief described "two /vs card descriptors". The real footprint of hardcoded plugin figures:

| Location | Occurrences |
|---|---|
| `src/contents/vs/*.yaml` | 61 |
| `src/contents/resources/**` | ~25 |
| `src/contents/orchestration/*.yaml` | 14 |
| blog titles / video titles (`1300+`, `1600+`) | dated content, leave alone |

These are rendered sentences and FAQ answers ("Kestra ships with 1400+ plugins covering dbt, Airbyte…"), not hero stats — templating indexed prose is a different job with a different review. Scoped to a **follow-up content PR** by decision; the inventory above is the worklist.

Also still client-side: `src/components/content/PluginCount.vue`, used as `:PluginCount` inside blog markdown. Its default no longer renders a zero (it falls back to the committed value), but feeding it a real build-time value means plumbing through the MDC renderer — same follow-up.

## Bonus: the blueprints count (brief point 7)

A blueprints endpoint **does** exist and is already wired live: `fetchTotalBlueprintsCount()` hits `/blueprints/versions/latest?size=1&page=1`. So `480+` was not hardcoded either — but it carried the same `catch → "0"` bug, which would have rendered `0+ Blueprints, ready to build.` as an H1. Hardened here via the same fallback.

## Verified

Full `astro build`, then grepped `dist/`. Note the brief's suggested grep (`"0+ Plugins"`) matches by substring — it hits `1300+ Plugins`, `1600+ Plugins`, `1,200+ Plugins` — so it can never reach zero. Anchored instead:

```
grep -rlE '(^|[^0-9])0\+ ?[Pp]lugins' dist/     -> 0 files
grep -rlE '(^|[^0-9])0\+ ?[Bb]lueprints' dist/  -> 0 files
```

Same value everywhere it is templated:

| Page | Rendered |
|---|---|
| `/` | `1900+ Plugins`, `1900+ plugins` |
| `/enterprise` | `1900+ Plugins` (was `0+`) |
| `/1-0` | `1900+ Plugins` (was `0+` ×2) |
| `/pricing` | `1900+ Plugins` (was `1,200+`) |
| `/overview` | `1900+ plugins` |
| `/vs` | `1900+ plugins` |
| `/features/code-in-any-language` | `1900+ integrations` |
| JSON-LD `SoftwareApplication` | `language-agnostic, 1900+ plugins` (was `1400+`) |

Header stars now in static HTML: `<span>27,850</span>`.

Both failure paths exercised by temporarily patching the resolver:

| Simulated | Result |
|---|---|
| API returns 200 with `[]` | **build fails** — `[counts] plugin count came back as 0, below the 1000 floor. Refusing to build…` |
| Fetch fails (404) | build succeeds, `[counts] using committed fallback plugin count (1906, as of 2026-08-18)` |

`npm run test:unit` 43/43 pass, `oxlint` clean on all touched files.

The `1400+ plugins` still visible on `/vs` comes from the content YAML descriptors — expected, that is the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)