### PR TITLE
fix(ui): add external link icon to Courses and Webinars in Learn menu (#5447)

### DIFF
--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -316,6 +316,7 @@
                                         <div class="item-row">
                                             <component :is="item.icon" />
                                             <span>{{ item.title }}</span>
+                                            <OpenInNew v-if="item.target === '_blank'" class="external-link-icon" />
                                         </div>
                                     </a>
                                 </li>
@@ -636,6 +637,7 @@
                                                         <span>{{
                                                             item.title
                                                         }}</span>
+                                                        <OpenInNew v-if="item.target === '_blank'" class="external-link-icon" />
                                                         <strong
                                                             v-if="item.tag"
                                                             class="tag"
@@ -718,6 +720,7 @@
     import GithubButton from "~/components/layout/GithubButton.vue"
     import Magnify from "vue-material-design-icons/Magnify.vue"
     import Close from "vue-material-design-icons/Close.vue"
+    import OpenInNew from "vue-material-design-icons/OpenInNew.vue"
     import Segment from "vue-material-design-icons/Segment.vue"
     import { menuWidths } from "~/utils/menu-sizes"
     import { menuItems } from "~/utils/menu-items"
@@ -1831,6 +1834,15 @@
             width: 16px;
             height: 16px;
             filter: brightness(0);
+        }
+    }
+
+    .external-link-icon {
+        margin-left: 0.25rem;
+
+        :deep(svg) {
+            width: 0.9rem;
+            height: 0.9rem;
         }
     }
 </style>

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -1800,6 +1800,10 @@
                                         align-self: unset;
                                         color: var(--ks-icon-color);
                                         transition: color 0.2s ease;
+
+                                        &.external-link-icon {
+                                            margin: 0;
+                                        }
                                     }
 
                                     &:hover {
@@ -1837,12 +1841,12 @@
         }
     }
 
-    .external-link-icon {
-        margin-left: 0.25rem;
+    .external-link-icon.material-design-icon {
+        margin: 0;
 
         :deep(svg) {
-            width: 0.9rem;
-            height: 0.9rem;
+            width: 14px;
+            height: 14px;
         }
     }
 </style>

--- a/src/utils/menu-items.ts
+++ b/src/utils/menu-items.ts
@@ -173,7 +173,8 @@ export const menuItems: MenuItems = {
             {
                 icon: School,
                 title: "Courses",
-                link: "https://academy.kestra.io"
+                link: "https://academy.kestra.io",
+                target: "_blank"
             },
             {
                 icon: PresentationPlay,


### PR DESCRIPTION
## Summary
Adds an external-link icon (`OpenInNew`) next to **Courses** and **Webinars** in the top nav **Learn** dropdown, since both links redirect users off the main site. Also adds `target: "_blank"` to **Courses**, which was missing it unlike Webinars — this was needed for the icon condition to apply consistently to both external links, and fixes Courses previously opening in the same tab.

## Changes
- `src/utils/menu-items.ts`: added `target: "_blank"` to the Courses entry
- `src/components/layout/Header.vue`: imported `OpenInNew` from `vue-material-design-icons` (already used elsewhere in the repo) and rendered it conditionally on `item.target === '_blank'`, in both the desktop flyout and mobile dropdown views

## Screenshots
**Desktop**
<img width="810" height="691" alt="image" src="https://github.com/user-attachments/assets/0262a171-960d-452e-8af3-5446bcec02cf" />

**Mobile**
<img width="455" height="802" alt="image" src="https://github.com/user-attachments/assets/def0c283-7e79-49e7-a25e-f8d66b0ef560" />

Closes #5447