### PR TITLE
seo(blog): mark the pre-launch 2.0 post as GA and link the deep dives

### DIFF
--- a/src/contents/blogs/kestra-2-0-almost-here/index.md
+++ b/src/contents/blogs/kestra-2-0-almost-here/index.md
@@ -56,7 +56,7 @@ And if you would rather watch before you jump in, we are hosting a series of pre
 
 Your existing flows continue to work. A few advanced constructs, such as ForEach and trigger conditions, will require a guided migration.
 
-We would rather tell you now than surprise you later, so we built the tooling first. The [flow migration CLI](https://github.com/kestra-io/kestra2-flow-migration) is already public: point it at your flow YAML to get a per-flow diff of what 2.0 changes, and preview everything with a dry run before touching anything. The full migration guide documents every change with before-and-after examples.
+We would rather tell you now than surprise you later, so we built the tooling first. The [flow migration CLI](https://github.com/kestra-io/kestra2-flow-migration) is already public: point it at your flow YAML to get a per-flow diff of what 2.0 changes, and preview everything with a dry run before touching anything. The [full migration guide](/docs/migration-guide/v2.0.0) documents every change with before-and-after examples.
 
 ## The releases you remember are the ones you were part of
 
@@ -65,3 +65,7 @@ Kestra exists because engineers adopted it, contributed to it, and trusted that 
 Kestra 2.0 is almost here. Download [the latest release candidate](https://github.com/kestra-io/kestra/releases/tag/v2.0.0-rc7), or [pull the same build from Docker Hub](https://hub.docker.com/layers/kestra/kestra/v2.0.0-rc7/images/sha256-e85ab0746d54f7d6c87cbc31fefa587caeb28f78b55ea81a89e893eadf3e6442). Then join the [Early Adopter Program](/early-adopter-program), or tell us what you found on [Slack](/slack).
 
 The engine is rebuilt. Help shape the future of orchestration.
+
+:::alert{type="info"}
+**Update, September 8, 2026: Kestra 2.0 is generally available.** The engineering deep dives are out: [what changed in the engine](/blogs/2026-09-01-kestra20-rebuild-engine), [the 1.3 against 2.0 benchmarks](/blogs/performance-improvements-2-0), [how to choose your backend](/blogs/kestra-2-0-backend-choice), [any flow as a tool your agents can call](/blogs/2026-09-04-kestra-2-0-flows-as-agent-tools), and [plugin performance improvements](/blogs/plugin-performance-improvements).
+:::


### PR DESCRIPTION
Part of the SEO/GEO pass on the five Kestra 2.0 launch posts. One PR per page — this one is the pre-launch post that feeds them.

**Page:** [/blogs/kestra-2-0-almost-here](https://kestra.io/blogs/kestra-2-0-almost-here) (6 August, call for release candidates)

- Adds an `:::alert{type="info"}` update block marking 2.0 as generally available and pointing at the five engineering deep dives. It is the strongest pre-launch page in the cluster and it currently dead-ends on an RC download.
- *"The full migration guide"* was plain text while `/docs/migration-guide/v2.0.0` returns 200. Now a link.

**Note for review:** the update block asserts GA on 8 September 2026. If the GA date moves, this is the one PR of the six that needs its copy adjusted.

All targets return 200. Rendered locally: the alert renders as `doc-alert alert alert-info`, no raw directive syntax leaking.

Sibling PRs: #5510, #5511, #5512, #5513, #5514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
