### PR TITLE
docs(migration): warn against secrets metadata migration in read-only mode

### DIFF
--- a/src/contents/docs/11.migration-guide/v1.1.0/kv-secrets-metadata-migration/index.md
+++ b/src/contents/docs/11.migration-guide/v1.1.0/kv-secrets-metadata-migration/index.md
@@ -43,6 +43,10 @@ kestra:
 Secrets metadata migration is only necessary for Enterprise users. Open-source users will see an exception error: `❌ Secrets Metadata migration failed: Secret migration is not needed in the OSS version`.
 :::
 
+:::alert{type="warning"}
+Do **not** run the secrets metadata migration when your secret manager is configured in **read-only** mode. Read-only secret managers do not use the secrets metadata store, so the migration is neither needed nor supported: the command fails on purpose with a message explaining this. Skipping it is expected and safe — secrets keep resolving at runtime and remain listed in the UI.
+:::
+
 Once the migration is complete, the container will stop automatically. You can then move back to the usual command to run the server:
 
 ```yaml

--- a/src/contents/docs/11.migration-guide/v1.1.0/kv-secrets-metadata-migration/index.md
+++ b/src/contents/docs/11.migration-guide/v1.1.0/kv-secrets-metadata-migration/index.md
@@ -43,8 +43,8 @@ kestra:
 Secrets metadata migration is only necessary for Enterprise users. Open-source users will see an exception error: `❌ Secrets Metadata migration failed: Secret migration is not needed in the OSS version`.
 :::
 
-:::alert{type="warning"}
-Do **not** run the secrets metadata migration when your secret manager is configured in **read-only** mode. Read-only secret managers do not use the secrets metadata store, so the migration is neither needed nor supported: the command fails on purpose with a message explaining this. Skipping it is expected and safe — secrets keep resolving at runtime and remain listed in the UI.
+:::alert{type="info"}
+The secrets metadata migration automatically **skips any tenant or namespace whose secret manager is in read-only mode** — read-only secret managers do not use the secrets metadata store, so nothing needs to be migrated for them, and each skipped namespace is logged. Writable tenants and namespaces are migrated as usual, so a setup that mixes read-only and writable secret managers still migrates correctly. Skipped read-only namespaces are unaffected: their secrets keep resolving at runtime and remain listed in the UI.
 :::
 
 Once the migration is complete, the container will stop automatically. You can then move back to the usual command to run the server:

--- a/src/contents/docs/11.migration-guide/v1.3.0/lts-migration/index.md
+++ b/src/contents/docs/11.migration-guide/v1.3.0/lts-migration/index.md
@@ -28,8 +28,8 @@ Three migration commands must be run — **all three are required** for a comple
 The `secrets` migration applies only to **Enterprise Edition** users. Open-source users can skip it — running it on OSS will produce an exception that can be safely ignored.
 :::
 
-:::alert{type="warning"}
-Do **not** run the `secrets` migration when your secret manager is configured in **read-only** mode. Read-only secret managers do not use the secrets metadata store, so the migration is neither needed nor supported: the command fails on purpose with a message explaining this, and skipping it has no impact on your instance — secrets keep resolving at runtime and remain listed in the UI.
+:::alert{type="info"}
+The `secrets` migration automatically **skips any tenant or namespace whose secret manager is in read-only mode** — read-only secret managers do not use the secrets metadata store, so nothing needs to be migrated for them, and each skipped namespace is logged. Writable tenants and namespaces are migrated as usual, so a setup that mixes read-only and writable secret managers still migrates correctly. Skipped read-only namespaces are unaffected: their secrets keep resolving at runtime and remain listed in the UI.
 :::
 
 ## Order of operations

--- a/src/contents/docs/11.migration-guide/v1.3.0/lts-migration/index.md
+++ b/src/contents/docs/11.migration-guide/v1.3.0/lts-migration/index.md
@@ -28,6 +28,10 @@ Three migration commands must be run — **all three are required** for a comple
 The `secrets` migration applies only to **Enterprise Edition** users. Open-source users can skip it — running it on OSS will produce an exception that can be safely ignored.
 :::
 
+:::alert{type="warning"}
+Do **not** run the `secrets` migration when your secret manager is configured in **read-only** mode. Read-only secret managers do not use the secrets metadata store, so the migration is neither needed nor supported: the command fails on purpose with a message explaining this, and skipping it has no impact on your instance — secrets keep resolving at runtime and remain listed in the UI.
+:::
+
 ## Order of operations
 
 1. **Stop Kestra** — shut down all running Kestra server components to avoid inconsistent reads/writes during migration.


### PR DESCRIPTION
## Problem

The metadata migration guides don't mention that `kestra migrate metadata secrets` cannot run when the secret manager is in **read-only** mode. A customer running AWS Secrets Manager in read-only (scoped) mode hit a cryptic `secretsmanager:GetSecretValue` permission error and was unsure whether it was a blocker.

## Fix

Add a warning to both the 1.3 LTS migration guide and the 1.1 KV & Secrets metadata migration guide: read-only secret managers do not use the secrets metadata store, so the migration is neither needed nor supported, and skipping it is expected and safe.

## Evidence

Companion code PR (which makes the command fail with a clear message in read-only mode): kestra-io/kestra-ee#10631.

Closes https://github.com/kestra-io/kestra-ee/issues/10630.
