### PR TITLE
docs: address review comments on 2.0 blog and kestractl install docs

### DIFF
--- a/src/contents/blogs/release-2-0/index.md
+++ b/src/contents/blogs/release-2-0/index.md
@@ -474,11 +474,9 @@ Plugins can now ship Vue.js frontend components that load into the Kestra UI at 
 
 Each component is compiled as a Module Federation micro-frontend using `@kestra-io/artifact-sdk` and bundled into the plugin JAR. At startup, Kestra discovers these bundles and makes them available to the host UI without static linking.
 
-Components call the Kestra API through `@kestra-io/kestra-sdk`, which provides typed methods for executions, flows, metrics, logs, and live progress events.
-
 A concrete example: a task runner that breaks execution into distinct infrastructure phases (scheduling, image pull, file transfer, task code) can render a `topology-details` component showing per-phase timing directly in the execution view, so slow executions have an identifiable owner. Without a plugin artifact, that timing data lives in raw log output.
 
-Plugin artifacts are available to all plugin authors in 2.0. The [plugin artifact developer guide](/docs/plugin-developer-guide/pluigin-ui) covers the SDK, slot registration, and bundling setup.
+Plugin artifacts are available to all plugin authors in 2.0. The [plugin artifact developer guide](/docs/plugin-developer-guide/plugin-ui) covers the SDK, slot registration, and bundling setup.
 
 ## Additional Improvements
 

--- a/src/contents/docs/kestra-cli/kestractl/index.md
+++ b/src/contents/docs/kestra-cli/kestractl/index.md
@@ -16,11 +16,15 @@ For server components and system maintenance commands (starting standalone serve
 Source code and releases are available at [github.com/kestra-io/kestractl](https://github.com/kestra-io/kestractl).
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | VERSION=2 bash
+curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | bash
 ```
 
 :::alert{type="warning"}
-The default install script (without `VERSION=2`) installs kestractl 1.x, which is compatible with Kestra 1.x only. Pass `VERSION=2` to install the Kestra 2.0-compatible release.
+The default install script installs kestractl 2.0, compatible with Kestra 2.0 only. For Kestra 1.x, pass `VERSION=1`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | VERSION=1 bash
+```
 :::
 
 ## Quick Setup


### PR DESCRIPTION
## Summary
Follow-up from review comments left on #5178 (already merged):
- Remove the `@kestra-io/kestra-sdk` mention in the 2.0 blog post's Plugin Artifacts section, since that dependency was removed.
- Fix typo in plugin artifact developer guide link (`pluigin-ui` -> `plugin-ui`) and tighten the surrounding sentence.
- Fix `kestractl` install docs: the default install script now installs kestractl 2.0 (compatible with Kestra 2.0); use `VERSION=1` for Kestra 1.x.

## Test plan
- [ ] Docs build passes