### PR TITLE
docs: make the 60 seconds video modal close button visible

### DIFF
--- a/src/components/home/SixtySeconds.astro
+++ b/src/components/home/SixtySeconds.astro
@@ -75,7 +75,17 @@
             border: none;
             background: transparent;
             padding: 0.5rem;
-            color: var(--ks-content-primary);
+            /* The backdrop is always dark, so this cannot follow the theme
+               tokens: --ks-content-primary is dark in light mode and
+               --ks-content-primary-inverse is dark in dark mode. */
+            color: #fff;
+            opacity: 0.75;
+            transition: opacity 0.2s ease;
+
+            &:hover,
+            &:focus-visible {
+                opacity: 1;
+            }
         }
         .video-container {
             iframe {


### PR DESCRIPTION
## What

On the homepage, "See Kestra in 60 seconds" opens a video modal whose close X was dark on a dark backdrop and hard to find.

## Why this shape

The button used `--ks-content-primary`, which is dark in light mode. The backdrop is `rgb(0 0 0 / 80%)` in **both** themes, so:

- `--ks-content-primary` → dark in light mode, invisible
- `--ks-content-primary-inverse` → dark in dark mode, invisible

No theme token works when the surface is fixed, so the colour is fixed too. That follows what `layout/GithubButton.vue` and `preview-access/Features.vue` already do for text on always-dark surfaces. Added a comment so the next person does not swap it back to a token.

Also added `hover` and `focus-visible` opacity, since a transparent text button gave no feedback at all.

## Testing

Open the homepage modal in both light and dark mode and confirm the X reads clearly and responds to hover.

Closes #5385

