### PR TITLE
docs: remove overflow and margin adjustments for company logos in LogoBar

### DIFF
--- a/src/components/home/LogoBar.astro
+++ b/src/components/home/LogoBar.astro
@@ -56,7 +56,6 @@ const logos = import.meta.glob<{ default: ImageMetadata }>(
 
     .companies-container {
         width: 100%;
-        overflow: hidden;
         @include media-breakpoint-down(sm) {
             margin-top: 1rem;
         }
@@ -67,10 +66,6 @@ const logos = import.meta.glob<{ default: ImageMetadata }>(
             justify-content: center;
             gap: 2rem;
 
-            @include media-breakpoint-up(sm) {
-                gap: 2rem;
-                margin-left: -14px;
-            }
             @include media-breakpoint-up(xl) {
                 gap: 3rem;
             }
@@ -82,7 +77,6 @@ const logos = import.meta.glob<{ default: ImageMetadata }>(
                 flex-wrap: wrap;
                 gap: 0;
                 row-gap: 2rem;
-                margin-left: 0;
             }
         }
 


### PR DESCRIPTION
fixes: https://github.com/kestra-io/docs/issues/5346

---

Ref img: 

<img width="932" height="745" alt="Screenshot 2026-08-20 at 12 48 16 PM" src="https://github.com/user-attachments/assets/1b025637-a0b4-4fbe-8b27-c8ebd821212b" />

---