### PR TITLE
docs: drop redundant KESTRA_PLUGINS_AUTO_INSTALL_ENABLED from get-started commands

### DIFF
--- a/src/components/get-started/Hero.astro
+++ b/src/components/get-started/Hero.astro
@@ -20,7 +20,6 @@ const dockerCommand = `<span class="t-cmd">docker</span> <span class="t-sub">run
   <span class="t-flag">-v</span> <span class="t-val">kestra_db:/app/data</span> <span class="t-bs">\\</span>
   <span class="t-flag">-v</span> <span class="t-val">/var/run/docker.sock:/var/run/docker.sock</span> <span class="t-bs">\\</span>
   <span class="t-flag">-v</span> <span class="t-val">/tmp:/tmp</span> <span class="t-bs">\\</span>
-  <span class="t-flag">-e</span> <span class="t-val">KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true</span> <span class="t-bs">\\</span>
   <span class="t-val">kestra/kestra:latest-slim</span> <span class="t-sub">server local</span>`
 ---
 

--- a/src/components/get-started/SetupSteps.astro
+++ b/src/components/get-started/SetupSteps.astro
@@ -12,7 +12,6 @@ const dockerCommandUnix = `docker run --pull=always --rm -it -p 8080:8080 --user
   -v kestra_db:/app/data \\
   -v /var/run/docker.sock:/var/run/docker.sock \\
   -v /tmp:/tmp \\
-  -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true \\
   kestra/kestra:latest-slim server local`
 
 const dockerCommandWindows = `docker run --pull=always --rm -it -p 8080:8080 --user=root ^
@@ -21,7 +20,6 @@ const dockerCommandWindows = `docker run --pull=always --rm -it -p 8080:8080 --u
   -v kestra_db:/app/data ^
   -v /var/run/docker.sock:/var/run/docker.sock ^
   -v /tmp:/tmp ^
-  -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true ^
   kestra/kestra:latest-slim server local`
 ---
 

--- a/src/contents/docs/01.quickstart/index.md
+++ b/src/contents/docs/01.quickstart/index.md
@@ -30,7 +30,6 @@ docker run --pull=always --rm -it -p 8080:8080 --user=root \
   -v kestra_db:/app/data \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /tmp:/tmp \
-  -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true \
   kestra/kestra:latest-slim server local
 ```
 
@@ -45,7 +44,7 @@ If you re-run the command and Docker reports `You have to remove (or rename) tha
 :::
 
 :::alert{type="info"}
-The `kestra/kestra:latest-slim` image ships without any plugins to keep the download small. The `KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true` environment variable makes Kestra install any plugin automatically the first time a flow needs it, so you don't need to pre-install anything. If you prefer an image with all plugins bundled, use `kestra/kestra:latest` instead.
+The `kestra/kestra:latest-slim` image ships without any plugins to keep the download small. Plugin auto-install is on by default for `server local`, so Kestra installs any plugin automatically the first time a flow needs it — no need to pre-install anything. If you prefer an image with all plugins bundled, use `kestra/kestra:latest` instead.
 :::
 
 The container is ready when the logs show `Main server is running at http://...:8080`.

--- a/src/contents/docs/02.installation/02.docker/index.md
+++ b/src/contents/docs/02.installation/02.docker/index.md
@@ -23,14 +23,13 @@ docker run --pull=always --rm -it -p 8080:8080 --user=root \
   -v kestra_db:/app/data \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /tmp:/tmp \
-  -e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true \
   kestra/kestra:latest-slim server local
 ```
 
 Open http://localhost:8080 in your browser to launch the UI and start building your first flows.
 
 :::alert{type="info"}
-The `kestra/kestra:latest-slim` image ships without any plugins to keep the download small. With `KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true`, Kestra installs any plugin automatically the first time a flow needs it, so you don't need to pre-install anything. If you prefer an image with all plugins bundled, use `kestra/kestra:latest` instead.
+The `kestra/kestra:latest-slim` image ships without any plugins to keep the download small. Plugin auto-install is on by default for `server local`, so Kestra installs any plugin automatically the first time a flow needs it — no need to pre-install anything. If you prefer an image with all plugins bundled, use `kestra/kestra:latest` instead.
 :::
 
 :::alert{type="info"}


### PR DESCRIPTION
## Summary
- `server local` forces `kestra.storage.type=local`, and `PluginAutoInstallService.computeEnabled` defaults auto-install to on for OSS + local storage. Setting `KESTRA_PLUGINS_AUTO_INSTALL_ENABLED=true` alongside `server local` was a no-op.
- Dropped the flag from the `docker run` commands in the homepage hero, get-started 3-step widget, quickstart, and docker install guide.
- Updated the adjacent info boxes to say auto-install is on by default for `server local` instead of instructing readers to set the var.

Left untouched (out of scope, not command snippets): 2.0 release notes/changelog/blog (historical record of the feature launch), and the general "-slim image" prose further down `02.installation/02.docker/index.md` / `12.standalone-server`, which correctly describe the flag for personas where it isn't on by default.

## Test plan
- [ ] Visual check of homepage hero + get-started widget commands
- [ ] `docker run ... kestra/kestra:latest-slim server local` (no `-e KESTRA_PLUGINS_AUTO_INSTALL_ENABLED`) still auto-installs plugins on first flow save