### PR TITLE
docs(assets): document that asset ids are unique per tenant

### DIFF
--- a/src/contents/docs/07.enterprise/02.governance/01.assets/index.md
+++ b/src/contents/docs/07.enterprise/02.governance/01.assets/index.md
@@ -47,7 +47,7 @@ Every asset includes these fields:
 
 ## Asset identifier
 
-An asset is uniquely identified by its `id` and the tenant (`tenantId`) where you create it - the `id` must be unique per tenant. Neither the namespace nor the type is part of that identity: two assets with the same `id` and different namespaces or types cannot exist in the same tenant. Creating an asset with an `id` that is already taken is rejected, and the type of an existing asset cannot be changed.
+An asset is uniquely identified by its `id` and the tenant (`tenantId`) where you create it - the `id` must be unique per tenant. Neither the namespace nor the type is part of that identity: two assets with the same `id` and different namespaces or types cannot exist in the same tenant. Creating an asset with an `id` that is already taken is rejected.
 
 You can attach a namespace to an asset to improve filtering and to restrict visibility so only users or groups with the appropriate RBAC can access the asset.
 

--- a/src/contents/docs/07.enterprise/02.governance/01.assets/index.md
+++ b/src/contents/docs/07.enterprise/02.governance/01.assets/index.md
@@ -47,7 +47,9 @@ Every asset includes these fields:
 
 ## Asset identifier
 
-An asset is uniquely identified by its `id` and the tenant (`tenantId`) where you create it. You can attach a namespace to an asset to improve filtering and to restrict visibility so only users or groups with the appropriate RBAC can access the asset.
+An asset is uniquely identified by its `id` and the tenant (`tenantId`) where you create it - the `id` must be unique per tenant. Neither the namespace nor the type is part of that identity: two assets with the same `id` and different namespaces or types cannot exist in the same tenant. Creating an asset with an `id` that is already taken is rejected, and the type of an existing asset cannot be changed.
+
+You can attach a namespace to an asset to improve filtering and to restrict visibility so only users or groups with the appropriate RBAC can access the asset.
 
 ## Asset type
 


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra-ee/issues/10083.
Related to https://github.com/kestra-io/kestra-ee/issues/6574.

## What

Strengthens the "Asset identifier" section of the Assets docs: asset IDs are unique per tenant, neither the namespace nor the type is part of the identity, creating an asset with an ID that is already taken is rejected, and the type of an existing asset cannot be changed. Companion to the EE fix for the issues above.