### PR TITLE
fix(docs): serve changelog pages as Markdown at .md URLs

### DIFF
--- a/src/pages/docs/changelog.md.ts
+++ b/src/pages/docs/changelog.md.ts
@@ -1,0 +1,26 @@
+import type { APIRoute } from "astro"
+import { renderChangelogIndexMarkdown } from "~/utils/changelogMarkdown"
+import { fetchMajorReleases } from "~/utils/fetchChangelogVersions"
+
+// Same limit as the getStaticPaths in src/pages/docs/changelog/[tag].astro, so
+// the index lists exactly the release pages that get built.
+const CHANGELOG_RELEASES = 150
+
+/**
+ * Serves the changelog index page (`/docs/changelog`) as raw Markdown at
+ * `/docs/changelog.md`.
+ *
+ * The release notes themselves live behind `/docs/changelog/{tag}.md`; this
+ * index gives AI agents and other tools a single entry point to discover them
+ * instead of returning a 404.
+ */
+export const GET: APIRoute = async () => {
+    const releases = await fetchMajorReleases(CHANGELOG_RELEASES)
+
+    return new Response(renderChangelogIndexMarkdown(releases), {
+        status: 200,
+        headers: {
+            "Content-Type": "text/markdown; charset=utf-8",
+        },
+    })
+}

--- a/src/pages/docs/changelog/[tag].md.ts
+++ b/src/pages/docs/changelog/[tag].md.ts
@@ -1,0 +1,42 @@
+import type { APIRoute, GetStaticPaths } from "astro"
+import { renderReleaseMarkdown } from "~/utils/changelogMarkdown"
+import {
+    fetchMajorReleases,
+    type GitHubRelease,
+} from "~/utils/fetchChangelogVersions"
+
+// Same limit as the getStaticPaths in src/pages/docs/changelog/[tag].astro, so
+// every release page that gets built also gets a Markdown endpoint.
+const CHANGELOG_RELEASES = 150
+
+export const getStaticPaths = (async () => {
+    const releases = await fetchMajorReleases(CHANGELOG_RELEASES)
+    return releases.map((release: GitHubRelease) => ({
+        params: { tag: release.tag_name },
+        props: { release },
+    }))
+}) satisfies GetStaticPaths
+
+/**
+ * Serves a release notes page (`/docs/changelog/{tag}`) as raw Markdown at
+ * `/docs/changelog/{tag}.md`.
+ *
+ * The catch-all route `docs/[...docsPath].md.ts` only emits paths for the
+ * `docs` content collection, and changelog pages are built from the GitHub
+ * releases API instead of Markdown files in this repo. Without this endpoint
+ * every `/docs/changelog/*.md` URL 404s, which breaks the "append .md to any
+ * kestra.io/docs/* URL" contract advertised in DocsLayout and llms-full.txt.
+ */
+export const GET: APIRoute = ({ props }) => {
+    const release = (props as { release?: GitHubRelease }).release
+    if (!release) {
+        return new Response("Not found", { status: 404 })
+    }
+
+    return new Response(renderReleaseMarkdown(release), {
+        status: 200,
+        headers: {
+            "Content-Type": "text/markdown; charset=utf-8",
+        },
+    })
+}

--- a/src/utils/changelogMarkdown.test.ts
+++ b/src/utils/changelogMarkdown.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest"
+import type { GitHubRelease } from "~/utils/fetchChangelogVersions"
+import {
+    renderChangelogIndexMarkdown,
+    renderReleaseMarkdown,
+} from "~/utils/changelogMarkdown"
+
+// Shaped like the GitHub releases payload after fetchMajorReleases(): the body is
+// already Markdown with commit links rewritten.
+const release = (over: Partial<GitHubRelease> = {}): GitHubRelease => ({
+    tag_name: "v1.3.35",
+    name: "v1.3.35",
+    body: "## Changelog\n\n### 🐛 Bug Fixes",
+    published_at: "2026-08-25T09:12:33Z",
+    draft: false,
+    prerelease: false,
+    ...over,
+})
+
+describe("renderReleaseMarkdown", () => {
+    it("prefixes the release body with the release name as an h1", () => {
+        expect(renderReleaseMarkdown(release())).toBe(
+            "# v1.3.35\n\n## Changelog\n\n### 🐛 Bug Fixes",
+        )
+    })
+
+    it("falls back to the tag when the release has no name", () => {
+        const md = renderReleaseMarkdown(release({ name: undefined }))
+        expect(md.startsWith("# v1.3.35\n\n")).toBe(true)
+    })
+
+    it("does not emit 'undefined' when the body is missing", () => {
+        const md = renderReleaseMarkdown(
+            release({ body: undefined as unknown as string }),
+        )
+        expect(md).toBe("# v1.3.35\n\n")
+    })
+})
+
+describe("renderChangelogIndexMarkdown", () => {
+    it("links every release to its page with the publication date", () => {
+        const md = renderChangelogIndexMarkdown([
+            release(),
+            release({ tag_name: "v1.0.57", name: "v1.0.57" }),
+        ])
+
+        expect(md).toContain(
+            "- [v1.3.35](https://kestra.io/docs/changelog/v1.3.35) — 2026-08-25",
+        )
+        expect(md).toContain(
+            "- [v1.0.57](https://kestra.io/docs/changelog/v1.0.57) — 2026-08-25",
+        )
+        expect(md.startsWith("# Release Notes\n")).toBe(true)
+    })
+
+    it("omits the separator when a release has no publication date", () => {
+        const md = renderChangelogIndexMarkdown([
+            release({ published_at: undefined as unknown as string }),
+        ])
+
+        expect(md).toContain(
+            "- [v1.3.35](https://kestra.io/docs/changelog/v1.3.35)\n",
+        )
+        expect(md).not.toContain("—")
+    })
+
+    it("still renders a usable page when the release list is empty", () => {
+        const md = renderChangelogIndexMarkdown([])
+        expect(md).toContain("# Release Notes")
+        expect(md).not.toContain("- [")
+    })
+})

--- a/src/utils/changelogMarkdown.ts
+++ b/src/utils/changelogMarkdown.ts
@@ -1,0 +1,31 @@
+import type { GitHubRelease } from "~/utils/fetchChangelogVersions"
+
+export const CHANGELOG_BASE_URL = "https://kestra.io/docs/changelog"
+
+/** Renders a single release as the Markdown served at `/docs/changelog/{tag}.md`. */
+export function renderReleaseMarkdown(release: GitHubRelease): string {
+    const title = release.name || release.tag_name
+    return `# ${title}\n\n${release.body ?? ""}`
+}
+
+/** Renders the release index served at `/docs/changelog.md`. */
+export function renderChangelogIndexMarkdown(
+    releases: GitHubRelease[],
+): string {
+    const lines = releases.map((release) => {
+        const title = release.name || release.tag_name
+        const url = `${CHANGELOG_BASE_URL}/${release.tag_name}`
+        const date = release.published_at?.slice(0, 10)
+        return date ? `- [${title}](${url}) — ${date}` : `- [${title}](${url})`
+    })
+
+    return [
+        "# Release Notes",
+        "",
+        "Stay up to date with the latest Kestra releases and updates.",
+        "Append `.md` to any release URL below to retrieve its notes as plain Markdown.",
+        "",
+        ...lines,
+        "",
+    ].join("\n")
+}


### PR DESCRIPTION
## Problem

Every `/docs/changelog/*.md` URL returns a **404 HTML error page**, while the same URL without the extension returns 200.

I checked all 591 docs URLs in [`sitemap/docs.xml`](https://kestra.io/sitemap/docs.xml):

| Result | Count |
|---|---|
| `200` + `text/markdown` | 490 |
| `404` + `text/html` | **101** |

All 101 failures are the changelog namespace — the index (`/docs/changelog.md`) plus its 100 release pages (`v0.22.41` → `v1.3.36`). No other docs URL is affected.

This breaks a contract the site advertises in two places:

- `DocsLayout.astro` — "Append `.md` to any `kestra.io/docs/*` URL for plain Markdown."
- `llms-full.txt.ts` — same statement

So an AI agent that follows the documented instruction gets a 404 on every single release note.

## Cause

The catch-all route `src/pages/docs/[...docsPath].md.ts` builds its paths from `getCollection("docs")`, i.e. the Markdown files in this repo. Changelog pages are built from the GitHub releases API in `src/pages/docs/changelog/[tag].astro` and belong to no content collection, so no `.md` path was ever emitted for them.

## Fix

- `src/pages/docs/changelog/[tag].md.ts` — mirrors the `getStaticPaths` of `[tag].astro` (same `fetchMajorReleases` source and 150 limit), so every release page that gets built also gets a Markdown endpoint
- `src/pages/docs/changelog.md.ts` — the index, listing every release with its date and page URL, as a discovery entry point
- `src/utils/changelogMarkdown.ts` — rendering extracted so it is unit-testable, keeping the routes thin
- `src/utils/changelogMarkdown.test.ts` — 6 tests (name/tag fallback, missing body, missing date, empty release list)

Both endpoints return `text/markdown; charset=utf-8`, matching the existing `docs.md.ts` and `[...docsPath].md.ts` pattern. Release bodies keep the commit-link rewriting already done by `fetchMajorReleases`.

## Verification

Against the local dev server, replaying the exact 101 URLs that 404 in production:

- **99/101 → `200 text/markdown`**
- 2 remaining (`v1.2.3`, `v0.23.27`) 404 in **both** HTML and `.md` — they have dropped out of the GitHub API response window, so their `.astro` pages 404 too. Unrelated to this change; see follow-up below.

Spot-checked output of `/docs/changelog/v1.3.35.md` (h1, sections, rewritten commit links, contributors) and `/docs/changelog.md` (100 dated release links). `vitest run`: 10 files / 79 tests passing. `oxlint` clean.

## Follow-ups (not in this PR)

1. **The changelog is absent from `llms.txt` and `llms-full.txt`** (0 occurrences of `docs/changelog` in either). Release notes remain invisible to LLM consumers even with these endpoints live; they should be listed.
2. **`fetchMajorReleases(150)` requests `per_page=150`, but the GitHub API caps `per_page` at 100.** Only ~100 release pages are ever built, so older changelog URLs silently start 404ing as new releases ship — including URLs that were in the sitemap and may be linked externally. Worth pagination or a redirect strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)