### PR TITLE
fix(plugins): stop underline gaps on Contributors link hover

### DIFF
--- a/src/components/plugins/versions/OverviewPanel.vue
+++ b/src/components/plugins/versions/OverviewPanel.vue
@@ -218,6 +218,7 @@
 
                         &:hover {
                             text-decoration: underline;
+                            text-decoration-skip-ink: none;
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Contributors link on plugin pages ("Maintained by" panel) showed a broken/segmented underline on hover.
- Cause: default `text-decoration-skip-ink: auto` punches gaps around letter stems, not just descenders.
- Fix: set `text-decoration-skip-ink: none` on hover for that link.

## Test plan
- [x] Verified with agent-browser on `/plugins/core`: `getComputedStyle` now reports `text-decoration-skip-ink: none` on hover.
- [ ] Visual check on a plugin page in the deployed preview.