### PR TITLE
Copy: self-hosted positioning fixes (/enterprise, /features, /pricing)

### DIFF
--- a/src/components/common/GetStarted.astro
+++ b/src/components/common/GetStarted.astro
@@ -23,7 +23,7 @@ const PLANS = [
         description: [
             "Built for critical environments.",
             "SSO, RBAC, audit logs, multi-tenancy. Isolated workers and dedicated task runners.",
-            "Hybrid environments: Cloud, On-Prem, Air-Gapped.",
+            "Hybrid environments: any cloud, on-prem, or air-gapped.",
             "SLA-backed support and a dedicated customer success program.",
         ],
         image: ENTERPRISE_IMAGE,

--- a/src/components/enterprise/Dashboard.vue
+++ b/src/components/enterprise/Dashboard.vue
@@ -22,7 +22,7 @@
                 <h6 data-usal="fade-l">
                     <Plus class="icon me-2" />Enterprise-Ready Deployment:<br>
                     <span class="fw-normal">
-                        Cloud, On-Prem, Air-Gapped
+                        Any cloud, on-prem, or air-gapped
                         <span class="deployments">
                             <span v-html="awsSVG"></span>
                             <span v-html="vectorSVG"></span>

--- a/src/components/enterprise/StatsHeader.astro
+++ b/src/components/enterprise/StatsHeader.astro
@@ -19,7 +19,7 @@ const { stats } = Astro.props
         <h2 data-usal="fade-l">Enterprise Edition</h2>
         <p data-usal="fade-r">Built for critical environments.</p>
         <p data-usal="fade-r">SSO, RBAC, audit logs, multi-tenancy. Isolated workers and dedicated task runners.</p>
-        <p data-usal="fade-r">Hybrid environments, Cloud, On-Prem, Air-Gapped.</p>
+        <p data-usal="fade-r">Hybrid environments: any cloud, on-prem, or air-gapped.</p>
         <p class="mb-0" data-usal="fade-r">SLA-backed support and a dedicated customer success program.</p>
 
         {

--- a/src/components/price/Header.astro
+++ b/src/components/price/Header.astro
@@ -41,7 +41,7 @@ const ENTERPRISE_EXTRAS = [
         icon: Plus,
     },
     {
-        text: "Run anywhere Cloud, On-Prem, Air-Gapped",
+        text: "Run anywhere: any cloud, on-prem, or air-gapped",
         icon: Plus,
         showLogos: true,
     },

--- a/src/contents/vs/pagerduty.yaml
+++ b/src/contents/vs/pagerduty.yaml
@@ -208,7 +208,7 @@ platformStrengths:
       description: "Kestra triggers on PagerDuty alerts, Kafka events, webhooks, and file detection. Automated diagnosis, conditional remediation, human approval gates, and ITSM ticket closure all happen in a single declarative workflow—no handoffs between tools."
     - title: "Git-Native Runbooks That Actually Scale"
       description: "Every workflow is YAML you can commit, review in a pull request, and deploy through CI/CD. When Mercy Health's team needed to update their incident response playbook, it was a PR—not a UI change on a live production system."
-    - title: "Works Anywhere: Cloud, On-Prem, Air-Gapped"
+    - title: "Works Anywhere: Any cloud, on-prem, or air-gapped"
       description: "Deploy Kestra on Kubernetes, Docker, or bare metal. Run remote workers close to targets in hybrid and OT environments. Air-gap deployments supported for regulated industries—the Austrian Ministry of Defense runs Kestra fully disconnected from the internet."
 
 decisionGuide:

--- a/src/contents/vs/vmware-cloud-foundation.yaml
+++ b/src/contents/vs/vmware-cloud-foundation.yaml
@@ -210,7 +210,7 @@ platformStrengths:
       description: "Kestra handles catalog-driven VM provisioning with dynamic Apps, approval gates, and vSphere integration—everything vRA does, plus Terraform, Ansible, and multi-cloud support. One tool, one contract, one set of logs. No JavaScript, no proprietary APIs."
     - title: "Git-Native from Day One"
       description: "Every workflow is YAML you can commit, review in a pull request, and deploy through CI/CD. Fortune 500 platform teams manage all their infrastructure provisioning logic as code—versioned, testable, and auditable. No hidden state in a portal, no manual change tracking."
-    - title: "Works Anywhere: Cloud, On-Prem, Air-Gapped"
+    - title: "Works Anywhere: Any cloud, on-prem, or air-gapped"
       description: "Deploy Kestra on Kubernetes, Docker, or bare metal. Run remote workers close to vSphere targets for hybrid environments. Air-gap deployments supported for regulated industries—no external connectivity required. ITZBund and the Austrian Ministry of Defense run Kestra fully disconnected."
 
 decisionGuide:

--- a/src/pages/enterprise/index.astro
+++ b/src/pages/enterprise/index.astro
@@ -15,7 +15,7 @@ import CustomerQuotes from "~/components/common/CustomerQuotes.astro"
 
 const title = "Get More Out of Your Data With the Enterprise Edition"
 const description =
-    "Get full access of all the Open source features and unlock the full potential with Enterprise only features"
+    "Everything in open-source Kestra plus enterprise governance: RBAC, SSO, audit logs, multi-tenancy, and high availability — self-hosted on your infrastructure."
 
 const STATS = [
     {
@@ -47,7 +47,7 @@ const items = [
     },
     {
         question: "Can Kestra Enterprise be self-hosted?",
-        answer: "Yes. Enterprise Edition runs fully self-hosted in your own infrastructure — including air-gapped environments — or as a managed deployment. You keep your data in your environment.",
+        answer: "Yes. Enterprise Edition runs fully self-hosted in your own infrastructure — including air-gapped environments. You keep your data in your environment.",
     },
     {
         question: "What security and compliance features are included?",
@@ -73,7 +73,7 @@ const items = [
         <SchemaSoftwareApplication
             id="https://kestra.io/#enterprise-edition"
             name="Kestra Enterprise Edition"
-            description="Kestra Enterprise is a workflow orchestration platform for engineering teams running mission-critical operations at scale. Built-in governance, enterprise security, SSO, RBAC, audit logs, and horizontal scalability. Self-hosted or managed."
+            description="Kestra Enterprise is a workflow orchestration platform for engineering teams running mission-critical operations at scale. Built-in governance, enterprise security, SSO, RBAC, audit logs, and horizontal scalability. Self-hosted on your own infrastructure."
             url="https://kestra.io/enterprise"
             isVariantOf="https://kestra.io/#software"
         />

--- a/src/pages/features/index.astro
+++ b/src/pages/features/index.astro
@@ -51,7 +51,7 @@ const items = [
     },
     {
         question: "What deployment options exist?",
-        answer: "OSS: Docker, Kubernetes (Helm charts), single-VM. Enterprise/Cloud: Managed hosting, HA, air-gapped deployments.",
+        answer: "OSS: Docker, Kubernetes (Helm charts), single-VM. Enterprise: self-hosted on your own infrastructure, with HA and air-gapped deployments. Cloud: fully managed by Kestra, with no infrastructure to run.",
     },
     {
         question: "How does event-driven orchestration work?",


### PR DESCRIPTION
Text-only copy fixes removing live strings that contradict the SELF MANAGED / FULLY MANAGED nav grouping. No URL, H1, design or numeric changes. The word "Edition" is untouched (separate PR pending sign-off).

## Changes

**1. `/enterprise` FAQ — "Can Kestra Enterprise be self-hosted?"**
Dropped "or as a managed deployment". Enterprise is self-hosted only; Kestra Cloud is the managed offering.

**2. `/features` FAQ — "What deployment options exist?"**
`Enterprise/Cloud: Managed hosting, HA, air-gapped deployments.` → `Enterprise: self-hosted on your own infrastructure, with HA and air-gapped deployments. Cloud: fully managed by Kestra, with no infrastructure to run.`

**3. Sitewide phrase — "Cloud, On-Prem, Air-Gapped" → "any cloud, on-prem, or air-gapped"**
In the old phrasing "Cloud" reads as *Kestra Cloud*; it actually means the customer's own cloud.

**4. `/enterprise` meta description**
Replaced "Get full access of all the Open source features and unlock the full potential with Enterprise only features" (broken grammar + banned word) with `Everything in open-source Kestra plus enterprise governance: RBAC, SSO, audit logs, multi-tenancy, and high availability — self-hosted on your infrastructure.` `og:description` and `twitter:description` derive from the same prop in `layout.astro`, so all three update together — verified 3 occurrences in the built HTML.

## Audit — surface beyond the original brief

The brief expected the phrase on `/enterprise` (×2), `/features` and `/pricing`. Two of those live in shared components, so the real blast radius is wider:

| Source | Rendered on |
|---|---|
| `components/enterprise/Dashboard.vue` | `/enterprise` |
| `components/enterprise/StatsHeader.astro` | `/enterprise` |
| `components/price/Header.astro` | `/pricing` |
| `components/common/GetStarted.astro` | **`/`, `/vs`, `/features`, `/orchestration`** |
| `contents/vs/vmware-cloud-foundation.yaml` | `/vs/vmware-cloud-foundation` |
| `contents/vs/pagerduty.yaml` | `/vs/pagerduty` |

So the homepage, `/vs`, `/orchestration` and two comparison pages were carrying the same phrase and are fixed here too.

**One extra fix, same contradiction:** `/enterprise` `SchemaSoftwareApplication` structured data ended with "Self-hosted or managed." → "Self-hosted on your own infrastructure." This is the exact claim change #1 removes, in the machine-readable copy that feeds AI answer engines. Flagging explicitly since it wasn't in the brief.

**Reviewed, deliberately not changed:**
- `Is Kestra self-hosted or managed?` FAQ on ~30 `/orchestration/*` pages — describes Kestra *overall* (self-hosted OSS/Enterprise + managed Cloud + air-gapped). Consistent with the new grouping, not a contradiction.
- "unlock the full potential" in 4 `/resources/*` articles — banned word, but editorial body copy outside this brief's scope. Worth a separate cleanup.
- Lowercase "on-prem, air-gapped" prose in 3 `/resources/*` articles — reads correctly in context.

## Verification

`npm run build` passes. Grep over `dist/`:

| String | Matches |
|---|---|
| `or as a managed deployment` | 0 |
| `On-Prem, Air-Gapped` (old casing) | 0 in pages/components — remaining hits are the lowercase `/resources` prose noted above |
| `unlock the full potential` | 0 on `/enterprise` — remaining hits are the `/resources` articles noted above |
| `Enterprise/Cloud: Managed hosting` | 0 |
| `Self-hosted or managed.` (enterprise schema) | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
