### PR TITLE
seo(blog): link "how to choose your backend" and point at the MCP server docs

### DIFF
--- a/src/contents/blogs/2026-09-04-kestra-2-0-flows-as-agent-tools/index.md
+++ b/src/contents/blogs/2026-09-04-kestra-2-0-flows-as-agent-tools/index.md
@@ -153,4 +153,6 @@ The **MCP server and the MCP Tool Trigger are open source**. Exposing your flows
 
 Join the Kestra 2.0 launch webinar on September 8th, 2026 at 15:00 UTC. [Register here](https://luma.com/194wtite).
 
-For the architecture underneath, read [what changed in the engine](https://kestra.io/blogs/2026-09-01-kestra20-rebuild-engine) and how to choose your backend. Setup is in the [MCP server docs](https://kestra.io/docs/ai-tools), the [AI Copilot docs](https://kestra.io/docs/ai-tools/ai-copilot), and the [Agent Skills repository](https://github.com/kestra-io/agent-skills).
+For the architecture underneath, read [what changed in the engine](/blogs/2026-09-01-kestra20-rebuild-engine) and [how to choose your backend](/blogs/kestra-2-0-backend-choice). Setup is in the [MCP server docs](/docs/ai-tools/mcp-server), the [AI Copilot docs](/docs/ai-tools/ai-copilot), and the [Agent Skills repository](https://github.com/kestra-io/agent-skills).
+
+Every tool call is an execution, so the [2.0 throughput and latency numbers](/blogs/performance-improvements-2-0) apply to agent traffic too, and the upgrade path is in the [2.0 migration guide](/docs/migration-guide/v2.0.0).


### PR DESCRIPTION
Part of the SEO/GEO pass on the five Kestra 2.0 launch posts. One PR per page.

**Page:** [/blogs/2026-09-04-kestra-2-0-flows-as-agent-tools](https://kestra.io/blogs/2026-09-04-kestra-2-0-flows-as-agent-tools)

- The closing paragraph read *"read [what changed in the engine](…) and how to choose your backend"* — the second reference was **plain text** while [the target post](https://kestra.io/blogs/kestra-2-0-backend-choice) exists. Now a link.
- The *"MCP server docs"* anchor pointed at the `/docs/ai-tools` index rather than `/docs/ai-tools/mcp-server`.
- Absolute `https://kestra.io/…` URLs switched to relative paths, matching the other posts in the wave.
- A closing line ties agent traffic to the 2.0 throughput numbers and the migration guide — every tool call is an execution, so those numbers apply.

All targets return 200. Rendered locally to confirm.

### Not in this PR

*"What is open source and what is not"* is currently two bold-heavy paragraphs. An OSS/Enterprise table there is what an LLM will lift when asked whether Kestra's MCP support is free — the question this post exists to answer. Separate PR if you want it.

Sibling PRs: `seo/blog-2-0-rebuild-engine-links`, `seo/blog-2-0-performance-links`, `seo/blog-2-0-backend-choice-links`, `seo/blog-2-0-plugin-performance-links`, `seo/blog-2-0-almost-here-ga-update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
