### PR TITLE
docs: fix website typos and stop force-capitalizing breadcrumbs

### DIFF
--- a/src/components/common/Slack.astro
+++ b/src/components/common/Slack.astro
@@ -15,7 +15,7 @@ import Link from "~/components/common/Link.astro"
                 <p>
                     Join our <a href="https://kestra.io/slack"
                         >Slack Community</a
-                    > to share ideas and best practices,get help <br
+                    > to share ideas and best practices, get help <br
                         class="d-none d-lg-block"
                     />
                     with technical questions, and discuss with other developers.

--- a/src/components/features/core/Operate.astro
+++ b/src/components/features/core/Operate.astro
@@ -16,7 +16,7 @@ import monitor from "~/assets/features/core/monitor.png"
 const FEATURES = [
     { icon: "mdi:restore", title: "Retries and failure policies" },
     { icon: "mdi:clock-time-five-outline", title: "Timeouts and concurrency limits" },
-    { icon: "mdi:server-outline", title: "Worker group assignement" },
+    { icon: "mdi:server-outline", title: "Worker group assignment" },
     { icon: "mdi:text-box-outline", title: "Automatic log capture" },
     { icon: "mdi:alert", title: "Error handling and conditional branching" },
 ]

--- a/src/components/layout/Breadcrumb.vue
+++ b/src/components/layout/Breadcrumb.vue
@@ -113,8 +113,5 @@
                 }
             }
         }
-        .link {
-            text-transform: capitalize;
-        }
     }
 </style>

--- a/src/contents/customer-stories/modernizing-mission-critical-workflows-in-a-highly-regulated-environment/index.md
+++ b/src/contents/customer-stories/modernizing-mission-critical-workflows-in-a-highly-regulated-environment/index.md
@@ -20,7 +20,7 @@ kpi1: |-
   pharmacy relies on Kestra workflows
 kpi2: |-
   ##### 50+
-  cricital workflows modernized
+  critical workflows modernized
 kpi3: |-
   ##### 30+ Years
   old platform, replaced in few months

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -51,7 +51,7 @@ const GETTING_STARTED_FAQ = [
         answer: 'Kestra is designed to be easy to install and set up. The installation process involves following the <a href="/get-started">official documentation</a>, which provides step-by-step instructions on how to get started with Kestra on various platforms, including Docker, Kubernetes, and Helm. We are also available on our <a target="_blank" href="/slack">Slack channel</a> to provide assistance and answer any questions you might have during the installation process.',
     },
     {
-        question: "Is there there a community or support forum for Kestra?",
+        question: "Is there a community or support forum for Kestra?",
         answer: 'Yes, Kestra has a growing community. You can join the <a target="_blank" href="https://kestra.io/slack">Kestra Slack channel</a> to ask questions, share your experience, and connect with other users and developers.',
     },
 ]

--- a/src/pages/use-cases/databases-management.astro
+++ b/src/pages/use-cases/databases-management.astro
@@ -168,7 +168,7 @@ const CARDS_DATA = [
     {
         icon: CloudRefreshVariant,
         cardInfo: {
-            title: "Data Consitency",
+            title: "Data Consistency",
             description:
                 "Maintain integrity across all database environments through automated migrations and backups.",
         },


### PR DESCRIPTION
## What

Two small fixes.

**Typos (#5389)** — five visible copy errors:

| Page | Was | Now |
|---|---|---|
| /faq | "Is there there a community" | "Is there a community" |
| /use-cases/databases-management | Data Consitency | Data Consistency |
| /features | Worker group assignement | Worker group assignment |
| customer story | cricital workflows | critical workflows |
| Slack section | best practices,get help | best practices, get help |

**Breadcrumb (#5277)** — removed `text-transform: capitalize` from the docs breadcrumb. It capitalized every word, which is wrong for names that are not title case, such as Pebble functions. Text now renders as authored.

## Testing

Text-only and one CSS rule removed. Worth a look at a docs page breadcrumb to confirm nothing now reads lowercase that should not.

Closes #5389
Closes #5277
