### PR TITLE
fix(search): drop search results with null titles breaking the Blogs facet

### DIFF
--- a/src/components/layout/Search.vue
+++ b/src/components/layout/Search.vue
@@ -259,6 +259,7 @@
     import ContentCopy from "vue-material-design-icons/ContentCopy.vue"
     import posthog from "posthog-js"
     import { $fetchApi } from "~/utils/fetch"
+    import { prepareSearchResults } from "~/utils/searchResults"
 
     export default {
         props: {
@@ -336,23 +337,12 @@
                 })
                     .then((response) => {
                         this.initialLoad = true
-                        if (response?.results?.length) {
-                            this.searchResults = response.results.map(
-                                (result) => {
-                                    const searchTerm = value
-                                        ?.trim()
-                                        ?.toLowerCase()
-                                    if (searchTerm) {
-                                        const index = result.title
-                                            .toLowerCase()
-                                            .indexOf(searchTerm)
-                                        if (index !== -1) {
-                                            result.highlightTitle = `${result.title.slice(0, index)}<mark>${result.title.slice(index, index + searchTerm.length)}</mark>${result.title.slice(index + searchTerm.length)}`
-                                        }
-                                    }
-                                    return result
-                                },
-                            )
+                        const results = prepareSearchResults(
+                            response?.results,
+                            value,
+                        )
+                        if (results.length) {
+                            this.searchResults = results
 
                             this.selectedIndex = 0
                             this.selectedItem = this.searchResults[0]

--- a/src/utils/searchResults.test.ts
+++ b/src/utils/searchResults.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import { prepareSearchResults } from "~/utils/searchResults"
+
+const blog = (overrides: Record<string, unknown> = {}) => ({
+    url: "blogs/hello-assets",
+    type: "BLOGS",
+    title: "Hello, Assets: Unifies Orchestration, Catalogs, and Lineage",
+    highlights: [],
+    ...overrides,
+})
+
+describe("prepareSearchResults", () => {
+    // Regression: the BLOGS facet rendered "No results found" because the
+    // index contained blogs/CLAUDE (a frontmatter-less file) with a null
+    // title, and mapping over it threw before any result could render.
+    it("drops entries with a null title instead of failing the whole list", () => {
+        const results = prepareSearchResults(
+            [
+                blog(),
+                { url: "blogs/CLAUDE", type: "BLOGS", title: null },
+                blog({ url: "blogs/release-1-2", title: "Kestra 1.2" }),
+            ],
+            "assets",
+        )
+
+        expect(results.map((r) => r.url)).toEqual([
+            "blogs/hello-assets",
+            "blogs/release-1-2",
+        ])
+    })
+
+    it("drops entries missing the url or type the UI renders", () => {
+        const results = prepareSearchResults(
+            [blog({ url: undefined }), blog({ type: undefined }), blog()],
+            "assets",
+        )
+
+        expect(results).toHaveLength(1)
+    })
+
+    it("marks the matched part of the title, case-insensitively", () => {
+        const [result] = prepareSearchResults([blog()], "ASSETS")
+
+        expect(result.highlightTitle).toBe(
+            "Hello, <mark>Assets</mark>: Unifies Orchestration, Catalogs, and Lineage",
+        )
+    })
+
+    it("leaves titles without a match unhighlighted", () => {
+        const [result] = prepareSearchResults([blog()], "terraform")
+
+        expect(result.highlightTitle).toBeUndefined()
+    })
+
+    it("skips highlighting for an empty or blank search value", () => {
+        expect(prepareSearchResults([blog()], "")[0].highlightTitle)
+            .toBeUndefined()
+        expect(prepareSearchResults([blog()], "   ")[0].highlightTitle)
+            .toBeUndefined()
+        expect(prepareSearchResults([blog()], undefined)[0].highlightTitle)
+            .toBeUndefined()
+    })
+
+    it("returns an empty list for a missing or non-array response", () => {
+        expect(prepareSearchResults(undefined, "assets")).toEqual([])
+        expect(prepareSearchResults(null, "assets")).toEqual([])
+        expect(prepareSearchResults({ results: [] }, "assets")).toEqual([])
+    })
+})

--- a/src/utils/searchResults.ts
+++ b/src/utils/searchResults.ts
@@ -1,0 +1,44 @@
+export interface SearchResult {
+    url: string
+    type: string
+    title: string
+    highlights?: string[]
+    highlightTitle?: string
+}
+
+/**
+ * Prepare raw search API results for rendering.
+ *
+ * The index can contain entries without a title (e.g. a file indexed
+ * without frontmatter); the UI reads title/url/type unconditionally, so
+ * such entries are dropped rather than letting one of them break the
+ * whole result list. The matched part of each title is wrapped in
+ * <mark> for highlighting.
+ */
+export function prepareSearchResults(
+    results: unknown,
+    searchValue?: string,
+): SearchResult[] {
+    if (!Array.isArray(results)) {
+        return []
+    }
+
+    const searchTerm = searchValue?.trim()?.toLowerCase()
+
+    return results
+        .filter(
+            (result): result is SearchResult =>
+                typeof result?.title === "string" &&
+                typeof result?.url === "string" &&
+                typeof result?.type === "string",
+        )
+        .map((result) => {
+            if (searchTerm) {
+                const index = result.title.toLowerCase().indexOf(searchTerm)
+                if (index !== -1) {
+                    result.highlightTitle = `${result.title.slice(0, index)}<mark>${result.title.slice(index, index + searchTerm.length)}</mark>${result.title.slice(index + searchTerm.length)}`
+                }
+            }
+            return result
+        })
+}


### PR DESCRIPTION
fixes: https://github.com/kestra-io/docs/issues/5360

---

ref: 

https://github.com/user-attachments/assets/02d33781-7d0b-4627-929e-d74469708ff3

---