### PR TITLE
Quantify exit cost on Google Workflows alternatives page

### DIFF
--- a/src/contents/resources/google-workflows-alternatives/index.md
+++ b/src/contents/resources/google-workflows-alternatives/index.md
@@ -16,6 +16,31 @@ faq:
   - question: "Can Kestra replace Google Workflows for GCP orchestration?"
     answer: "Yes, Kestra can orchestrate GCP services through its extensive plugin ecosystem (e.g., BigQuery, GCS, Cloud Functions) while providing the flexibility to integrate non-GCP tools and manage workflows declaratively across multiple clouds, effectively replacing Google Workflows for broader use cases."
 author: "Virgile Fanucci"
+schema:
+  "@context": "https://schema.org"
+  "@type": "ItemList"
+  name: "Top 5 Google Workflows Alternatives"
+  itemListElement:
+    - "@type": "ListItem"
+      position: 1
+      name: "Kestra"
+      url: "https://kestra.io/vs/google-workflows"
+    - "@type": "ListItem"
+      position: 2
+      name: "Apache Airflow / Google Cloud Composer"
+      url: "https://kestra.io/vs/airflow"
+    - "@type": "ListItem"
+      position: 3
+      name: "n8n"
+      url: "https://kestra.io/vs/n8n"
+    - "@type": "ListItem"
+      position: 4
+      name: "AWS Step Functions"
+      url: "https://kestra.io/vs/aws-step-functions"
+    - "@type": "ListItem"
+      position: 5
+      name: "Temporal"
+      url: "https://kestra.io/vs/temporal"
 ---
 
 Google Workflows offers a serverless approach to orchestrating GCP services, but many teams seek alternatives for broader cloud strategies, cost control, or specific feature sets. That search increasingly comes from infrastructure teams as much as data teams: groups midway through an on-premise to GCP migration who want their automation to survive the next platform decision as well as this one. This guide explores leading options for application, process, [infrastructure](/resources/infrastructure/hybrid-infrastructure-automation), and data pipeline automation, helping you choose an orchestrator that aligns with your operational needs and technical stack.
@@ -120,119 +145,3 @@ Temporal is a durable execution platform for developers, enabling the creation o
 ## How to choose the right alternative
 
 For **multi-cloud flexibility** and declarative workflows, [Kestra is the ideal choice](/vs/google-workflows). **Data engineering teams** with deep Python expertise might prefer [Airflow/Composer](/vs/airflow). **SaaS-heavy automation** points to [n8n](/vs/n8n). For **AWS-native serverless** workloads, [Step Functions](/vs/aws-step-functions) excel. Meanwhile, **application developers** needing durable execution should consider [Temporal](/vs/temporal). Each tool addresses a different center of gravity, from data to infrastructure to application logic.
-
-## Structured data
-
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "Why look for alternatives to Google Workflows?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Users often seek alternatives to Google Workflows to reduce cloud vendor lock-in, address limitations in specific use cases like complex data pipelines, or to gain more control over execution environments beyond Google Cloud's native offerings."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What does it cost to migrate off Google Workflows?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Measure it in layers. Your business logic (scripts, queries, containers) is portable. Your workflow definition is not: the Google Workflows DSL only runs on Google Cloud, so leaving means rewriting the orchestration itself, not repointing it. With a declarative YAML orchestrator, the definition stays a file you own and only the provider-specific connection tasks change."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is the best open-source alternative to Google Workflows?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Kestra stands out as a leading open-source alternative, offering declarative YAML-based workflows that can orchestrate tasks across any cloud, on-premise, or hybrid environment. It supports a wide array of programming languages and integrates with diverse tools."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Can Kestra replace Google Workflows for GCP orchestration?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes, Kestra can orchestrate GCP services through its extensive plugin ecosystem (e.g., BigQuery, GCS, Cloud Functions) while providing the flexibility to integrate non-GCP tools and manage workflows declaratively across multiple clouds, effectively replacing Google Workflows for broader use cases."
-      }
-    }
-  ]
-}
-```
-
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "ItemList",
-  "name": "Top 5 Google Workflows Alternatives",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "Kestra",
-      "url": "https://kestra.io/vs/google-workflows"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "Apache Airflow / Google Cloud Composer",
-      "url": "https://kestra.io/vs/airflow"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "n8n",
-      "url": "https://kestra.io/vs/n8n"
-    },
-    {
-      "@type": "ListItem",
-      "position": 4,
-      "name": "AWS Step Functions",
-      "url": "https://kestra.io/vs/aws-step-functions"
-    },
-    {
-      "@type": "ListItem",
-      "position": 5,
-      "name": "Temporal",
-      "url": "https://kestra.io/vs/temporal"
-    }
-  ]
-}
-```
-
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "Home",
-      "item": "https://kestra.io/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "Resources",
-      "item": "https://kestra.io/resources"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Infrastructure",
-      "item": "https://kestra.io/resources/infrastructure"
-    },
-    {
-      "@type": "ListItem",
-      "position": 4,
-      "name": "Google Workflows Alternatives: Choose Your Orchestration",
-      "item": "https://kestra.io/resources/infrastructure/google-workflows-alternatives"
-    }
-  ]
-}
-```

--- a/src/contents/resources/google-workflows-alternatives/index.md
+++ b/src/contents/resources/google-workflows-alternatives/index.md
@@ -9,6 +9,8 @@ slug: "google-workflows-alternatives"
 faq:
   - question: "Why look for alternatives to Google Workflows?"
     answer: "Users often seek alternatives to Google Workflows to reduce cloud vendor lock-in, address limitations in specific use cases like complex data pipelines, or to gain more control over execution environments beyond Google Cloud's native offerings."
+  - question: "What does it cost to migrate off Google Workflows?"
+    answer: "Measure it in layers. Your business logic (scripts, queries, containers) is portable. Your workflow definition is not: the Google Workflows DSL only runs on Google Cloud, so leaving means rewriting the orchestration itself, not repointing it. With a declarative YAML orchestrator, the definition stays a file you own and only the provider-specific connection tasks change."
   - question: "What is the best open-source alternative to Google Workflows?"
     answer: "Kestra stands out as a leading open-source alternative, offering declarative YAML-based workflows that can orchestrate tasks across any cloud, on-premise, or hybrid environment. It supports a wide array of programming languages and integrates with diverse tools."
   - question: "Can Kestra replace Google Workflows for GCP orchestration?"
@@ -16,11 +18,58 @@ faq:
 author: "Virgile Fanucci"
 ---
 
-Google Workflows offers a serverless approach to orchestrating GCP services, but many teams seek alternatives for broader cloud strategies, cost control, or specific feature sets. This guide explores leading options for application, process, and data pipeline automation, helping you choose an orchestrator that aligns with your operational needs and technical stack.
+Google Workflows offers a serverless approach to orchestrating GCP services, but many teams seek alternatives for broader cloud strategies, cost control, or specific feature sets. That search increasingly comes from infrastructure teams as much as data teams: groups midway through an on-premise to GCP migration who want their automation to survive the next platform decision as well as this one. This guide explores leading options for application, process, [infrastructure](/resources/infrastructure/hybrid-infrastructure-automation), and data pipeline automation, helping you choose an orchestrator that aligns with your operational needs and technical stack.
 
 ## Why look for an alternative to Google Workflows?
 
-Google Workflows' strengths lie in its serverless, GCP-native integration, ideal for simple service choreography within Google Cloud. However, users often seek alternatives due to vendor lock-in, limited extensibility beyond GCP services, and a more code-centric approach that can hinder broader team collaboration or hybrid/multi-cloud deployments.
+Google Workflows' strengths lie in its serverless, GCP-native integration, ideal for simple service choreography within Google Cloud. The reason teams look elsewhere, cited first and most often, is exit cost: the workflow definition is a Google-specific DSL, so leaving Google Cloud means rewriting the orchestration layer rather than repointing it — [what that actually costs is worth decomposing](#what-migrating-off-google-workflows-actually-costs-you). Behind that come limited extensibility beyond GCP services and a code-centric approach that can hinder broader team collaboration or hybrid/multi-cloud deployments.
+
+## What migrating off Google Workflows actually costs you
+
+Lock-in is usually argued as a licensing question: is the tool proprietary or not. That framing is not actionable. The useful question is narrower — on the day you leave, what has to be rewritten?
+
+Any orchestrated workload has three layers:
+
+1. **Business logic** — the scripts, queries, and containers that do the work.
+2. **Workflow definition** — the order, the dependencies, the retries, the schedule.
+3. **Connection layer** — the credentials and API calls that bind each step to a specific provider's services.
+
+With Google Workflows, layers 2 and 3 are the same artifact. The syntax only runs on Google Cloud Workflows, and its steps are addressed as GCP API calls, so a move off Google Cloud takes the workflow definition with it. There is nothing to port, only a rewrite.
+
+With a declarative orchestrator, layers 1 and 2 are files you already own, and only layer 3 names a provider:
+
+```yaml
+id: nightly_report
+namespace: company.ops
+
+tasks:
+  - id: build_report
+    type: io.kestra.plugin.scripts.python.Script
+    outputFiles:
+      - report.csv
+    script: |
+      with open("report.csv", "w") as f:
+          f.write("orders\n1\n2\n3\n")
+
+  - id: archive
+    type: io.kestra.plugin.gcp.gcs.Upload
+    from: "{{ outputs.build_report.outputFiles['report.csv'] }}"
+    to: "gs://ops-archive/report.csv"
+```
+
+Moving that flow to AWS changes the `archive` task and nothing above it:
+
+```yaml
+  - id: archive
+    type: io.kestra.plugin.aws.s3.Upload
+    from: "{{ outputs.build_report.outputFiles['report.csv'] }}"
+    bucket: ops-archive
+    key: report.csv
+```
+
+The Python step, the dependency between the two tasks, the retries, the schedule, the version history in Git: all unchanged. That is the difference between porting a workflow and rebuilding one, and buyers do this arithmetic before they call a vendor. This is how a systems engineer at a US financial services company, evaluating a GCP migration, put it:
+
+> I did some research where they have some of these kinds of things that are baked in to the GCP. But I know that I would be absolutely against us moving that way, because then if we have to move out of Google Cloud, we have to migrate our entire workflow orchestration. Whereas worst case with Kestra — well, we have the full workflows in YAML. We have all the scripts here. We just have to find a different way to connect them. So that's a huge selling point as well.
 
 ## How we evaluated these alternatives
 
@@ -85,6 +134,14 @@ For **multi-cloud flexibility** and declarative workflows, [Kestra is the ideal 
       "acceptedAnswer": {
         "@type": "Answer",
         "text": "Users often seek alternatives to Google Workflows to reduce cloud vendor lock-in, address limitations in specific use cases like complex data pipelines, or to gain more control over execution environments beyond Google Cloud's native offerings."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What does it cost to migrate off Google Workflows?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Measure it in layers. Your business logic (scripts, queries, containers) is portable. Your workflow definition is not: the Google Workflows DSL only runs on Google Cloud, so leaving means rewriting the orchestration itself, not repointing it. With a declarative YAML orchestrator, the definition stays a file you own and only the provider-specific connection tasks change."
       }
     },
     {


### PR DESCRIPTION
## What

The page argued lock-in as an abstraction in an enumeration — *"vendor lock-in, limited extensibility beyond GCP services, and a more code-centric approach"*. Everybody writes that. It never quantified what leaving actually costs, which is precisely the calculation prospects run on their own before they call us.

## Changes

**New H2 `What migrating off Google Workflows actually costs you`** (~220 words). Reframes the question: the useful measure of lock-in isn't "is it proprietary", it's "what has to be rewritten on the day you leave". Decomposes the workload into three layers — business logic, workflow definition, connection layer — and shows that Google Workflows collapses layers 2 and 3 into a single Google-specific artifact, while a declarative orchestrator keeps 1 and 2 as files you already own.

**A 15-line flow proves it.** Same flow, GCP and AWS: the Python step, the dependency, the retries, the schedule and the Git history are unchanged; only the connector task differs. Task types and properties checked against the plugin schemas (`gcp.gcs.Upload` takes `to:`, `aws.s3.Upload` takes `bucket:`/`key:`), and the script uses only the stdlib so it runs in the default image without a `dependencies:` block.

**Closed on a buyer verbatim**, attributed anonymously (no name, no company). It doesn't say lock-in is bad — it describes a mechanism: what a cloud-native solution locks in is the *entire* orchestration, whereas with declarative YAML what's left to redo is only the connection layer. That reasoning comes from a systems engineer who had done the arithmetic before the call, not from a vendor.

**Exit cost promoted to the first reason** in the opening H2, with a link to the new section, instead of being buried mid-sentence with two other grievances.

**Intro widened to the infrastructure buyer** — the team midway through an on-premise to GCP migration that doesn't want to re-lock itself. Links to `hybrid-infrastructure-automation` for now; to be repointed at `infrastructure-automation-tools` / `self-healing-infrastructure` once those ship.

**Fourth FAQ entry** `What does it cost to migrate off Google Workflows?` — condensed version of the new section, targeting LLM citation.

## Second commit: removing the dead structured-data block

The page ended with a `## Structured data` H2 holding JSON-LD in ` ```json ` code fences. A code fence renders as `<pre><code>`, never as `<script type="application/ld+json">` — so that block was never structured data, just 114 lines of visible JSON (31% of the body) and a stray table-of-contents entry. `FAQPage` is already generated from the `faq:` frontmatter (`ResourceArticle.astro:74`) and `BreadcrumbList` globally (`layout.astro:213`), so only the `ItemList` carried anything unique; it moves to the `schema:` frontmatter field, which the template renders as real JSON-LD.

The 7 other pages with the same defect are handled in #5475. This page is fixed here rather than there because this PR already edits that exact region — otherwise the two PRs would conflict.

## Verified

Rendered on the dev server: anchor resolves, the new H2 sits second in the table of contents, the page emits `BreadcrumbList` + `Organization` + `Article` + `ItemList` + `FAQPage` (4 questions), the `ItemList` now served deep-equals the one that was buried in the body, both YAML blocks parse, internal links return 200, no console errors, and `Structured data` appears nowhere in the HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)