### PR TITLE
seo(blog): fix the 2.0 engine post outline and link it to the rest of the series

### DIFF
--- a/src/contents/blogs/2026-09-01-kestra20-rebuild-engine/index.md
+++ b/src/contents/blogs/2026-09-01-kestra20-rebuild-engine/index.md
@@ -10,11 +10,9 @@ author:
 image: ./main.jpg
 ---
 
-# We rebuilt the Kestra engine. Here is what changed and what it brought you.
-
 Kestra 2.0 is the most significant release in the product's history. Beyond UI updates and AI capabilities, the Kestra team identified challenges with the current engine implementation and rewrote it. Not a coat of paint on the existing 1.x internals, but an actual replacement for how work is scheduled, dispatched, and run. This post is for people who operate Kestra or who are curious about what changed underneath and why it matters. This post focuses on key architectural changes and the resulting benefits.
 
-### Workers in a 1.x world
+## Workers in a 1.x world
 
 The 1.x architecture has worked and scaled for many organizations since the product's inception. But it had a shape that created recurring pain. Workers are a core server component that executes runnable tasks and polls triggers directly connected to the database.  
 ![Kestra 1.x architecture](./1x.png)  
@@ -24,24 +22,24 @@ As shown in Figure 1, the worker lives in the same control plane as the other Ke
 
 The database, a.k.a. the JDBC Backend in the figure above, is a critical piece of the platform. It is responsible for both serving as a repository for content such as metadata, flow definitions, and execution records and acting as the queue itself. The queue carries all internal messages between Kestra services. Under heavy execution volume, the database became the coordination bottleneck, with executions queued, waiting to be picked up, while everyone contended for it. To help mitigate these performance issues, two engine implementations ran side by side: a JDBC implementation and a Kafka Streams implementation. Two repository and queue options meant two codebases doing the same job. This doubled the surface area and doubled the work for every fix.
 
-### The biggest release in the history of Kestra
+## The biggest release in the history of Kestra
 
 In Kestra 2.0, we decided to rewrite the engine to address not only the worker issue but also other technical debt that has accumulated over the years. This release of Kestra 2.0 is by far our most significant, with its benefits stemming directly from the engine rewrite.
 
 ![Kestra 2.0 architecture](./arch.png)  
 Figure 2: Kestra 2.0 architecture
 
-### Queue and Repository are no longer bundled choices
+## Queue and Repository are no longer bundled choices
 
-In version 1.x, the queue and repository were tightly coupled as a fixed pair; you selected a bundle. You could choose JDBC for the queue or a combination of Kafka and Elasticsearch. That’s it. Version 2.0 separates them, allowing you to choose the queue and repository independently to best suit your needs. You can start by running everything on a single database and later move the queue to a faster system or scale the repository without rewriting any workflows. This change removes the Kafka Streams engine. There is now a single implementation of the executor, the scheduler, and the worker, regardless of which queue backend you run underneath. For you, that means behavior is consistent across backends rather than subtly different between the JDBC and Kafka paths, and fixes land once instead of twice.
+In version 1.x, the queue and repository were tightly coupled as a fixed pair; you selected a bundle. You could choose JDBC for the queue or a combination of Kafka and Elasticsearch. That’s it. Version 2.0 separates them, allowing you to [choose the queue and repository independently](/blogs/kestra-2-0-backend-choice) to best suit your needs. You can start by running everything on a single database and later move the queue to a faster system or scale the repository without rewriting any workflows. This change removes the Kafka Streams engine. There is now a single implementation of the executor, the scheduler, and the worker, regardless of which queue backend you run underneath. For you, that means behavior is consistent across backends rather than subtly different between the JDBC and Kafka paths, and fixes land once instead of twice.
 
-The edition split here matters, so it is worth stating plainly. Open source runs on JDBC with your Postgres or MySQL for both the queue and the repository. The additional queue backends, Redis, AMQP, and Kafka, are the Enterprise differentiator. Use Redis or AMQP when you want low latency, Kafka when you want high availability, or JDBC when you want a balanced middle that is simplest to run.
+The edition split here matters, so it is worth stating plainly. Open source runs on JDBC with your Postgres or MySQL for both the queue and the repository. The additional queue backends, Redis, AMQP, and Kafka, are the [Kestra Enterprise](/enterprise) differentiator. Use Redis or AMQP when you want low latency, Kafka when you want high availability, or JDBC when you want a balanced middle that is simplest to run.
 
-### Indexer Service
+## Indexer Service
 
 With the new flexible back end, customers can now more easily move off of a database to a larger-scale message queue like Kafka and Redis for storage.  This service copies data from the queue into the repository for the front-end web server to consume and present to the user. This service doesn’t apply when you use JDBC since it's already in a queryable service, but it's mentioned here to raise awareness of this service. 
 
-### Introducing the Controller
+## Introducing the Controller
 
 We addressed workers' dependency on the database by making them independent of it. To do this, we added a new component called the Controller. It sits between the Worker and the Kestra back-end components such as the queue and repository. With respect to the worker, all communication to Kestra goes through the controller.  
 ![Kestra 2.0 high-level architecture with the Controller](./simple.png)  
@@ -49,7 +47,7 @@ Figure 3: Kestra 2.0 high-level architecture showing new controller service
 
 Since workers no longer talk directly to the backend, they don't need to store sensitive database credentials.  The connection between the worker and the controller is a single gRPC connection that can be secured with mutual TLS.
 
-### You can now put workers almost anywhere
+## You can now put workers almost anywhere
 
 This is the direct payoff of a worker that holds no database connection. Because the only thing a worker needs to reach is the Controller, over an outbound gRPC connection, you can place workers in deployments that were awkward or impossible before:
 
@@ -60,14 +58,23 @@ This is the direct payoff of a worker that holds no database connection. Because
 
 For teams with data-residency requirements, this is a key point. It allows you to keep the workers and components that handle your data within your perimeter, while the control plane operates as a managed service elsewhere. The data plane remains where your rules specify it should be. If your network topology requires multi-region setups, Worker Groups allow you to steer specific workloads to specific worker pools with capacity guarantees.
 
-### Less data now moves through the engine
+## Less data now moves through the engine
 
-A less obvious benefit of the rewrite, and one that operators notice daily, is that the engine no longer carries unnecessary data. Task outputs load only when needed. The executor retrieves an output only when needed, rather than passing all outputs through the queue just in case downstream components need them. In systems with millions of executions, this significantly reduces unnecessary data transfer. Now, minimal information flows over the queue. This change primarily enhances UI responsiveness and throughput under load, as the queue handles less work per execution. This dramatic performance improvement is one of the benefits an end user will experience with this engine rewrite. Expect to see blog posts arrive post-launch that show data comparing 1.x and the new 2.0 release.
+A less obvious benefit of the rewrite, and one that operators notice daily, is that the engine no longer carries unnecessary data. Task outputs load only when needed. The executor retrieves an output only when needed, rather than passing all outputs through the queue just in case downstream components need them. In systems with millions of executions, this significantly reduces unnecessary data transfer. Now, minimal information flows over the queue. This change primarily enhances UI responsiveness and throughput under load, as the queue handles less work per execution. This dramatic performance improvement is one of the benefits an end user will experience with this engine rewrite. The [1.3 against 2.0 benchmarks](/blogs/performance-improvements-2-0) show what that adds up to: twice the sustained throughput on the same Postgres, and a flat p99.
 
 Logs can live in their own backend. The new Log Data Store lets you point logs to a different store from the rest of your data, choose from JDBC, Elasticsearch, DataDog, or Splunk, at general availability. Logs are the bulkiest, highest-churn data Kestra writes, so moving them off your primary database takes real pressure off it. The logs still appear in the Kestra UI exactly as before; they are just sourced from wherever you put them.
 
-### Where to learn more
+## Where to learn more
 
 Check out the Kestra 2.0 launch webinar on September 8th, 2026. [**Register here**](https://luma.com/194wtite) to learn more about this and other areas of this new release\!
 
 For a deeper dive into the backend, watch out for the pre-launch webinar where we discuss these backend changes in more detail\! [**Watch the video**](https://www.youtube.com/watch?v=_ijZ1x7s2Uk)
+
+The rest of the 2.0 engine series:
+
+- [Performance upgrades in Kestra 2.0](/blogs/performance-improvements-2-0): the 1.3 against 2.0 benchmarks, and where the ceiling sits now.
+- [Your backend is a choice](/blogs/kestra-2-0-backend-choice): the three architectures we recommend, and what each one buys you.
+- [Any flow is a tool your agents can call](/blogs/2026-09-04-kestra-2-0-flows-as-agent-tools): the MCP trigger, and why every agent call is a normal execution.
+- [Plugin performance improvements](/blogs/plugin-performance-improvements): the same audit applied to the plugins on the hot path.
+
+The reference for the components above is the [architecture documentation](/docs/architecture), and the upgrade path from 1.x is in the [2.0 migration guide](/docs/migration-guide/v2.0.0).


### PR DESCRIPTION
Part of the SEO/GEO pass on the five Kestra 2.0 launch posts. One PR per page 

**Page:** [/blogs/2026-09-01-kestra20-rebuild-engine](https://kestra.io/blogs/2026-09-01-kestra20-rebuild-engine)

This is the pillar of the wave (the four other 2.0 posts link to it) 

### Heading outline

Verified live in the HTML: the page had **two `<h1>`**. The template renders `title:` as the `<h1>`, and the body opened with `# We rebuilt the Kestra engine. Here is what changed and what it brought you.` — worded differently from the title. On top of that, all eight body headings were `###`, so the outline was `h1 → h1 → h3` with **no `<h2>` at all**.

- body `<h1>` removed
- the eight `###` promoted to `##`

After the change, rendered locally: one `<h1>`, eight `<h2>`.

### Internal links

The post had **zero** internal links — it pointed only at Luma and YouTube. It now links the four siblings, `/docs/architecture` and `/docs/migration-guide/v2.0.0`, all on prose that was already there plus one "rest of the series" list in *Where to learn more*.

### Stale forward-reference

> Expect to see blog posts arrive post-launch that show data comparing 1.x and the new 2.0 release.

Those posts are published. Replaced with a link to the benchmarks and the number they land on.

### Verification

Rendered on a local dev server: one `<h1>`, eight `<h2>`, every new link present, no raw directive syntax leaking. All link targets return 200.

### The rest of the series

- `seo/blog-2-0-performance-links`
- `seo/blog-2-0-backend-choice-links`
- `seo/blog-2-0-agent-tools-links`
- `seo/blog-2-0-plugin-performance-links`
- `seo/blog-2-0-almost-here-ga-update`

Each PR touches exactly one file and none depends on another — every link target is already live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
