### PR TITLE
docs(api-reference): add pages for the API problem types

### DIFF
--- a/src/contents/docs/api-reference/03.problems/ai-request-failed.md
+++ b/src/contents/docs/api-reference/03.problems/ai-request-failed.md
@@ -1,0 +1,38 @@
+---
+title: "Kestra API Error: AI request failed"
+h1: AI request failed
+sidebarTitle: AI request failed
+description: The ai-request-failed problem type is returned when an AI Copilot request cannot be completed, usually because of the model provider or the prompt.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+An AI Copilot request could not be completed.
+
+- **HTTP status** — `422 Unprocessable Content`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/ai-request-failed`
+
+## When you get it
+
+- The configured model provider rejects the call or returns an unusable response.
+- The prompt, or the flow it was asked to work on, cannot be processed.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/ai-request-failed",
+  "title": "AI request failed",
+  "status": 422,
+  "detail": "The model provider rejected the request: context length exceeded.",
+  "instance": "/api/v1/main/ai/generate/flow"
+}
+```
+
+## How to handle it
+
+This is a client error rather than a server error because the cause is usually the request or the provider configuration, not a fault in Kestra. Retrying an identical prompt rarely helps.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/app-error.md
+++ b/src/contents/docs/api-reference/03.problems/app-error.md
@@ -1,0 +1,38 @@
+---
+title: "Kestra API Error: App error"
+h1: App error
+sidebarTitle: App error
+description: The app-error problem type is returned when an App rejects a Kestra API request because of its definition or its current runtime state.
+icon: /src/contents/docs/icons/api.svg
+editions: ["EE", "Cloud"]
+---
+
+An App rejected the request because of its definition or its current runtime state.
+
+- **HTTP status** — `422 Unprocessable Content`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/app-error`
+
+## When you get it
+
+- An App request is submitted that its definition does not accept.
+- An App is acted on in a state that does not allow that transition.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/app-error",
+  "title": "App error",
+  "status": 422,
+  "detail": "App 'onboarding' is not in a state that accepts this request.",
+  "instance": "/api/v1/main/apps/onboarding"
+}
+```
+
+## How to handle it
+
+The `detail` is the App's own explanation, and it decides whether the request or the App definition is what needs changing. See [Apps](../../07.enterprise/04.scalability/apps/index.md).
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/bad-request.md
+++ b/src/contents/docs/api-reference/03.problems/bad-request.md
@@ -1,0 +1,39 @@
+---
+title: "Kestra API Error: Bad request"
+h1: Bad request
+sidebarTitle: Bad request
+description: The bad-request problem type is returned when a Kestra API request is malformed, and for any 4xx status that has no more specific problem type.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The request is malformed. This is also the type reported for any 4xx status that has no more specific type of its own.
+
+- **HTTP status** — `400 Bad Request`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/bad-request`
+
+## When you get it
+
+- A route's required binding cannot be satisfied by the request.
+- A source-search query is not valid syntax.
+- A search expression takes too long to evaluate and is abandoned.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/bad-request",
+  "title": "Bad request",
+  "status": 400,
+  "detail": "Bad request",
+  "instance": "/api/v1/main/flows"
+}
+```
+
+## How to handle it
+
+Read the `detail`: on this type it is the only description of what the server could not make sense of.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/bulk-validation-failed.md
+++ b/src/contents/docs/api-reference/03.problems/bulk-validation-failed.md
@@ -1,0 +1,49 @@
+---
+title: "Kestra API Error: Bulk validation failed"
+h1: Bulk validation failed
+sidebarTitle: Bulk validation failed
+description: The bulk-validation-failed problem type is returned when a Kestra API bulk endpoint rejects a request, with one errors entry per rejected item.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+A bulk endpoint rejected the request and reports one `errors` entry per rejected item.
+
+- **HTTP status** — `400 Bad Request`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/bulk-validation-failed`
+
+## When you get it
+
+- One or more items in a bulk create, update, or delete cannot be accepted.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/bulk-validation-failed",
+  "title": "Bulk validation failed",
+  "status": 400,
+  "detail": "Bulk validation failed",
+  "instance": "/api/v1/main/executions/resume/by-ids",
+  "errors": [
+    {
+      "detail": "Execution '4NFYr' is not paused.",
+      "path": "4NFYr",
+      "type": "https://kestra.io/docs/api-reference/problems/conflict"
+    },
+    {
+      "detail": "Execution '7wKmQ' not found.",
+      "path": "7wKmQ",
+      "type": "https://kestra.io/docs/api-reference/problems/not-found"
+    }
+  ]
+}
+```
+
+## How to handle it
+
+Each entry names the item in `path` and carries its own `type`, so a missing item can be told apart from a conflicting one without parsing text. No item is partially applied: the whole request is rejected.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/conflict.md
+++ b/src/contents/docs/api-reference/03.problems/conflict.md
@@ -1,0 +1,41 @@
+---
+title: "Kestra API Error: Conflict"
+h1: Conflict
+sidebarTitle: Conflict
+description: The conflict problem type is returned when the current state of a Kestra resource does not allow the operation requested.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The resource's current state does not allow the operation.
+
+- **HTTP status** — `409 Conflict`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/conflict`
+
+## When you get it
+
+- The execution is not in a state that allows the action: restarting one that is not terminated, resuming one that is not paused, or acting on one that was killed.
+- The flow, or the trigger the request targets, is disabled.
+- A trigger is unlocked when it was not locked, or a backfill action does not apply to its current state.
+- An AI Copilot turn is already in flight on the thread.
+- A lock is held by another in-flight operation on the same resource.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/conflict",
+  "title": "Conflict",
+  "status": 409,
+  "detail": "Cannot restart execution: current state is 'RUNNING', expected terminated.",
+  "instance": "/api/v1/main/executions/4NFYrJfMEBQpLNDsGwXWZg/actions/restart"
+}
+```
+
+## How to handle it
+
+Re-read the resource before deciding what to do. Some conflicts clear on their own, such as a lock or an execution that is still running; others, such as a disabled flow, need a change before the request can succeed.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/entity-already-exists.md
+++ b/src/contents/docs/api-reference/03.problems/entity-already-exists.md
@@ -1,0 +1,38 @@
+---
+title: "Kestra API Error: Entity already exists"
+h1: Entity already exists
+sidebarTitle: Entity already exists
+description: The entity-already-exists problem type is returned when a Kestra API create request uses an identifier that is already taken.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The identifier you are trying to create is already taken.
+
+- **HTTP status** — `409 Conflict`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/entity-already-exists`
+
+## When you get it
+
+- A flow, namespace, user, role, or service account is created with an id that exists.
+- A create request that had already succeeded is sent again.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/entity-already-exists",
+  "title": "Entity already exists",
+  "status": 409,
+  "detail": "A flow with id 'my-flow' already exists in namespace 'company.team'.",
+  "instance": "/api/v1/main/flows"
+}
+```
+
+## How to handle it
+
+Use the update endpoint to change the existing resource, or pick a different id. Create is not idempotent, so a retried create reporting this often means the first attempt succeeded.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/feature-disabled.md
+++ b/src/contents/docs/api-reference/03.problems/feature-disabled.md
@@ -1,0 +1,38 @@
+---
+title: "Kestra API Error: Feature disabled by license"
+h1: Feature disabled by license
+sidebarTitle: Feature disabled by license
+description: The feature-disabled problem type is returned when a Kestra API endpoint belongs to a feature the instance's license does not include.
+icon: /src/contents/docs/icons/api.svg
+editions: ["EE", "Cloud"]
+---
+
+The endpoint belongs to a feature that this instance's license does not include.
+
+- **HTTP status** — `403 Forbidden`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/feature-disabled`
+
+## When you get it
+
+- An Enterprise endpoint is called whose feature is not in the license.
+- The license has expired.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/feature-disabled",
+  "title": "Feature disabled by license",
+  "status": 403,
+  "detail": "Feature 'AUDIT_LOGS' is not enabled by the current license.",
+  "instance": "/api/v1/main/auditlogs/search"
+}
+```
+
+## How to handle it
+
+Do not retry. This differs from [`forbidden`](./forbidden.md): no permission change will make it succeed, because the feature is not available on the instance at all.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/forbidden.md
+++ b/src/contents/docs/api-reference/03.problems/forbidden.md
@@ -1,0 +1,39 @@
+---
+title: "Kestra API Error: Access denied"
+h1: Access denied
+sidebarTitle: Access denied
+description: The forbidden problem type is returned when a Kestra API caller is authenticated but is not allowed to perform the operation.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The caller is authenticated but is not allowed to perform this operation.
+
+- **HTTP status** — `403 Forbidden`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/forbidden`
+
+## When you get it
+
+- The caller's role does not grant the required permission.
+- The resource is in a namespace outside the caller's granted namespaces.
+- An AI Copilot tool call is one the caller is not permitted to make.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/forbidden",
+  "title": "Access denied",
+  "status": 403,
+  "detail": "Access denied",
+  "instance": "/api/v1/main/flows"
+}
+```
+
+## How to handle it
+
+Do not retry: the outcome will not change without a permission change. Cloud and Enterprise instances report `feature-disabled`, `license-limit-exceeded`, or `policy-violation` instead when one of those is the actual reason.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/index.md
+++ b/src/contents/docs/api-reference/03.problems/index.md
@@ -1,0 +1,189 @@
+---
+title: "Kestra API Errors: RFC 9457 Problem Details"
+h1: Problem details
+sidebarTitle: Problem Details
+description: Every Kestra API error is an RFC 9457 problem details document. Reference for its members, its field-level errors, and the catalog of problem types.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+hideSubMenus: true
+---
+
+Every error the Kestra API returns is an [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html) problem details document, served as `application/problem+json`. Two things are outside that: the Model Context Protocol transport under `/mcp/`, whose errors are JSON-RPC 2.0 envelopes, and the few routes that answer with an error body of their own, which is left as the route sent it.
+
+A request that tries to create a flow whose id is taken returns:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/entity-already-exists",
+  "title": "Entity already exists",
+  "status": 409,
+  "detail": "A flow with id 'my-flow' already exists in namespace 'company.team'.",
+  "instance": "/api/v1/main/flows"
+}
+```
+
+## Document members
+
+| Member | Always present | Description |
+|---|---|---|
+| `type` | yes | Stable identifier of the kind of problem, as a URI that resolves to its page below. This is the only member to branch on. |
+| `title` | yes | Short summary of the kind of problem. Identical for every occurrence of a given `type`, and never parameterised. |
+| `status` | yes | The HTTP status code, repeated in the body for convenience. |
+| `detail` | yes | Explanation of this particular occurrence, written for a human. |
+| `instance` | yes | Path of the request that produced the problem. |
+| `errors` | no | Field-level or per-item errors, when several problems are reported at once. |
+| `traceId` | no | Correlation identifier for the matching server-side log entry. Present on server errors only. |
+
+Absent members are omitted rather than sent as `null`.
+
+## Branch on type, never on text
+
+`type` is a permanent, published URI. Once a type ships it is never renamed or repurposed, so it is safe to switch on:
+
+```python
+if problem["type"].endswith("/entity-already-exists"):
+    ...
+```
+
+`title` is stable for a given `type` and never contains values from the request, which makes it safe to display verbatim or to use as a key for your own translations.
+
+`detail` is the opposite. It is written for whoever reads the error, it embeds ids and paths from the request, and its wording changes between releases. Never parse it, and never make behavior depend on it.
+
+:::alert{type="info"}
+`status` and `type` agree, with one exception: an endpoint that explicitly raises an unusual status reports that status as sent, rather than having it normalised to the type's own. Read `status` from the response.
+:::
+
+## Field-level errors
+
+When a request fails for more than one reason, each reason is an entry in `errors`:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/validation-failed",
+  "title": "Validation failed",
+  "status": 422,
+  "detail": "Validation failed",
+  "instance": "/api/v1/main/flows",
+  "errors": [
+    {
+      "detail": "must not be null",
+      "pointer": "/tasks/0/type",
+      "path": "tasks[my-task].type"
+    }
+  ]
+}
+```
+
+| Member | Description |
+|---|---|
+| `detail` | What is wrong with this field or item. |
+| `pointer` | [RFC 6901](https://www.rfc-editor.org/rfc/rfc6901.html) JSON Pointer locating the field in the submitted document. |
+| `path` | Friendlier locator that names tasks and inputs by their id. Not a JSON Pointer. |
+| `type` | The item's own problem type, on bulk endpoints where it differs per item. |
+
+Both locators are carried because neither is enough on its own: `pointer` is valid for machine use, and `path` is what to show a user. Entries are ordered deterministically, so the same request always produces the same document.
+
+## Server errors
+
+A `5xx` problem never echoes the underlying exception message. Its `detail` is always the same fixed sentence, and it carries a `traceId` that ties the response to the server log entry holding the real cause:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/internal-error",
+  "title": "Internal server error",
+  "status": 500,
+  "detail": "An unexpected error occurred. Quote the traceId when contacting support.",
+  "instance": "/api/v1/main/flows",
+  "traceId": "4bf92f3577b34da6a3ce929d0e0e4736"
+}
+```
+
+Quote the `traceId` when reporting the problem. The `errors` member is never populated on a server error.
+
+## Unknown types
+
+The catalog below grows as new kinds of failure are given a type of their own, so handle any `type` you do not recognise by its status class: a `4xx` is something to fix in the request, a `5xx` is something to retry or report. Types already published are never removed and never change meaning, so code written against the catalog keeps working.
+
+## Catalog
+
+Types marked Cloud and Enterprise Edition are returned only by those editions. Every other type is returned by all editions.
+
+### Request payload
+
+| Type | Status | Title |
+|---|---|---|
+| [`invalid-json`](./invalid-json.md) | `422` | Invalid JSON |
+| [`invalid-plugin-type`](./invalid-plugin-type.md) | `422` | Invalid plugin type |
+| [`invalid-format`](./invalid-format.md) | `422` | Invalid value format |
+| [`invalid-request-body`](./invalid-request-body.md) | `422` | Invalid request body |
+| [`invalid-argument`](./invalid-argument.md) | `422` | Invalid argument |
+
+### Request line and query string
+
+| Type | Status | Title |
+|---|---|---|
+| [`bad-request`](./bad-request.md) | `400` | Bad request |
+| [`invalid-query-parameter`](./invalid-query-parameter.md) | `400` | Invalid query parameter |
+| [`invalid-query-filters`](./invalid-query-filters.md) | `400` | Invalid query filters |
+
+### Entity validation
+
+| Type | Status | Title |
+|---|---|---|
+| [`validation-failed`](./validation-failed.md) | `422` | Validation failed |
+| [`invalid-entity`](./invalid-entity.md) | `422` | Invalid entity |
+| [`bulk-validation-failed`](./bulk-validation-failed.md) | `400` | Bulk validation failed |
+
+### Authentication and authorization
+
+| Type | Status | Title |
+|---|---|---|
+| [`unauthenticated`](./unauthenticated.md) | `401` | Authentication required |
+| [`forbidden`](./forbidden.md) | `403` | Access denied |
+
+### Resource state
+
+| Type | Status | Title |
+|---|---|---|
+| [`not-found`](./not-found.md) | `404` | Resource not found |
+| [`conflict`](./conflict.md) | `409` | Conflict |
+| [`entity-already-exists`](./entity-already-exists.md) | `409` | Entity already exists |
+| [`resource-expired`](./resource-expired.md) | `410` | Resource has expired |
+| [`locked`](./locked.md) | `423` | Resource is locked |
+
+### Protocol-level rejections
+
+| Type | Status | Title |
+|---|---|---|
+| [`method-not-allowed`](./method-not-allowed.md) | `405` | Method not allowed |
+| [`not-acceptable`](./not-acceptable.md) | `406` | Not acceptable |
+| [`payload-too-large`](./payload-too-large.md) | `413` | Payload too large |
+| [`unsupported-media-type`](./unsupported-media-type.md) | `415` | Unsupported media type |
+| [`too-many-requests`](./too-many-requests.md) | `429` | Too many requests |
+
+### AI Copilot
+
+| Type | Status | Title |
+|---|---|---|
+| [`ai-request-failed`](./ai-request-failed.md) | `422` | AI request failed |
+
+### Server errors
+
+| Type | Status | Title |
+|---|---|---|
+| [`internal-error`](./internal-error.md) | `500` | Internal server error |
+| [`migration-required`](./migration-required.md) | `503` | Migration required |
+| [`service-unavailable`](./service-unavailable.md) | `503` | Service unavailable |
+| [`timeout`](./timeout.md) | `504` | Operation timed out |
+
+### Cloud and Enterprise Edition
+
+| Type | Status | Title |
+|---|---|---|
+| [`feature-disabled`](./feature-disabled.md) | `403` | Feature disabled by license |
+| [`license-limit-exceeded`](./license-limit-exceeded.md) | `403` | License limit reached |
+| [`resource-leased`](./resource-leased.md) | `423` | Resource is leased |
+| [`invalid-credentials`](./invalid-credentials.md) | `400` | Invalid credentials |
+| [`password-policy-violation`](./password-policy-violation.md) | `422` | Password policy not met |
+| [`policy-violation`](./policy-violation.md) | `403` | Policy violation |
+| [`app-error`](./app-error.md) | `422` | App error |

--- a/src/contents/docs/api-reference/03.problems/internal-error.md
+++ b/src/contents/docs/api-reference/03.problems/internal-error.md
@@ -1,0 +1,40 @@
+---
+title: "Kestra API Error: Internal server error"
+h1: Internal server error
+sidebarTitle: Internal server error
+description: The internal-error problem type is returned when a Kestra API request fails for a reason the caller cannot fix, and carries a traceId for support.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The request failed for a reason that is not the caller's to fix.
+
+- **HTTP status** — `500 Internal Server Error`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/internal-error`
+
+## When you get it
+
+- An unhandled failure occurs anywhere in the server.
+- A secret backend, internal storage, or the database cannot be reached.
+- A flow cannot be processed for reasons beyond validation.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/internal-error",
+  "title": "Internal server error",
+  "status": 500,
+  "detail": "An unexpected error occurred. Quote the traceId when contacting support.",
+  "instance": "/api/v1/main/flows",
+  "traceId": "4bf92f3577b34da6a3ce929d0e0e4736"
+}
+```
+
+## How to handle it
+
+The `detail` is the same fixed string on every server error and never carries the exception message, so an internal message can never reach the caller. The real cause is in the server log under the same `traceId`, which is what to quote when contacting support. `errors` is never populated on a server error.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/invalid-argument.md
+++ b/src/contents/docs/api-reference/03.problems/invalid-argument.md
@@ -1,0 +1,39 @@
+---
+title: "Kestra API Error: Invalid argument"
+h1: Invalid argument
+sidebarTitle: Invalid argument
+description: The invalid-argument problem type is returned when a Kestra API endpoint receives an argument it cannot accept, outside of whole-entity validation.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+An argument the endpoint received is not acceptable. This is the general-purpose type for a rejected argument that is not a whole-entity validation failure.
+
+- **HTTP status** — `422 Unprocessable Content`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/invalid-argument`
+
+## When you get it
+
+- A value falls outside the set the endpoint accepts.
+- An identifier is not well formed.
+- A path variable or query value cannot be converted to the type the route declares.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/invalid-argument",
+  "title": "Invalid argument",
+  "status": 422,
+  "detail": "Namespace 'My Namespace' is not a valid namespace identifier.",
+  "instance": "/api/v1/main/flows"
+}
+```
+
+## How to handle it
+
+Correct the argument named in the `detail`. When the failure came from binding a path variable or a query value, the `detail` is the fixed title instead, because the underlying message names internal Java classes; the parameter's declared type is then in the OpenAPI schema for the endpoint.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/invalid-credentials.md
+++ b/src/contents/docs/api-reference/03.problems/invalid-credentials.md
@@ -1,0 +1,37 @@
+---
+title: "Kestra API Error: Invalid credentials"
+h1: Invalid credentials
+sidebarTitle: Invalid credentials
+description: The invalid-credentials problem type is returned when a Kestra API request submits a credential, such as an existing password, that does not match the one on record.
+icon: /src/contents/docs/icons/api.svg
+editions: ["EE", "Cloud"]
+---
+
+A credential submitted inside the request does not match the one on record.
+
+- **HTTP status** — `400 Bad Request`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/invalid-credentials`
+
+## When you get it
+
+- A password change supplies an old password that is not the current one.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/invalid-credentials",
+  "title": "Invalid credentials",
+  "status": 400,
+  "detail": "The old password is incorrect.",
+  "instance": "/api/v1/users/5Dv3JXqPzT/password"
+}
+```
+
+## How to handle it
+
+This is not the type for a failed sign-in. A request carrying no credentials, or credentials the server rejects while authenticating it, is reported as [`unauthenticated`](./unauthenticated.md). This type means the request was authenticated, and then submitted a further credential that did not match.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/invalid-entity.md
+++ b/src/contents/docs/api-reference/03.problems/invalid-entity.md
@@ -1,0 +1,41 @@
+---
+title: "Kestra API Error: Invalid entity"
+h1: Invalid entity
+sidebarTitle: Invalid entity
+description: The invalid-entity problem type is returned when a Kestra API request is rejected by a domain rule rather than a field constraint, and for any unmapped 422.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+A domain rule rejects the entity, rather than a field-level constraint. This is also the type reported for any 422 that has no more specific type.
+
+- **HTTP status** — `422 Unprocessable Content`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/invalid-entity`
+
+## When you get it
+
+- A KV Store value cannot be stored as submitted.
+- A trigger configuration is internally inconsistent.
+- An execution's inputs or outputs fail validation.
+- A task's worker group matches no configured Worker Queue.
+- On Cloud and Enterprise instances, credentials cannot be used in the form they were submitted.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/invalid-entity",
+  "title": "Invalid entity",
+  "status": 422,
+  "detail": "No worker queue matches worker group 'gpu'.",
+  "instance": "/api/v1/main/flows"
+}
+```
+
+## How to handle it
+
+Unlike `validation-failed`, there is usually no field to attribute this to, so the `detail` carries the whole explanation.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/invalid-format.md
+++ b/src/contents/docs/api-reference/03.problems/invalid-format.md
@@ -1,0 +1,39 @@
+---
+title: "Kestra API Error: Invalid value format"
+h1: Invalid value format
+sidebarTitle: Invalid value format
+description: The invalid-format problem type is returned when a value in a Kestra API request cannot be converted to the type its member requires.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+A value is in the right place but cannot be converted to the type that member requires.
+
+- **HTTP status** — `422 Unprocessable Content`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/invalid-format`
+
+## When you get it
+
+- A non-numeric string is sent for a numeric field.
+- A duration or timestamp is not valid ISO 8601.
+- A value fails scalar coercion, for example an input whose declared type does not match what was submitted.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/invalid-format",
+  "title": "Invalid value format",
+  "status": 422,
+  "detail": "Cannot convert 'yesterday' to an Instant.",
+  "instance": "/api/v1/main/flows"
+}
+```
+
+## How to handle it
+
+Correct the format of the value. The type each member expects is in the OpenAPI schema for the endpoint.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/invalid-json.md
+++ b/src/contents/docs/api-reference/03.problems/invalid-json.md
@@ -1,0 +1,47 @@
+---
+title: "Kestra API Error: Invalid JSON"
+h1: Invalid JSON
+sidebarTitle: Invalid JSON
+description: The invalid-json problem type is returned when a Kestra API request body cannot be parsed as JSON or cannot be mapped onto the shape the endpoint expects.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The request body could not be read, either because it is not valid JSON or because it does not map onto the shape the endpoint expects.
+
+- **HTTP status** — `422 Unprocessable Content`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/invalid-json`
+
+## When you get it
+
+- The body is syntactically broken, such as an unclosed brace, a trailing comma, or an unquoted key.
+- The body parses, but a member has the wrong shape, such as an object where a string is expected.
+
+:::alert{type="info"}
+Endpoints that take a flow, a policy, or a dashboard receive it as source text and parse it themselves, so a malformed document there is reported as [`validation-failed`](./validation-failed.md) rather than here. This type covers the request bodies the API binds onto a typed object.
+:::
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/invalid-json",
+  "title": "Invalid JSON",
+  "status": 422,
+  "detail": "Invalid JSON",
+  "instance": "/api/v1/main/triggers/backfill/delete",
+  "errors": [
+    {
+      "path": "namespace"
+    }
+  ]
+}
+```
+
+## How to handle it
+
+Fix the payload and resend. The `detail` is the fixed title rather than the parser's own message, because that message names internal Java classes. When the parser knew where the problem was, a single `errors` entry carries the `path` to it, and no entry is reported when it did not.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/invalid-plugin-type.md
+++ b/src/contents/docs/api-reference/03.problems/invalid-plugin-type.md
@@ -1,0 +1,40 @@
+---
+title: "Kestra API Error: Invalid plugin type"
+h1: Invalid plugin type
+sidebarTitle: Invalid plugin type
+description: The invalid-plugin-type problem type is returned when a request binds a plugin object straight from JSON and its type field names a class the instance cannot resolve.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+A `type` field in the payload names a plugin class this instance cannot resolve.
+
+- **HTTP status** — `422 Unprocessable Content`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/invalid-plugin-type`
+
+## When you get it
+
+- A request binds a task, trigger, or condition object straight from JSON, and the plugin class it names is misspelt or not installed on the instance you are calling.
+
+:::alert{type="info"}
+A misspelt or missing plugin type inside a **flow** does not produce this response. Flows, policies, and dashboards are submitted as source text and validated after parsing, so an unresolvable type there is reported as [`validation-failed`](./validation-failed.md), with the offending type named in an `errors` entry. That is how you will meet this failure from the current API; no endpoint binds a plugin object directly today, and the type stays published for the ones that will.
+:::
+
+## The `errors` entry
+
+When this type is reported, a single `errors` entry names the unresolved class and where it sits in the submitted document:
+
+```json
+{
+  "detail": "Unknown type 'io.kestra.plugin.scripts.python.Comands'.",
+  "path": "tasks[0].type"
+}
+```
+
+Every other member is the same as on any problem document.
+
+## How to handle it
+
+Check the spelling first, then whether the plugin is installed. `GET /api/v1/plugins` lists what the instance has.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/invalid-query-filters.md
+++ b/src/contents/docs/api-reference/03.problems/invalid-query-filters.md
@@ -1,0 +1,39 @@
+---
+title: "Kestra API Error: Invalid query filters"
+h1: Invalid query filters
+sidebarTitle: Invalid query filters
+description: The invalid-query-filters problem type is returned when the filters on a Kestra API list endpoint cannot be parsed or reference a field that cannot be filtered.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The `filters` on a list endpoint could not be parsed, or they reference something that cannot be filtered on.
+
+- **HTTP status** — `400 Bad Request`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/invalid-query-filters`
+
+## When you get it
+
+- The `filters[...]` syntax is malformed.
+- The field is one the endpoint does not support filtering on.
+- The operator does not apply to that field's type.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/invalid-query-filters",
+  "title": "Invalid query filters",
+  "status": 400,
+  "detail": "Unknown filter field 'stat'.",
+  "instance": "/api/v1/main/executions/search"
+}
+```
+
+## How to handle it
+
+Check the field and the operator against the filters the endpoint documents. An unrecognised filter is rejected rather than ignored, so that a query never silently returns unfiltered results.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/invalid-query-parameter.md
+++ b/src/contents/docs/api-reference/03.problems/invalid-query-parameter.md
@@ -1,0 +1,39 @@
+---
+title: "Kestra API Error: Invalid query parameter"
+h1: Invalid query parameter
+sidebarTitle: Invalid query parameter
+description: The invalid-query-parameter problem type is returned when a Kestra API request omits a query parameter the route requires.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+A query parameter the route requires is missing.
+
+- **HTTP status** — `400 Bad Request`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/invalid-query-parameter`
+
+## When you get it
+
+- A required query parameter is not sent.
+
+A parameter that is present but carries a value the route cannot convert to its declared type is reported as [`invalid-argument`](./invalid-argument.md) instead: the conversion failure is raised before the parameter is judged missing.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/invalid-query-parameter",
+  "title": "Invalid query parameter",
+  "status": 400,
+  "detail": "Required query parameter 'namespace' is missing.",
+  "instance": "/api/v1/main/flows/search"
+}
+```
+
+## How to handle it
+
+Add or correct the parameter. The parameters each endpoint accepts, and their types, are in the OpenAPI schema.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/invalid-request-body.md
+++ b/src/contents/docs/api-reference/03.problems/invalid-request-body.md
@@ -1,0 +1,39 @@
+---
+title: "Kestra API Error: Invalid request body"
+h1: Invalid request body
+sidebarTitle: Invalid request body
+description: The invalid-request-body problem type is returned when a Kestra API endpoint requires a request body and the one it received is missing or unusable.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The endpoint requires a body and the one it received cannot be used.
+
+- **HTTP status** — `422 Unprocessable Content`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/invalid-request-body`
+
+## When you get it
+
+- A `POST` or `PUT` is sent with no body at all.
+- A required part of a multipart request is missing.
+- A webhook trigger's inputs could not be rendered from the request that fired it.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/invalid-request-body",
+  "title": "Invalid request body",
+  "status": 422,
+  "detail": "Required body is missing.",
+  "instance": "/api/v1/main/flows"
+}
+```
+
+## How to handle it
+
+Send the body the endpoint documents. For webhooks the failure happens while rendering the trigger's own input expressions against the request, so the flow definition is what needs fixing, not the caller.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/license-limit-exceeded.md
+++ b/src/contents/docs/api-reference/03.problems/license-limit-exceeded.md
@@ -1,0 +1,39 @@
+---
+title: "Kestra API Error: License limit reached"
+h1: License limit reached
+sidebarTitle: License limit reached
+description: The license-limit-exceeded problem type is returned when a license check fails while serving a Kestra API request, for example an expired license or a configuration the license does not cover.
+icon: /src/contents/docs/icons/api.svg
+editions: ["EE", "Cloud"]
+---
+
+A license check failed while the request was being served.
+
+- **HTTP status** — `403 Forbidden`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/license-limit-exceeded`
+
+## When you get it
+
+- The license has expired, or the instance is configured to use something the license does not cover.
+
+Most license checks run when the instance starts, and a failing one stops it from starting rather than producing this response, so this type is rare in practice. A single feature that the license does not include is reported as [`feature-disabled`](./feature-disabled.md) instead.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/license-limit-exceeded",
+  "title": "License limit reached",
+  "status": 403,
+  "detail": "The maximum number of Kestra Worker threads allowed by the license has been exceeded (64/32). Please reach out to sales@kestra.io.",
+  "instance": "/api/v1/main/flows"
+}
+```
+
+## How to handle it
+
+Do not retry. The `detail` names what the license does not allow, and resolving it needs a configuration or a licensing change, not a change to the request.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/locked.md
+++ b/src/contents/docs/api-reference/03.problems/locked.md
@@ -1,0 +1,37 @@
+---
+title: "Kestra API Error: Resource is locked"
+h1: Resource is locked
+sidebarTitle: Resource is locked
+description: The locked problem type is returned when a Kestra resource is locked against the operation attempted. Leased resources report resource-leased instead.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The resource is locked against the operation you attempted.
+
+- **HTTP status** — `423 Locked`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/locked`
+
+## When you get it
+
+- An endpoint answers `423` because the resource is held against the operation requested.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/locked",
+  "title": "Resource is locked",
+  "status": 423,
+  "detail": "Resource is locked",
+  "instance": "/api/v1/main/flows"
+}
+```
+
+## How to handle it
+
+Retry once the lock clears. On Cloud and Enterprise instances, a resource held by another user's lease reports [`resource-leased`](./resource-leased.md) instead, whose `detail` names the holder and the expiry.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/method-not-allowed.md
+++ b/src/contents/docs/api-reference/03.problems/method-not-allowed.md
@@ -1,0 +1,37 @@
+---
+title: "Kestra API Error: Method not allowed"
+h1: Method not allowed
+sidebarTitle: Method not allowed
+description: The method-not-allowed problem type is returned when a Kestra API path exists but does not accept the HTTP method used.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The path exists but does not accept the HTTP method used.
+
+- **HTTP status** — `405 Method Not Allowed`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/method-not-allowed`
+
+## When you get it
+
+- A `POST` is sent to a read-only route, or a `GET` to a route that only accepts `POST`.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/method-not-allowed",
+  "title": "Method not allowed",
+  "status": 405,
+  "detail": "Method not allowed",
+  "instance": "/api/v1/main/flows"
+}
+```
+
+## How to handle it
+
+The response carries an `Allow` header listing the methods that would have worked, as required by RFC 9110.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/migration-required.md
+++ b/src/contents/docs/api-reference/03.problems/migration-required.md
@@ -1,0 +1,40 @@
+---
+title: "Kestra API Error: Migration required"
+h1: Migration required
+sidebarTitle: Migration required
+description: The migration-required problem type is returned when a Kestra instance cannot serve requests until a pending data migration has run.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The instance cannot serve the request until a data migration has run.
+
+- **HTTP status** — `503 Service Unavailable`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/migration-required`
+
+## When you get it
+
+- A migration is required and has not been started.
+- A migration is in progress.
+- The migration lock is held by another instance.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/migration-required",
+  "title": "Migration required",
+  "status": 503,
+  "detail": "An unexpected error occurred. Quote the traceId when contacting support.",
+  "instance": "/api/v1/main/flows",
+  "traceId": "9c1f2b0a7e8d4a5cb1e6f30d2a94c7b1"
+}
+```
+
+## How to handle it
+
+Retrying will keep failing until the migration completes: this needs an operator, not a client change. See the [migration guide](../../11.migration-guide/index.mdx) for the release being upgraded to.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/not-acceptable.md
+++ b/src/contents/docs/api-reference/03.problems/not-acceptable.md
@@ -1,0 +1,37 @@
+---
+title: "Kestra API Error: Not acceptable"
+h1: Not acceptable
+sidebarTitle: Not acceptable
+description: The not-acceptable problem type is returned when a Kestra API endpoint cannot produce any media type the request's Accept header allows.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The endpoint cannot produce any of the media types your `Accept` header allows.
+
+- **HTTP status** — `406 Not Acceptable`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/not-acceptable`
+
+## When you get it
+
+- The `Accept` header excludes the type the endpoint produces.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/not-acceptable",
+  "title": "Not acceptable",
+  "status": 406,
+  "detail": "Not acceptable",
+  "instance": "/api/v1/main/flows"
+}
+```
+
+## How to handle it
+
+Send `Accept: application/json`, or drop the header. Error responses themselves are always served as `application/problem+json`.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/not-found.md
+++ b/src/contents/docs/api-reference/03.problems/not-found.md
@@ -1,0 +1,41 @@
+---
+title: "Kestra API Error: Resource not found"
+h1: Resource not found
+sidebarTitle: Resource not found
+description: The not-found problem type is returned when no Kestra resource exists at the identifier given, and when a request matches no API route at all.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+There is no resource at the identifier given. This is also returned when the request matched no route at all.
+
+- **HTTP status** — `404 Not Found`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/not-found`
+
+## When you get it
+
+- The flow, execution, namespace, or user id is unknown.
+- The id is correct but belongs to another tenant.
+- The resource has since been deleted.
+- The secret or namespace file does not exist.
+- The path is not an endpoint of this API.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/not-found",
+  "title": "Resource not found",
+  "status": 404,
+  "detail": "Flow 'my-flow' not found in namespace 'company.team'.",
+  "instance": "/api/v1/main/flows/company.team/my-flow"
+}
+```
+
+## How to handle it
+
+A 404 deliberately says nothing about whether the resource ever existed. Reporting that difference would let an unauthorized caller probe for names.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/password-policy-violation.md
+++ b/src/contents/docs/api-reference/03.problems/password-policy-violation.md
@@ -1,0 +1,45 @@
+---
+title: "Kestra API Error: Password policy not met"
+h1: Password policy not met
+sidebarTitle: Password policy not met
+description: The password-policy-violation problem type is returned when a submitted password does not satisfy the instance's configured password policy.
+icon: /src/contents/docs/icons/api.svg
+editions: ["EE", "Cloud"]
+---
+
+The submitted password does not satisfy the instance's configured password policy.
+
+- **HTTP status** — `422 Unprocessable Content`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/password-policy-violation`
+
+## When you get it
+
+- A password is set or changed in a way that breaks one or more policy rules.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/password-policy-violation",
+  "title": "Password policy not met",
+  "status": 422,
+  "detail": "Password policy not met",
+  "instance": "/api/v1/users/5Dv3JXqPzT/password",
+  "errors": [
+    {
+      "detail": "must be at least 12 characters long"
+    },
+    {
+      "detail": "must contain at least one digit"
+    }
+  ]
+}
+```
+
+## How to handle it
+
+One `errors` entry is reported per unmet rule, so the whole list can be shown at once instead of one rule per attempt.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/payload-too-large.md
+++ b/src/contents/docs/api-reference/03.problems/payload-too-large.md
@@ -1,0 +1,38 @@
+---
+title: "Kestra API Error: Payload too large"
+h1: Payload too large
+sidebarTitle: Payload too large
+description: The payload-too-large problem type is returned when a Kestra API request body exceeds a configured size limit, including the internal queue message limit.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The request body exceeds a configured size limit.
+
+- **HTTP status** — `413 Content Too Large`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/payload-too-large`
+
+## When you get it
+
+- The body is over `micronaut.server.max-request-size`.
+- A message the request would place on the internal queue is over the queue's maximum message size, for example an execution whose inputs or outputs are too large.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/payload-too-large",
+  "title": "Payload too large",
+  "status": 413,
+  "detail": "Message is too big.",
+  "instance": "/api/v1/main/flows"
+}
+```
+
+## How to handle it
+
+Split the request, or move the bulk of the data into internal storage and pass a URI. Raising `micronaut.server.max-request-size` addresses the first cause only; the queue limit is separate and belongs to the queue backend's configuration.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/policy-violation.md
+++ b/src/contents/docs/api-reference/03.problems/policy-violation.md
@@ -1,0 +1,45 @@
+---
+title: "Kestra API Error: Policy violation"
+h1: Policy violation
+sidebarTitle: Policy violation
+description: The policy-violation problem type is returned when a governance policy blocks an execution of the flow the request asked to run.
+icon: /src/contents/docs/icons/api.svg
+editions: ["EE", "Cloud"]
+---
+
+A governance policy blocks the flow from running, so no execution is created.
+
+- **HTTP status** — `403 Forbidden`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/policy-violation`
+
+## When you get it
+
+- An execution is requested for a flow that the policies applying to it block.
+
+The policy chain is resolved again at execution time, because a policy can postdate the flow. A flow that was accepted when it was saved can therefore still be blocked here.
+
+:::alert{type="info"}
+A policy that rejects a flow **as it is saved** is reported as [`validation-failed`](./validation-failed.md), with one `errors` entry per blocking rule: the request is not forbidden, the flow is not valid. This type covers execution only.
+:::
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/policy-violation",
+  "title": "Policy violation",
+  "status": 403,
+  "detail": "Execution blocked by governance policy: task type 'io.kestra.plugin.scripts.shell.Commands' is forbidden [policy=no-shell-tasks, task=run-script]",
+  "instance": "/api/v1/main/executions/company.team/my-flow"
+}
+```
+
+The `detail` names each blocking rule, the policy it came from, and the task it was raised on.
+
+## How to handle it
+
+This is a 403 rather than a 409 by design: a 409 would suggest transient state the caller can retry past, and a policy denial is not one. Either the flow changes, or the policy does. See [Policies](../../07.enterprise/02.governance/policies/index.md).
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/resource-expired.md
+++ b/src/contents/docs/api-reference/03.problems/resource-expired.md
@@ -1,0 +1,37 @@
+---
+title: "Kestra API Error: Resource has expired"
+h1: Resource has expired
+sidebarTitle: Resource has expired
+description: The resource-expired problem type is returned when a Kestra resource existed but its lifetime has passed, such as a KV Store value read after its TTL.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The resource existed, but its lifetime has passed.
+
+- **HTTP status** — `410 Gone`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/resource-expired`
+
+## When you get it
+
+- A KV Store value is read after its TTL has elapsed.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/resource-expired",
+  "title": "Resource has expired",
+  "status": 410,
+  "detail": "The requested value has expired",
+  "instance": "/api/v1/main/namespaces/company.team/kv/my-key"
+}
+```
+
+## How to handle it
+
+Write the value again rather than retrying the read. The expired entry is deleted as part of the read that reports it, so reading the same key again reports [`not-found`](./not-found.md): this response is the one chance to tell an expired value apart from a key that was never set.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/resource-leased.md
+++ b/src/contents/docs/api-reference/03.problems/resource-leased.md
@@ -1,0 +1,38 @@
+---
+title: "Kestra API Error: Resource is leased"
+h1: Resource is leased
+sidebarTitle: Resource is leased
+description: The resource-leased problem type is returned when another user holds an edit lease on a Kestra resource, so it cannot be changed or deleted yet.
+icon: /src/contents/docs/icons/api.svg
+editions: ["EE", "Cloud"]
+---
+
+Someone else holds an edit lease on the resource, so it cannot be changed or deleted yet.
+
+- **HTTP status** — `423 Locked`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/resource-leased`
+
+## When you get it
+
+- A resource another user has open is edited or deleted.
+- A lease is acquired on a resource that is already leased.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/resource-leased",
+  "title": "Resource is leased",
+  "status": 423,
+  "detail": "Lease on 'ASSET'.'my-asset' is held until 2026-09-08T14:32:10Z by USER 'alice@example.com'.",
+  "instance": "/api/v1/main/assets/my-asset"
+}
+```
+
+## How to handle it
+
+The `detail` names the current holder and when the lease expires, so a client can show who to ask and when to retry. This is the Cloud and Enterprise counterpart of [`locked`](./locked.md).
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/service-unavailable.md
+++ b/src/contents/docs/api-reference/03.problems/service-unavailable.md
@@ -1,0 +1,38 @@
+---
+title: "Kestra API Error: Service unavailable"
+h1: Service unavailable
+sidebarTitle: Service unavailable
+description: The service-unavailable problem type is returned when a Kestra instance is running but temporarily unable to serve the request.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The instance is running but is not currently able to serve the request.
+
+- **HTTP status** — `503 Service Unavailable`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/service-unavailable`
+
+## When you get it
+
+- A component the endpoint depends on is starting, shutting down, or unreachable.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/service-unavailable",
+  "title": "Service unavailable",
+  "status": 503,
+  "detail": "An unexpected error occurred. Quote the traceId when contacting support.",
+  "instance": "/api/v1/main/flows",
+  "traceId": "1d8e4c7a5b2f4e6d9a0c3b7f1e5d8a24"
+}
+```
+
+## How to handle it
+
+Retry with backoff. Unlike `internal-error`, this type says the failure is expected to be transient.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/timeout.md
+++ b/src/contents/docs/api-reference/03.problems/timeout.md
@@ -1,0 +1,42 @@
+---
+title: "Kestra API Error: Operation timed out"
+h1: Operation timed out
+sidebarTitle: Operation timed out
+description: The timeout problem type is returned when a Kestra API request, or a call it makes to another service, does not complete within its allowed time.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The request did not complete within the time allowed for it.
+
+- **HTTP status** — `504 Gateway Timeout`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/timeout`
+
+## When you get it
+
+- A route, or a call it makes to another service, gives up on a request that took too long.
+
+:::alert{type="info"}
+A task that exceeds its own `timeout` inside a flow does not produce this response. It fails that task run, and the execution reports it like any other task failure.
+:::
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/timeout",
+  "title": "Operation timed out",
+  "status": 504,
+  "detail": "An unexpected error occurred. Quote the traceId when contacting support.",
+  "instance": "/api/v1/main/flows",
+  "traceId": "e7a1c93b5d2f48e6b0a7c1d4f9e2b503"
+}
+```
+
+## How to handle it
+
+Retry with backoff. Like every `5xx`, the `detail` is fixed and the real cause is in the server log under the same `traceId`.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/too-many-requests.md
+++ b/src/contents/docs/api-reference/03.problems/too-many-requests.md
@@ -1,0 +1,39 @@
+---
+title: "Kestra API Error: Too many requests"
+h1: Too many requests
+sidebarTitle: Too many requests
+description: The too-many-requests problem type is returned when a Kestra API request is rejected because a capacity or usage cap has been reached.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The request was rejected because a capacity or usage cap has been reached.
+
+- **HTTP status** — `429 Too Many Requests`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/too-many-requests`
+
+## When you get it
+
+- AI Copilot is already running its maximum number of concurrent turns.
+- An AI Copilot thread has reached the maximum number of turns it may hold.
+- A rate limit in front of the instance has been reached.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/too-many-requests",
+  "title": "Too many requests",
+  "status": 429,
+  "detail": "AI Copilot is at capacity (8 concurrent turns); retry shortly.",
+  "instance": "/api/v1/main/ai/threads/4NFYrJfMEBQ/chat"
+}
+```
+
+## How to handle it
+
+Back off before retrying, honouring `Retry-After` when the response carries it. The two AI Copilot caps differ: capacity is transient and worth retrying, while a thread that has reached its turn limit will not accept more, so start a new thread instead.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/unauthenticated.md
+++ b/src/contents/docs/api-reference/03.problems/unauthenticated.md
@@ -1,0 +1,38 @@
+---
+title: "Kestra API Error: Authentication required"
+h1: Authentication required
+sidebarTitle: Authentication required
+description: The unauthenticated problem type is returned when a Kestra API request carries no credentials, or credentials the server will not accept.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The request carried no credentials, or credentials the server would not accept.
+
+- **HTTP status** — `401 Unauthorized`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/unauthenticated`
+
+## When you get it
+
+- No API token or session cookie is sent.
+- The token or session has expired or been revoked.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/unauthenticated",
+  "title": "Authentication required",
+  "status": 401,
+  "detail": "Authentication required",
+  "instance": "/api/v1/main/flows"
+}
+```
+
+## How to handle it
+
+Authenticate and resend. A browser request to a UI route is redirected to the login page instead of receiving this document; API routes always receive the document.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/unsupported-media-type.md
+++ b/src/contents/docs/api-reference/03.problems/unsupported-media-type.md
@@ -1,0 +1,38 @@
+---
+title: "Kestra API Error: Unsupported media type"
+h1: Unsupported media type
+sidebarTitle: Unsupported media type
+description: The unsupported-media-type problem type is returned when a Kestra API endpoint does not accept the Content-Type of the request body.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The endpoint does not accept the `Content-Type` of the request body.
+
+- **HTTP status** — `415 Unsupported Media Type`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/unsupported-media-type`
+
+## When you get it
+
+- A body is sent as `text/plain` to an endpoint that consumes JSON.
+- A request that has a body is sent with no `Content-Type`.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/unsupported-media-type",
+  "title": "Unsupported media type",
+  "status": 415,
+  "detail": "Unsupported media type",
+  "instance": "/api/v1/main/flows"
+}
+```
+
+## How to handle it
+
+Set `Content-Type` to what the endpoint consumes: `application/json` for most, `multipart/form-data` for file uploads.
+
+For the members every problem document carries, see [Problem Details](./index.md).

--- a/src/contents/docs/api-reference/03.problems/validation-failed.md
+++ b/src/contents/docs/api-reference/03.problems/validation-failed.md
@@ -1,0 +1,50 @@
+---
+title: "Kestra API Error: Validation failed"
+h1: Validation failed
+sidebarTitle: Validation failed
+description: The validation-failed problem type is returned when a Kestra API request is well formed but the entity it carries breaks one or more constraints.
+icon: /src/contents/docs/icons/api.svg
+editions: ["OSS", "EE", "Cloud"]
+---
+
+The request is well formed, but the entity it carries breaks one or more constraints. One `errors` entry is reported per violated constraint.
+
+- **HTTP status** — `422 Unprocessable Content`
+- **`type`** — `https://kestra.io/docs/api-reference/problems/validation-failed`
+
+## When you get it
+
+- A required property is absent, empty, or out of range.
+- A flow, trigger, or input definition fails its own validation rules.
+
+## Example response
+
+A response reporting this problem:
+
+```json
+{
+  "type": "https://kestra.io/docs/api-reference/problems/validation-failed",
+  "title": "Validation failed",
+  "status": 422,
+  "detail": "Validation failed",
+  "instance": "/api/v1/main/flows",
+  "errors": [
+    {
+      "detail": "must not be null",
+      "pointer": "/tasks/0/type",
+      "path": "tasks[my-task].type"
+    },
+    {
+      "detail": "must not be empty",
+      "pointer": "/id",
+      "path": "id"
+    }
+  ]
+}
+```
+
+## How to handle it
+
+Render the `errors` array against your form. Each entry carries two locators because neither is sufficient alone: `pointer` is a valid RFC 6901 JSON Pointer for machine use, and `path` names tasks and inputs by their id for display. Entries are ordered deterministically, so the same input always produces the same document.
+
+For the members every problem document carries, see [Problem Details](./index.md).


### PR DESCRIPTION
Every error the Kestra API returns carries a `type` URI under `https://kestra.io/docs/api-reference/problems/`, and none of those URIs resolved to anything. A client following the identifier it was handed got a 404.

Adds `api-reference/03.problems/`: an index page covering the RFC 9457 format (the seven `ProblemDetail` members, why to branch on `type` rather than on `detail`, the `errors` entry shape, the fixed-`detail`-plus-`traceId` rule for 5xx, and how to treat an unrecognised type), plus one page per published type with its status, when you get it, an example document, and how to handle it. `hideSubMenus` keeps the 35 children out of the sidebar.

Coverage is checked against the source catalogs rather than by hand: all 28 constants in `ProblemTypes` and all 7 in `EeProblemTypes`, with slugs, titles and statuses matching in both directions, no page missing and none invented. The EE-only types are marked `editions: ["EE", "Cloud"]`.

Two notes for review:

- Page titles use the wire `title` verbatim (`Policy violation`, not `Policy Violation`), against the style guide's Title Case rule. Readers arrive by searching the exact string from a response, and `ProblemType` treats the title as a stable translation key, so diverging seemed worse than the style miss. Happy to flip it.
- No site build ran locally: `node_modules` here is still the pre-Astro install. Frontmatter was validated against the zod schema in `src/content.config.ts` and every relative link against the filesystem.