### PR TITLE
seo(resources): publish dbt-core-vs-dbt-cloud (recovered draft)

### DIFF
--- a/src/contents/resources/dbt-core-vs-dbt-cloud/index.md
+++ b/src/contents/resources/dbt-core-vs-dbt-cloud/index.md
@@ -1,0 +1,158 @@
+---
+title: "dbt Core vs. dbt Cloud: Key Differences & How to Choose"
+description: "Compare dbt Core vs. dbt Cloud to understand their key differences. Discover which solution best fits your data team's needs, whether you prioritize control or convenience."
+metaTitle: "dbt Core vs. dbt Cloud: Differences & Choice Guide"
+metaDescription: "Compare dbt Core vs. dbt Cloud on cost, control, and operations. See which one fits your data team, from self-hosted CLI to a fully managed platform."
+tag: "data"
+date: 2026-08-28
+slug: "dbt-core-vs-dbt-cloud"
+faq:
+  - question: "What is dbt Cloud?"
+    answer: "dbt Cloud is a fully managed, cloud-hosted SaaS platform that provides a complete environment for developing, testing, and deploying dbt projects. It includes a web-based IDE, a scheduler, logging, and collaboration features, all built on top of the open-source dbt Core engine. It's designed for teams seeking convenience, scalability, and an all-in-one solution without managing infrastructure."
+  - question: "What is dbt Core?"
+    answer: "dbt Core is the open-source command-line tool that forms the foundation of all dbt offerings. It allows data professionals to transform data in their warehouse using SQL-based models, tests, and documentation. dbt Core provides maximum flexibility and control, requiring users to manage their own development environment, scheduling, and infrastructure."
+  - question: "Is dbt Core free to use?"
+    answer: "Yes, dbt Core is entirely free and open-source under an Apache 2.0 license. Users only incur costs for the infrastructure they use to run it (e.g., cloud compute, data warehouse usage, separate orchestrator). It's ideal for teams who want full control and are comfortable with self-managing their environment."
+  - question: "Is dbt Cloud free?"
+    answer: "dbt Cloud offers a Developer plan which is free for individual users, allowing limited access to its features. For teams and production use, dbt Cloud operates on a subscription model with paid tiers that offer more users, advanced features, and increased job concurrency. While there's a free entry point, serious team usage requires a paid subscription."
+  - question: "What are the main differences between dbt Core and dbt Cloud?"
+    answer: "The primary differences lie in infrastructure management, development environment, scheduling, and collaboration. dbt Core is self-hosted, requiring manual setup for everything, offering full control. dbt Cloud is a managed SaaS, providing an integrated IDE, scheduler, and collaboration tools out-of-the-box, simplifying operations at the cost of some flexibility."
+  - question: "Who manages the infrastructure around dbt Core vs. dbt Cloud?"
+    answer: "With dbt Core, your team is responsible for managing all underlying infrastructure, including development environments, orchestrators, and compute resources. For dbt Cloud, dbt Labs manages the platform's infrastructure, handling the web IDE, scheduler, and other services, allowing your team to focus solely on data transformation logic."
+---
+
+Data transformation is a critical component of the modern data stack, and dbt (data build tool) has become the standard for analytics engineering. As data teams scale, a common question arises: should we use dbt Core or dbt Cloud? While both build on dbt’s SQL-based transformation framework, they cater to different operational preferences and scale requirements.
+
+This article will break down the key differences between dbt Core and dbt Cloud, examining their respective strengths and trade-offs. We’ll explore how each solution impacts infrastructure management, development workflows, collaboration, and costs, helping you choose the right path for your data team.
+
+## Understanding dbt Core and dbt Cloud
+
+At its heart, dbt is a transformation engine that allows you to build, test, and document data models using SQL. The choice between Core and Cloud isn't about the transformation logic itself, but about how you operationalize it.
+
+### What is dbt Core? The open-source engine
+
+dbt Core is the open-source, command-line tool that started it all. It provides the fundamental capabilities to compile SQL `SELECT` statements into tables and views in your data warehouse. With dbt Core, you have a powerful framework for modular data modeling, automated testing, and documentation generation.
+
+Because it's a CLI tool, dbt Core gives you complete control. You are responsible for setting up your development environment, managing dependencies, and scheduling job runs. This typically involves integrating it with other tools like a version control system (Git), a local IDE (like VS Code), and an external [orchestrator to run dbt Core in production](/blogs/2026-03-09-dbt-core-with-kestra). The [dbt CLI plugin](/plugins/plugin-dbt/dbt-cli) is the engine that executes your `dbt run` or `dbt build` commands.
+
+### What is dbt Cloud? The managed platform
+
+dbt Cloud is a commercial SaaS platform built on top of dbt Core. It provides a complete, web-based solution that handles not just the transformation but also the entire development and deployment lifecycle. It includes a browser-based IDE, a built-in scheduler, native Git integration, CI/CD automation, and tools for collaboration and documentation hosting.
+
+With dbt Cloud, the focus shifts from managing infrastructure to building data models. It's an all-in-one solution designed to accelerate development and simplify operations for data teams. While it offers less direct control over the underlying environment, it significantly reduces the operational burden. Even with its built-in scheduler, many teams find they need a more capable solution for [orchestrating dbt Cloud jobs](/blogs/2026-03-26-using-dbt-cloud-with-kestra) as part of a larger [ETL pipeline with tools like Airbyte](/blueprints/airbyte-cloud-dbt-cloud).
+
+## Core Differences: dbt Core vs. dbt Cloud
+
+The decision between dbt Core and dbt Cloud hinges on several key trade-offs. Let's break them down.
+
+### Infrastructure Management and Hosting
+
+- **dbt Core**: You manage everything. This includes provisioning the compute resources to run dbt, setting up Python environments, and maintaining the scheduler. This model offers maximum flexibility, making it suitable for complex [multi-cloud orchestration](/resources/infrastructure/multi-cloud-orchestration) or environments with strict security requirements. But it also means higher operational overhead.
+- **dbt Cloud**: It’s a fully managed SaaS platform. dbt Labs handles all the infrastructure, including hosting, scaling, and maintenance. This convenience allows your team to focus on analytics engineering rather than [infrastructure automation](/resources/infrastructure/automation).
+
+### Development Environment and Tooling
+
+- **dbt Core**: Developers use their preferred local IDE (e.g., VS Code, PyCharm) and command-line tools. This is ideal for engineers who are comfortable with a traditional software development workflow and want to customize their environment. All changes are managed through a standard [Git workflow](/docs/best-practices/git).
+- **dbt Cloud**: It features a web-based IDE that comes pre-configured with Git integration. This provides a consistent and accessible development environment for all team members, regardless of their local setup. It lowers the barrier to entry and simplifies onboarding.
+
+### Scheduling and Orchestration Capabilities
+
+- **dbt Core**: It has no built-in scheduler. To run dbt Core jobs in production, you must use an external [orchestrator](/resources/data/orchestrator). This gives you the flexibility to choose a tool that fits your entire stack, enabling you to build complex dependencies between dbt jobs and other processes.
+- **dbt Cloud**: It includes an integrated scheduler that can run jobs on a schedule, trigger runs via API, or run CI checks on pull requests. This is sufficient for workflows that are entirely contained within dbt. For more complex [data orchestration](/resources/data/data-orchestration) involving multiple tools, you might still need an external orchestrator to call the dbt Cloud API. Kestra provides [integrations for both dbt Core and dbt Cloud](/plugins/plugin-dbt).
+
+### Collaboration Features
+
+- **dbt Core**: Collaboration relies on standard software development practices like Git pull requests and code reviews. Documentation is generated locally and must be hosted separately.
+- **dbt Cloud**: Collaboration is a core feature. It offers a shared development environment, automatically generated documentation hosting (dbt Explorer), and metadata integration. This makes it easier for teams to work together, review code, and understand data lineage.
+
+### Security, Governance, and Access Control
+
+- **dbt Core**: Security is entirely your responsibility. You must configure authentication, manage credentials for your data warehouse, and set up any access controls yourself.
+- **dbt Cloud**: It provides enterprise-grade security features out-of-the-box, including role-based access control (RBAC), SSO integration, and audit logs. This simplifies [governance and security management](/docs/enterprise/governance), especially for larger organizations.
+
+### Pricing and Cost Considerations
+
+- **dbt Core**: The software is free and open-source. The costs are associated with the infrastructure you use to run it (compute instances, data warehouse usage, orchestrator licensing).
+- **dbt Cloud**: It offers a free Developer tier for individuals. For teams, it’s a subscription-based service with [pricing](/pricing) tiers based on the number of developer seats and features. While there's a subscription fee, it can be offset by reduced infrastructure and operational costs.
+
+## Who Manages the Infrastructure Around dbt?
+
+This is the central question. With **dbt Core**, your team is responsible for the entire stack surrounding the tool. You must provision servers or containers, install Python and dbt, configure CI/CD pipelines, and set up and maintain a separate orchestration tool. This approach treats dbt as a component in a larger, self-managed stack, often defined using [Infrastructure as Code (IaC)](/resources/infrastructure/what-is-infrastructure-as-code) principles.
+
+With **dbt Cloud**, dbt Labs manages the application layer—the IDE, scheduler, and metadata services. Your team is still responsible for managing access to your data warehouse, but you offload the complexity of running and maintaining the dbt application itself. This model helps teams [reduce orchestration complexity](/resources/infrastructure/orchestration-problems-complexity) for their transformation layer.
+
+## When to Choose Which dbt Solution
+
+The right choice depends on your team's context, maturity, and priorities.
+
+### Ideal Use Cases for dbt Core
+
+Choose dbt Core if your team:
+- **Has strong engineering expertise**: Comfortable with the command line, Git, and managing infrastructure.
+- **Requires maximum control and customization**: Needs to run dbt in a specific environment or integrate it deeply with custom tooling.
+- **Has an existing orchestration platform**: Already uses a powerful orchestrator like Kestra to [manage dbt jobs](/blogs/2024-04-02-dbt-kestra) and can easily add dbt as another step.
+- **Is on a tight budget**: Wants to avoid subscription fees and has the engineering resources to manage the infrastructure. A good example is running [dbt transformations on DuckDB from Git](/blueprints/dbt-duckdb) for a low-cost setup.
+
+### Ideal Use Cases for dbt Cloud
+
+Choose dbt Cloud if your team:
+- **Wants to move fast and reduce operational overhead**: Prefers to focus on building models rather than managing infrastructure.
+- **Is growing or has mixed technical skills**: Benefits from a user-friendly web IDE and integrated tools that simplify onboarding.
+- **Needs strong collaboration features**: Requires a centralized platform for development, code reviews, and documentation.
+- **Prioritizes integrated CI/CD and observability**: Wants out-of-the-box continuous integration checks and job monitoring. For more details, see how to [orchestrate dbt workflows](/docs/use-cases/dbt).
+
+## Making Your Decision: Key Factors to Consider
+
+As you weigh your options, consider these four factors:
+
+### Team Size and Technical Expertise
+
+Smaller, highly technical teams may find the control of dbt Core appealing. Larger teams or those with a mix of analysts and engineers often benefit from the structured, collaborative environment of dbt Cloud.
+
+### Project Complexity and Scalability Needs
+
+For simple projects, the overhead of setting up dbt Core with an orchestrator might be unnecessary. As your projects grow in complexity with more models, dependencies, and developers, the managed environment and CI/CD features of dbt Cloud become increasingly valuable.
+
+### Budget and Resource Availability
+
+Calculate the Total Cost of Ownership (TCO). For dbt Core, factor in the cost of engineering time for setup and maintenance. For dbt Cloud, weigh the subscription fee against the productivity gains and reduced operational burden.
+
+### Integration with Existing Data Stack
+
+Consider how dbt fits into your end-to-end [data pipeline](/resources/data/data-pipeline). Do you need to trigger dbt jobs after an ingestion tool runs? Do you need to run [data quality](/resources/data/data-quality) checks or trigger a [reverse ETL](/resources/data/reverse-etl) sync after dbt models are updated? Your integration needs will influence whether a simple built-in scheduler is sufficient or if a more powerful, universal orchestrator is required. This is where a platform for modern data engineers can unify your stack.
+
+## How Kestra Complements Both dbt Core and dbt Cloud
+
+Regardless of your choice, a universal orchestration platform like Kestra can enhance your dbt workflows. Because Kestra is language- and tool-agnostic, it can manage dependencies across your entire data stack.
+
+**For dbt Core users**, Kestra provides the missing scheduling and operational layer. You can define your entire ELT workflow in a single declarative YAML file, from running [parallel Airbyte syncs to triggering dbt Core transformations](/blueprints/airbyte-sync-parallel-with-dbt). Kestra's event-driven triggers, resilient error handling, and broad plugin catalog let you build resilient, production-grade pipelines around dbt Core.
+
+```yaml
+id: dbt-core-run
+namespace: company.team
+tasks:
+  - id: git-clone
+    type: io.kestra.plugin.git.Clone
+    url: https://github.com/your-org/dbt-project.git
+    branch: main
+  - id: dbt-build
+    type: io.kestra.plugin.dbt.cli.DbtCLI
+    runner: DOCKER
+    commands:
+      - dbt build
+```
+
+**For dbt Cloud users**, Kestra extends orchestration beyond the transformation layer. While dbt Cloud can run its own jobs, Kestra can manage the entire [end-to-end data flow](/blogs/2023-06-26-end-to-end-data-orchestration). You can use Kestra to trigger an ingestion job, then call the [dbt Cloud API](/plugins/plugin-dbt/dbt-cloud) to run a transformation, and finally trigger a reverse ETL sync—all within a single, observable workflow. This provides a unified control plane for all your data operations.
+
+This is [why Kestra](/docs/why-kestra) is built to be a central hub, connecting various tools like dbt into a cohesive and reliable system.
+
+## Conclusion: Transformation Framework vs. Platform
+
+The choice between dbt Core and dbt Cloud is a classic trade-off between control and convenience.
+
+- **dbt Core** is a powerful, flexible transformation framework that puts you in complete control of your environment. It’s best for teams with the engineering capacity to build and manage their own data platform.
+- **dbt Cloud** is an all-in-one platform that covers the entire analytics engineering lifecycle. It’s ideal for teams who want to maximize productivity and minimize operational overhead.
+
+Both are excellent tools that have revolutionized data transformation. The right choice depends on your team’s unique needs, resources, and goals. As your data stack grows, consider a universal orchestrator to tie all your tools together into a single, manageable stack.
+
+To learn more about building and orchestrating data workflows, explore our [Data Engineering Resources](/resources/data) and see how you can build more reliable [data pipelines with Kestra](/data).


### PR DESCRIPTION
## What

`/resources/data/dbt-core-vs-dbt-cloud` — 1822 words, 7 H2s.

This is a **recovered page**. The draft was generated on **2026-05-15** ([vfanucci/kestra-seo](https://github.com/vfanucci/kestra-seo), `drafts/2026-W21/`), merged into the SEO repo, and then never published — the PR closed and nothing tracked it afterwards.

It surfaced in an audit of all **157 pipeline drafts against the 283 live resource pages**. It was the only draft with **no live equivalent**: the five existing dbt pages cover integrations, dbt-on-Airflow, tests, SQLMesh and the Fivetran merger, but not the Core vs Cloud comparison.

## Repair pass

The draft predates the July sanitizer, so it carried the full set of legacy artifacts:

| issue | fix |
|---|---|
| whole-file ```` ```yaml ```` fence | unwrapped — this is the artifact that makes a page render as plaintext |
| 27 full `https://kestra.io/...` URLs | converted to absolute paths (R2) |
| `tag: "Data Orchestration"` | → `data`. The old value is not in the enum and would have produced a broken `/resources/{tag}/` URL |
| `metaDescription` 176 chars, ending `Read more!` | rewritten to 149 chars |
| 12 banned stems | removed per `guidelines/05-anti-patterns.md` |
| `/data` linked twice | de-duplicated (S4: max one link per destination) |

## On the date

Set to **2026-08-28**, today — not the May generation date. The URL is new and goes live now; dating it in May would claim three months of history it does not have.

## Verified

- **All 26 internal links return 200**
- Front-matter complete · `metaTitle` 50 chars · `metaDescription` 149 · `faq` 6 entries
- No duplicate link destinations · no protocol-relative links · no remaining full kestra.io URLs
- Code fences balanced · H1 not duplicated by a body heading · no FAQ H2 in body · no manual JSON-LD

🤖 Generated with [Claude Code](https://claude.com/claude-code)