### PR TITLE
fix(docs): clamp markdown images to the content column

### DIFF
--- a/src/assets/styles/markdown.scss
+++ b/src/assets/styles/markdown.scss
@@ -268,6 +268,12 @@
     iframe {
         max-width: 100%;
     }
+    // Only markdown rendered from raw HTML (versioned docs, plugins, blueprints)
+    // needs this: Astro's image pipeline already constrains the latest docs'.
+    img {
+        max-width: 100%;
+        height: auto;
+    }
     iframe {
         width: 100%;
         margin-bottom: $spacer;


### PR DESCRIPTION
Images on the versioned docs overflow the content column and spill over the table of contents — e.g. [/docs/1.1/architecture](https://kestra.io/docs/1.1/architecture), whose `jdbc.gif` is 1280px wide in a 768px column.

The `markdown-styles` mixin clamps `video` and `iframe` to the column but never `img`. The latest docs never noticed: their images go through Astro's image pipeline, which emits already-constrained ones. Versioned docs render raw markdown HTML fetched from api.kestra.io, so the `<img>` arrives with no width, no height and no class, and lays out at its natural size. The clamp goes in the mixin, next to the `video, iframe` rule that already owns this concern, rather than in the versioned page.

`height: auto` is part of the fix, not decoration: `max-width` alone would distort any image whose height is otherwise pinned.

Measured on a local dev server, per image (`getBoundingClientRect().width` vs the column's `clientWidth` — page `scrollWidth` never detected this, the container clips):

| | content column | GIF rendered | overflows |
|---|---|---|---|
| before | 768px | 1280px | yes |
| after | 609px | 609px | no |

- `/docs/1.1/architecture`, `/docs/1.1/tutorial`: no image overflows; card icons still exactly 48x48; the iframe is unaffected
- `/docs/architecture`, `/blogs/2022-04-27-etl-vs-elt`: unchanged, aspect ratios intact
- 390px viewport: the GIF renders at 343px, no overflow

The mixin is shared, so blueprints and plugin docs inherit the clamp as well. That is intended, but not verified as a fix there: neither corpus has an image in its markdown body today, so nothing on those surfaces changes now — the rule means the next one is clamped.

No tests: this is CSS with no unit seam, and adding a versioned page to the visual-regression fixtures would make the suite depend on a live api.kestra.io fetch, plus new multi-MB baselines.

Unrelated, noticed while verifying and left alone: versioned pages render bare YouTube `<iframe>`s without the `.video-container` wrapper the latest docs use, so those embeds come out unstyled.