### PR TITLE
fix(ci): skip organization members in contributor onboarding and post as the Kestra bot

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -11,12 +11,9 @@ permissions: {}
 
 jobs:
   welcome:
-    # author_association filters out publicly visible insiders cheaply, but it reports private organization members as plain contributors,
-    # so the authoritative check is the explicit membership lookup in the steps below (see https://github.com/kestra-io/docs/pull/4318).
+    # author_association misses organization members with private membership, so the membership lookup below is the authoritative check.
     if: ${{ github.event.pull_request.user.type != 'Bot' && !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) && (github.event.action == 'opened' || github.event.pull_request.merged) }}
     runs-on: ubuntu-latest
-    # No GITHUB_TOKEN permissions needed: every API call below goes through the bot app token,
-    # which also makes the comments show up as the Kestra bot instead of github-actions.
     steps:
       - name: Generate a bot token
         id: bot-token
@@ -39,7 +36,7 @@ jobs:
               core.info(`@${username} is a member of the ${context.repo.owner} organization. Exiting..`);
               core.setOutput('is-member', 'true');
             } catch (error) {
-              // 404 is the API's way of saying "not a member"; anything else is a real failure worth surfacing.
+              // 404 means the author is not an organization member.
               if (error.status !== 404) {
                 throw error;
               }

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -11,16 +11,43 @@ permissions: {}
 
 jobs:
   welcome:
-    # GitHub already resolves the author's relationship to the repository, so internal contributors are filtered out without an API lookup.
+    # author_association filters out publicly visible insiders cheaply, but it reports private organization members as plain contributors,
+    # so the authoritative check is the explicit membership lookup in the steps below (see https://github.com/kestra-io/docs/pull/4318).
     if: ${{ github.event.pull_request.user.type != 'Bot' && !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) && (github.event.action == 'opened' || github.event.pull_request.merged) }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read # reading the author's commit history
-      issues: read # reading the author's issues and pull requests
-      pull-requests: write # commenting and reacting on the pull request
+    # No GITHUB_TOKEN permissions needed: every API call below goes through the bot app token,
+    # which also makes the comments show up as the Kestra bot instead of github-actions.
     steps:
+      - name: Generate a bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.GH_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          owner: kestra-io
+          repositories: docs
+
+      - name: Check organization membership
+        id: membership
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ steps.bot-token.outputs.token }}
+          script: |
+            const username = context.payload.pull_request.user.login;
+            try {
+              await github.rest.orgs.checkMembershipForUser({org: context.repo.owner, username});
+              core.info(`@${username} is a member of the ${context.repo.owner} organization. Exiting..`);
+              core.setOutput('is-member', 'true');
+            } catch (error) {
+              // 404 is the API's way of saying "not a member"; anything else is a real failure worth surfacing.
+              if (error.status !== 404) {
+                throw error;
+              }
+              core.setOutput('is-member', 'false');
+            }
+
       - name: Welcome a first pull request
-        if: github.event.action == 'opened'
+        if: github.event.action == 'opened' && steps.membership.outputs.is-member == 'false'
         uses: actions/github-script@v9
         env:
           # Kept out of the script itself: interpolated there, a backtick or ${ would break out and run as JS.
@@ -33,6 +60,7 @@ jobs:
 
             Thanks for all the efforts so far! 🍀
         with:
+          github-token: ${{ steps.bot-token.outputs.token }}
           script: |
             const author = context.payload.pull_request.user.login;
             const issue_number = context.payload.pull_request.number;
@@ -67,7 +95,7 @@ jobs:
             });
 
       - name: Congratulate on a first merged pull request
-        if: github.event.action == 'closed'
+        if: github.event.action == 'closed' && steps.membership.outputs.is-member == 'false'
         uses: actions/github-script@v9
         env:
           # Kept out of the script itself for the same reason as above: a backtick or ${ interpolated there would break out and run as JS.
@@ -80,6 +108,7 @@ jobs:
 
             Thanks again for making Kestra better - and don't forget to ⭐ the repo!
         with:
+          github-token: ${{ steps.bot-token.outputs.token }}
           script: |
             const author = context.payload.pull_request.user.login;
 


### PR DESCRIPTION
## What

Two changes to the contributor onboarding workflow (`welcome.yml`):

1. **Skip organization members reliably.** The `author_association` pre-filter reports organization members with private membership as plain contributors, so they still received the first-time-contributor welcome and congratulation comments - see https://github.com/kestra-io/docs/pull/4318, where a `kestra-io` member got both. The workflow now performs an explicit `kestra-io` membership lookup via the API and exits early for members. The cheap `author_association` job-level filter is kept as a fast path.

2. **Post as the Kestra bot.** All API calls (reactions and comments) now go through a token minted from the `GH_BOT_APP_ID` / `GH_BOT_PRIVATE_KEY` app - the same bot identity (`hello@kestra.io`) already used by the other `CI` workflows - so the onboarding comments are no longer posted by `github-actions`. The job-level `GITHUB_TOKEN` permissions are dropped since nothing uses that token anymore.

Note: the bot app needs the organization `members: read` permission for the membership lookup; a missing permission fails the run loudly rather than silently welcoming members.

Related to https://github.com/kestra-io/kestra/pull/18349.