### PR TITLE
docs: update quickstart anchor

### DIFF
--- a/src/contents/docs/index.mdx
+++ b/src/contents/docs/index.mdx
@@ -20,7 +20,7 @@ Thanks to <PluginCount client:idle /> plugins and an embedded code editor with G
 
 <HomePageButtons
     buttons={[
-        { label: "Quickstart →", href: "/docs/quickstart#start-kestra" },
+        { label: "Quickstart →", href: "/docs/quickstart#step-1-start-the-kestra-container" },
         { label: "Why Kestra?", href: "/docs/why-kestra" },
         { label: "Why Enterprise Edition?", href: "/docs/oss-vs-paid" },
     ]}


### PR DESCRIPTION
Closes https://github.com/kestra-io/docs/issues/5379

Fixed. The href now matches the actual rehypeHeadingIds-generated anchor for "Step 1: Start the Kestra container". The tradeoff is that rewording that heading will break the link again, but there's no way around that without adding a custom heading ID plugin to the build.