### PR TITLE
seo(blog): connect the plugin performance post to the 2.0 wave

### DIFF
--- a/src/contents/blogs/plugin-performance-improvements/index.md
+++ b/src/contents/blogs/plugin-performance-improvements/index.md
@@ -13,7 +13,7 @@ image: ./main.png
 
 Plugins are how Kestra talks to the outside world: databases, message queues, object stores, and APIs. They sit on the hot path of almost every execution, so a small inefficiency in a plugin quietly becomes a big one once you are moving millions of rows or thousands of messages.
 
-Kestra 2.0 [rebuilds the engine](/blogs/2026-09-01-kestra20-rebuild-engine) around the same idea, doing less work per execution. Plugins are the other half of that hot path, so we recently went through several of them looking for exactly that. Two patterns kept coming up. Work that was repeated on every row or every call when it only needed to happen once, and a handful of places that dropped data or errors without ever telling you. This post walks through the fixes, spread across seven plugins.
+We recently went through several plugins looking for exactly that. Two patterns kept coming up. Work that was repeated on every row or every call when it only needed to happen once, and a handful of places that dropped data or errors without ever telling you. This post walks through the fixes, spread across seven plugins.
 
 Here is what we cover:
 

--- a/src/contents/blogs/plugin-performance-improvements/index.md
+++ b/src/contents/blogs/plugin-performance-improvements/index.md
@@ -13,7 +13,7 @@ image: ./main.png
 
 Plugins are how Kestra talks to the outside world: databases, message queues, object stores, and APIs. They sit on the hot path of almost every execution, so a small inefficiency in a plugin quietly becomes a big one once you are moving millions of rows or thousands of messages.
 
-We recently went through several plugins looking for exactly that. Two patterns kept coming up. Work that was repeated on every row or every call when it only needed to happen once, and a handful of places that dropped data or errors without ever telling you. This post walks through the fixes, spread across seven plugins.
+Kestra 2.0 [rebuilds the engine](/blogs/2026-09-01-kestra20-rebuild-engine) around the same idea, doing less work per execution. Plugins are the other half of that hot path, so we recently went through several of them looking for exactly that. Two patterns kept coming up. Work that was repeated on every row or every call when it only needed to happen once, and a handful of places that dropped data or errors without ever telling you. This post walks through the fixes, spread across seven plugins.
 
 Here is what we cover:
 
@@ -222,7 +222,7 @@ Not every fix shows up in a benchmark, and honestly these next three worried us 
 
 ## Conclusion
 
-None of these changes touch how you write a flow. You get them for free by upgrading. They came out of a fairly simple habit: read the hot paths and ask what work is being repeated, then check whether a task can fail without saying so. Pool the connection, cache the formatter, batch the round-trip, check the future.
+None of these changes touch how you write a flow. You get them for free by upgrading, alongside the [engine-level gains in 2.0](/blogs/performance-improvements-2-0). They came out of a fairly simple habit: read the hot paths and ask what work is being repeated, then check whether a task can fail without saying so. Pool the connection, cache the formatter, batch the round-trip, check the future.
 
 Individually each one is small. Together they add up, and they matter most exactly when you are running at scale, which is where you least want a plugin getting in the way. Plugins are a big surface, we have only been through a handful so far, and we are not done. Performance and correctness across the plugin ecosystem stay a focus for us.
 


### PR DESCRIPTION
Part of the SEO/GEO pass on the five Kestra 2.0 launch posts. One PR per page.

**Page:** [/blogs/plugin-performance-improvements](https://kestra.io/blogs/plugin-performance-improvements)

This post was **fully orphaned**: zero inbound links, and no outbound link except `/slack` twice. Nothing on kestra.io indicated it was part of the 2.0 launch, even though it shares its premise with the engine rewrite — find the work being repeated on the hot path and stop doing it.

- The intro now frames it against [the engine rewrite](https://kestra.io/blogs/2026-09-01-kestra20-rebuild-engine).
- The conclusion points at [the engine-level 2.0 gains](https://kestra.io/blogs/performance-improvements-2-0).

Both targets return 200. Rendered locally to confirm.

### Not in this PR

The title (`Plugin performance improvements`) carries no version, no entity and no claim, in a post whose body has 28 table rows of benchmarks. Proposed in the audit: `How we sped up seven Kestra plugins on the hot path` (60 chars with the `| Kestra` suffix). Left out because title changes are a copy decision, not a linking one.

Sibling PRs: #5510, #5511, #5512, #5513, plus the pre-launch post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
