### PR TITLE
seo(resources): publish W35 batch — 5 new concept pages

### DIFF
--- a/src/contents/resources/agent-observability/index.md
+++ b/src/contents/resources/agent-observability/index.md
@@ -1,0 +1,171 @@
+---
+title: "Agent Observability: Tracing and Monitoring AI Agent Behavior"
+description: "Agent observability provides deep insights into the internal state and behavior of AI agents, enabling effective tracing, evaluation, and monitoring. Learn how to debug, optimize, and ensure the reliability of your agentic workflows in production."
+metaTitle: "Agent Observability for AI: Trace, Monitor, Evaluate"
+metaDescription: "Implement agent observability to trace, monitor, and evaluate AI behavior. Debug, optimize, and ensure the reliability of AI workflows in production."
+tag: "ai"
+date: 2026-08-27
+slug: "agent-observability"
+faq:
+  - question: "What does agent observability mean?"
+    answer: "Agent observability refers to the ability to understand the internal state and behavior of AI agents by examining external signals like logs, metrics, and traces. It provides visibility into an agent's decision-making process, tool interactions, and performance, which is essential for debugging, evaluation, and ensuring reliable operation in production environments."
+  - question: "Is ChatGPT an agent or LLM?"
+    answer: "ChatGPT is primarily an LLM (Large Language Model), a sophisticated neural network trained to understand and generate human-like text. While it can be a core component of an AI agent, an agent typically involves additional capabilities such as planning, memory, and the ability to use external tools to achieve goals. ChatGPT itself doesn't inherently possess these agentic features without external integration."
+  - question: "What is an AI agent observability platform?"
+    answer: "An AI agent observability platform provides specialized tools and frameworks for tracing, monitoring, and evaluating the behavior of AI agents. These platforms help track agent decisions, tool calls, data flows, and performance metrics across development and production, offering insights needed to identify issues, improve agent reliability, and ensure compliance."
+  - question: "What are the top 3 AI agents?"
+    answer: "Defining the 'top 3' AI agents can be subjective and depends on the specific use case (e.g., sales, data analysis, customer support). But prominent examples often include agents built on large language models that demonstrate advanced reasoning, tool-use capabilities, and autonomous decision-making in complex environments, such as those leveraging advanced planning and memory architectures."
+  - question: "What are the 7 types of AI agents?"
+    answer: "AI agents can be categorized by their design and capabilities, including simple reflex agents, model-based reflex agents, goal-based agents, utility-based agents, learning agents, multi-agent systems, and human-in-the-loop agents. Each type has distinct observability needs, from tracking simple condition-action rules to complex decision trees and inter-agent communication."
+---
+
+> **TL;DR** — Agent observability is the practice of gaining deep insights into the internal workings and external interactions of AI agents. It involves systematically collecting and analyzing traces, logs, and metrics to understand agent decision-making, evaluate performance, debug issues, and ensure reliable and compliant operation across development and production.
+
+AI agents promise autonomous decision-making and dynamic problem-solving, but their opaque nature often creates a "black box" problem. Without clear visibility into an agent's thought process, tool calls, and outcomes, debugging failures, optimizing performance, and ensuring compliance become formidable challenges. This lack of transparency can erode trust and hinder the adoption of agentic systems in production.
+
+Agent observability bridges this gap, transforming opaque agent behavior into actionable insights. It provides the necessary tools and methodologies to trace every decision, log every interaction, and monitor every outcome, so teams can build, deploy, and manage reliable AI agents with confidence.
+
+## How Agent Observability Works: Tracing, Metrics, and Evaluation
+
+Agent observability provides a complete view into the behavior and performance of [agentic AI](/resources/ai/agentic-ai) systems. It’s not a single tool but a practice built on three core components: tracing, metrics and logging, and evaluation. Together, they offer the visibility needed to move agents from experimental prototypes to reliable production systems.
+
+The primary goal is to answer critical questions about an [AI agent's](/resources/ai/ai-agent) behavior: What did it do? Why did it make that choice? Was it successful? How much did it cost? This is essential for debugging, ensuring safety, managing costs, and meeting compliance requirements.
+
+**Tracing Agent Activity**
+Tracing provides a step-by-step record of an agent's execution path. This includes its internal monologue (the "thought" process), the sequence of tools it called, the inputs provided to each tool, and the outputs received. A complete trace is the single most valuable artifact for debugging a failed or unexpected agent interaction, as it reconstructs the exact chain of events that led to the outcome.
+
+**Metrics and Logging**
+While traces show the sequence of events, metrics and logs quantify the agent's performance and capture its state. Key metrics include:
+-   **Latency:** How long did the agent take to complete a task?
+-   **Token Usage:** How many tokens were consumed by the LLM calls?
+-   **Error Rates:** How often did the agent or its tools fail?
+-   **Tool Call Frequency:** Which tools are used most often?
+
+Logs capture detailed, unstructured data about specific events, providing context that metrics alone cannot.
+
+**Evaluation Frameworks**
+Evaluation assesses the quality and correctness of an agent's output. This goes beyond simple success/failure metrics to measure factors like factual accuracy, relevance, tone, and adherence to safety guidelines. A rigorous [LLM evaluation](/resources/ai/llm-evaluation) framework is a critical part of observability, allowing teams to score agent performance against predefined benchmarks and business objectives.
+
+It's also important to distinguish between the core LLM and the agent. An LLM like ChatGPT is the engine, but an agent is the entire system built around it, including prompts, tools, and memory. The LLM processes language, while the agent uses the LLM to reason and act toward a goal. Effective [AI agent orchestration](/resources/ai/ai-agent-orchestration) is what turns a powerful LLM into a useful agent.
+
+## Why AI Agents Need Disciplined Orchestration for Observability
+
+Agent observability isn't just about collecting data; it's about collecting the *right* data in a structured, correlated way. This is where an orchestration platform becomes essential. An orchestrator is the central control plane, connecting the agent's actions across a diverse mix of tools, APIs, and databases.
+
+An orchestration layer provides several key capabilities for observability:
+-   **Unified Data Collection:** It captures logs, metrics, and execution data from every component in the workflow—the agent, the tools it calls, and the surrounding infrastructure—in one place.
+-   **Correlation and Context:** By managing the end-to-end process, an orchestrator can automatically correlate a specific tool call with the agent's request that triggered it, providing a complete causal chain.
+-   **State Persistence:** It durably stores the state of each workflow execution, including all inputs, outputs, and metadata, creating an auditable and replayable record of agent activity.
+-   **Automated Error Handling:** Orchestration platforms can define automated responses to observed behaviors, such as retrying a failed tool call, sending an alert, or escalating to a human for review.
+-   **Cost and Resource Monitoring:** By tracking API calls and execution times, the orchestrator provides the raw data needed for effective cost management and performance optimization.
+
+Without a dedicated orchestration layer, achieving full [workflow observability](/resources/infrastructure/workflow-observability) for agentic systems requires stitching together multiple disparate tools, leading to data silos and incomplete traces. An orchestrator provides the foundational structure needed for an end-to-end approach, similar to the principles of [data observability](/resources/data/data-observability). For more details on configuring these systems, refer to Kestra's documentation on [observability and networking](/docs/configuration/observability-and-networking).
+
+## Orchestrate Agent Observability with Kestra: A Multi-Agent Monitoring Flow
+
+A declarative orchestration platform like Kestra provides a powerful framework for building observable agentic workflows. By defining both the agent's tasks and the surrounding observability logic in code, you create a system that is transparent, auditable, and easy to manage.
+
+Consider a scenario where an AI agent is tasked with analyzing a customer support ticket, querying a database for user history, and drafting a response. The following Kestra flow orchestrates this process, ensuring every step is logged and failures are handled gracefully.
+
+```yaml
+id: observable-support-agent
+namespace: company.team.ai
+
+tasks:
+  - id: start-log
+    type: io.kestra.plugin.core.log.Log
+    message: "Starting support ticket analysis for ticket ID {{ trigger.data.ticketId }}"
+
+  - id: analyze-ticket
+    type: io.kestra.plugin.ai.agent.AIAgent
+    model: "openai/gpt-4o"
+    prompt: |
+      You are a support agent. Analyze the following ticket and determine the user's account ID and the core issue.
+      Ticket: {{ trigger.data.ticketContent }}
+      Respond with a JSON object containing 'accountId' and 'issueSummary'.
+    temperature: 0.2
+    maxTokens: 256
+
+  - id: get-user-history
+    type: io.kestra.plugin.jdbc.postgresql.Query
+    # This task would query a database using the accountId from the previous task
+    # For simplicity, we are returning a mock result here.
+    sql: "SELECT 'Mock user history' as history;"
+    fetchOne: true
+    disabled: true # Disabled for demonstration; in production, this would be enabled.
+
+  - id: draft-response-agent
+    type: io.kestra.plugin.ai.agent.AIAgent
+    model: "openai/gpt-4o"
+    prompt: |
+      Based on the issue summary "{{ outputs['analyze-ticket'].content.issueSummary }}" and user history, draft a helpful and empathetic response.
+    temperature: 0.7
+
+  - id: final-output
+    type: io.kestra.plugin.core.debug.Return
+    format: "{{ outputs['draft-response-agent'].content }}"
+
+errors:
+  - id: alert-on-failure
+    type: io.kestra.plugin.notifications.slack.SlackExecution
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    message: "Critical failure in observable-support-agent for ticket {{ trigger.data.ticketId }}. Please review execution logs."
+```
+
+A few things are worth noticing in this flow:
+-   **Declarative Definition:** The entire process, including the agent's prompts and the error handling logic, is defined in a single, version-controlled YAML file.
+-   **Built-in Tracing:** Kestra's UI automatically provides a visual graph and detailed logs for every task execution, creating a complete trace without any extra setup.
+-   **Automated Alerting:** The `errors` block ensures that any failure in the agent or its tools will trigger an immediate Slack notification, enabling rapid response.
+-   **Cross-Tool Observability:** The flow integrates an [AI Agent task](/docs/ai-tools/ai-agents) with a database query, providing end-to-end visibility across different systems.
+-   **Cost-Awareness Foundation:** While not explicit, logs from the `AIAgent` task can be parsed to extract token usage, which can then be aggregated for cost monitoring.
+
+For more examples, explore Kestra's [AI agent blueprints](/blueprints/ai-agent-calling-flows).
+
+### Choosing the Right Observability Strategy for Agent Architectures
+
+The complexity of observability depends heavily on the agent's architecture. Different types of agents have unique monitoring needs.
+
+Common agent types include:
+1.  **Simple Reflex Agents:** Act based on the current situation, ignoring past history. Observability is straightforward, focusing on input-output pairs.
+2.  **Model-Based Reflex Agents:** Maintain an internal model of the world. Tracing needs to capture how this internal state changes over time.
+3.  **Goal-Based Agents:** Plan sequences of actions to achieve a goal. Observability must track the planning process and deviations from the plan.
+4.  **Utility-Based Agents:** Choose actions that maximize a utility function. Monitoring should focus on the utility calculations and outcomes.
+5.  **Learning Agents:** Improve their performance over time. Observability needs to track learning progress and model drift.
+6.  **Multi-Agent Systems:** Involve multiple agents collaborating. Tracing must capture inter-agent communication and emergent group behavior.
+7.  **Human-in-the-Loop Agents:** Incorporate human feedback. Observability must log human interventions and their impact.
+
+The "top" agents are typically those applied to high-value business problems, such as [Sales AI Agents](/resources/ai/sales-ai-agent) that automate lead qualification, or data analysis agents that can query databases and generate insights. As architectures evolve, particularly towards [multi-agent systems](/resources/ai/multi-agent-system), the need for sophisticated observability that can handle [multi-agent collaboration](/resources/ai/multi-agent-collaboration-evolving-orchestration) becomes even more critical.
+
+## Exploring AI Agent Observability Platforms and Tools
+
+An AI agent observability platform is a specialized solution designed to provide the deep visibility required for agentic systems. These platforms go beyond traditional monitoring by offering features tailored to the unique challenges of AI.
+
+Key features to look for include:
+-   **End-to-End Tracing:** The ability to follow a request through the entire agentic chain, from the initial prompt to the final output, including all intermediate LLM calls and tool uses.
+-   **Custom Metrics & Dashboards:** Flexible tools for defining and visualizing key performance indicators (KPIs) like accuracy, latency, cost per task, and user satisfaction.
+-   **Evaluation & A/B Testing:** Frameworks for systematically evaluating agent performance against benchmarks and comparing different versions of prompts, models, or tools.
+-   **Alerting & Anomaly Detection:** Proactive notifications for issues like performance degradation, unexpected behavior, or prompt injection attempts.
+-   **Cost Monitoring:** Detailed tracking of token consumption and API usage to manage expenses effectively.
+
+The market includes LLM-specific observability tools (like Langfuse), general-purpose monitoring platforms adding AI features, and [AI-native orchestration platforms](/resources/ai/ai-native-orchestration-platform) like Kestra that provide observability as an integrated part of the workflow management system. Kestra's integrations, such as the one for [Langfuse observability](/plugins/plugin-ai/io.kestra.plugin.ai.domain.langfuseobservability), allow teams to combine the strengths of orchestration with specialized AI monitoring. The concept of [MCP Orchestration](/resources/ai/mcp-orchestration) further extends this by providing a standardized way to manage and observe interactions between agents and their tools.
+
+## Where Agent Observability Pays Off: Use Cases and Benefits
+
+Implementing a rigorous agent observability strategy delivers tangible benefits across the AI development lifecycle. It moves teams from reactive debugging to proactive management, fostering trust and accelerating the adoption of AI agents in production.
+
+-   **Faster Debugging:** Detailed traces and logs dramatically reduce the time it takes to identify the root cause of an agent's failure or unexpected behavior.
+-   **Improved Performance:** By analyzing metrics on latency, cost, and accuracy, teams can iteratively refine prompts, select better models, and optimize tool usage.
+-   **Enhanced Governance and Compliance:** A complete audit trail of every agent decision and action is essential for regulatory compliance, security reviews, and internal governance.
+-   **Effective Cost Management:** Precise tracking of token usage and API calls allows for accurate cost attribution and helps prevent budget overruns.
+-   **Safer Human-in-the-Loop Interventions:** Observability provides the context needed for humans to effectively review, approve, or correct agent actions, ensuring a reliable safety net.
+
+Ultimately, observability is the foundation for building production-ready [AI agents](/blogs/introducing-ai-agents). It provides the control and insight necessary to manage the inherent complexity and non-determinism of agentic systems, as highlighted in guides on [orchestrating agentic workflows](/blogs/orchestrate-ai-agents-kestra) and conducting effective [AI agent evaluation](/resources/ai/ai-agent-evaluation).
+
+## Related Concepts
+
+-   [What is Agentic Orchestration? Definition & Components](/resources/ai/agentic-orchestration)
+-   [Build AI Agents: Step-by-Step with Kestra Orchestration](/resources/ai/how-to-build-an-ai-agent)
+-   [Kestra AI Tools – Copilot, Agents, Agent Skills, and RAG Workflows](/docs/ai-tools)
+-   [Kestra 1.1 introduces New Filters, No-Code Dashboards, Human Tasks, AI Agent tool and Dozens of New Plugins](/blogs/release-1-1)
+-   [Stop writing glue code around your AI pipelines.](/ai-automation)
+-   [AI Orchestration Resources: LLMOps, RAG & Agentic Workflow Guides](/resources/ai)

--- a/src/contents/resources/agentic-business-process-automation/index.md
+++ b/src/contents/resources/agentic-business-process-automation/index.md
@@ -1,0 +1,185 @@
+---
+title: "Agentic Business Process Automation: Orchestrating Autonomous Workflows"
+description: "Explore agentic business process automation, how AI agents transform enterprise workflows with autonomy and intelligence, and the critical role of orchestration for governance and reliability."
+metaTitle: "Agentic Business Process Automation & Orchestration"
+metaDescription: "Understand agentic business process automation, how AI agents drive autonomous workflows, and how orchestration ensures governance and reliability."
+tag: business
+date: 2026-08-26
+slug: "agentic-business-process-automation"
+faq:
+  - question: "What is agentic business process automation?"
+    answer: "Agentic Business Process Automation (BPA) integrates autonomous AI agents into business workflows. Unlike traditional rules-based automation, agentic BPA enables systems to make decisions, learn, and adapt to achieve specific goals, enhancing efficiency and responsiveness across enterprise operations."
+  - question: "How does agentic automation differ from traditional RPA?"
+    answer: "Traditional RPA automates repetitive, rules-based tasks by mimicking human actions. Agentic automation, powered by generative AI, goes further by allowing agents to understand context, make autonomous decisions, and adapt to unforeseen situations, moving from task automation to goal-driven outcome automation."
+  - question: "How can AI agents automate business processes effectively?"
+    answer: "AI agents automate business processes by performing tasks like data analysis, decision-making, and system interactions. Orchestration platforms provide the framework for these agents to operate reliably, integrating them with existing systems, managing human-in-the-loop approvals, and ensuring auditability across complex workflows."
+  - question: "What is the '30% rule' in AI and how does it impact agentic BPA?"
+    answer: "The '30% rule' in AI suggests that approximately 30% of AI-generated content or decisions may require human review or correction. For agentic BPA, this highlights the importance of human-in-the-loop mechanisms and disciplined orchestration to manage exceptions and ensure accuracy and compliance without hindering autonomy."
+  - question: "What role does orchestration play in agentic business process automation?"
+    answer: "Orchestration is essential for agentic BPA, providing the control plane to define, execute, monitor, and govern autonomous workflows. It ensures agents operate within defined boundaries, handles complex dependencies, manages errors, integrates tools, and provides audit trails and human oversight for critical decisions."
+  - question: "Which types of jobs are most likely to collaborate with AI agents?"
+    answer: "Jobs requiring creative problem-solving, strategic thinking, complex decision-making, and human empathy are most likely to collaborate with AI agents. Roles in management, specialized engineering, creative industries, and customer-facing positions will evolve to supervise, refine, and apply agentic insights rather than be replaced."
+---
+
+> **TL;DR** — Agentic business process automation (BPA) places autonomous AI agents inside business workflows. Unlike rules-based automation, which follows a fixed script, agentic BPA lets systems plan, decide, and adapt to reach a stated goal. Agents call tools, keep memory of prior steps, and hand off to humans when a decision needs approval or falls outside their confidence.
+
+Traditional business process automation (BPA) has delivered efficiency by streamlining repetitive, rules-based tasks. Yet, many critical business processes remain manual, complex, or brittle because they require dynamic decision-making, contextual understanding, and adaptation to unforeseen circumstances. These are precisely the areas where rigid, predefined automation often breaks down.
+
+Enter agentic business process automation: a new paradigm leveraging AI agents to infuse autonomy and intelligence directly into workflows. This approach moves beyond simple task execution, enabling systems to understand goals, make adaptive decisions, and interact intelligently with diverse systems and human stakeholders.
+
+## How autonomous agents transform business processes
+
+### From rules-based to goal-driven: The shift to agentic automation
+
+For decades, enterprise automation relied on deterministic logic. Systems followed strict "if-this-then-that" pathways. If an incoming invoice matched a specific schema, it was routed to accounts payable; otherwise, it flagged an exception. While effective for structured environments, this rigid design struggled when confronted with unstructured data, ambiguous inputs, or novel scenarios.
+
+Agentic automation changes this fundamental dynamic. Instead of scripting every single procedural step, engineers define high-level goals and operational boundaries. An [AI Agent](/resources/ai/ai-agent) evaluates the context, breaks down the objective into actionable steps, and determines the most efficient path forward. 
+
+This evolution shifts the burden from manual script maintenance to intent-driven management. Rather than hardcoding integration endpoints for every potential variation, teams deploy autonomous entities capable of reasoning over runtime information, calling external tools, and evaluating outcomes. This capability forms the backbone of modern [Agentic Orchestration](/resources/ai/agentic-orchestration), bridging the gap between raw machine learning models and deterministic enterprise execution.
+
+### Core components of an agentic business process
+
+To understand how agentic systems operate within a corporate stack, it is helpful to examine their underlying architecture. An autonomous agent inside a business workflow is not merely a prompt sent to a language model; it is a coordinated execution unit composed of several distinct elements:
+
+1. **The Reasoning Core (LLM):** The cognitive engine responsible for interpreting goals, planning multi-step actions, and synthesizing unstructured data into structured outputs.
+2. **Memory Systems:** Short-term context windows for ongoing task execution and long-term retrieval systems (such as vector databases) for organizational history, past decisions, and policy guidelines.
+3. **Tool Interfaces:** First-class integrations with APIs, databases, message queues, and SaaS platforms that allow the agent to execute actions (e.g., querying a database, writing a file, or sending an alert).
+4. **The Execution Framework:** The surrounding orchestration layer that provisions compute resources, manages state, enforces security boundaries, and routes data between tasks.
+
+Compared to legacy Robotic Process Automation (RPA)—which historically relied on screen-scraping and brittle UI interactions as detailed in guides on [What Is UiPath?](/resources/infrastructure/what-is-uipath)—agentic workflows operate at the data and API layer, making them vastly more resilient to user-interface changes and system updates.
+
+## Why agentic BPA needs disciplined orchestration
+
+While autonomous AI agents bring unprecedented flexibility to business operations, introducing them into production environments introduces new failure modes. Left unmanaged, an autonomous agent can hallucinate parameters, enter infinite execution loops, or execute unauthorized data modifications. Transitioning agentic automation from a local prototype to an enterprise-grade capability requires a disciplined control plane.
+
+### Governance and auditability
+
+Enterprise workflows must comply with internal policies, industry regulations, and legal standards. Autonomous agents cannot operate as a black box. Organizations need complete visibility into *why* an agent made a specific decision, what data it consulted, and which tools it invoked. Disciplined orchestration provides immutable audit trails for every execution step, ensuring that compliance teams can inspect, review, and verify agent behavior across every business unit.
+
+### Human-in-the-loop controls
+
+The reality of enterprise AI is that autonomy requires supervision. Critical financial transactions, customer data deletions, and high-value approvals cannot be fully delegated to an unmonitored algorithm. Effective agentic orchestration incorporates native [Approval Workflow](/resources/business/approval-workflow) patterns, allowing workflows to pause execution, present context and recommendations to a human operator via Slack or a dedicated UI, and resume only upon explicit sign-off.
+
+### Integration complexity
+
+An AI agent is only as powerful as the systems it can reach. Enterprise technology stacks are notoriously fragmented, spanning legacy on-premises databases, cloud data warehouses, microservices, and third-party SaaS APIs. Orchestration platforms unify these disparate layers into a single execution context, allowing agents to query databases, trigger cloud jobs, and update ticketing systems within a single declarative run.
+
+### Reliability, error handling, and the "30% rule"
+
+In artificial intelligence circles, the "30% rule" highlights that a significant percentage of AI-generated decisions or outputs require validation, refinement, or correction. Network timeouts, rate limits, API schema changes, and model hallucinations are inevitable in production. Orchestration provides enterprise-grade resilience primitives—such as exponential backoffs, automated retries, dead-letter queues, and fallback branches—ensuring that transient errors do not derail core business processes. For a deeper dive into maintaining secure operational control, see resources on [Workflow Governance](/resources/infrastructure/workflow-governance).
+
+## Orchestrating agentic business processes with Kestra: An expense approval flow
+
+To see how these concepts translate into reality, consider an automated expense processing pipeline. In this scenario, an incoming expense report submitted via webhook triggers an initial validation script. If the AI agent detects policy anomalies or unusual spending patterns, it pauses execution and routes the report to a manager for review. If the report is clean, it proceeds directly to payment processing.
+
+```yaml
+id: agentic_expense_approval
+namespace: company.finance
+
+triggers:
+  - id: webhook_trigger
+    type: io.kestra.plugin.core.trigger.Webhook
+
+tasks:
+  - id: preprocessing
+    type: io.kestra.plugin.core.flow.WorkingDirectory
+    tasks:
+      - id: extract_metadata
+        type: io.kestra.plugin.scripts.python.Script
+        script: |
+          import json
+          import os
+          
+          payload = os.environ.get('KESTRA_TRIGGER_PAYLOAD', '{}')
+          data = json.loads(payload)
+          
+          # Write structured payload for the agent
+          with open('expense.json', 'w') as f:
+              json.dump(data, f)
+          print(f"Extracted expense report for employee: {data.get('employee_id')}")
+
+  - id: evaluate_with_agent
+    type: io.kestra.plugin.ai.agent.AIAgent
+    instructions: |
+      You are an AI financial auditor. Analyze the expense report in expense.json against company policy:
+      1. Meals cannot exceed $75 per day without receipt.
+      2. Travel must be booked via the corporate portal.
+      Return a JSON object with keys 'flagged' (boolean) and 'reason' (string).
+    model: gpt-4o
+
+  - id: check_anomaly
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ outputs.evaluate_with_agent.flagged == true }}"
+    then:
+      - id: notify_and_pause
+        type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+        url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+        payload: |
+          {
+            "text": "⚠️ Expense report flagged by AI auditor. Reason: {{ outputs.evaluate_with_agent.reason }}. Manual approval required."
+          }
+
+      - id: human_approval
+        type: io.kestra.plugin.core.flow.Pause
+        delay: PT48H
+
+  - id: finalize_processing
+    type: io.kestra.plugin.scripts.python.Script
+    script: |
+      print("Expense report successfully processed and queued for reimbursement.")
+```
+
+### Worth noticing in this workflow:
+- **Declarative YAML definition:** The entire end-to-end process—including data extraction, AI evaluation, conditional routing, and human-in-the-loop pauses—is defined in clean, version-controlled code, matching practices outlined in documentation on [AI Agents in Kestra](/docs/ai-tools/ai-agents).
+- **Native human-in-the-loop control:** The `Pause` task halts execution when an anomaly is detected, preventing automated errors from resulting in improper financial disbursements.
+- **Secure credential management:** Sensitive endpoints like the Slack webhook URL are injected securely using runtime secrets (`{{ secret('...') }}`), keeping credentials out of source control.
+- **Complete auditability:** Every intermediate output, agent evaluation decision, and human sign-off is preserved in Kestra's execution history, satisfying strict enterprise governance requirements.
+
+## Key benefits of agentic BPA for enterprises
+
+Integrating autonomous agents into orchestrated workflows delivers measurable advantages that surpass both manual operations and legacy automation tooling.
+
+### Enhancing operational efficiency and productivity
+
+Modern enterprises deal with vast quantities of unstructured data—customer emails, support tickets, invoices, and contracts. Traditional automation fails when faced with variability, requiring human intervention to parse documents and enter data into downstream systems. Autonomous agents ingest, categorize, and act on unstructured inputs instantly. By handling routine cognitive tasks, agentic BPA frees domain experts to focus on strategic initiatives rather than transactional overhead.
+
+### Improving accuracy and reducing human error
+
+Manual data entry and repetitive decision-making are prone to fatigue and inconsistency. AI agents apply validation logic uniformly across millions of executions. When combined with deterministic orchestration rules, agentic systems cross-reference internal databases, verify compliance criteria, and flag discrepancies with high precision, dramatically reducing error rates in critical operational pipelines.
+
+### Driving business agility and responsiveness
+
+Market conditions change rapidly, and rigid IT workflows often take weeks or months to update. Agentic BPA allows organizations to adapt business logic dynamically. Because workflows are goal-driven and orchestrated via flexible code or declarative YAML, modifying an agent's instructions or adding a new tool integration requires seconds rather than a complete software refactoring. For further reading on quantifying these efficiency gains, review resources on [Automation ROI](/resources/business/automation-roi) and the [Business Case for Automation](/resources/business/business-case-for-automation).
+
+### Scalability and optimization of complex workflows
+
+As organizations grow, the sheer volume of inter-system dependencies creates severe operational bottlenecks. Orchestration platforms provide elastic scaling, worker groups, and distributed execution backends to handle spikes in workload volume without manual intervention. Autonomous agents distribute computational load intelligently across available infrastructure, optimizing throughput across data, infrastructure, and business domains.
+
+## Real-world applications of agentic business process automation
+
+The true value of agentic BPA is best understood through its practical application across core enterprise functions.
+
+### Transforming customer service and support
+
+Customer support organizations struggle with high ticket volumes and repetitive inquiries. Agentic workflows transform support operations by ingesting incoming customer requests, analyzing sentiment, searching internal knowledge bases using semantic retrieval, and drafting personalized responses. For complex issues requiring account modifications, the agent invokes secure backend tools to resolve the issue directly, escalating to a human agent only when emotional intelligence or policy exceptions are required.
+
+### Streamlining financial operations and accounting
+
+Finance departments process thousands of invoices, purchase orders, and expense reports monthly. Agentic BPA automates the entire procure-to-pay lifecycle. AI agents extract line items from non-standard PDF invoices, match them against purchase orders in enterprise resource planning (ERP) systems, detect anomalous pricing variances, and initiate payment approvals. This eliminates manual data entry and accelerates financial closing cycles.
+
+### Optimizing supply chain and logistics
+
+Global supply chains are vulnerable to disruption from weather, port congestion, and supplier delays. Autonomous agents monitor real-time shipping feeds, weather data, and inventory levels continuously. When a disruption occurs, the agent evaluates alternative shipping routes, calculates cost impacts, and drafts revised logistics plans for procurement manager approval, minimizing downtime and fulfillment delays.
+
+### Revolutionizing IT Service Management (ITSM)
+
+IT operations teams spend countless hours triaging user access requests, resetting passwords, and resolving routine alerts. Integrating agentic workflows into ITSM platforms enables automated remediation. When an alert fires, an AI agent analyzes system logs, identifies root causes, executes safe diagnostic commands or infrastructure patches, and updates ticket statuses automatically. For broader operational context, explore frameworks on [Business Process Automation](/resources/business/business-process-automation) and [Employee Ticket Automation](/resources/infrastructure/employee-ticket-automation).
+
+## Related concepts
+
+- [Agentic Workflows](/resources/ai/agentic-workflows)
+- [AI-Native Orchestration Platforms](/resources/ai/ai-native-orchestration-platform)
+- [Best Workflow Automation Tools of 2026](/resources/infrastructure/best-workflow-automation-tools)
+- [Workflow Automation Software](/resources/business/workflow-automation-software)
+- [Best IT Automation Platform](/resources/infrastructure/it-automation-platform)
+- [AI Orchestration Resources](/resources/ai/ai-orchestration)

--- a/src/contents/resources/cloud-automation/index.md
+++ b/src/contents/resources/cloud-automation/index.md
@@ -1,0 +1,132 @@
+---
+title: "Cloud Automation: Orchestrate Your Infrastructure from One Control Plane"
+description: "Cloud automation removes manual effort from provisioning, managing, and scaling cloud infrastructure. Explore how declarative orchestration unifies workflows across diverse cloud environments and operational tasks, ensuring consistency and compliance."
+metaTitle: "Cloud Automation: Orchestrate Your Cloud Infrastructure"
+metaDescription: "Automate cloud operations end to end. Learn how declarative orchestration unifies provisioning, scaling, and compliance across multi-cloud environments."
+tag: "infrastructure"
+date: 2026-08-26
+slug: "cloud-automation"
+faq:
+  - question: "What is cloud automation?"
+    answer: "Cloud automation is the practice of using software and tools to automatically manage, provision, and operate cloud computing resources and services. This includes tasks like deploying virtual machines, configuring networks, scaling applications, and managing security policies, reducing manual effort and human error."
+  - question: "What are the top cloud automation tools?"
+    answer: "Leading cloud automation tools include infrastructure-as-code (IaC) platforms like Terraform and OpenTofu, configuration management tools like Ansible, cloud-native services like AWS Step Functions or Azure Logic Apps, and universal orchestration platforms like Kestra that can coordinate all of these."
+  - question: "Is automation replaced by AI in the cloud?"
+    answer: "No, AI is enhancing cloud automation rather than replacing it. AI can optimize automated processes by predicting resource needs, identifying anomalies, and even generating automation code (e.g., Kestra's Copilot). Automation provides the execution layer, while AI offers intelligence and optimization."
+  - question: "What are the top cloud technologies driving automation?"
+    answer: "Key cloud technologies driving automation include Kubernetes for container orchestration, serverless computing (Lambda, Cloud Functions) for event-driven tasks, Infrastructure-as-Code (IaC) for declarative resource management, and API-driven services that enable programmatic control of cloud resources."
+  - question: "Which cloud is most in demand for automation?"
+    answer: "Demand for cloud automation spans all major providers (AWS, Azure, GCP) as organizations increasingly adopt multi-cloud and hybrid strategies. The focus is less on a single cloud and more on unified platforms that can automate across diverse environments, regardless of provider."
+  - question: "How does cloud automation improve security and compliance?"
+    answer: "Cloud automation enforces security policies consistently, automates compliance checks, and speeds incident response. By codifying infrastructure and operations, it reduces configuration drift, ensures least-privilege access, and provides auditable trails for all changes, minimizing human error."
+  - question: "Can cloud automation handle hybrid and multi-cloud environments?"
+    answer: "Yes, modern cloud automation platforms are designed to manage hybrid and multi-cloud environments. They provide a single control plane to orchestrate resources and workflows across on-premises data centers and multiple public cloud providers, ensuring consistency and governance."
+---
+
+> **TL;DR** — Cloud automation is the practice of using software to reduce or eliminate manual work in managing cloud infrastructure. It covers provisioning, configuration, deployment, monitoring, and scaling, executed from version-controlled definitions rather than console clicks. The result is faster delivery, fewer configuration errors, consistent security policy enforcement, and predictable costs across hybrid and multi-cloud environments.
+
+Managing cloud infrastructure manually is a losing battle. As environments grow across multiple clouds and on-premises systems, the sheer volume of provisioning, configuration, and operational tasks overwhelms even the most dedicated teams. This leads to inconsistent setups, security gaps, and slow delivery times.
+
+Cloud automation offers a strategic escape from this complexity. By codifying and automating these repetitive tasks, organizations can achieve consistent, compliant, and rapidly scalable operations. To understand how this fits into broader operational strategies, review the principles of [infrastructure automation](/resources/infrastructure/automation).
+
+## Defining Cloud Automation: Beyond Manual Tasks
+
+Cloud automation refers to the programmatic control, deployment, and management of cloud computing resources without human intervention. While early cloud adoption relied heavily on manual clicking in web consoles or custom shell scripts, modern automation treats infrastructure as software. 
+
+The scope of cloud automation extends across the entire lifecycle of digital assets:
+- **Provisioning:** Allocating compute, storage, and networking resources on demand.
+- **Configuration:** Initializing operating systems, installing packages, and applying runtime settings.
+- **Deployment:** Pushing application updates and infrastructure manifests safely across environments.
+- **Monitoring and Scaling:** Automatically adjusting resource allocations based on workload demands or metrics.
+- **Security and Compliance:** Enforcing security baselines and running audit checks continuously.
+
+Moving beyond basic scripts requires dependable definition frameworks. Establishing clear practices around [infrastructure as code](/resources/infrastructure/what-is-infrastructure-as-code) ensures that your cloud state is always version-controlled and reproducible.
+
+## The Tangible Benefits of Automated Cloud Operations
+
+Adopting automated cloud workflows shifts engineering culture away from fire-fighting and toward reliable, predictable delivery. 
+
+### Increased Efficiency and Reduced Costs
+Automating repetitive administrative tasks frees engineering teams to focus on core product development. Automated scheduling also ensures that non-production environments spin down outside of business hours, preventing resource waste and optimizing overall cloud spend. For a deeper financial perspective, evaluate the metrics detailed in [automation ROI guidelines](/resources/business/automation-roi).
+
+### Enhanced Security and Compliance
+Manual configurations introduce human error and configuration drift. Automation enforces security baselines consistently across every deployment. By codifying policies, organizations meet regulatory frameworks more easily and maintain clean audit trails. Learn more about maintaining security standards in the [SOC 2 compliance guide](/resources/infrastructure/soc2-compliance).
+
+### Improved Scalability and Agility
+Dynamic scaling requires automated triggers and fast resource provisioning. Automation allows engineering organizations to scale infrastructure up or down instantly in response to user traffic, accelerating time-to-market for new features.
+
+## How Cloud Automation Works: Core Components and Approaches
+
+Effective cloud automation relies on a set of specialized tools working in concert, coordinated by a central workflow engine.
+
+1. **Infrastructure as Code (IaC):** Tools like Terraform and OpenTofu declare the desired state of infrastructure in configuration files.
+2. **Configuration Management:** Utilities such as Ansible handle software installation and patch management on active servers.
+3. **Event-Driven Triggers:** Systems listen for webhooks, message queues, or storage events to launch workflows instantly when changes occur.
+4. **Orchestration Engines:** A universal control plane connects IaC plans, API calls, scripts, and approval gates into end-to-end pipelines.
+
+When scaling across complex environments, teams often transition from siloed scripts to unified workflows. This is particularly evident when comparing legacy approaches with modern alternatives, as seen in the analysis of [VMware Aria Automation alternatives](/vs/vmware-cloud-foundation). Modern teams also adopt [GitOps principles](/resources/infrastructure/gitops) to manage operational state, ensuring that code repositories remain the single source of truth. Implementing [event-driven orchestration](/resources/infrastructure/event-driven-orchestration) allows infrastructure to react in real time to operational triggers rather than waiting on rigid cron schedules.
+
+## Orchestrate Cloud Automation with Kestra: Governed Multi-Cloud Provisioning
+
+Managing multi-cloud and hybrid environments requires an orchestrator that can coordinate disparate tools—such as VMware vCenter, public cloud APIs, and notification channels—within a single declarative flow. 
+
+Below is an example of a Kestra workflow that coordinates a multi-step provisioning process across hybrid infrastructure, complete with a manual approval gate and a notification step.
+
+```yaml
+id: hybrid_cloud_provisioning
+namespace: company.infrastructure
+
+triggers:
+  - id: webhook_trigger
+    type: io.kestra.plugin.core.trigger.Webhook
+
+tasks:
+  - id: approval_gate
+    type: io.kestra.plugin.core.flow.Pause
+    description: "Pause execution for infrastructure team review and approval."
+
+  - id: provision_vmware
+    type: io.kestra.plugin.ee.vmware.vcenter.CreateVm
+    url: "{{ secret('VCENTER_URL') }}"
+    username: "{{ secret('VCENTER_USER') }}"
+    password: "{{ secret('VCENTER_PASSWORD') }}"
+    datacenter: "Datacenter"
+    vmName: "prod-app-{{ execution.id }}"
+    template: "ubuntu-base-template"
+
+  - id: configure_gcp_resources
+    type: io.kestra.plugin.gcp.cli.GCloudCLI
+    commands:
+      - gcloud compute instances create app-instance-{{ execution.id }} --zone=us-central1-a --machine-type=e2-medium
+
+  - id: notify_slack
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    payload: '{"text": "Cloud automation workflow {{ flow.id }} completed successfully for execution {{ execution.id }}."}'
+```
+
+### Worth noticing in this workflow:
+- **Declarative Definition:** The entire multi-cloud provisioning sequence is defined in clear YAML, making it fully version-controlled and auditable.
+- **Human-in-the-Loop Governance:** The pause task enforces an approval gate before executing resource creation in production environments.
+- **Hybrid Integration:** The workflow orchestrates tasks across an on-premises VMware vCenter instance and Google Cloud Platform via CLI execution.
+- **Secure Secret Management:** All credentials are securely injected at runtime via `{{ secret('...') }}` rather than hardcoded into the configuration.
+
+For organizations transitioning from rigid legacy setups, this level of control provides a clear path forward, mirroring successful migrations achieved by enterprises replacing aging automation layers as highlighted in our case study on [securing hybrid cloud automation](/customers/fortune-500-company). To explore how to unify your entire operational landscape, visit our [infrastructure automation platform overview](/infra-automation).
+
+## Where Cloud Automation Pays Off: Key Use Cases
+
+Cloud automation delivers immediate value across several critical operational domains:
+
+- **Automated Resource Provisioning:** Spin up isolated staging or development environments on demand for engineering teams.
+- **Cost Optimization:** Automatically schedule resource teardowns or scale-downs to manage expenses, aligning with [FinOps practices](/resources/infrastructure/what-is-finops).
+- **Disaster Recovery Automation:** Orchestrate reliable, automated failover routines across regions or cloud providers.
+- **Security Policy Enforcement:** Automatically apply network access rules, firewall updates, and compliance checks on newly created assets.
+- **Hybrid Cloud Management:** Maintain consistent operations across on-premises data centers and multiple public cloud providers, as detailed in guides on [multi-cloud orchestration](/resources/infrastructure/multi-cloud-orchestration) and [hybrid cloud automation](/resources/infrastructure/hybrid-cloud-automation).
+
+## Related concepts
+
+- [Best Workflow Automation Tools of 2026](/resources/infrastructure/best-workflow-automation-tools)
+- [Top Cloud Orchestration Tools for Unified Workflows in 2026](/resources/infrastructure/cloud-orchestration-tools)
+- [IT Process Automation: Orchestrating Efficiency](/resources/infrastructure/it-process-automation)
+- [Modern Orchestration vs. Legacy Workload Automation](/vs/broadcom)
+- [IBM Workload Automation vs Kestra](/vs/ibm-workload-automation)

--- a/src/contents/resources/llm-cost-optimization/index.md
+++ b/src/contents/resources/llm-cost-optimization/index.md
@@ -1,0 +1,174 @@
+---
+title: "LLM Cost Optimization: Strategies for Efficient AI Workflows"
+description: "Understand the key drivers of LLM costs and explore practical strategies for optimization, including model routing, caching, and prompt engineering. Discover how Kestra orchestrates these techniques for sustainable AI efficiency."
+metaTitle: "LLM Cost Optimization: Reduce AI Spending"
+metaDescription: "Learn practical LLM cost optimization strategies, from model selection and caching to prompt engineering, to reduce AI spending without losing performance."
+tag: ai
+date: 2026-08-27
+slug: llm-cost-optimization
+faq:
+  - question: What are the biggest cost drivers in LLMs?
+    answer: The primary cost drivers for Large Language Models include token usage (both input and output), the choice of model (larger, more capable models are more expensive), frequent API calls, and the length and complexity of prompts. Inefficient context management and redundant calls also contribute significantly to escalating costs.
+  - question: Can LLM cost optimization impact model performance?
+    answer: Yes, LLM cost optimization can impact model performance if not implemented carefully. Strategies like aggressive context compaction or using smaller, less capable models for complex tasks might reduce output quality. The goal is to find an optimal balance where costs are minimized without compromising essential performance or accuracy.
+  - question: What tools are available for LLM cost monitoring?
+    answer: Various tools exist for LLM cost monitoring, ranging from built-in provider dashboards (e.g., OpenAI, Anthropic) to specialized AI gateways and orchestration platforms like Kestra. These tools help track token usage, API calls, and spend across different models and applications, providing visibility into cost drivers.
+  - question: How does dynamic model routing help optimize LLM costs?
+    answer: Dynamic model routing optimizes LLM costs by directing requests to the most cost-effective model or provider available for a given task, based on criteria like prompt complexity, required latency, or current pricing. This prevents overpaying for simpler tasks that cheaper models can handle adequately.
+  - question: What is the role of caching in LLM cost reduction?
+    answer: Caching reduces LLM costs by storing and reusing responses for identical or very similar prompts. Instead of making a new API call and incurring charges, the system retrieves the previously generated answer from the cache, significantly cutting down on redundant expenses, especially for frequently asked questions or common queries.
+  - question: Is fine-tuning a cost-effective LLM optimization strategy?
+    answer: Fine-tuning can be a highly cost-effective LLM optimization strategy in the long run. By training a smaller, specialized model on your specific dataset, you can often achieve comparable or better performance for niche tasks than a larger, general-purpose model, leading to significantly lower inference costs per query.
+---
+
+> **TL;DR** — LLM cost optimization is the practice of reducing what large language models cost to run without giving up quality. Spend is driven by input and output tokens, model choice, context length, retries, and redundant calls. The main levers are routing each request to the cheapest model that can handle it, caching repeated answers, and compacting prompts.
+
+As AI applications move from experimentation to production, the operational costs associated with Large Language Models (LLMs) can quickly escalate, impacting budgets and hindering scalability. Uncontrolled token usage, inefficient API calls, and suboptimal model selection can turn promising AI initiatives into financial burdens.
+
+This guide provides practical strategies for LLM cost optimization, showing how to reduce AI spending without sacrificing performance or output quality. We'll explore key levers for cost reduction and demonstrate how a powerful orchestration platform like Kestra can automate, monitor, and govern these strategies for sustainable AI efficiency.
+
+## How LLM Costs Accumulate: Understanding the Drivers
+
+Optimizing costs starts with understanding where the money goes. LLM expenses aren't just about API calls; they are a function of several interacting factors that can accumulate rapidly if left unmanaged.
+
+### Token Usage and Pricing Models
+
+At the heart of LLM costs is the concept of a "token." A token is a piece of a word, and providers bill based on the number of tokens processed for both the input (your prompt) and the output (the model's response). Different models and providers have vastly different pricing tiers. For example, a state-of-the-art model like GPT-5 is significantly more expensive per token than a smaller, faster model like Google's Gemini Flash. Long context windows, while powerful, can also lead to high costs if prompts are not managed efficiently. A single complex query with a large document attached can cost more than a thousand simple queries.
+
+### Hidden Costs: Latency, Retries, and Context Management
+
+Beyond direct token costs, several hidden factors contribute to the total expense. Latency can impact user experience, potentially leading to repeated or abandoned requests that still incur costs. Failed API calls due to rate limits or temporary outages necessitate retries, doubling the cost for a single intended query. Inefficient context management—sending redundant information or the entire chat history with every turn—inflates input token counts unnecessarily. Each of these factors represents a point of financial leakage in an AI workflow.
+
+## Why Orchestration is Key to LLM Cost Optimization
+
+Managing these cost drivers manually is not scalable. This is where orchestration becomes a critical control plane for cost efficiency. An orchestration platform allows you to implement intelligent, automated logic around your LLM interactions.
+
+Instead of hard-coding calls to a single expensive model, an orchestrator can:
+-   **Provide dynamic control** over every LLM interaction, applying logic before and after each call.
+-   **Implement intelligent routing and caching**, choosing the right model for the job and avoiding redundant API calls.
+-   **Establish centralized monitoring and governance**, giving you a single view of your AI spending and usage patterns.
+-   **Automate cost-saving techniques** across the entire AI workflow, from data ingestion to response delivery.
+
+By treating LLM calls as governable tasks within a larger process, you move from a reactive to a proactive approach to cost management. This is fundamental for building [AI agent orchestration](/resources/ai/ai-agent-orchestration) systems that are both powerful and economically viable.
+
+## 5+ Levers for Effective LLM Cost Optimization
+
+With an orchestration framework in place, you can systematically apply several powerful levers to reduce your LLM spend.
+
+### Strategic Model Selection and Routing
+
+Not all tasks require the most powerful model. A key optimization strategy is to match the model's capability to the task's complexity. Simple tasks like data extraction or sentiment analysis can often be handled by smaller, cheaper models, while complex reasoning or creative generation might require a state-of-the-art model. Dynamic routing automates this selection process, directing prompts to the most cost-effective model that can meet the quality bar for that specific request.
+
+### Prompt Engineering and Context Compaction
+
+The size of your prompt directly impacts cost. Effective prompt engineering aims to achieve the desired output with the fewest possible tokens. This includes using zero-shot prompts where possible, refining instructions for conciseness, and structuring data efficiently. Advanced techniques like prompt compression can further reduce token count by removing non-essential information from the context without sacrificing performance.
+
+### Caching and Batching LLM Calls
+
+Many applications receive repetitive queries. Caching responses for identical or semantically similar prompts can eliminate a significant number of redundant API calls. A simple key-value store can cache exact matches, while more advanced semantic caching can identify and serve responses for conceptually similar queries. Batching multiple requests into a single API call can reduce overhead and often unlocks more efficient processing on the provider's end. A well-designed blueprint for a [semantic cache with Redis](/blueprints/ai-semantic-cache-redis) can be a foundational component of this strategy.
+
+### Fine-tuning and Knowledge Distillation
+
+For high-volume, domain-specific tasks, fine-tuning a smaller, open-source model can be more cost-effective in the long run than continuously prompting a large, general-purpose one. Fine-tuning adapts a model to your specific data and vocabulary, often achieving superior performance with a fraction of the inference cost. Knowledge distillation takes this a step further by training a small "student" model to mimic the outputs of a larger "teacher" model, capturing its capabilities in a more efficient package.
+
+### Implementing an AI Gateway for Control and Visibility
+
+An AI gateway centralizes all LLM API requests from various applications into a single point of control. This allows you to enforce universal policies like rate limiting, authentication, and request/response logging. It provides a unified dashboard for monitoring token consumption, tracking costs per user or application, and identifying optimization opportunities. An orchestrator can serve as the engine for this gateway, applying complex logic and routing rules to every request that passes through it.
+
+## Orchestrate LLM Cost Optimization with Kestra: Dynamic Model Routing Example
+
+The following Kestra workflow demonstrates how to implement two key optimization levers: caching and dynamic model routing. The flow exposes a webhook that accepts a user prompt. It first checks a built-in cache (Kestra's KV store) for an existing answer. If the prompt is new, it routes it to a cheap model (Gemini) for short prompts or an expensive model (OpenAI) for longer ones. The new response is then cached before being returned.
+
+```yaml
+id: llm-cost-optimized-router
+namespace: company.team.ai
+
+tasks:
+  - id: check_cache
+    type: io.kestra.plugin.core.kv.Get
+    namespace: llm-cache
+    key: "{{ trigger.body | jq('.prompt') | hash('md5') }}"
+    errorOnMissing: false
+
+  - id: check_cache_hit
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ outputs.check_cache.value != null }}"
+    then:
+      - id: return_cached_response
+        type: io.kestra.plugin.core.http.Request
+        uri: "{{ trigger.body | jq('.responseUrl') }}"
+        method: POST
+        body: "{{ outputs.check_cache.value }}"
+    else:
+      - id: route_by_complexity
+        type: io.kestra.plugin.core.flow.If
+        condition: "{{ trigger.body | jq('.prompt') | length > 500 }}"
+        then:
+          - id: call_openai_expensive
+            type: io.kestra.plugin.openai.ChatCompletion
+            apiKey: "{{ secret('OPENAI_API_KEY') }}"
+            model: "gpt-4o"
+            tasks:
+              - role: "user"
+                content: "{{ trigger.body | jq('.prompt') }}"
+        else:
+          - id: call_gemini_cheap
+            type: io.kestra.plugin.gemini.ChatCompletion
+            apiKey: "{{ secret('GEMINI_API_KEY') }}"
+            model: "gemini-1.5-flash-latest"
+            tasks:
+              - role: "user"
+                content: "{{ trigger.body | jq('.prompt') }}"
+      
+      - id: get_response
+        type: io.kestra.plugin.core.debug.Return
+        format: "{{ outputs.call_openai_expensive.choices[0].message.content || outputs.call_gemini_cheap.choices[0].message.content }}"
+
+      - id: cache_new_response
+        type: io.kestra.plugin.core.kv.Set
+        namespace: llm-cache
+        key: "{{ trigger.body | jq('.prompt') | hash('md5') }}"
+        value: "{{ outputs.get_response.value }}"
+
+      - id: return_new_response
+        type: io.kestra.plugin.core.http.Request
+        uri: "{{ trigger.body | jq('.responseUrl') }}"
+        method: POST
+        body: "{{ outputs.get_response.value }}"
+
+triggers:
+  - id: webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: "llm-request"
+```
+
+### What This Flow Accomplishes
+
+-   **Intelligent Caching**: The flow uses the MD5 hash of the prompt as a cache key. The `io.kestra.plugin.core.kv.Get` task attempts to retrieve a stored response, and `errorOnMissing: false` prevents the flow from failing if the key doesn't exist. This single step avoids countless redundant API calls.
+-   **Dynamic Routing Logic**: The `If` task checks the length of the incoming prompt. If it's over 500 characters, it's routed to the more capable (and expensive) OpenAI model. Shorter prompts are sent to the cost-effective Gemini Flash model. This simple logic ensures you only pay for power when you need it.
+-   **Centralized and Auditable**: Every execution, including the routing decision, token usage, and final output, is logged and visible in Kestra's UI. This provides a clear audit trail for debugging and further cost analysis.
+-   **Extensibility**: This pattern can be easily extended. You could add more conditions to the router, such as checking for keywords, calling a classification model first, or even A/B testing different models and logging their performance.
+
+### Balancing Cost, Performance, and Quality
+
+Effective LLM cost optimization is not just about slashing expenses; it's about achieving the best possible performance for the lowest possible cost. Each strategy involves trade-offs. Using a smaller model is cheaper but may yield lower-quality results for complex tasks. Aggressive caching can reduce API calls but might serve stale information if not managed properly. The key is to establish clear metrics for what "quality" means for your application and to perform continuous [LLM evaluation](/resources/ai/llm-evaluation) to ensure your optimization efforts aren't compromising the user experience.
+
+## Where LLM Cost Optimization Pays Off: Real-World Scenarios
+
+Applying these orchestrated strategies delivers tangible benefits across various AI applications:
+
+-   **Automated RAG Pipelines**: In a [RAG pipeline](/resources/ai/rag-pipeline), caching retrieved documents and routing summarization tasks to cheaper models can drastically reduce costs while maintaining fast, relevant responses.
+-   **Agentic Workflows**: An AI agent can be orchestrated to select tools and models based on a predefined budget, making cost a primary constraint in its decision-making process.
+-   **Batch Data Processing**: When summarizing or classifying large datasets, batching API calls and using fine-tuned models can reduce costs by orders of magnitude compared to single, expensive API calls for each item. You can see this pattern in action in blueprints like the [AI Starship Recommender](/blueprints/ai-starship-recommender).
+-   **Customer Service Chatbots**: Tiered LLM usage, where simple queries are handled by a small, fast model and only escalated to a more powerful one when necessary, optimizes costs while ensuring a responsive user experience.
+
+Ultimately, LLM cost optimization is an ongoing discipline, not a one-time fix. With a declarative orchestration platform, you can build a sustainable, efficient, and governable AI practice that delivers business value without runaway spend.
+
+## Related concepts
+
+-   [AI Orchestration Resources: LLMOps, RAG & Agentic Workflows](/resources/ai/ai-orchestration)
+-   [What is Agentic Orchestration? Definition & Components](/resources/ai/agentic-orchestration)
+-   [AI-Native Orchestration Platforms: Tools & Comparison](/resources/ai/ai-native-orchestration-platform)
+-   [Open Source Orchestration: Maximize Cost Savings with Kestra](/resources/infrastructure/open-source-orchestration-cost-savings)
+-   [What is FinOps? Cloud Cost Management Explained](/resources/infrastructure/what-is-finops)
+-   [Kestra Resources: Guides for Data, AI, Infrastructure & Business](/resources)

--- a/src/contents/resources/service-automation/index.md
+++ b/src/contents/resources/service-automation/index.md
@@ -1,0 +1,162 @@
+---
+title: "Service Automation: Unifying Workflows Across IT, Data, and AI"
+description: "Explore service automation as a unified strategy for orchestrating workflows across IT, data, and business functions. Learn how declarative, event-driven platforms simplify complex processes."
+metaTitle: "Service Automation: Unified Workflows for IT & Data"
+metaDescription: "Service automation unifies IT, data, and business operations. Learn how declarative orchestration speeds service delivery and keeps workflows auditable."
+tag: "infrastructure"
+date: 2026-08-26
+slug: "service-automation"
+faq:
+  - question: "What is service automation?"
+    answer: "Service automation is the use of technology to automate tasks and processes across various service domains, including IT, customer support, and field operations. It aims to reduce manual effort, increase efficiency, improve consistency, and enhance the overall experience for employees and customers by orchestrating workflows across disparate systems."
+  - question: "What are some examples of service automation?"
+    answer: "Examples include automated IT incident response (e.g., triaging tickets, running diagnostics, escalating to the right team), automated customer support (e.g., chatbots, self-service portals), automated employee onboarding (e.g., provisioning accounts, assigning training), and automated field service dispatch and routing."
+  - question: "What are the four types of automation?"
+    answer: "While classifications vary, common types include Basic Automation (simple, repetitive tasks), Process Automation (structured, rule-based workflows), Robotic Process Automation (RPA for UI-based tasks), and Intelligent Automation (AI/ML-driven, decision-making capabilities)."
+  - question: "Is AI a type of automation?"
+    answer: "AI is not a type of automation in itself, but rather a capability that enhances automation. AI (like machine learning, natural language processing) enables 'intelligent automation' by allowing systems to learn, make decisions, and adapt, moving beyond rigid rules to handle more complex and nuanced service scenarios."
+  - question: "Can I learn automation in 2 months?"
+    answer: "Learning automation within two months is achievable for foundational skills, especially with low-code/declarative platforms. Mastering complex enterprise-wide automation, including integration with diverse systems and advanced error handling, requires ongoing learning and practical experience."
+  - question: "What are the top 10 automation tools?"
+    answer: "The 'top' tools depend on the use case. For enterprise-wide orchestration across IT, data, and AI, Kestra, Ansible, and Terraform are prominent. For business process management, Camunda. For RPA, UiPath. For SaaS integration, Workato or n8n. The best tool unifies your existing stack."
+---
+
+> **TL;DR** — Service automation uses technology to run and coordinate repeatable tasks across IT, customer support, and business operations without manual intervention. It spans ticket triage, provisioning, incident remediation, and approval routing, connecting the systems that own each step. Done well, it cuts handling time, removes routine queue work, and produces an auditable record of every action taken.
+
+Manual processes and fragmented tools often create bottlenecks in enterprise service delivery, leading to inefficiencies, errors, and frustrated teams. Whether it's IT incident response, customer support, or employee onboarding, the lack of a cohesive automation strategy can stifle productivity and hinder innovation.
+
+This article explores service automation as a strategic imperative, detailing how a unified orchestration approach can simplify operations across diverse service domains. We'll examine the core components, benefits, and practical applications, culminating in a real-world example of how Kestra enables declarative, event-driven service automation.
+
+## How Service Automation Unifies Operations
+
+Service automation moves beyond simple task automation to create cohesive, end-to-end workflows that connect disparate systems and teams. It's the practice of using a central control plane to manage, execute, and monitor service-related processes.
+
+### Defining Service Automation
+
+Service automation is the strategic application of technology to orchestrate and execute workflows that deliver a service, whether internal (IT support, HR onboarding) or external (customer support, field service). It differs from narrower concepts like Robotic Process Automation (RPA), which focuses on mimicking human UI interactions, or simple scripting. True service automation integrates with systems at the API level, managing logic, state, and error handling across the entire process.
+
+### Core Components of an Automated Service Stack
+
+A capable service automation platform typically includes:
+*   **A Workflow Engine:** The core component that executes defined processes, manages task dependencies, and handles state.
+*   **Triggers:** Mechanisms that initiate workflows based on events, schedules, or API calls. This could be a new ticket in ServiceNow, a file landing in a specific directory, or a cron-based schedule.
+*   **Integrations (Plugins):** Pre-built connectors that allow the workflow engine to interact with other systems (e.g., ITSM tools, cloud providers, databases, messaging queues) without extensive custom code.
+*   **Human-in-the-Loop Capabilities:** Features that allow workflows to pause for manual approval or input before proceeding, ensuring oversight for critical operations.
+*   **Observability and Auditing:** Dashboards, logs, and audit trails that provide visibility into every workflow execution, simplifying debugging and compliance.
+
+### Beyond Basic Automation: A Unified Approach
+
+The goal is to move from isolated scripts and single-purpose tools to a unified platform for [IT process automation](/resources/infrastructure/it-process-automation). A unified approach means the same platform that handles IT incident response can also manage data pipelines or [business process automation](/resources/business/business-process-automation), using a consistent, declarative model. This reduces tool sprawl, standardizes governance, and allows teams to share skills and components.
+
+## Why Modern Enterprises Need Unified Service Automation
+
+Adopting a unified service automation strategy is critical for scaling operations, managing complexity, and maintaining a competitive edge. The benefits extend beyond simple cost savings to fundamental improvements in how services are delivered and managed.
+
+Enterprises that centralize their automation efforts see significant gains. For example, Crédit Agricole's IT production arm (CAGIP) transformed its infrastructure operations by using Kestra to scale workflows across more than 100 clusters, replacing fragmented scripts with a single, governed orchestration layer. Similarly, Germany's public-sector IT provider, Dataport, standardized its API-driven cloud orchestration to create a government-grade control plane.
+
+Key drivers for adoption include:
+*   **Reducing Manual Toil:** Automating repetitive tasks frees up skilled engineers to focus on high-value work. This matters for tasks like [employee ticket automation](/resources/infrastructure/employee-ticket-automation), where manual routing and resolution are inefficient.
+*   **Improving Efficiency and Speed:** Automated workflows execute faster and more reliably than manual processes, accelerating service delivery for everything from infrastructure provisioning to customer issue resolution.
+*   **Cutting Operational Costs:** Automation reduces the human hours required for routine tasks and minimizes the cost of errors. A Fortune 500 industrial company replaced VMware Aria Automation with Kestra, cutting costs while securing hybrid cloud automation across IT and OT environments.
+*   **Ensuring Compliance and Governance:** Centralized orchestration provides a complete, auditable record of every action taken. This is vital for regulated industries, from [financial services](/use-cases/financial-services) to the [public sector](/use-cases/public-services), where every change must be tracked.
+*   **Enhancing Experience:** Faster, more consistent service delivery improves satisfaction for both employees and customers. A frictionless onboarding process or a rapidly resolved support ticket builds trust and loyalty.
+
+## Orchestrate Service Automation with Kestra: Incident Triage Example
+
+A common IT service automation scenario is the initial triage and diagnosis of an incident. The following Kestra workflow automates this process: it's triggered by a webhook from ServiceNow, fetches the incident details, runs a diagnostic PowerShell script on the affected host, updates the ticket, and notifies the on-call team via Slack.
+
+```yaml
+id: servicenow-incident-triage
+namespace: company.team.it_operations
+
+triggers:
+  - id: new-incident-webhook
+    type: io.kestra.plugin.core.trigger.Webhook
+    key: "your-secret-webhook-key"
+
+tasks:
+  - id: fetch-incident-details
+    type: io.kestra.plugin.servicenow.Get
+    tableName: "incident"
+    sysId: "{{ trigger.body.sys_id }}"
+    username: "{{ secret('SERVICENOW_USER') }}"
+    password: "{{ secret('SERVICENOW_PASSWORD') }}"
+    instance: "{{ secret('SERVICENOW_INSTANCE') }}"
+
+  - id: check-incident-category
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ outputs['fetch-incident-details'].body.result.category == 'Hardware' }}"
+    then:
+      - id: run-windows-health-check
+        type: io.kestra.plugin.scripts.powershell.Commands
+        commands:
+          - Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -Property Name, TotalPhysicalMemory
+          - Get-CimInstance -ClassName Win32_Processor | Select-Object -Property Name, NumberOfCores
+          - Get-Service -Name 'wuauserv' | Select-Object -Property Status, DisplayName
+        host: "{{ outputs['fetch-incident-details'].body.result.cmdb_ci.display_value }}"
+        username: "{{ secret('WINDOWS_USER') }}"
+        password: "{{ secret('WINDOWS_PASSWORD') }}"
+
+      - id: update-servicenow-ticket
+        type: io.kestra.plugin.servicenow.Update
+        tableName: "incident"
+        sysId: "{{ trigger.body.sys_id }}"
+        payload:
+          work_notes: "Automated health check completed. Output:\n{{ outputs['run-windows-health-check'].output.stdOut }}"
+          state: "2" # In Progress
+        username: "{{ secret('SERVICENOW_USER') }}"
+        password: "{{ secret('SERVICENOW_PASSWORD') }}"
+        instance: "{{ secret('SERVICENOW_INSTANCE') }}"
+
+      - id: notify-on-call-channel
+        type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+        url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+        payload: |
+          {
+            "text": "Incident {{ trigger.body.number }} triaged automatically. Health check run on {{ outputs['fetch-incident-details'].body.result.cmdb_ci.display_value }}. Please review."
+          }
+
+errors:
+  - id: handle-failure
+    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+    url: "{{ secret('SLACK_WEBHOOK_URL') }}"
+    payload: |
+      {
+        "text": "ERROR: Incident triage flow failed for incident {{ trigger.body.number }}. Please investigate manually. Error on task: {{ error.taskrun.taskId }}"
+      }
+```
+
+This example showcases several key aspects of effective service automation:
+*   **Declarative & Version-Controlled:** The entire workflow is defined in a simple YAML file that can be stored in Git, reviewed, and versioned like any other piece of code.
+*   **Event-Driven:** The process starts automatically the moment an incident is created, without manual intervention. See more patterns for [ServiceNow orchestration](/orchestration/servicenow).
+*   **Polyglot Execution:** The flow integrates a PowerShell script to interact with a Windows machine, demonstrating that orchestration is not tied to a single language or environment.
+*   **Reliability:** The `errors` block ensures that any failure in the automation process immediately triggers an alert, preventing silent failures and ensuring a human can intervene. Explore more blueprints for [ServiceNow incident remediation](/blueprints/servicenow-incident-ansible-remediation) or [webhook-triggered healthchecks](/blueprints/servicenow-webhook-powershell-healthcheck).
+
+### Choosing the Right Automation Model
+
+The example above is event-driven, which is ideal for reactive processes like incident management. But service automation also relies on scheduled workflows (e.g., daily health checks, nightly backups) and human-initiated flows (e.g., self-service software installation). A declarative, YAML-based approach provides the flexibility to model all these patterns within a single, consistent framework, improving governance and maintainability compared to code-first, imperative approaches.
+
+## Where Service Automation Delivers Impact Across the Enterprise
+
+A unified orchestration platform breaks down silos, allowing a consistent automation strategy to be applied across different business functions.
+
+### IT Service Automation: Incident Management and Provisioning
+
+Beyond incident triage, IT teams use service automation for infrastructure provisioning, patch management, and user access control. Workflows can automate the entire lifecycle of a virtual machine, from provisioning in VMware to configuration with Ansible and registration in a CMDB. This is a core part of modern [VMware automation](/resources/infrastructure/vmware-automation).
+
+### Customer Service Automation: Enhancing Support Operations
+
+In customer support, automation can handle ticket routing, sentiment analysis of incoming requests, and triggering follow-up actions in a CRM. By integrating with AI services, workflows can provide initial responses or gather necessary information before escalating to a human agent, improving response times.
+
+### Business Process Automation: Onboarding and Approvals
+
+Service automation is also applied to core business processes. Employee onboarding, for instance, involves multiple systems: HR, IT, and finance. An automated workflow can provision accounts, assign equipment, enroll in benefits, and schedule orientation sessions. Similarly, complex [approval workflows](/resources/business/approval-workflow) for expenses or contracts can be orchestrated to ensure compliance and speed.
+
+## Related Concepts
+
+*   [Hybrid Infrastructure Automation](/resources/infrastructure/hybrid-infrastructure-automation): Extending automation across on-premise and cloud environments.
+*   [Runbook Automation Tools](/resources/infrastructure/runbook-automation-tools-2026): Automating operational procedures and incident response.
+*   [Workflow Governance](/resources/infrastructure/workflow-governance): Implementing policies and controls for automated processes.
+*   [Kestra vs. Control-M](/vs/control-m): Comparing modern orchestration with legacy job schedulers.
+*   [Kestra vs. PagerDuty Process Automation](/vs/pagerduty): A look at runbook automation platforms.
+*   [Kestra vs. VMware Aria Automation](/vs/vmware-cloud-foundation): Contrasting declarative orchestration with platform-specific automation.


### PR DESCRIPTION
## What

Five new `concept` pages from the SEO pipeline.

| page | URL | words | target |
|---|---|---|---|
| Cloud automation | `/resources/infrastructure/cloud-automation` | 962 | 1800 |
| Service automation | `/resources/infrastructure/service-automation` | 1239 | 1600 |
| Agentic business process automation | `/resources/business/agentic-business-process-automation` | 1638 | 2800 |
| Agent observability | `/resources/ai/agent-observability` | 1731 | 2100 |
| LLM cost optimization | `/resources/ai/llm-cost-optimization` | 1559 | 2300 |

Source: `vfanucci/kestra-seo` [#357](https://github.com/vfanucci/kestra-seo/pull/357), [#359](https://github.com/vfanucci/kestra-seo/pull/359), [#361](https://github.com/vfanucci/kestra-seo/pull/361), [#362](https://github.com/vfanucci/kestra-seo/pull/362), [#363](https://github.com/vfanucci/kestra-seo/pull/363).

## Editorial pass before import

**16 dead links fixed on `service-automation`.** Every internal link on that page was written protocol-relative — `[…](//resources/infrastructure/it-process-automation)`. A browser resolves `//resources/…` as the *host* `resources`, so all 16 would have 404'd in production. The pipeline's link check missed them because it tests `https://kestra.io` + `//resources/…`, which servers tolerate and return 200 for. Rewritten to single-slash absolute paths.

**38 banned stems removed**, checked against `guidelines/05-anti-patterns.md`: `robust`, `comprehensive`, `seamless(ly)`, `streamline`, `however`, `furthermore`, `additionally`, `ecosystem`, `crucial`, `holistic`, `empower`, `leverage`, `acts as`. Each rewritten in place, meaning preserved.

**4 TL;DR blockquotes expanded** to the concept template's 40–60 word spec — they were 24, 34, 37 and 37 words. This block is the featured-snippet and LLM-citation asset, so being under spec matters.

**Link destinations de-duplicated** (S4: max one link per destination). Where a body link was repeated in `## Related concepts`, the contextual body link was kept and the navigation entry swapped for a different relevant page, so each block keeps 5–6 distinct destinations.

## Verified

- **All 66 internal links return 200**
- Front-matter complete on all five · `metaTitle` ≤ 60 · `metaDescription` 147–155 · `faq` 5–7 entries
- Exactly one runnable flow per page; **every plugin FQCN checked against `context/plugin-classes.txt`**; all YAML blocks parse
- `## Related concepts` present with 5–6 entries · no FAQ H2 in body · no manual JSON-LD · no H1 duplicated by a body heading · code fences balanced

## One thing to know before merging

**All five are below their outline word-count target**, from −17% to −47%. This is not a per-page accident: the `concept` template's prescribed structure (TL;DR + 4–5 H2s + one flow + Related concepts) caps out around 1200–1700 words, while the outline derives its target from competitor medians. Two of these ran on `gemini-2.5-pro` and two on `gemini-3.5-flash-lite`, and the shortfall shows on both — so it is the spec, not the model. Being tracked upstream; publishing is the author's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
