### PR TITLE
fix(ui): align rotating word baseline in hero heading (#5435)

### DIFF
--- a/src/components/home/AnimatedWord.vue
+++ b/src/components/home/AnimatedWord.vue
@@ -34,20 +34,25 @@
         display: inline-block;
         overflow: hidden;
         vertical-align: bottom;
-        height: 1.2em;
+        height: 2.375rem;
         position: relative;
         // force a fixed width to prevent layout shift; adjust as needed based on longest word
         width: 115px;
         @include media-breakpoint-up(md) {
+            height: 3.9375rem;
             width: 200px;
         }
     }
 
     .word {
         display: block;
-        height: 1.2em;
-        line-height: 1.2em;
+        height: 2.375rem;
+        line-height: 2.375rem;
         white-space: nowrap;
+        @include media-breakpoint-up(md) {
+            height: 3.9375rem;
+            line-height: 3.9375rem;
+        }
     }
 
     .slide-enter-active,

--- a/src/components/home/AnimatedWord.vue
+++ b/src/components/home/AnimatedWord.vue
@@ -34,25 +34,21 @@
         display: inline-block;
         overflow: hidden;
         vertical-align: bottom;
-        height: 2.375rem;
+        // 1lh resolves to the line-height inherited from .hero h1, so the box
+        // tracks the heading's line box exactly at every breakpoint
+        height: 1lh;
         position: relative;
         // force a fixed width to prevent layout shift; adjust as needed based on longest word
         width: 115px;
         @include media-breakpoint-up(md) {
-            height: 3.9375rem;
             width: 200px;
         }
     }
 
     .word {
         display: block;
-        height: 2.375rem;
-        line-height: 2.375rem;
+        height: 1lh;
         white-space: nowrap;
-        @include media-breakpoint-up(md) {
-            height: 3.9375rem;
-            line-height: 3.9375rem;
-        }
     }
 
     .slide-enter-active,

--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -136,6 +136,7 @@ import LogoBar from "./LogoBar.astro"
         grid-area: 1/1/2/2;
         font-weight: 500;
         font-size: 2rem;
+        line-height: 2.375rem;
         @include media-breakpoint-up(md) {
             font-size: 3.5rem;
             line-height: 3.9375rem;


### PR DESCRIPTION
## Summary
Fixes the vertical alignment of the rotating word ("Run" / "Control" / "Govern") in the homepage hero heading so it sits inline with the same baseline and size as the surrounding static text, instead of appearing bigger and offset upward.

## Root cause
`.animated-word` in `AnimatedWord.vue` used a fixed `1.2em` height/line-height that didn't match `.hero h1`'s actual line-height, pushing the rotating word out of alignment. Also added an explicit `line-height` to `.hero h1` at the mobile breakpoint, which previously had none and relied on a browser default — needed so both files' height math can match exactly at each screen size.

## Changes
- `src/components/home/AnimatedWord.vue`: `.animated-word` and `.word` height/line-height now exactly match `.hero h1`'s line-height at both mobile and desktop breakpoints
- `src/components/home/Hero.astro`: added explicit `line-height: 2.375rem` for `.hero h1` at the mobile breakpoint

## Screenshots
**Desktop**
<img width="983" height="587" alt="image" src="https://github.com/user-attachments/assets/775b0ca8-f03f-40ec-9733-bdbdcb94e593" />

**Mobile**
<img width="470" height="861" alt="image" src="https://github.com/user-attachments/assets/681d0eea-eb8c-42ed-b13f-3290fcd6294f" />

Closes #5435