### PR TITLE
fix(blueprints): degrade gracefully when the API can't build a graph

### DIFF
--- a/src/pages/blueprints/[id].astro
+++ b/src/pages/blueprints/[id].astro
@@ -1,7 +1,7 @@
 ---
 export const prerender = false
 import { Icon } from "astro-icon/components"
-import { $fetchApiCached } from "~/utils/fetch"
+import { $fetchApiCached, $fetchApiCachedOptional } from "~/utils/fetch"
 import Layout from "~/components/layout.astro"
 import Header from "~/components/blueprints/Header.astro"
 import BlueprintHero from "~/components/blueprints/BlueprintHero.astro"
@@ -136,10 +136,17 @@ if (isCategoryPage && category) {
         return Astro.redirect("/404")
     }
 
-    graph = await $fetchApiCached(`/blueprints/${id}/versions/latest/graph`)
-    detailTags = await $fetchApiCached<BlueprintTag[]>(
-        `/blueprints/versions/latest/tags`,
+    // The graph endpoint 422s when the API can't deserialize a flow (e.g. a
+    // plugin field it doesn't know yet); render the page without the topology.
+    graph = await $fetchApiCachedOptional(
+        `/blueprints/${id}/versions/latest/graph`,
     )
+    // Tags and related rows are decorative: a failing tags endpoint degrades
+    // the header pills and drops the "More ..." rows, it must not 500 the page.
+    detailTags =
+        (await $fetchApiCachedOptional<BlueprintTag[]>(
+            `/blueprints/versions/latest/tags`,
+        )) ?? []
 
     if (pageData.tags && pageData.tags.length > 0) {
         const pageTags = pageData.tags
@@ -154,9 +161,9 @@ if (isCategoryPage && category) {
         ].slice(0, 2)
 
         for (const tag of orderedTags) {
-            const data = await $fetchApiCached<{ results: Blueprint[] }>(
-                `/blueprints/versions/latest?tags=${tag.id}&size=10`,
-            )
+            const data = await $fetchApiCachedOptional<{
+                results: Blueprint[]
+            }>(`/blueprints/versions/latest?tags=${tag.id}&size=10`)
 
             if (data && data.results.length > 0) {
                 const rowBlueprints = data.results
@@ -344,12 +351,30 @@ if (isCategoryPage && category) {
                                     />
                                 </div>
                                 <div class="topology">
-                                    <Detail
-                                        client:only
-                                        page={pageData}
-                                        flow={pageData.flow}
-                                        graph={graph}
-                                    />
+                                    {graph ? (
+                                        <Detail
+                                            client:only
+                                            page={pageData}
+                                            flow={pageData.flow}
+                                            graph={graph}
+                                        />
+                                    ) : (
+                                        <div class="topology-unavailable">
+                                            <Icon
+                                                name="mdi:alert-circle-outline"
+                                                class="topology-unavailable-icon"
+                                            />
+                                            <p class="topology-unavailable-title">
+                                                Diagram unavailable
+                                            </p>
+                                            <p class="topology-unavailable-body">
+                                                We could not build the topology
+                                                for this blueprint. The flow
+                                                itself is valid, use the YAML on
+                                                the left to run it.
+                                            </p>
+                                        </div>
+                                    )}
                                 </div>
                             </div>
                         </div>
@@ -450,6 +475,41 @@ if (isCategoryPage && category) {
 
             :global(.mdc-renderer pre) {
                 padding-bottom: 1rem;
+            }
+
+            // Shown in place of the vue-flow topology when the API cannot
+            // build the graph (it 422s on flows it fails to deserialize).
+            .topology-unavailable {
+                flex: 1;
+                border-radius: 8px;
+                border: $block-border;
+                background-color: var(--ks-background-secondary);
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                gap: .5rem;
+                padding: $rem-2;
+                text-align: center;
+
+                .topology-unavailable-icon {
+                    width: 2rem;
+                    height: 2rem;
+                    color: var(--ks-content-secondary);
+                }
+
+                .topology-unavailable-title {
+                    margin: 0;
+                    font-weight: 600;
+                    color: var(--ks-content-primary);
+                }
+
+                .topology-unavailable-body {
+                    margin: 0;
+                    max-width: 32ch;
+                    font-size: $font-size-sm;
+                    color: var(--ks-content-secondary);
+                }
             }
 
             .topology {

--- a/src/pages/blueprints/[id].astro
+++ b/src/pages/blueprints/[id].astro
@@ -50,6 +50,7 @@ let categoryBlueprints: Blueprint[] = []
 let categoryTags: BlueprintTag[] = []
 let categoryTagId: string | undefined
 let categoryQ: string | undefined
+let categoryFetchFailed = false
 let heroSiblings: SiblingPill[] = []
 let subCategoryRows: { name: string; blueprints: Blueprint[] }[] = []
 const PAGE_SIZE = 24
@@ -69,18 +70,28 @@ const coreToolIndex = await fetchCoreToolIndex(fullCatalog)
 if (isCategoryPage && category) {
     categoryQ = Astro.url.searchParams.get("q") ?? undefined
 
-    categoryTags = await $fetchApiCached<BlueprintTag[]>(
-        `/blueprints/versions/latest/tags`,
-    )
+    // A category listing with no data is still a usable page (hero, siblings,
+    // FAQ), so an API hiccup empties the grid rather than 500ing.
+    categoryTags =
+        (await $fetchApiCachedOptional<BlueprintTag[]>(
+            `/blueprints/versions/latest/tags`,
+        )) ?? []
     const tag = categoryTags.find((t) => t.name === category.name)
     categoryTagId = tag?.id
 
-    const { results = [], total = 0 } = tag
-        ? ((await $fetchApiCached<{ results: Blueprint[]; total: number }>(
+    const listing = tag
+        ? await $fetchApiCachedOptional<{
+              results: Blueprint[]
+              total: number
+          }>(
               `/blueprints/versions/latest?size=${PAGE_SIZE}&page=1&tags=${tag.id}` +
                   (categoryQ ? `&q=${encodeURIComponent(categoryQ)}` : ""),
-          )) ?? { results: [], total: 0 })
+          )
         : { results: [], total: 0 }
+
+    // Tells the empty state apart from a genuinely empty category.
+    categoryFetchFailed = categoryTags.length === 0 || listing === undefined
+    const { results = [], total = 0 } = listing ?? { results: [], total: 0 }
 
     categoryBlueprints = results
     categoryTotal = total
@@ -96,7 +107,9 @@ if (isCategoryPage && category) {
     }))
 
     if (tag) {
-        const sample = await $fetchApiCached<{ results: Blueprint[] }>(
+        const sample = await $fetchApiCachedOptional<{
+            results: Blueprint[]
+        }>(
             `/blueprints/versions/latest?size=${SUBCATEGORY_SAMPLE_SIZE}&page=1&tags=${tag.id}`,
         )
 
@@ -303,9 +316,11 @@ if (isCategoryPage && category) {
                             ) : (
                                 <div class="col-12 text-center py-5">
                                     <p>
-                                        {categoryQ
-                                            ? `No ${category.name} blueprints found for "${categoryQ}".`
-                                            : "No blueprints tagged with this category yet."}
+                                        {categoryFetchFailed
+                                            ? "We could not load blueprints right now. Please try again in a moment."
+                                            : categoryQ
+                                              ? `No ${category.name} blueprints found for "${categoryQ}".`
+                                              : "No blueprints tagged with this category yet."}
                                     </p>
                                     <a
                                         href="/blueprints"

--- a/src/pages/sitemap/blueprints.xml.ts
+++ b/src/pages/sitemap/blueprints.xml.ts
@@ -5,20 +5,6 @@ import { useBlueprintsList } from "~/composables/useBlueprintsList.ts"
 import { CATEGORY_TILE_META } from "~/utils/blueprints/categoryMeta"
 import { sitemapResponse, formatLastMod } from "~/utils/sitemap.ts"
 
-/**
- * Blueprints listed by the API whose page currently returns a 500.
- *
- * Their `/blueprints/{id}/versions/latest` payload is fine, but
- * `/blueprints/{id}/versions/latest/graph` answers 422 and the page fetches the
- * graph outside a try/catch, so the render throws. Nothing in the list payload
- * distinguishes them, hence the explicit list. Drop an entry once its page
- * returns 200 again.
- */
-const BROKEN_BLUEPRINTS = new Set([
-    "azure-blob-backup-retention-cutover",
-    "ldap-employee-offboarding-deprovision",
-])
-
 export const GET: APIRoute = async () => {
     const data = (await useBlueprintsList({ page: 1, size: 9999 })) as {
         results: Blueprint[]
@@ -34,7 +20,6 @@ export const GET: APIRoute = async () => {
 
     const urls = data.results
         // `Blueprint.id` is declared as a number in src/type.d.ts but the API returns a slug.
-        .filter((r) => !BROKEN_BLUEPRINTS.has(String(r.id)))
         .map((r) => ({ loc: `https://kestra.io/blueprints/${r.id}`, lastmod: formatLastMod(r.updatedAt) }))
 
     return sitemapResponse([...categoryUrls, ...urls])

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -95,6 +95,24 @@ export async function $fetchApiCached<T = any>(
     return await $fetchApi<T>(url, cachingConfig)
 }
 
+// Same as $fetchApiCached but resolves to undefined when the API fails, for
+// decorative data that must not take the whole page down.
+export async function $fetchApiCachedOptional<T = any>(
+    url: string,
+    init: RequestInit = {},
+): Promise<T | undefined> {
+    try {
+        return await $fetchApiCached<T>(url, init)
+    } catch (error) {
+        const status = (error as { response?: { status?: number } })?.response
+            ?.status
+        console.warn(
+            `Optional API fetch failed (${status ?? "network"}): ${url}`,
+        )
+        return undefined
+    }
+}
+
 export async function $fetchApiRawCached(
     url: string,
     init: RequestInit = {},


### PR DESCRIPTION
### The 500

`/blueprints/ai-github-daily-healthcheck` returns a 500. The cause is upstream:

```
GET https://api.kestra.io/v1/blueprints/ai-github-daily-healthcheck/versions/latest/graph
422 Invalid entity: Unrecognized field "chatConfiguration"
    (class io.kestra.plugin.ai.domain.ChatConfiguration), not marked as ignorable
```

The API's plugin version is behind the blueprint's, so it can't deserialize the flow well enough to build a graph. The blueprint's own payload is fine. The docs page fetched the graph outside a try/catch, so one unhappy blueprint took the entire page with it.

This will happen again on every blueprint that lands ahead of the API's plugin jars, so the page should survive it.

### What changed

- `$fetchApiCachedOptional` in `src/utils/fetch.ts`: resolves to `undefined` and logs a warning instead of throwing. For decorative data only.
- The graph, the tag list and the per-tag related rows now use it. The blueprint payload itself still redirects to `/404` on failure, unchanged.
- The `.topology` column always renders. Without a graph it shows a "Diagram unavailable" panel styled like the topology card, pointing the reader at the YAML, rather than collapsing and leaving a gap where a diagram should be.
- The three category-listing fetches (`/blueprints/{category}`) got the same treatment. Its grid already had an empty state, but the copy would have lied about a failure ("no blueprints tagged with this category yet"), so it now tells a fetch failure apart from an actually empty category.
- Dropped `BROKEN_BLUEPRINTS` from `src/pages/sitemap/blueprints.xml.ts`. It was a hardcoded list of blueprints excluded from the sitemap purely because their pages 500'd. Both entries now return 200 from the graph endpoint, and the page no longer cares either way.

Degradation order: graph fails, you get the placeholder; tags fail, you lose the header pills and the "More ..." rows and keep everything else.

### Verified locally

| URL | before | after |
| --- | --- | --- |
| `/blueprints/ai-github-daily-healthcheck` (graph 422) | 500 | 200, placeholder panel, no `.topology` island |
| `/blueprints/azure-blob-backup-retention-cutover` (graph 200) | 200 | 200, real topology |
| `/sitemap/blueprints.xml` | 200 | 200 |
| `/blueprints/ai`, `/blueprints/data`, `?q=` hit and miss | 200 | 200, unchanged |

With every optional fetch forced to throw, `/blueprints/ai` returns 200 with the "could not load blueprints" message and `/blueprints/ai-github-daily-healthcheck` returns 200 with the placeholder panel.

`tsc --noEmit` reports nothing new on the touched files (the repo has pre-existing errors in `versionedNavigation`).

### Not in scope

Server islands were considered and rejected for this: `server:defer` has no per-island error boundary, so a throwing island returns a failed response and renders nothing. It would swap a loud 500 for a silent blank slot plus a round trip. They'd help these pages for caching, not resilience, and that's a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
