### PR TITLE
docs: restore top padding on use-case code blocks

### DIFF
--- a/src/components/common/BlueprintTabs.astro
+++ b/src/components/common/BlueprintTabs.astro
@@ -264,7 +264,7 @@ const {
                                     transition: max-height 0.3s ease;
                                 }
                                 :global(.mdc-renderer pre) {
-                                    padding: 0 1rem 1rem 1rem;
+                                    padding-bottom: 1rem;
                                 }
 
                                 &:global(:not(.is-expanded)) {


### PR DESCRIPTION
## What

The YAML code blocks on the use-case pages had no space above the first line, so `id: claims-triage-payout` sat flush against the top border under the copy button.

`BlueprintTabs` was re-declaring all four sides as `padding: 0 1rem 1rem 1rem`, zeroing the top.

## Why this shape

Matching what already exists rather than inventing a value:

- base rule, `_mdc-renderer.scss`: `padding: 1rem; padding-bottom: 0`
- blueprint detail page, `blueprints/[id].astro`: `padding-bottom: 1rem`

So the convention is to keep the base 1rem and add the bottom back. This changes `BlueprintTabs` to the identical one-line override, giving 1rem on all sides and dropping the redundant re-declaration.

## Testing

Affects the code block on every `/use-cases/*` page, which all share this component. Worth checking one page renders with even spacing top and bottom.

Closes #5398
