### PR TITLE
fix(docs): give feedback modal a visible panel background

### DIFF
--- a/src/components/docs/HelpfulVote.vue
+++ b/src/components/docs/HelpfulVote.vue
@@ -169,8 +169,8 @@
     }
 
     .modal-content {
-        background-color: var(--ks-background-box);
-        border: 1px solid var(--ks-dialog-border);
+        background-color: var(--ks-background-body);
+        border: 1px solid var(--ks-border-primary);
         color: var(--ks-content-primary);
         .modal-header {
             padding: 10px 16px;


### PR DESCRIPTION
fixes: https://github.com/kestra-io/docs/issues/5393

---

Two lines: swap the undefined tokens for the ones the site's existing modals
(`common/Modal.vue`, the search modal in `app.scss`) already use:

- `--ks-background-box` → `--ks-background-body`
- `--ks-dialog-border` → `--ks-border-primary`

---

Ref img: 

<img width="498" height="400" alt="Screenshot 2026-09-02 at 3 11 27 PM" src="https://github.com/user-attachments/assets/21fd40e5-40fb-443d-92f1-668d0007a9e3" />

<img width="498" height="404" alt="Screenshot 2026-09-02 at 3 11 37 PM" src="https://github.com/user-attachments/assets/fe43b4d7-c310-4f20-bcf3-d2704e4added" />


---