### PR TITLE
feat(lp-header): implement sticky header and adjust styles for better layout

### DIFF
--- a/src/components/lp/workflow-orchestration/LpHeader.astro
+++ b/src/components/lp/workflow-orchestration/LpHeader.astro
@@ -18,18 +18,18 @@ import GithubButton from "~/components/layout/GithubButton.vue"
 
 <style lang="scss">
     .lp-header {
+        position: sticky;
+        top: 0;
+        z-index: $zindex-fixed;
         display: flex;
         align-items: center;
         justify-content: space-between;
         gap: 1rem;
-        /* The design floats this band on the frame's near-black ground, flush
-         * against the hero below — whose own blooms start lower down, so a flat
-         * fill here joins the two seamlessly. */
+        min-height: var(--top-bar-height, 80px);
         background-color: var(--lp-bg-dark);
-        padding: 1.5rem 1rem;
+        padding: 1rem;
         @include media-breakpoint-up(lg) {
-            /* 80px tall with a 100px inset, per the design's nav band. */
-            min-height: 80px;
+            /* A 100px inset, per the design's nav band. */
             padding: 1rem 6.25rem;
         }
     }

--- a/src/pages/lp/workflow-orchestration.astro
+++ b/src/pages/lp/workflow-orchestration.astro
@@ -101,5 +101,10 @@ const faqItems = [
         --lp-border-subtle: #e9e9ee;
 
         background-color: #ffffff;
+        overflow-x: clip;
+    }
+    
+    :global(html) {
+        --top-bar-height: 80px;
     }
 </style>


### PR DESCRIPTION
fixes: https://github.com/kestra-io/docs/issues/5343

---

Ref img's:

- Mobile,

<img width="449" height="687" alt="Screenshot 2026-08-20 at 7 10 59 PM" src="https://github.com/user-attachments/assets/0b63d0ee-bae4-4e7a-9749-ebc0ba87c290" />

- Tablet / Laptop screens
<img width="1512" height="652" alt="Screenshot 2026-08-20 at 7 10 42 PM" src="https://github.com/user-attachments/assets/070e3793-09c7-4697-ae33-add1148d430c" />

---