### PR TITLE
fix(docs): resolve colocated image refs on versioned doc pages

### DIFF
--- a/src/pages/docs-versioned.astro
+++ b/src/pages/docs-versioned.astro
@@ -153,4 +153,11 @@ const navigation = [
         line-height: 3.25rem;
         margin: 0 auto;
     }
+
+    // Screenshots arrive at native size through set:html. Cap them here so the
+    // column holds whether or not medium-zoom's own reset has bound yet.
+    .mdc-renderer :global(img) {
+        max-width: 100%;
+        height: auto;
+    }
 </style>

--- a/src/utils/renderVersionedDoc.test.ts
+++ b/src/utils/renderVersionedDoc.test.ts
@@ -879,6 +879,46 @@ title: T
         expect(html).toContain('href="#here"')
     })
 
+    it("re-points a 1.2+ colocated relative image at the versioned asset API", async () => {
+        const { html } = await renderVersionedDocBody({
+            version: "1.3",
+            path: "tutorial/fundamentals",
+            markdown: `---\ntitle: T\n---\n![Create flow](./create_button.png)`,
+            children: {
+                docs: { title: "Docs" },
+                "docs/tutorial": { title: "Tutorial", isIndex: true },
+                "docs/tutorial/fundamentals": { title: "Fundamentals", isIndex: true },
+            },
+        })
+        expect(html).toContain(
+            'src="https://api.kestra.io/v1/docs/docs/tutorial/fundamentals/create_button.png/versions/1.3.0"',
+        )
+        expect(html).not.toContain('src="./create_button.png"')
+    })
+
+    it("re-points a relative image that walks up out of the page's directory", async () => {
+        const { html } = await renderVersionedDocBody({
+            version: "1.3",
+            path: "use-cases/dbt",
+            markdown: `---\ntitle: T\n---\n![editor](../../15.how-to-guides/dbt/dbt-code-editor.png)`,
+            children: {
+                docs: { title: "Docs" },
+                "docs/use-cases/dbt": { title: "dbt", isIndex: true },
+            },
+        })
+        expect(html).toContain(
+            'src="https://api.kestra.io/v1/docs/docs/how-to-guides/dbt/dbt-code-editor.png/versions/1.3.0"',
+        )
+    })
+
+    it("tags images `zoom`, like latest's rehype plugin", async () => {
+        const html = await render(`---
+title: T
+---
+![diagram](/docs/x.png)`)
+        expect(html).toContain('class="zoom"')
+    })
+
     it("re-points a raw-HTML video src and poster", async () => {
         const html = await render(`---
 title: T

--- a/src/utils/renderVersionedDoc.ts
+++ b/src/utils/renderVersionedDoc.ts
@@ -7,9 +7,11 @@ import {
     directDocChildren,
     docLinkBaseDir,
     frontmatterField,
+    isRelativeAssetRef,
     isRelativeDocHref,
     isVersionedAssetRef,
     plainDocText,
+    resolveRelativeAssetRef,
     resolveVersionedDocLink,
     versionedAssetUrl,
     type DocChildren,
@@ -330,8 +332,9 @@ function repointAbsoluteDocHref(
 
 // Pre-pass over the parsed tree, mutating in place before serialize:
 // - asset refs re-pointed at the versioned asset API (mirrors the in-app
-//   ProseImg + doc store); only root-absolute refs with a file extension (see
-//   isVersionedAssetRef) — external and protocol-relative refs are left alone
+//   ProseImg + doc store): root-absolute refs (<=1.1) directly, colocated
+//   relative ones (1.2+) resolved against the page's own directory first —
+//   external and protocol-relative refs are left alone
 // - relative in-content links resolved to versioned pretty URLs (the raw
 //   source-relative "NN.foo.md" hrefs are all dead routes)
 // - heading ids assigned via a fresh GithubSlugger per render (the memoized
@@ -342,9 +345,21 @@ function transformTree(node: MdcNode | undefined, ctx: TransformCtx): void {
     if (node.type === "element" && node.tag && node.props) {
         for (const attr of ASSET_ATTRS[node.tag] ?? []) {
             const v = node.props[attr]
-            if (typeof v === "string" && isVersionedAssetRef(v)) {
-                node.props[attr] = versionedAssetUrl(ctx.apiUrl, ctx.version, v)
+            if (typeof v !== "string") continue
+            const ref = isRelativeAssetRef(v)
+                ? resolveRelativeAssetRef(ctx.baseDir, v)
+                : v
+            if (isVersionedAssetRef(ref)) {
+                node.props[attr] = versionedAssetUrl(ctx.apiUrl, ctx.version, ref)
             }
+        }
+        // Latest's rehype img-plugin tags every image `zoom`, what medium-zoom
+        // binds to for click-to-enlarge.
+        if (node.tag === "img") {
+            const existing = node.props.className
+            node.props.className = existing
+                ? [...(Array.isArray(existing) ? existing : [existing]), "zoom"]
+                : "zoom"
         }
         if (node.tag === "a") {
             const href = node.props.href

--- a/src/utils/versionedDocs.test.ts
+++ b/src/utils/versionedDocs.test.ts
@@ -11,8 +11,10 @@ import {
     docLinkBaseDir,
     frontmatterField,
     plainDocText,
+    isRelativeAssetRef,
     isRelativeDocHref,
     isVersionedAssetRef,
+    resolveRelativeAssetRef,
     resolveVersionedDocLink,
     versionedAssetUrl,
     decideVersionedRoute,
@@ -148,6 +150,64 @@ describe("docLinkBaseDir", () => {
 
     it("is the root for the version home", () => {
         expect(docLinkBaseDir("", children)).toBe("")
+    })
+
+    it("is the page itself for a childless index page (1.2+ shape)", () => {
+        // Every 1.2+ page is an index.md in its own directory, so a page with
+        // no child PAGES still owns the directory its screenshots sit in.
+        expect(
+            docLinkBaseDir("tutorial/fundamentals", {
+                ...children,
+                "docs/tutorial/fundamentals": { title: "Fundamentals", isIndex: true },
+            }),
+        ).toBe("tutorial/fundamentals")
+    })
+})
+
+describe("isRelativeAssetRef", () => {
+    it("matches the 1.2+ colocated asset refs", () => {
+        expect(isRelativeAssetRef("./create-button.png")).toBe(true)
+        expect(isRelativeAssetRef("../okta/sso.png")).toBe(true)
+        expect(isRelativeAssetRef("x.gif")).toBe(true)
+    })
+
+    it("leaves root-absolute, external and anchor refs alone", () => {
+        expect(isRelativeAssetRef("/docs/tutorial/x.png")).toBe(false)
+        expect(isRelativeAssetRef("https://cdn.example/x.png")).toBe(false)
+        expect(isRelativeAssetRef("data:image/png;base64,AAAA")).toBe(false)
+        expect(isRelativeAssetRef("#frag")).toBe(false)
+    })
+
+    it("leaves extension-less relative paths (doc links) alone", () => {
+        expect(isRelativeAssetRef("./01.fundamentals")).toBe(false)
+        expect(isRelativeAssetRef("")).toBe(false)
+    })
+})
+
+describe("resolveRelativeAssetRef", () => {
+    it("resolves a colocated ref against the page's own directory", () => {
+        expect(resolveRelativeAssetRef("tutorial/fundamentals", "./create_button.png")).toBe(
+            "/docs/tutorial/fundamentals/create_button.png",
+        )
+        expect(resolveRelativeAssetRef("tutorial/fundamentals", "create_button.png")).toBe(
+            "/docs/tutorial/fundamentals/create_button.png",
+        )
+    })
+
+    it("walks up and drops ordering prefixes from directory segments", () => {
+        expect(
+            resolveRelativeAssetRef("use-cases/dbt", "../../15.how-to-guides/dbt/x.png"),
+        ).toBe("/docs/how-to-guides/dbt/x.png")
+    })
+
+    it("keeps a query/hash suffix and never strips the filename's own prefix", () => {
+        expect(resolveRelativeAssetRef("ui/flows", "./1.2-editor.png?v=2")).toBe(
+            "/docs/ui/flows/1.2-editor.png?v=2",
+        )
+    })
+
+    it("clamps a ref that walks above the docs root", () => {
+        expect(resolveRelativeAssetRef("", "../../x.png")).toBe("/docs/x.png")
     })
 })
 

--- a/src/utils/versionedDocs.ts
+++ b/src/utils/versionedDocs.ts
@@ -146,18 +146,45 @@ export function missingDocFallbackHref(
 }
 
 /**
- * True for an asset reference we should re-point at the versioned asset API: a
- * root-absolute path ending in a file extension (e.g. "/docs/tutorial/x.png",
- * "/autocompletion.gif"). The whole doc corpus authors assets this way — there
- * are no "./"/"../" relative refs — so a relative ref (which we'd need the page's
- * own path to resolve, like the in-app ProseImg's "/./" substitution) is left
- * untouched: it renders no worse than today and never occurs in practice.
- * External (http(s)/protocol-relative/data/mailto/tel) and anchor refs are also
- * left alone, so an external <iframe src> or //cdn asset is never rewritten.
+ * True for a root-absolute asset ref with a file extension ("/docs/tutorial/x.png"),
+ * how the corpus authored assets up to 1.1. Relative refs go through resolveRelativeAssetRef.
  */
 export function isVersionedAssetRef(src: string): boolean {
     if (!src || !src.startsWith("/") || src.startsWith("//")) return false
     return /\.[a-z0-9]+$/i.test(src.split(/[?#]/)[0])
+}
+
+/**
+ * True for a 1.2+ colocated asset ref ("./create-button.png", "../okta/sso.png").
+ * Extension test as in isAssetShapedDocPath, so "./01.fundamentals" isn't one.
+ */
+export function isRelativeAssetRef(src: string): boolean {
+    if (!src || src.startsWith("/") || src.startsWith("#")) return false
+    if (/^[a-z][a-z0-9+.-]*:/i.test(src)) return false
+    return isAssetShapedDocPath(src.split(/[?#]/)[0])
+}
+
+/**
+ * Relative asset ref -> the root-absolute form versionedAssetUrl expects, resolved against
+ * `baseDir`. Directory ordering prefixes drop (the served tree is the cleaned one), filenames keep theirs.
+ */
+export function resolveRelativeAssetRef(baseDir: string, src: string): string {
+    const cut = src.search(/[?#]/)
+    const path = cut === -1 ? src : src.slice(0, cut)
+    const suffix = cut === -1 ? "" : src.slice(cut)
+    const segments = path.split("/")
+    const file = segments.pop() ?? ""
+    const parts = baseDir ? baseDir.split("/") : []
+    for (const raw of segments) {
+        if (raw === "" || raw === ".") continue
+        if (raw === "..") {
+            parts.pop()
+            continue
+        }
+        parts.push(raw.replace(/^\d+\./, ""))
+    }
+    parts.push(file)
+    return `/docs/${parts.join("/")}${suffix}`
 }
 
 /**
@@ -188,15 +215,15 @@ export function isRelativeDocHref(href: string): boolean {
 }
 
 /**
- * The directory the page's own markdown lives in, which relative links resolve
- * against. A page that has children in the flat map is a directory index
- * (docs/06.tutorial/index.md) so its links resolve inside itself; a leaf page
- * (docs/06.tutorial/05.outputs.md) resolves against its parent. The version
- * home ("") is docs/index.md -> "".
+ * The directory the page's markdown lives in, which relative links and asset refs resolve
+ * against: itself for an index page, its parent for a leaf. Version home ("") -> "".
  */
 export function docLinkBaseDir(path: string, children: DocChildren): string {
     const cleaned = path.replace(/^\/+|\/+$/g, "")
     if (!cleaned) return ""
+    // Since 1.2 every page is its own directory's index.md, so one with no
+    // child PAGES (only colocated screenshots) is still a directory.
+    if (children[`docs/${cleaned}`]?.isIndex) return cleaned
     const prefix = `docs/${cleaned}/`
     if (Object.keys(children).some((k) => k.startsWith(prefix))) return cleaned
     const slash = cleaned.lastIndexOf("/")


### PR DESCRIPTION
Closes https://github.com/kestra-io/docs/issues/5508

### Root cause

The corpus changed asset conventions at 1.2, and the versioned renderer only knew the old one. Confirmed against the archive API:

| version | ref in markdown | `isIndex` |
| --- | --- | --- |
| 1.1 `docs/tutorial/fundamentals` | `[](/docs/tutorial/fundamentals/create_button.png)` | `false` |
| 1.3 same page | `[](./create_button.png)` | `true` |

`isVersionedAssetRef` matches root-absolute refs only, so every 1.2+ relative ref was serialized verbatim and the browser resolved it against the page URL (`/docs/1.3/tutorial/create_button.png`). Hence the all-or-nothing breakage per version: 464 images on 1.3, 478 on 1.2.

### Changes

- `versionedDocs.ts`: `isRelativeAssetRef` + `resolveRelativeAssetRef(baseDir, src)`, producing the root-absolute path `versionedAssetUrl` already expects. Directory ordering prefixes drop (the served tree is the cleaned one), filenames keep theirs, query/hash survives.
- `docLinkBaseDir`: trust the children endpoint's `isIndex` before the has-child-pages heuristic. That heuristic cannot see a directory whose only contents are screenshots, which is exactly the 1.2+ shape. Falls back to the old check for versions that don't report the field, so 1.0/1.1 leaf pages are unaffected.
- `renderVersionedDoc.ts`: media attrs (`img`/`source`/`video`/`audio` `src`, `poster`) run through the resolver before the existing versioned-asset rewrite; `img` picks up the `zoom` class latest's rehype plugin adds.
- `docs-versioned.astro`: `.mdc-renderer :global(img) { max-width: 100% }`. Oversized images on 1.0/1.1 (reported in the issue thread) were images never getting `medium-zoom`'s `.medium-zoom-image` cap, so a 3000px screenshot arrived at full majestic size. CSS handles it without waiting on the script.

Side effect worth knowing about: relative *links* on 1.2+ pages were resolving one level too high for the same reason (`../05.flowable/index.md` landed on `/docs/1.3/flowable`). The `docLinkBaseDir` change fixes those too.

Assets stay version-scoped: the resolver only builds the path, and `versionedAssetUrl(apiUrl, ctx.version, ref)` pins the snapshot, with `baseDir` derived from that version's own children map.

### Testing

285 unit tests pass, `astro check` reports 0 errors. 8 new tests cover the resolver (colocated ref, parent walk, prefix stripping, query suffix, root clamp) and the render path end to end at `1.3`.

Not verified: `api.kestra.io` is blocked by the session's network policy, so I could not fetch a rewritten URL and see a 200. The shape is derived from the 1.1 refs that load today (`{api}/docs/docs/tutorial/fundamentals/create_button.png/versions/1.1.0`) plus the fact that page paths in the same tree are served prefix-stripped. Worth one curl against a preview deploy before merge.

Card icons on 1.2/1.3 were already handled by the `/src/contents` prefix strip in `childCardsHtml`, so they are not part of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwK5zJucNq5JmgvfYhtMXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwK5zJucNq5JmgvfYhtMXF)_