### PR TITLE
Make structured data on 7 alternatives pages actually work

### DIFF
--- a/src/contents/resources/amazon-mwaa-alternatives/index.md
+++ b/src/contents/resources/amazon-mwaa-alternatives/index.md
@@ -22,6 +22,47 @@ faq:
 author: "elliot"
 hub: "data"
 alternatives_count: 7
+schema:
+  "@context": "https://schema.org"
+  "@type": "ItemList"
+  name: "Top Amazon MWAA Alternatives"
+  itemListElement:
+    - "@type": "ListItem"
+      position: 1
+      item:
+        "@type": "SoftwareApplication"
+        name: "Kestra"
+        url: "https://kestra.io"
+    - "@type": "ListItem"
+      position: 2
+      item:
+        "@type": "SoftwareApplication"
+        name: "Apache Airflow (Self-Hosted)"
+    - "@type": "ListItem"
+      position: 3
+      item:
+        "@type": "SoftwareApplication"
+        name: "Astronomer Astro"
+    - "@type": "ListItem"
+      position: 4
+      item:
+        "@type": "SoftwareApplication"
+        name: "Prefect"
+    - "@type": "ListItem"
+      position: 5
+      item:
+        "@type": "SoftwareApplication"
+        name: "Dagster"
+    - "@type": "ListItem"
+      position: 6
+      item:
+        "@type": "SoftwareApplication"
+        name: "Argo Workflows"
+    - "@type": "ListItem"
+      position: 7
+      item:
+        "@type": "SoftwareApplication"
+        name: "Apache NiFi"
 ---
 
 Amazon Managed Workflows for Apache Airflow (MWAA) offers data teams a managed service for Apache Airflow, abstracting away some of the operational burden. However, as organizations scale their data pipelines, many encounter challenges such as escalating costs, vendor lock-in to the AWS ecosystem, and the inherent complexities of Airflow's Python-centric DAG-as-code model. These factors often prompt a search for more flexible, cost-effective, or broader orchestration alternatives. The leading alternatives to Amazon MWAA in 2026 include Kestra, self-hosted Apache Airflow, Astronomer Astro, Prefect, Dagster, Argo Workflows, and Apache NiFi—each suited to different workloads such as multi-cloud data orchestration, infrastructure automation, or asset-centric data lineage. This article will compare these options to help you identify the ideal solution for your specific data and operational needs.
@@ -133,160 +174,3 @@ The best alternative depends entirely on your team's needs, skills, and strategi
 Moving away from Amazon MWAA opens up a diverse landscape of powerful orchestration tools. While managed Airflow provides a convenient entry point, its limitations in cost, flexibility, and operational scope lead many to seek alternatives. The right choice depends on your primary workload: Python-native teams may prefer Prefect, analytics engineers might lean towards Dagster's asset model, and Kubernetes-native shops will find Argo Workflows a natural fit.
 
 However, for organizations looking to break down silos and establish a single, auditable control plane across all technical domains, Kestra offers a compelling solution. By embracing a declarative, language-agnostic approach, it provides the flexibility to orchestrate any workflow, anywhere. To see how this works in practice, explore our library of [workflow blueprints](https://kestra.io/blueprints).
-
-## Structured data
-
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "Is MWAA expensive?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "MWAA's pricing can accumulate quickly, especially with numerous DAGs and high resource usage. The base hourly cost (around $0.50/hour) combines with charges for metadata storage, logging, and network traffic, making cost optimization a common challenge for users."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is the difference between MWAA and Astro?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Astro provides a multi-cloud managed Airflow experience, deployable across AWS, Azure, and GCP. MWAA is a fully AWS-native service, limiting deployments to the AWS ecosystem. Organizations with multi-cloud strategies often prefer Astro for its broader deployment flexibility."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is the difference between Airflow and MWAA?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Apache Airflow is the open-source workflow orchestration framework. MWAA is Amazon's managed service offering of Apache Airflow, handling infrastructure, scaling, and patching. While MWAA simplifies operations, it introduces AWS vendor lock-in and still inherits Airflow's Python-centric DAG-as-code model."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Is Kestra better than Airflow?",
-      "acceptedAnswer": {
-        "@type":": "Answer",
-        "text": "Kestra offers a declarative, YAML-based approach to workflow definition, which can simplify versioning and rollbacks compared to Airflow's Python DAGs. It also provides native polyglot execution and is designed as a universal control plane for data, AI, and infrastructure workflows, offering broader applicability than Airflow's data-centric focus."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is the AWS equivalent of Airflow?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Amazon Managed Workflows for Apache Airflow (MWAA) is the direct AWS equivalent, offering a fully managed service for Apache Airflow environments. Other AWS services like AWS Step Functions or AWS Glue can also orchestrate workflows but serve different architectural patterns and use cases."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Does Airbnb still use Airflow?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes, Airbnb, the creator of Apache Airflow, continues to use it extensively for orchestrating its data pipelines. However, like many large organizations, they also employ other specialized tools alongside Airflow for various aspects of their data and infrastructure management."
-      }
-    }
-  ]
-}
-```
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "ItemList",
-  "name": "Top Amazon MWAA Alternatives",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Kestra",
-        "url": "https://kestra.io"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Apache Airflow (Self-Hosted)"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Astronomer Astro"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 4,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Prefect"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 5,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Dagster"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 6,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Argo Workflows"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 7,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Apache NiFi"
-      }
-    }
-  ]
-}
-```
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "Home",
-      "item": "https://kestra.io/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "Resources",
-      "item": "https://kestra.io/resources"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Data Engineering Resources",
-      "item": "https://kestra.io/resources/data"
-    },
-    {
-      "@type": "ListItem",
-      "position": 4,
-      "name": "Top Amazon MWAA alternatives for data pipelines",
-      "item": "https://kestra.io/resources/data/top-amazon-mwaa-alternatives"
-    }
-  ]
-}
-```

--- a/src/contents/resources/azure-alternatives/index.md
+++ b/src/contents/resources/azure-alternatives/index.md
@@ -20,6 +20,49 @@ faq:
 author: "virgile"
 hub: "infrastructure"
 alternatives_count: 6
+schema:
+  "@context": "https://schema.org"
+  "@type": "ItemList"
+  name: "Top Azure Alternatives"
+  description: "A list of the top alternatives to Microsoft Azure for cloud computing and workflow orchestration."
+  itemListElement:
+    - "@type": "ListItem"
+      position: 1
+      item:
+        "@type": "Service"
+        name: "Kestra"
+        description: "The Universal Orchestration Control Plane for unifying workloads across any cloud."
+        url: "https://kestra.io"
+    - "@type": "ListItem"
+      position: 2
+      item:
+        "@type": "Service"
+        name: "Amazon Web Services (AWS)"
+        description: "The market-leading cloud provider with the broadest portfolio of services."
+    - "@type": "ListItem"
+      position: 3
+      item:
+        "@type": "Service"
+        name: "Google Cloud Platform (GCP)"
+        description: "A cloud provider specializing in data analytics, AI/ML, and Kubernetes."
+    - "@type": "ListItem"
+      position: 4
+      item:
+        "@type": "Service"
+        name: "DigitalOcean"
+        description: "A developer-focused cloud platform known for simplicity and transparent pricing."
+    - "@type": "ListItem"
+      position: 5
+      item:
+        "@type": "Service"
+        name: "Scaleway & OVHcloud"
+        description: "Leading European cloud providers focused on data sovereignty."
+    - "@type": "ListItem"
+      position: 6
+      item:
+        "@type": "Service"
+        name: "Harness"
+        description: "A cloud-native DevOps and software delivery platform."
 ---
 
 The cloud computing landscape is constantly evolving, with organizations continually re-evaluating their infrastructure choices. While Microsoft Azure offers a robust suite of services, many factors—from cost optimization and vendor lock-in concerns to specific regional requirements or a desire for simpler developer experiences—drive the search for alternatives. The leading alternatives to Azure in 2026 range from fellow hyperscalers like AWS and GCP to specialized platforms like DigitalOcean and European providers like Scaleway, each suited to different workloads.
@@ -135,150 +178,3 @@ Selecting the best alternative depends entirely on your team's priorities and us
 The search for Azure alternatives reveals a vibrant and diverse cloud market. While hyperscalers like AWS and GCP remain the most direct competitors, a rich ecosystem of specialized IaaS, PaaS, and orchestration platforms offers compelling advantages in simplicity, cost, and functionality.
 
 As organizations increasingly adopt multi-cloud and hybrid strategies, the need for a flexible, vendor-agnostic control plane becomes critical. A universal orchestration platform like Kestra allows you to harness the best of each provider, defining your infrastructure and application workflows as code while avoiding vendor lock-in. By choosing the right combination of infrastructure and orchestration, you can build a resilient, cost-effective, and future-proof cloud strategy.
-
-## Structured data
-
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "What is an alternative to Azure?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "An alternative to Azure is any cloud platform that provides similar services, such as hosting, scaling, and deploying applications. These platforms offer alternatives for various reasons, including different pricing models, simpler interfaces, or specialized services. Examples include AWS, Google Cloud, DigitalOcean, Scaleway, and Kestra, among others."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is a competitor of Microsoft Azure?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Microsoft Azure's main competitors are other hyperscale cloud providers like Amazon Web Services (AWS) and Google Cloud Platform (GCP). However, many other platforms compete in specific niches, offering specialized services, different pricing, or regional advantages, such as DigitalOcean for simplicity or Scaleway for European data sovereignty."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Who are the big 3 cloud providers?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "The three biggest cloud service providers globally are Amazon Web Services (AWS), Google Cloud Platform (GCP), and Microsoft Azure. These providers dominate the market, offering extensive portfolios of services ranging from compute and storage to advanced AI and machine learning capabilities."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is Azure being replaced with?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Azure itself is not being replaced, but some specific services may evolve or be rebranded. For instance, Azure Active Directory has been rebranded as Microsoft Entra ID. For organizations looking to move away from Azure, a variety of alternatives offer similar or enhanced capabilities, depending on their specific needs."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Can Kestra replace Azure?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Kestra is not a direct replacement for Azure as an IaaS/PaaS cloud provider. Instead, Kestra acts as an orchestration control plane that can coordinate workflows across Azure, other clouds, on-premise infrastructure, and various tools. It can orchestrate Azure services, complementing or enhancing existing Azure deployments, or facilitate multi-cloud strategies."
-      }
-    }
-  ]
-}
-```
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "ItemList",
-  "name": "Top Azure Alternatives",
-  "description": "A list of the top alternatives to Microsoft Azure for cloud computing and workflow orchestration.",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "item": {
-        "@type": "Service",
-        "name": "Kestra",
-        "description": "The Universal Orchestration Control Plane for unifying workloads across any cloud.",
-        "url": "https://kestra.io"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "item": {
-        "@type": "Service",
-        "name": "Amazon Web Services (AWS)",
-        "description": "The market-leading cloud provider with the broadest portfolio of services."
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "item": {
-        "@type": "Service",
-        "name": "Google Cloud Platform (GCP)",
-        "description": "A cloud provider specializing in data analytics, AI/ML, and Kubernetes."
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 4,
-      "item": {
-        "@type": "Service",
-        "name": "DigitalOcean",
-        "description": "A developer-focused cloud platform known for simplicity and transparent pricing."
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 5,
-      "item": {
-        "@type": "Service",
-        "name": "Scaleway & OVHcloud",
-        "description": "Leading European cloud providers focused on data sovereignty."
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 6,
-      "item": {
-        "@type": "Service",
-        "name": "Harness",
-        "description": "A cloud-native DevOps and software delivery platform."
-      }
-    }
-  ]
-}
-```
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "Home",
-      "item": "https://kestra.io"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "Resources",
-      "item": "https://kestra.io/resources"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Infrastructure",
-      "item": "https://kestra.io/resources/infrastructure"
-    },
-    {
-      "@type": "ListItem",
-      "position": 4,
-      "name": "Azure alternatives: Top Cloud Computing Platforms"
-    }
-  ]
-}
-```

--- a/src/contents/resources/chef-alternatives/index.md
+++ b/src/contents/resources/chef-alternatives/index.md
@@ -16,6 +16,47 @@ faq:
     answer: "Yes. Salt (SaltStack) is licensed under Apache 2.0 and its source code remains publicly available on GitHub. SaltStack was acquired by VMware in 2020 and VMware was subsequently acquired by Broadcom in 2023, which now sponsors and manages the open-source Salt Project. Enterprise support and commercial add-ons are available through Broadcom."
   - question: "What is the difference between Chef, Ansible, and Puppet?"
     answer: "Chef uses a Ruby-based recipe DSL for agent-based configuration management, requiring a Chef Server and agents on each node. Ansible is agentless, communicating over SSH with YAML playbooks — the simplest to get started with. Puppet uses its own declarative Puppet language (manifests in .pp files) with an agent-based, model-driven approach that excels at enforcing desired state at scale. All three focus on configuration management, whereas a tool like Kestra adds higher-level, event-driven orchestration across infrastructure, data, and AI workflows."
+schema:
+  "@context": "https://schema.org"
+  "@type": "ItemList"
+  name: "Top Chef Alternatives for IT Automation"
+  description: "A list of the best alternatives to Chef for infrastructure automation and configuration management."
+  itemListElement:
+    - "@type": "ListItem"
+      position: 1
+      item:
+        "@type": "SoftwareApplication"
+        name: "Kestra"
+        url: "https://kestra.io/vs/chef"
+        description: "A universal orchestration control plane that unifies data, AI, and infrastructure workflows with declarative YAML."
+    - "@type": "ListItem"
+      position: 2
+      item:
+        "@type": "SoftwareApplication"
+        name: "Ansible"
+        url: "https://www.ansible.com/"
+        description: "An agentless IT automation tool that uses YAML playbooks for configuration management and application deployment."
+    - "@type": "ListItem"
+      position: 3
+      item:
+        "@type": "SoftwareApplication"
+        name: "Puppet"
+        url: "https://www.puppet.com/"
+        description: "An agent-based, declarative configuration management platform for large-scale enterprise environments."
+    - "@type": "ListItem"
+      position: 4
+      item:
+        "@type": "SoftwareApplication"
+        name: "SaltStack"
+        url: "https://saltproject.io/"
+        description: "A high-speed, event-driven infrastructure automation tool using a master-minion architecture."
+    - "@type": "ListItem"
+      position: 5
+      item:
+        "@type": "SoftwareApplication"
+        name: "GitLab CI/CD"
+        url: "https://about.gitlab.com/stages-devops-lifecycle/continuous-integration/"
+        description: "An integrated DevOps platform with built-in CI/CD for building, testing, and deploying applications and infrastructure."
 ---
 Chef has long been a cornerstone of IT automation, empowering DevOps teams with its powerful agent-based configuration management and Ruby DSL. For over a decade, it has helped organizations define infrastructure as code, ensuring consistency and repeatability across complex environments. However, as infrastructure ecosystems evolve, many platform engineers and DevOps professionals are re-evaluating their orchestration stack. The shift towards agentless architectures, simpler declarative languages, and unified control planes for diverse workloads is driving a search for more agile and operationally lightweight alternatives.
 
@@ -111,98 +152,3 @@ Moving away from Chef is not just about replacing one tool with another; it's an
 For teams looking beyond traditional configuration management, a universal orchestration platform like Kestra provides a powerful control plane to unify all your workflows. By embracing a declarative, event-driven, and language-agnostic approach, you can build resilient, scalable, and auditable automation for your entire technology stack.
 
 Ready to modernize your IT automation and unify your workflows? Explore Kestra's [infrastructure automation capabilities](https://kestra.io/infra-automation) and see how declarative orchestration can streamline your operations.
-
-## Structured data
-
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "Home",
-      "item": "https://kestra.io"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "Resources",
-      "item": "https://kestra.io/resources"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Infrastructure Automation Resources",
-      "item": "https://kestra.io/resources/infrastructure"
-    },
-    {
-      "@type": "ListItem",
-      "position": 4,
-      "name": "Chef Alternatives: Automate Your Workflow",
-      "item": "https://kestra.io/resources/infrastructure/chef-alternatives"
-    }
-  ]
-}
-```
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "ItemList",
-  "name": "Top Chef Alternatives for IT Automation",
-  "description": "A list of the best alternatives to Chef for infrastructure automation and configuration management.",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Kestra",
-        "url": "https://kestra.io/vs/chef",
-        "description": "A universal orchestration control plane that unifies data, AI, and infrastructure workflows with declarative YAML."
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Ansible",
-        "url": "https://www.ansible.com/",
-        "description": "An agentless IT automation tool that uses YAML playbooks for configuration management and application deployment."
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Puppet",
-        "url": "https://www.puppet.com/",
-        "description": "An agent-based, declarative configuration management platform for large-scale enterprise environments."
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 4,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "SaltStack",
-        "url": "https://saltproject.io/",
-        "description": "A high-speed, event-driven infrastructure automation tool using a master-minion architecture."
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 5,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "GitLab CI/CD",
-        "url": "https://about.gitlab.com/stages-devops-lifecycle/continuous-integration/",
-        "description": "An integrated DevOps platform with built-in CI/CD for building, testing, and deploying applications and infrastructure."
-      }
-    }
-  ]
-}
-```

--- a/src/contents/resources/databricks-workflows-alternatives/index.md
+++ b/src/contents/resources/databricks-workflows-alternatives/index.md
@@ -20,6 +20,48 @@ faq:
   - question: "Which orchestration tool is best for combining Databricks with other cloud services?"
     answer: "For orchestrating Databricks alongside a diverse set of other cloud services and on-premises systems, Kestra stands out. Its vendor-agnostic and declarative YAML approach allows seamless coordination of tasks across AWS, GCP, Azure, and your Databricks environment. This unified control plane reduces complexity and provides end-to-end visibility, making it ideal for multi-cloud or hybrid data strategies that include Databricks."
 author: "elliot"
+schema:
+  "@context": "https://schema.org"
+  "@type": "ItemList"
+  name: "Top Databricks Workflows Alternatives"
+  description: "A curated list of the best alternatives to Databricks Workflows for data, AI, and infrastructure orchestration."
+  itemListElement:
+    - "@type": "ListItem"
+      position: 1
+      item:
+        "@type": "SoftwareApplication"
+        name: "Kestra"
+        url: "https://kestra.io"
+    - "@type": "ListItem"
+      position: 2
+      item:
+        "@type": "SoftwareApplication"
+        name: "Apache Airflow"
+        url: "https://airflow.apache.org/"
+    - "@type": "ListItem"
+      position: 3
+      item:
+        "@type": "SoftwareApplication"
+        name: "Prefect"
+        url: "https://www.prefect.io/"
+    - "@type": "ListItem"
+      position: 4
+      item:
+        "@type": "SoftwareApplication"
+        name: "Matillion"
+        url: "https://www.matillion.com/"
+    - "@type": "ListItem"
+      position: 5
+      item:
+        "@type": "SoftwareApplication"
+        name: "Prophecy"
+        url: "https://www.prophecy.io/"
+    - "@type": "ListItem"
+      position: 6
+      item:
+        "@type": "SoftwareApplication"
+        name: "Pixeltable"
+        url: "https://pixeltable.com/"
 ---
 
 Databricks Workflows offers powerful, native orchestration for jobs within the Databricks Lakehouse Platform. It provides a streamlined experience for data and AI workloads, tightly integrated with the Databricks ecosystem. Yet, as organizations scale and diversify their technology stacks, the very strength of platform-native tools—deep integration—can become a limitation. Teams increasingly face challenges related to vendor lock-in, escalating costs, or the need to orchestrate workflows that span beyond a single cloud platform or domain.
@@ -133,157 +175,3 @@ For smaller teams, ease of use, a low barrier to entry, and strong community sup
 While Databricks Workflows is an effective tool for jobs contained within the Lakehouse, the modern data landscape often requires more. The shift is toward universal orchestration platforms that can manage diverse workloads across any cloud, system, or language. Solutions like Kestra offer a path away from vendor lock-in and toward a more flexible, scalable, and future-proof automation strategy. By choosing a declarative and extensible orchestrator, you empower your teams to build reliable workflows that unify your entire technology stack.
 
 Explore how Kestra can unify your data, AI, and infrastructure workflows. [Book a demo today](/demo) or [get started for free](/get-started).
-
-## Structured data
-
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "Is Databricks Workflows still worth using in 2026?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Databricks Workflows remains a strong choice for workloads that are entirely contained within the Databricks Lakehouse platform. Its native integration with Databricks services offers a streamlined experience for existing users. However, if your orchestration needs extend beyond the Databricks ecosystem, or if you're seeking to reduce vendor lock-in and optimize costs, exploring alternatives becomes essential to avoid fragmented automation."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What are the main limitations of Databricks Workflows?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Key limitations include platform lock-in, as it's primarily designed for Databricks-native workloads, making cross-cloud or hybrid orchestration challenging. It may also present cost considerations for larger scale or diverse workloads. Furthermore, its focus on data and AI workflows means it's less suited for broader infrastructure or business process orchestration, which might necessitate additional tools."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Can Kestra replace Databricks Workflows for data orchestration?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes, Kestra can replace or complement Databricks Workflows, especially for teams seeking a universal orchestration control plane. Kestra excels at coordinating heterogeneous workloads across various platforms, including Databricks, other clouds, and on-premises systems. It allows you to run Databricks jobs as tasks within a broader, declarative YAML-defined workflow, offering greater flexibility, polyglot execution, and reduced vendor lock-in."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is the best open-source alternative to Databricks Workflows?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "For open-source alternatives, Apache Airflow is a long-standing option, especially for Python-centric data teams. However, Kestra provides a more modern, declarative, and language-agnostic approach that extends beyond just data workflows to cover AI, infrastructure, and business processes. Kestra's open-source core offers high extensibility and deploy-anywhere flexibility without the operational overhead often associated with Airflow at scale."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "How does Databricks Workflows compare to Apache Airflow?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Databricks Workflows is tightly integrated with the Databricks Lakehouse, ideal for jobs running exclusively on that platform. Apache Airflow, in contrast, is a more generalized, Python-centric data orchestrator with a vast ecosystem. While Airflow offers flexibility, it comes with higher operational complexity. Kestra combines the best of both: the declarative simplicity and extensibility of a modern orchestrator, with the ability to integrate seamlessly with Databricks and other tools."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Which orchestration tool is best for combining Databricks with other cloud services?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "For orchestrating Databricks alongside a diverse set of other cloud services and on-premises systems, Kestra stands out. Its vendor-agnostic and declarative YAML approach allows seamless coordination of tasks across AWS, GCP, Azure, and your Databricks environment. This unified control plane reduces complexity and provides end-to-end visibility, making it ideal for multi-cloud or hybrid data strategies that include Databricks."
-      }
-    }
-  ]
-}
-```
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "ItemList",
-  "name": "Top Databricks Workflows Alternatives",
-  "description": "A curated list of the best alternatives to Databricks Workflows for data, AI, and infrastructure orchestration.",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Kestra",
-        "url": "https://kestra.io"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Apache Airflow",
-        "url": "https://airflow.apache.org/"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Prefect",
-        "url": "https://www.prefect.io/"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 4,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Matillion",
-        "url": "https://www.matillion.com/"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 5,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Prophecy",
-        "url": "https://www.prophecy.io/"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 6,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Pixeltable",
-        "url": "https://pixeltable.com/"
-      }
-    }
-  ]
-}
-```
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "Home",
-      "item": "https://kestra.io"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "Resources",
-      "item": "https://kestra.io/resources"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Data",
-      "item": "https://kestra.io/resources/data"
-    },
-    {
-      "@type": "ListItem",
-      "position": 4,
-      "name": "Databricks Workflows Alternatives: Unify Your Data Orchestration"
-    }
-  ]
-}
-```

--- a/src/contents/resources/microsoft-fabric-alternatives/index.md
+++ b/src/contents/resources/microsoft-fabric-alternatives/index.md
@@ -20,6 +20,53 @@ faq:
   - question: "How does Kestra fit into the Microsoft Fabric alternative landscape?"
     answer: "Kestra acts as an open-source, declarative orchestration control plane that can sit above or alongside Microsoft Fabric and its alternatives. It unifies workflows across data, AI, and infrastructure, allowing teams to orchestrate tasks in any language, on any cloud. This provides flexibility and vendor neutrality, preventing lock-in while integrating existing tools like Databricks, Snowflake, or even specific Fabric components."
 author: "elliot"
+schema:
+  "@context": "https://schema.org"
+  "@type": "ItemList"
+  name: "Top Microsoft Fabric Alternatives"
+  itemListElement:
+    - "@type": "ListItem"
+      position: 1
+      item:
+        "@type": "Thing"
+        name: "Kestra"
+        description: "The Declarative Orchestration Control Plane"
+    - "@type": "ListItem"
+      position: 2
+      item:
+        "@type": "Thing"
+        name: "Databricks"
+        description: "Unified Analytics Platform for Lakehouse"
+    - "@type": "ListItem"
+      position: 3
+      item:
+        "@type": "Thing"
+        name: "Snowflake"
+        description: "Cloud Data Platform for SQL-first Analytics"
+    - "@type": "ListItem"
+      position: 4
+      item:
+        "@type": "Thing"
+        name: "AWS Data & Analytics Services"
+        description: "Modular, Cloud-Native Ecosystem"
+    - "@type": "ListItem"
+      position: 5
+      item:
+        "@type": "Thing"
+        name: "Google Cloud Platform Data Tools"
+        description: "Scalable and Specialized Services"
+    - "@type": "ListItem"
+      position: 6
+      item:
+        "@type": "Thing"
+        name: "Peliqan"
+        description: "All-in-One Data Platform for Growing Teams"
+    - "@type": "ListItem"
+      position: 7
+      item:
+        "@type": "Thing"
+        name: "Oracle Cloud Infrastructure (OCI) Data Services"
+        description: "Enterprise-Grade Solutions"
 ---
 
 Microsoft Fabric emerged in 2023 as Microsoft's ambitious play to unify data, analytics, and AI under a single SaaS umbrella. While promising a streamlined experience, many organizations quickly encounter familiar challenges: vendor lock-in, complex pricing, and limitations for specific, highly customized workloads. As discussions on platforms like Reddit highlight, the desire for greater control and flexibility often drives the search for alternatives.
@@ -143,168 +190,3 @@ Selecting the right platform depends entirely on your specific context. Key fact
 The data landscape evolves rapidly. To future-proof your strategy, prioritize flexibility, open standards, and the ability to integrate new tools without being locked into a single vendor's ecosystem. This is where an orchestration control plane like Kestra provides significant value. By decoupling your workflow logic from your data platform, you can adapt your stack as new technologies emerge, ensuring your data strategy remains agile and resilient. Whether you need to manage [data workflows](/resources/data), [AI pipelines](/resources/ai), or [infrastructure automation](/resources/infrastructure), a universal orchestrator provides the foundation for a scalable and adaptable future.
 
 Ready to see how a declarative, vendor-neutral orchestration layer can unify your entire data stack? [Get started with Kestra today](/get-started).
-
-## Structured data
-
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "What are the core capabilities of Microsoft Fabric and its closest alternatives?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Microsoft Fabric unifies data integration, engineering, warehousing, analytics, and business intelligence within the Microsoft ecosystem, leveraging OneLake for storage. Alternatives like Databricks offer a unified lakehouse for large-scale data and ML, while Snowflake provides a cloud data platform with a SQL-first approach. Kestra offers a declarative, polyglot orchestration layer that integrates with all these tools and extends beyond data."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Is Fabric replacing ADF?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Fabric Data Factory is not merely ADF rebranded. It represents a SaaS-native evolution, moving beyond the PaaS model of Azure Data Factory. It is deeply integrated with OneLake, Lakehouse, Warehouse, and the broader Fabric analytics fabric, offering a more unified experience within the Microsoft ecosystem. Existing ADF users will find migration paths and similar functionalities within Fabric's Data Factory component."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Is Microsoft Fabric better than Databricks?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "The 'better' choice depends on specific priorities. If rapid deployment, tight integration with Microsoft tools, and streamlined governance are paramount, Microsoft Fabric is a strong contender. However, if use cases demand large-scale data processing, advanced ML pipelines, or architectural flexibility across different clouds and languages, Databricks often presents a stronger, more specialized solution."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Does Google have something like Microsoft Fabric?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "While Google Cloud Platform offers a rich suite of data and analytics services, it takes a modular approach rather than a single unified platform like Microsoft Fabric. Key components include BigQuery (serverless data warehouse), Dataflow (stream/batch processing), Dataproc (managed Spark/Hadoop), and Vertex AI (ML platform), and Looker (BI). These services can be combined to achieve similar functionalities but require more integration effort."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Does Microsoft have an ETL tool?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes, Microsoft offers several ETL tools. Historically, SQL Server Integration Services (SSIS) was a prominent on-premise solution. In the cloud, Azure Data Factory (ADF) has been its primary managed ETL/ELT service. With the introduction of Microsoft Fabric, the Data Factory component within Fabric now serves as the modern, SaaS-native ETL/ELT capability, deeply integrated into the broader analytics platform."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "How does Kestra fit into the Microsoft Fabric alternative landscape?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Kestra acts as an open-source, declarative orchestration control plane that can sit above or alongside Microsoft Fabric and its alternatives. It unifies workflows across data, AI, and infrastructure, allowing teams to orchestrate tasks in any language, on any cloud. This provides flexibility and vendor neutrality, preventing lock-in while integrating existing tools like Databricks, Snowflake, or even specific Fabric components."
-      }
-    }
-  ]
-}
-```
-
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "ItemList",
-  "name": "Top Microsoft Fabric Alternatives",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "item": {
-        "@type": "Thing",
-        "name": "Kestra",
-        "description": "The Declarative Orchestration Control Plane"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "item": {
-        "@type": "Thing",
-        "name": "Databricks",
-        "description": "Unified Analytics Platform for Lakehouse"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "item": {
-        "@type": "Thing",
-        "name": "Snowflake",
-        "description": "Cloud Data Platform for SQL-first Analytics"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 4,
-      "item": {
-        "@type": "Thing",
-        "name": "AWS Data & Analytics Services",
-        "description": "Modular, Cloud-Native Ecosystem"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 5,
-      "item": {
-        "@type": "Thing",
-        "name": "Google Cloud Platform Data Tools",
-        "description": "Scalable and Specialized Services"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 6,
-      "item": {
-        "@type": "Thing",
-        "name": "Peliqan",
-        "description": "All-in-One Data Platform for Growing Teams"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 7,
-      "item": {
-        "@type": "Thing",
-        "name": "Oracle Cloud Infrastructure (OCI) Data Services",
-        "description": "Enterprise-Grade Solutions"
-      }
-    }
-  ]
-}
-```
-
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "Home",
-      "item": "https://kestra.io/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "Resources",
-      "item": "https://kestra.io/resources"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Data",
-      "item": "https://kestra.io/resources/data"
-    },
-    {
-      "@type": "ListItem",
-      "position": 4,
-      "name": "Microsoft Fabric Alternatives: Top Competitors & More",
-      "item": "https://kestra.io/resources/data/microsoft-fabric-alternatives"
-    }
-  ]
-}
-```

--- a/src/contents/resources/prefect-alternatives/index.md
+++ b/src/contents/resources/prefect-alternatives/index.md
@@ -22,6 +22,56 @@ faq:
   - question: "What are the main factors when choosing a Prefect alternative?"
     answer: "Key factors include deployment model (self-hosted vs. managed), language support (Python-only vs. polyglot), architectural philosophy (code-first vs. declarative), scalability needs, integration ecosystem, and cost considerations. Aligning these with your team's specific requirements is crucial."
 author: "elliot"
+schema:
+  "@context": "https://schema.org"
+  "@type": "ItemList"
+  name: "Top Prefect Alternatives"
+  itemListElement:
+    - "@type": "ListItem"
+      position: 1
+      item:
+        "@type": "SoftwareApplication"
+        name: "Kestra"
+        url: "https://kestra.io/vs/prefect"
+    - "@type": "ListItem"
+      position: 2
+      item:
+        "@type": "SoftwareApplication"
+        name: "Apache Airflow"
+        url: "https://kestra.io/vs/airflow"
+    - "@type": "ListItem"
+      position: 3
+      item:
+        "@type": "SoftwareApplication"
+        name: "Dagster"
+        url: "https://kestra.io/vs/dagster"
+    - "@type": "ListItem"
+      position: 4
+      item:
+        "@type": "SoftwareApplication"
+        name: "ZenML"
+    - "@type": "ListItem"
+      position: 5
+      item:
+        "@type": "SoftwareApplication"
+        name: "Metaflow"
+    - "@type": "ListItem"
+      position: 6
+      item:
+        "@type": "SoftwareApplication"
+        name: "Windmill"
+        url: "https://kestra.io/vs/windmill"
+    - "@type": "ListItem"
+      position: 7
+      item:
+        "@type": "SoftwareApplication"
+        name: "Apache NiFi"
+        url: "https://kestra.io/vs/apache-nifi"
+    - "@type": "ListItem"
+      position: 8
+      item:
+        "@type": "SoftwareApplication"
+        name: "Mage"
 ---
 
 Prefect has established itself as a robust, Python-native workflow orchestrator, particularly popular for its focus on developer experience and dynamic workflows. However, as data and AI pipelines grow in complexity and span diverse technology stacks, many engineering teams find themselves evaluating alternatives. The increasing demand for language-agnostic solutions, declarative configuration, and greater control over self-hosted environments—especially with broader trends like the Airflow 3.0 migration prompting re-evaluation of orchestration layers—highlights a shifting landscape. For the category fundamentals behind these tools, see [what is data orchestration](/resources/data/data-orchestration).
@@ -162,180 +212,3 @@ While Prefect offers a powerful, modern experience for Python-based workflows, t
 However, for teams looking to break free from language constraints and unify their automation efforts, a platform like Kestra offers a compelling path forward. By embracing a declarative, language-agnostic, and event-driven approach, Kestra acts as a universal control plane for your entire technology stack. It empowers data, platform, and AI teams to build reliable, scalable, and observable workflows without being locked into a single programming paradigm.
 
 Ready to see how a declarative approach can simplify your orchestration? [Get started with Kestra](https://kestra.io/get-started) or [book a demo](https://kestra.io/demo) to explore its capabilities.
-
-## Structured data
-
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "Why should I consider alternatives to Prefect?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "While Prefect excels in Python-native dynamic workflows, teams often seek alternatives due to its Python-centric nature, potential operational overhead at scale, or a desire for more declarative, language-agnostic, or self-hosted deployment options that integrate across broader IT and AI stacks."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Is Kestra a good alternative to Prefect for data pipelines?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes, Kestra offers a strong alternative to Prefect, especially for teams needing polyglot task execution and declarative YAML workflows. It unifies data, AI, and infrastructure orchestration, providing flexibility beyond Python-only environments with robust event-driven capabilities and lower operational overhead."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "How does Apache Airflow compare to Prefect as an alternative?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Apache Airflow, a mature Python-based orchestrator, offers a vast operator ecosystem. Compared to Prefect, Airflow has a longer history and extensive community, but can involve higher operational complexity. It's suitable for Python-heavy teams, though many now seek modern alternatives."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What are the key advantages of Dagster over Prefect?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Dagster's asset-centric design provides superior data lineage and observability, appealing to analytics engineering teams. While both are Python-first, Dagster's explicit asset model and strong typing offer a different paradigm for managing data pipelines, particularly with dbt integration."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Are there self-hosted Prefect alternatives?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes, many Prefect alternatives offer robust self-hosting capabilities. Kestra, Apache Airflow, Dagster, and Windmill are prominent examples, providing flexibility for on-premise, hybrid, or air-gapped environments, addressing common needs for data sovereignty and infrastructure control."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Which Prefect alternative is best for ML-focused workflows?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "For ML-focused workflows, alternatives like ZenML and Metaflow offer specialized features for model training, versioning, and deployment. Kestra also supports AI workflows with native agentic capabilities and integrations with various ML tools, providing a versatile platform for MLOps."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What are the main factors when choosing a Prefect alternative?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Key factors include deployment model (self-hosted vs. managed), language support (Python-only vs. polyglot), architectural philosophy (code-first vs. declarative), scalability needs, integration ecosystem, and cost considerations. Aligning these with your team's specific requirements is crucial."
-      }
-    }
-  ]
-}
-```
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "ItemList",
-  "name": "Top Prefect Alternatives",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Kestra",
-        "url": "https://kestra.io/vs/prefect"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Apache Airflow",
-        "url": "https://kestra.io/vs/airflow"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Dagster",
-        "url": "https://kestra.io/vs/dagster"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 4,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "ZenML"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 5,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Metaflow"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 6,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Windmill",
-        "url": "https://kestra.io/vs/windmill"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 7,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Apache NiFi",
-        "url": "https://kestra.io/vs/apache-nifi"
-      }
-    },
-    {
-      "@type": "ListItem",
-      "position": 8,
-      "item": {
-        "@type": "SoftwareApplication",
-        "name": "Mage"
-      }
-    }
-  ]
-}
-```
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "Home",
-      "item": "https://kestra.io/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "Resources",
-      "item": "https://kestra.io/resources"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "Data Engineering Resources",
-      "item": "https://kestra.io/resources/data"
-    },
-    {
-      "@type": "ListItem",
-      "position": 4,
-      "name": "Prefect Alternatives: Orchestration Platforms for Data & AI Workflows",
-      "item": "https://kestra.io/resources/data/prefect-alternatives"
-    }
-  ]
-}
-```

--- a/src/contents/resources/zapier-alternatives/index.md
+++ b/src/contents/resources/zapier-alternatives/index.md
@@ -21,6 +21,51 @@ faq:
     answer: "The best free alternative depends on your needs. For visual building, Make offers a generous free plan with 1,000 operations per month. For technical users, open-source platforms like n8n and Activepieces offer powerful free, self-hosted versions with no task limits, providing maximum flexibility for those comfortable with managing their own instance."
   - question: "Can Kestra replace Zapier?"
     answer: "Kestra can replace Zapier, especially for technical and enterprise use cases. While Zapier is ideal for simple, no-code SaaS integrations, Kestra provides a more powerful, declarative (YAML-based) platform for orchestrating complex workflows across data, AI, and infrastructure. It's a better fit for engineers who need version control, scalability, and cost-effective automation beyond simple app connections."
+schema:
+  "@context": "https://schema.org"
+  "@type": "ItemList"
+  name: "Top 10 Zapier Alternatives"
+  itemListElement:
+    - "@type": "ListItem"
+      position: 1
+      name: "Kestra"
+      url: "https://kestra.io/resources/ai/zapier-alternatives#1-kestra-open-source-declarative-and-cross-domain-orchestration"
+    - "@type": "ListItem"
+      position: 2
+      name: "Make"
+      url: "https://kestra.io/resources/ai/zapier-alternatives#2-make-formerly-integromat-a-powerful-visual-builder"
+    - "@type": "ListItem"
+      position: 3
+      name: "n8n"
+      url: "https://kestra.io/resources/ai/zapier-alternatives#3-n8n-open-source-flexibility-and-self-hosting-options"
+    - "@type": "ListItem"
+      position: 4
+      name: "Pabbly Connect"
+      url: "https://kestra.io/resources/ai/zapier-alternatives#4-pabbly-connect-comprehensive-integration-suite"
+    - "@type": "ListItem"
+      position: 5
+      name: "Activepieces"
+      url: "https://kestra.io/resources/ai/zapier-alternatives#5-activepieces-open-source-with-a-growing-community"
+    - "@type": "ListItem"
+      position: 6
+      name: "Workato"
+      url: "https://kestra.io/resources/ai/zapier-alternatives#6-workato-advanced-integration-and-automation-for-enterprises"
+    - "@type": "ListItem"
+      position: 7
+      name: "Microsoft Power Automate"
+      url: "https://kestra.io/resources/ai/zapier-alternatives#7-microsoft-power-automate-for-businesses-in-the-microsoft-ecosystem"
+    - "@type": "ListItem"
+      position: 8
+      name: "IFTTT"
+      url: "https://kestra.io/resources/ai/zapier-alternatives#8-ifttt-simple-applets-for-personal-use"
+    - "@type": "ListItem"
+      position: 9
+      name: "HubSpot's Operations Hub"
+      url: "https://kestra.io/resources/ai/zapier-alternatives#9-hubspots-operations-hub-crm-focused-automation"
+    - "@type": "ListItem"
+      position: 10
+      name: "Lindy AI"
+      url: "https://kestra.io/resources/ai/zapier-alternatives#10-lindy-ai-intelligent-automation-workflows"
 ---
 
 Zapier has long been the go-to platform for connecting web applications and automating simple workflows. Its intuitive interface and vast integration library make it a powerful tool for many. However, as teams scale, workflows grow in complexity, or budgets tighten, many users find themselves asking: "Is there anything better than Zapier?" The answer often lies in alternatives that offer greater control, more flexible pricing, or deeper technical capabilities.
@@ -187,171 +232,3 @@ The automation market has matured far beyond simple app-to-app connections. Whil
 For teams moving beyond basic SaaS integrations, the choice is no longer just about which platform has the most connectors. It's about finding a solution that aligns with your technical practices, budget, and long-term vision. Open-source, declarative platforms like Kestra represent a significant step forward, providing an engineering-centric approach to automation that offers unparalleled flexibility, scalability, and cost control. By evaluating your specific requirements against the options presented here, you can select an automation platform that not only solves today's problems but also grows with you.
 
 Ready to explore a more powerful, declarative approach to orchestration? [Check out our pricing](https://kestra.io/pricing) or [book a demo](https://kestra.io/demo) to see how Kestra can unify your workflows.
-
-## Structured data
-
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "Is there anything better than Zapier?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes, several platforms may be better than Zapier depending on your needs. For visual workflow building, Make is a strong contender. For open-source flexibility, n8n is a popular choice. For technical teams needing to orchestrate complex data, AI, and infrastructure workflows, a declarative platform like Kestra offers more power, control, and cost-efficiency at scale."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Why is Zapier so expensive?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Zapier's pricing is based on task volume. Every single action in a multi-step workflow (a 'Zap') counts as a task. This means complex or frequently-run automations can consume your task allowance quickly, pushing you into more expensive pricing tiers even if your core use case remains simple. This model becomes costly for users with high-frequency or intricate workflows."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Is n8n cheaper than Zapier?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes, n8n is generally cheaper than Zapier, especially for technical users who can leverage its self-hosted open-source version, which has no task limits. Even its cloud-hosted plans offer more generous allowances than Zapier's entry-level tiers, making it a more cost-effective option for users with a high volume of tasks."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What's cheaper, Make or Zapier?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Make is typically cheaper than Zapier. Make's pricing is based on 'operations,' and it offers a larger number of operations in its free and paid plans compared to Zapier's task-based limits. For multi-step automations, Make's model is often more economical as complex workflows consume fewer billable units than on Zapier."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Does Microsoft have anything similar to Zapier?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes, Microsoft's alternative to Zapier is Power Automate. It is deeply integrated with the Microsoft 365, Dynamics 365, and Azure ecosystems. While Zapier excels at connecting a wide variety of third-party web apps, Power Automate is the stronger choice for organizations that primarily rely on Microsoft's suite of tools and services."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is the best free alternative to Zapier?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "The best free alternative depends on your needs. For visual building, Make offers a generous free plan with 1,000 operations per month. For technical users, open-source platforms like n8n and Activepieces offer powerful free, self-hosted versions with no task limits, providing maximum flexibility for those comfortable with managing their own instance."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Can Kestra replace Zapier?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Kestra can replace Zapier, especially for technical and enterprise use cases. While Zapier is ideal for simple, no-code SaaS integrations, Kestra provides a more powerful, declarative (YAML-based) platform for orchestrating complex workflows across data, AI, and infrastructure. It's a better fit for engineers who need version control, scalability, and cost-effective automation beyond simple app connections."
-      }
-    }
-  ]
-}
-```
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "ItemList",
-  "name": "Top 10 Zapier Alternatives",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "Kestra",
-      "url": "https://kestra.io/resources/ai/zapier-alternatives#1-kestra-open-source-declarative-and-cross-domain-orchestration"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "Make",
-      "url": "https://kestra.io/resources/ai/zapier-alternatives#2-make-formerly-integromat-a-powerful-visual-builder"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "n8n",
-      "url": "https://kestra.io/resources/ai/zapier-alternatives#3-n8n-open-source-flexibility-and-self-hosting-options"
-    },
-    {
-      "@type": "ListItem",
-      "position": 4,
-      "name": "Pabbly Connect",
-      "url": "https://kestra.io/resources/ai/zapier-alternatives#4-pabbly-connect-comprehensive-integration-suite"
-    },
-    {
-      "@type": "ListItem",
-      "position": 5,
-      "name": "Activepieces",
-      "url": "https://kestra.io/resources/ai/zapier-alternatives#5-activepieces-open-source-with-a-growing-community"
-    },
-    {
-      "@type": "ListItem",
-      "position": 6,
-      "name": "Workato",
-      "url": "https://kestra.io/resources/ai/zapier-alternatives#6-workato-advanced-integration-and-automation-for-enterprises"
-    },
-    {
-      "@type": "ListItem",
-      "position": 7,
-      "name": "Microsoft Power Automate",
-      "url": "https://kestra.io/resources/ai/zapier-alternatives#7-microsoft-power-automate-for-businesses-in-the-microsoft-ecosystem"
-    },
-    {
-      "@type": "ListItem",
-      "position": 8,
-      "name": "IFTTT",
-      "url": "https://kestra.io/resources/ai/zapier-alternatives#8-ifttt-simple-applets-for-personal-use"
-    },
-    {
-      "@type": "ListItem",
-      "position": 9,
-      "name": "HubSpot's Operations Hub",
-      "url": "https://kestra.io/resources/ai/zapier-alternatives#9-hubspots-operations-hub-crm-focused-automation"
-    },
-    {
-      "@type": "ListItem",
-      "position": 10,
-      "name": "Lindy AI",
-      "url": "https://kestra.io/resources/ai/zapier-alternatives#10-lindy-ai-intelligent-automation-workflows"
-    }
-  ]
-}
-```
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": "Home",
-      "item": "https://kestra.io/"
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": "Resources",
-      "item": "https://kestra.io/resources"
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": "AI",
-      "item": "https://kestra.io/resources/ai"
-    },
-    {
-      "@type": "ListItem",
-      "position": 4,
-      "name": "10 Best Zapier Alternatives & Competitors in 2026",
-      "item": "https://kestra.io/resources/ai/zapier-alternatives"
-    }
-  ]
-}
-```


### PR DESCRIPTION
## The problem

Seven resources pages end with a `## Structured data` H2 followed by JSON-LD in ` ```json ` code fences. A code fence renders as `<pre><code>`, **not** `<script type="application/ld+json">` — so none of it has ever been structured data. What it actually is:

- **A wall of raw JSON at the bottom of the article**, between 17% and 31% of the rendered body (174 lines on `prefect-alternatives`). Readers see it. LLMs ingest it as text, including a word-for-word duplicate of the FAQ that sits right above it.
- **A "Structured data" entry in every table of contents.**
- **`amazon-mwaa-alternatives` contains syntactically invalid JSON** — `"@type":": "Answer"` — that nobody ever noticed. That is the clearest available proof that nothing consumes these blocks.

Of the three schema types in there, two were already emitted properly elsewhere:

| Type | Already emitted? |
|---|---|
| `FAQPage` | Yes — generated from the `faq:` frontmatter, `ResourceArticle.astro:74-119` |
| `BreadcrumbList` | Yes — globally, `layout.astro:213` |
| `ItemList` | **No** — the only type with no equivalent |

## The change

Delete the `## Structured data` section, and move the `ItemList` into the `schema:` frontmatter field — already declared in the collection zod (`content.config.ts:236`, unused by any page until now) and rendered by the template as a real `<script type="application/ld+json">`.

```yaml
schema:
  "@context": "https://schema.org"
  "@type": "ItemList"
  name: "Top Chef Alternatives for IT Automation"
  itemListElement:
    - "@type": "ListItem"
      position: 1
      item:
        "@type": "SoftwareApplication"
        name: "Kestra"
```

The `@`-prefixed keys are quoted because `@` is a reserved YAML indicator at the start of an unquoted key.

Per page: the visible JSON and the TOC entry disappear, the `ItemList` starts being emitted as schema for the first time, and `amazon-mwaa` gains a valid `FAQPage` where its body one was broken. No prose is rewritten — the change is mechanical.

## Verified on all 7 pages

- Every `ItemList` now served in a `<script>` **deep-equals** the object previously buried in the body (compared against `git show origin/main:`) — zero data loss, no reformatting drift.
- Each page emits `BreadcrumbList` + `Organization` + `Article` + `ItemList` + `FAQPage`, all five parsing as valid JSON.
- The string `Structured data` appears nowhere in the rendered HTML.
- Frontmatter round-trips through the zod schema.

## Pages touched

`amazon-mwaa-alternatives` · `azure-alternatives` · `chef-alternatives` · `databricks-workflows-alternatives` · `microsoft-fabric-alternatives` · `prefect-alternatives` · `zapier-alternatives`

`google-workflows-alternatives` is the 8th page with this defect. It is fixed in #5472, which already edits that exact region — keeping it there avoids a merge conflict between the two PRs. The two can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)