### PR TITLE
fix(docs): remove duplicate thank-you message after feedback submission

### DIFF
--- a/src/components/docs/HelpfulVote.vue
+++ b/src/components/docs/HelpfulVote.vue
@@ -14,10 +14,6 @@
             </div>
         </div>
 
-        <div v-if="showThankYou" class="thank-you text-center mt-3">
-            <p>Thank you for your feedback! 👍</p>
-        </div>
-
         <div
             ref="modalRef"
             class="modal fade"
@@ -89,7 +85,6 @@
     const modalRef = ref(null)
     const feedbackText = ref("")
     const isSubmitted = ref(false)
-    const showThankYou = ref(false)
     const currentRating = ref(null)
 
     let bootstrapModal = null
@@ -112,17 +107,12 @@
             : "Sorry to hear that. How can we improve?"
         comment.value = ""
         isSubmitted.value = false
-        showThankYou.value = false
         posthog.capture("helpful", { positive: currentRating.value })
         bootstrapModal?.show()
     }
 
     const closeModal = () => {
         bootstrapModal?.hide()
-        showThankYou.value = true
-        setTimeout(() => {
-            showThankYou.value = false
-        }, 2000)
     }
 
     const submitFeedback = () => {
@@ -204,11 +194,6 @@
             color: #21ce9c;
             font-weight: 600;
         }
-    }
-
-    .thank-you p {
-        color: #21ce9c;
-        font-weight: 600;
     }
 
     .form-control {


### PR DESCRIPTION
Follow-up to #5473, which fixed the missing panel background on the same
docs feedback modal. Independent of that PR — different part of the file,
merges cleanly in either order.

## Problem

Two issues with the "Was this page helpful?" feedback flow:

1. **Duplicate thanks.** Submitting feedback showed the in-modal
   confirmation "Thanks for your feedback, we really appreciate it. 🙏",
   and then closing the modal showed a *second* "Thank you for your
   feedback! 👍" toast beneath the vote buttons, thanking the user twice
   for one action.
2. **Thanks without feedback.** The toast lived in `closeModal()`, which
   is wired to both the X icon and the Cancel button, so dismissing the
   modal without submitting anything still thanked the user. Dismiss paths
   were inconsistent too: X and Cancel showed the toast, Esc and backdrop
   click did not.

---

Video ref: 

https://github.com/user-attachments/assets/0c579af3-dd40-441f-b4ea-6863510f31e8

---