### PR TITLE
seo(resources): publish governing-ai-generated-workflows

### DIFF
--- a/src/contents/resources/ai-governance-workflows/index.md
+++ b/src/contents/resources/ai-governance-workflows/index.md
@@ -191,7 +191,7 @@ These are traditional, deterministic workflows common in MLOps, such as [ETL for
 
 ### Agentic AI workflows for execution
 
-These workflows involve [AI agents](https://kestra.io/resources/ai/ai-agent) that can use tools and make basic decisions to complete tasks. Governance here must also cover the agent's autonomy, ensuring its actions are constrained, auditable, and aligned with predefined rules. Kestra's platform allows you to build and manage these [AI agents](https://kestra.io/docs/ai-tools/ai-agents) within a controlled environment.
+These workflows involve [AI agents](https://kestra.io/resources/ai/ai-agent) that can use tools and make basic decisions to complete tasks. Governance here must also cover the agent's autonomy, ensuring its actions are constrained, auditable, and aligned with predefined rules. Kestra's platform allows you to build and manage these [AI agents](https://kestra.io/docs/ai-tools/ai-agents) within a controlled environment. When the workflow itself is written by a model rather than by a person, the control surface shifts again — see [governing AI-generated workflows](/resources/ai/governing-ai-generated-workflows).
 
 ### Agentic AI with strong governance for scale
 

--- a/src/contents/resources/governing-ai-generated-workflows/index.md
+++ b/src/contents/resources/governing-ai-generated-workflows/index.md
@@ -1,0 +1,128 @@
+---
+title: "Governing AI Generated Workflows: Control and Compliance"
+description: "Ensure auditability, compliance, and human oversight for your AI-generated workflows. Learn how declarative orchestration provides the control plane for safe, ethical, and efficient AI operations."
+metaTitle: "Governing AI Generated Workflows for AI Control"
+metaDescription: "Learn to govern AI-generated workflows effectively with declarative orchestration, ensuring complete compliance, auditability, and human oversight."
+tag: "ai"
+date: 2026-08-26
+slug: "governing-ai-generated-workflows"
+faq:
+  - question: "What are AI-generated workflows?"
+    answer: "AI-generated workflows are automated processes where significant steps or the entire workflow logic are created or influenced by AI models, such as LLMs or autonomous agents. This can range from code generation for tasks to agents making dynamic decisions and chaining tools, necessitating disciplined governance for reliability and compliance."
+  - question: "Why is governance essential for AI-generated workflows?"
+    answer: "Governance is essential for AI-generated workflows to mitigate risks associated with autonomy, such as unexpected outcomes, security vulnerabilities, and compliance breaches. It ensures transparency, auditability, and the ability to implement human oversight, maintaining control over AI's actions in production environments."
+  - question: "What role does declarative orchestration play in AI governance?"
+    answer: "Declarative orchestration provides a structured, auditable framework for AI governance. By defining workflows in YAML, every step, input, and output of an AI-generated process becomes version-controlled and reviewable. This makes it easier to implement policies, track changes, and enforce human-in-the-loop approvals."
+  - question: "How can I ensure human oversight in AI-generated workflows?"
+    answer: "Human oversight in AI-generated workflows can be ensured through human-in-the-loop (HITL) patterns. Orchestration platforms can introduce explicit pause tasks for review and approval before critical AI-driven actions proceed, allowing human operators to validate outputs, correct course, or provide feedback."
+  - question: "What are the key benefits of governing AI workflows?"
+    answer: "Governing AI workflows leads to increased reliability, enhanced security, and improved compliance with regulations. It also fosters trust in AI systems, reduces operational risks, and optimizes resource utilization by preventing uncontrolled or inefficient AI actions."
+  - question: "Can Kestra help with AI workflow governance?"
+    answer: "Yes, Kestra is designed to provide a dependable control plane for governing AI workflows. Its declarative YAML definitions, native support for AI agents and LLM tools, along with features like human-in-the-loop pauses, audit logs, and version control, enable transparent and auditable AI operations."
+  - question: "What are the risks of ungoverned AI workflows?"
+    answer: "Ungoverned AI workflows pose several risks, including unintended consequences, data breaches, regulatory non-compliance, and spiraling operational costs. Without clear oversight, autonomous AI can generate outputs that are biased, inaccurate, or harmful, leading to reputational damage and financial losses."
+---
+
+> **TL;DR** — Governing AI-generated workflows means putting a control plane around pipelines an AI wrote or an agent decides at runtime. Where traditional automation is deterministic and reviewable before it ships, these workflows choose their own steps. Governance restores what that removes: an audit trail of every decision, an approval gate before consequential actions, and bounded permissions the agent cannot exceed.
+
+The rise of AI-generated workflows, from automated code creation to autonomous agents, promises unprecedented efficiency. Yet, this power comes with a critical challenge: control. Without a real governance framework, these intelligent systems can operate as black boxes, introducing unpredictable risks, compliance gaps, and spiraling costs.
+
+This article explores why governing AI-generated workflows is not just a best practice, but a necessity. We'll work through the mechanisms that make AI workflows auditable, compliant, and safe, demonstrating how declarative orchestration provides the essential control plane for responsible AI deployment.
+
+## Understanding AI-Generated Workflows and Their Unique Challenges
+
+An AI-generated workflow is any automated process where an AI model dynamically creates, modifies, or executes steps. This extends beyond simple task automation and includes:
+- **Code Generation**: An LLM writes Python scripts, SQL queries, or Terraform configurations as part of a pipeline.
+- **Content Creation**: AI generates marketing copy, technical documentation, or data summaries.
+- **Agentic Actions**: An autonomous agent decides which tools to use and in what sequence to achieve a goal, such as analyzing a dataset or remediating a security alert.
+
+These workflows differ from traditional, deterministic automation in kind, not degree. Their autonomy and non-determinism introduce unique risks. Ungoverned, they can lead to unpredictable outcomes, generate insecure code, violate data privacy regulations, or incur massive, unforeseen costs by calling expensive APIs in a loop. Effective [AI orchestration](/resources/ai/ai-orchestration) must therefore include a strong governance layer to manage these challenges. The goal is to keep the power of [agentic workflows](/resources/ai/agentic-workflows) without losing operational control, especially when dealing with a complex [AI code generation workflow](/resources/ai/ai-code-generation-workflow).
+
+## Establishing the Pillars of Effective AI Workflow Governance
+
+A workable governance framework for AI workflows is built on several key pillars. These principles transform autonomous processes from a potential liability into a reliable asset.
+
+- **Transparency and Auditability**: Every decision, action, input, and output generated by an AI must be logged and traceable. A complete audit trail is non-negotiable for debugging, compliance, and understanding emergent AI behavior.
+- **Compliance and Policy Enforcement**: Workflows must operate within predefined boundaries. This means enforcing data privacy rules, adhering to industry regulations, and ensuring AI-generated outputs align with internal policies.
+- **Human-in-the-Loop (HITL) Oversight**: For critical or high-impact decisions, the workflow must pause for human review and approval. [Human-in-the-loop orchestration](/resources/ai/human-in-the-loop-orchestration) provides an essential safety mechanism to prevent costly errors.
+- **Version Control and Reproducibility**: Treating AI workflow definitions as code, stored in a Git repository, allows for peer review, controlled rollouts, and reliable rollbacks. It ensures that any change to an AI's behavior is deliberate and auditable.
+- **Security and Access Control**: AI models, the data they access, and the tools they can use must be secured. [Role-Based Access Control (RBAC)](/resources/infrastructure/rbac) ensures that AI agents operate with the principle of least privilege, minimizing the potential blast radius of a compromised or misbehaving agent.
+
+These pillars are not just theoretical; they are practical requirements for any organization looking to deploy [AI governance workflows](/resources/ai/ai-governance-workflows) safely.
+
+## Orchestrate Governing AI Workflows with Kestra: Ensuring Auditability and Control
+
+Declarative orchestration provides the ideal control plane for governing AI workflows. By defining the entire process in a structured YAML file, you create a single source of truth that is both human-readable and machine-executable. This approach makes governance inherent to the workflow's design.
+
+Consider a common scenario: generating a draft blog post with an AI agent, requiring human review before the content is finalized and logged for publication. This workflow combines AI autonomy with human oversight.
+
+```yaml
+id: ai-content-generation-with-human-review
+namespace: marketing.content
+
+tasks:
+  - id: generate-draft
+    type: io.kestra.plugin.ai.agent.AIAgent
+    model: gpt-4o
+    prompt: "Write a 500-word blog post about the importance of governing AI-generated workflows. The tone should be authoritative but accessible to a technical audience. Focus on the risks of ungoverned AI and the benefits of a declarative orchestration approach."
+
+  - id: human-review
+    type: io.kestra.plugin.core.flow.Pause
+    description: "Please review the AI-generated blog post draft. You can edit the content below. Click 'Resume' to approve or 'Kill' to reject."
+    tasks:
+      - id: reviewed-content
+        type: io.kestra.plugin.core.debug.Return
+        format: "{{ outputs['generate-draft'].content }}"
+
+  - id: log-approved-content
+    type: io.kestra.plugin.core.log.Log
+    message: |
+      ---
+      Approved Content for Publication
+      Timestamp: {{ execution.startDate }}
+      Reviewer: {{ execution.userId }}
+      ---
+      {{ outputs['human-review']['reviewed-content'] }}
+
+triggers:
+  - id: api-trigger
+    type: io.kestra.plugin.core.trigger.Webhook
+```
+
+This Kestra flow demonstrates several governance principles in action:
+
+*   **Declarative Control**: The entire process is defined in YAML. There are no hidden scripts or implicit actions. The agent's prompt, the human review step, and the final logging action are all explicit and version-controllable.
+*   **Built-in Audit Trail**: Kestra automatically logs the inputs and outputs of every task. An auditor can see the exact prompt given to the AI, the raw output it produced, who approved the content, and when it was approved.
+*   **Explicit Human-in-the-Loop**: The `Pause` task creates an explicit gate. The workflow stops until a human operator reviews the content and makes a decision, preventing the automatic publication of unvetted AI output.
+*   **Error Handling and Observability**: If the `AIAgent` task fails, the workflow's error handling mechanisms (which can be defined with an `errors` block) can trigger alerts, ensuring that failures in AI processes don't go unnoticed, a key lesson when [running AI workflows in production](/blogs/ai-workflows-in-production).
+
+This approach provides a practical blueprint for [building production-ready AI agents](/blogs/orchestrate-ai-agents-kestra) with the necessary guardrails.
+
+### Adapting Human Oversight: From Full Approval to Exception Handling
+
+The level of human oversight can be adapted to the risk profile of the workflow. While the example above uses a mandatory approval step for all outputs, other patterns are possible:
+
+- **Conditional Approval**: A `Pause` task can be placed within an `If` condition, triggering a review only if certain criteria are met, such as a low confidence score from the AI or the presence of sensitive keywords.
+- **Approval by Exception**: The workflow can proceed automatically unless an anomaly detection task flags the AI's output as unusual, in which case it is routed for human review.
+
+This flexibility allows teams to balance the need for control with the desire for automation speed, which is a core tenet of any effective [AI-native orchestration platform](/resources/ai/ai-native-orchestration-platform).
+
+## Where Governed AI Workflows Pay Off
+
+Implementing governance isn't just about mitigating risk; it unlocks the ability to safely deploy AI in high-value, mission-critical areas.
+
+- **Automated Content Generation**: Ensures brand voice, factual accuracy, and legal compliance before any content is published, scaling content creation without sacrificing quality.
+- **Dynamic Infrastructure Provisioning**: Allows an AI to suggest changes to cloud resources based on real-time metrics, with a human engineer approving the `terraform apply` command to prevent misconfigurations or cost overruns.
+- **Cybersecurity Remediation**: An AI agent can identify a threat and propose a remediation plan, but a security analyst validates the action to avoid disrupting critical systems with a false positive.
+- **Financial Reporting**: AI can generate summaries and identify anomalies in financial data, with an auditor verifying the insights before they are included in official reports, blending the power of [workflow automation software](/resources/business/workflow-automation-software) with human expertise.
+
+These use cases show that governance is the enabler for moving AI from experimental sandboxes to production environments, supported by the [best workflow automation tools](/resources/infrastructure/best-workflow-automation-tools) that offer these control mechanisms.
+
+## Related Concepts
+
+- [Best Workflow Monitoring Tools for 2026](/resources/infrastructure/workflow-monitoring-tools)
+- [Top SimplyAsk Alternatives & Competitors in 2026](/resources/ai/simplyask-alternatives)
+- [Kestra Resources: Guides for Data, AI, Infrastructure & More](/resources)
+- [Kestra AI Tools – Copilot, Agents, Agent Skills, and RAG Workflows](/docs/ai-tools)
+
+Governing AI-generated workflows is essential for any organization serious about scaling its AI initiatives responsibly. By adopting a declarative, auditable, and human-centric approach, you can build AI systems that are not only powerful but also trustworthy. Ready to implement governed AI workflows? Explore how Kestra can help you [stop writing glue code around your AI pipelines](/ai-automation).


### PR DESCRIPTION
One new resource page.

### governing AI generated workflows

Source: #360

`/resources/ai/governing-ai-generated-workflows`

Internal links:

- `/ai-automation`
- `/blogs/ai-workflows-in-production`
- `/blogs/orchestrate-ai-agents-kestra`
- `/docs/ai-tools`
- `/resources`
- `/resources/ai/agentic-workflows`
- `/resources/ai/ai-code-generation-workflow`
- `/resources/ai/ai-governance-workflows`
- `/resources/ai/ai-native-orchestration-platform`
- `/resources/ai/ai-orchestration`
- `/resources/ai/human-in-the-loop-orchestration`
- `/resources/ai/simplyask-alternatives`
- `/resources/business/workflow-automation-software`
- `/resources/infrastructure/best-workflow-automation-tools`
- `/resources/infrastructure/rbac`
- `/resources/infrastructure/workflow-monitoring-tools`

### Also

Adds the reciprocal link from `/resources/ai/ai-governance-workflows`.
