### PR TITLE
fix(partners): normalize JLCP logo and align card height with row (#5401)

### DIFF
--- a/src/components/partners/Lists.astro
+++ b/src/components/partners/Lists.astro
@@ -224,6 +224,7 @@ const PARTNERS = [
             width: 100%;
             max-width: 273px;
             min-height: 356px;
+            height: 100%;
             border-radius: 8px;
             padding: 16px;
             border: 1px solid var(--ks-border-secondary);

--- a/src/components/partners/assets/jlcp.svg
+++ b/src/components/partners/assets/jlcp.svg
@@ -1,5 +1,8 @@
-﻿<svg viewBox="41 46.886 276.693 267.422" xmlns="http://www.w3.org/2000/svg">
-  <!-- Icon symbol centered, black background removed, viewBox tightened to icon bounds -->
+<svg viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
+  <!-- Fundo preto -->
+  <rect width="360" height="360" fill="#050505"/>
+  <!-- Símbolo JLCP centralizado com padding (translate 41,35; scale ~1.0) -->
+  <!-- Original viewBox era 277x291; aplicamos translate para centralizar com 41px de padding lateral -->
   <g fill="#c3f53c" transform="translate(41, 35)">
     <rect x="0" y="11.886" width="160.453" height="54.821"/>
     <rect x="221.365" y="11.886" width="55.328" height="55.328"/>

--- a/src/components/partners/assets/jlcp.svg
+++ b/src/components/partners/assets/jlcp.svg
@@ -1,8 +1,5 @@
-<svg viewBox="0 0 360 360" xmlns="http://www.w3.org/2000/svg">
-  <!-- Fundo preto -->
-  <rect width="360" height="360" fill="#050505"/>
-  <!-- Símbolo JLCP centralizado com padding (translate 41,35; scale ~1.0) -->
-  <!-- Original viewBox era 277x291; aplicamos translate para centralizar com 41px de padding lateral -->
+﻿<svg viewBox="41 46.886 276.693 267.422" xmlns="http://www.w3.org/2000/svg">
+  <!-- Icon symbol centered, black background removed, viewBox tightened to icon bounds -->
   <g fill="#c3f53c" transform="translate(41, 35)">
     <rect x="0" y="11.886" width="160.453" height="54.821"/>
     <rect x="221.365" y="11.886" width="55.328" height="55.328"/>


### PR DESCRIPTION
## What
Fixes the JLCP card on `/partners` looking out of place — both the logo and the card height.

- **Logo**: `jlcp.svg` had a solid black background rect and excess canvas padding, making it render as a small dark square instead of a clean icon. Removed the background and tightened the viewBox to fit the icon.
- **Card height**: `.card` had no `height: 100%`, so it didn't fill its Bootstrap column when a row-mate's longer description made the column taller. Added `height: 100%` to `.lists .card` — cards now stretch to match their tallest row neighbor.

## Screenshots

**Before:**
<img width="1623" height="772" alt="image" src="https://github.com/user-attachments/assets/fe4e33dc-c64f-44b6-9221-8871242381b7" />

**After:**
<img width="1666" height="942" alt="image" src="https://github.com/user-attachments/assets/3d2e101e-a9e4-4fe9-93ba-2360842a4c17" />

Closes #5401