### PR TITLE
fix(plugins): inline the fallback redirect path to unblock astro check

### DIFF
--- a/src/pages/plugins/[...slug].astro
+++ b/src/pages/plugins/[...slug].astro
@@ -252,9 +252,8 @@ if (
         console.warn("Redirecting due to no content")
         // With a single slug segment the parent is the index: build "/plugins", not
         // "/plugins/", which the trailing-slash rule would bounce a second time.
-        const parentSlug = splitRouteSlug.slice(0, -1).join("/")
         return Astro.redirect(
-            parentSlug ? `/plugins/${parentSlug}` : "/plugins",
+            ["/plugins", ...splitRouteSlug.slice(0, -1)].join("/"),
             301,
         )
     }


### PR DESCRIPTION
## Problem

Every pull request against `main` currently fails **Lint & Astro Check** with a single diagnostic:

```
src/pages/plugins/[...slug].astro:255:15 - warning [astro] ts(6133): 'parentSlug' is declared but its value is never read.
```

It is a false positive — `parentSlug` *is* read two lines below, in the `Astro.redirect()` call — but the workflow runs reviewdog with `-fail-level=any`, so a warning is enough to fail the job. Confirmed red on `docs/2.0.0-release`, `chore/plugin-canonical-url-cleanup`, `fix/5447-external-link-icon-learn-menu` and `chore/terraform-docs-fix/docs-push-via-pr`, so this blocks everyone, not one branch.

The variable comes from #5246 (`fix(plugins): link index cards and the fallback redirect at canonical URLs`), merged today.

## Fix

Build the parent path inline, so there is no declaration left to flag. Behaviour is unchanged:

| `splitRouteSlug` | before | after |
| --- | --- | --- |
| `["aws"]` | `/plugins` | `/plugins` |
| `["aws", "s3"]` | `/plugins/aws` | `/plugins/aws` |

The comment explaining why the path must not end in a trailing slash is kept.

## Verification

Run locally against this branch:

- `npx astro check` → **0 errors, 0 warnings, 0 hints** (455 files)
- `npx oxlint src/pages/plugins/[...slug].astro` → no findings
- `npm run test:unit` → 9 files, 73 tests passed

## Note — follow-up, not in this PR

`SimilarPlugins.astro` still calls `prunePluginsForCards(similarPlugins, pluginsData ?? {})` without the third `urlIndex` argument, so `href` is `undefined` for every "Similar plugins" card and `PluginCard.vue` falls back to the pre-#5246 `slugify(subGroupTitle)` path. Those cards therefore still point at non-canonical URLs. Not a regression (that was the behaviour everywhere before #5246), but #5246's fix is incomplete there. It has `allPlugins` in scope, so it can build the index itself — I'll send that as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)