### PR TITLE
seo(about-us): align copy with Kestra 2.0

### DIFF
--- a/src/components/company/Investors.astro
+++ b/src/components/company/Investors.astro
@@ -120,9 +120,9 @@ const investorsProfiles = [
             investors and founders from leading technology companies.
             <br class="d-none d-lg-block" />
             <br />
-            These investments fuel Kestra's mission to redefine enterprise orchestration,
-            helping organizations orchestrate complex workflows across data, infrastructure,
-            AI, and applications.
+            These investments fuel Kestra's mission to redefine enterprise orchestration:
+            one platform for data pipelines, infrastructure, business applications
+            and AI agents, in any environment.
         </p>
     </div>
 

--- a/src/components/company/Mission.astro
+++ b/src/components/company/Mission.astro
@@ -9,19 +9,19 @@ const values = [
         icon: "mdi:check-decagram-outline",
         title: "Quality",
         description:
-            "We are committed to deliver a platform that meets the highest standards.",
+            "We are committed to delivering a platform that meets the highest standards.",
     },
     {
         icon: "mdi:hub",
         title: "Collaboration",
         description:
-            "We are creating a strong relationships with our users, customers, and team members.",
+            "We build strong relationships with our users, our customers and each other.",
     },
     {
         icon: "mdi:account-supervisor-circle-outline",
         title: "User-Centric",
         description:
-            "We incorporate users feedbacks and address their challenges as we continue to build Kestra.",
+            "We build Kestra around user feedback and the problems our users actually hit.",
     },
     {
         icon: "mdi:opacity",
@@ -35,13 +35,15 @@ const values = [
 <section class="mission">
     <div class="mission-content">
         <header data-usal="fade-r">
-            <h1>Staying <span class="highlight">True</span> to our Mission</h1>
+            <h2>Staying <span class="highlight">True</span> to our Mission</h2>
             <p>
-                Our values are at the core of everything we do. We are building
-                a platform that not only meets the needs of our users but also
-                exceeds their expectations. We are driven by a passion for
-                continuous improvement. We strive to develop new ideas and
-                solutions that redefine the orchestration landscape.
+                Our values are at the core of everything we do. Kestra 2.0 is
+                the clearest expression of them: a rebuilt execution engine,
+                workers that run in any region or air-gapped network, and flows
+                any AI agent can call as a tool — released under the same Apache
+                2.0 license we started with. The more autonomous systems become,
+                the more engineering rigor they demand, not less. That is the
+                platform we keep building.
             </p>
         </header>
 
@@ -125,7 +127,7 @@ const values = [
             }
 
             header {
-                h1 {
+                h2 {
                     margin-bottom: 24px;
                 }
 

--- a/src/components/company/Orchestrate.astro
+++ b/src/components/company/Orchestrate.astro
@@ -74,7 +74,10 @@ const CompanyLogos = [
                     any language, on any infrastructure, delivering unparalleled
                     freedom and flexibility. By simplifying complexity and
                     eliminating constraints, we enable developers to build
-                    faster, and collaborate freely without compromise.
+                    faster, and collaborate freely without compromise. With <a
+                        href="/two-zero">Kestra 2.0</a
+                    >, workers run wherever your rules require, and any flow can
+                    be exposed as a tool your agents call.
                 </p>
             </div>
         </div>
@@ -88,18 +91,17 @@ const CompanyLogos = [
                 </h2>
 
                 <p data-usal="fade-u delay-300">
-                    <strong>We are excited</strong> to see how <strong
-                        >Kestra</strong
-                    > transform the way<br />
-                    organizations approach orchestration.
+                    <strong>Kestra runs in production</strong> at enterprises worldwide<br
+                    />
+                    — retail, manufacturing, finance and public institutions.
                 </p>
                 <p data-usal="fade-u delay-400">
-                    We believe that
-                    <strong>Kestra's potential is limitless</strong>, and we<br
+                    They standardize <strong>data</strong>, <strong
+                        >infrastructure</strong
+                    >, <strong>applications</strong> and <strong>AI</strong> on<br
                     />
-                    are eager to explore new
-                    <strong>opportunities</strong> and<br />
-                    <strong>partnerships</strong> as we move forward.
+                    one orchestrator, with the governance and traceability<br />
+                    their auditors ask for.
                 </p>
 
                 <div class="logos" data-usal="fade-u delay-400">
@@ -269,6 +271,15 @@ const CompanyLogos = [
                         color: $white;
                         line-height: 1.6;
                         margin: $rem-1 auto;
+
+                        a {
+                            color: #a796ff;
+                            text-decoration: underline;
+
+                            &:hover {
+                                color: $white;
+                            }
+                        }
 
                         @media (max-width: 1399px) {
                             max-width: 600px;

--- a/src/pages/about-us.astro
+++ b/src/pages/about-us.astro
@@ -8,9 +8,9 @@ import Life from "~/components/company/Life.astro"
 import SeeHow from "~/components/common/SeeHow.astro"
 import assets from "~/assets/landing/assets.webp"
 
-const title = "About Us"
+const title = "About Us: Our Team, Values and Investors"
 const description =
-    "Discover the team and values behind our mission to empower data-driven organizations worldwide"
+    "Meet the team, values and investors behind Kestra: the Open Source Declarative orchestration platform for data, infrastructure, applications and AI agents."
 ---
 
 <Layout {title} {description} headerTheme="lightText">


### PR DESCRIPTION
## Why

`/about-us` had not had a copy rewrite since January (#3725). The only change since was #5326, which **removed** the news block. Result: zero mention of 2.0, agents or "workers anywhere" on the page, while the homepage now leads with *"One orchestrator. Every workflow. Agentic AI under the same controls."* Visitors arriving from the launch content — a lot of them come through blog and footer nav — land on the pre-2.0 story.

The page also had no link at all to `/two-zero`.

## What changed

Copy only. No layout, no component structure, no new assets.

| Where | Change |
|---|---|
| `about-us.astro` | Title → "About Us: Our Team, Values and Investors"; meta description rewritten |
| `Orchestrate.astro` — hero | Existing paragraph kept, one sentence appended on 2.0 (workers anywhere, flows as agent tools) carrying the page's only link to `/two-zero` |
| `Orchestrate.astro` — trust block | Rewritten around what enterprises actually run on Kestra |
| `Mission.astro` | Paragraph rewritten around 2.0 and Apache 2.0; `<h1>` → `<h2>` |
| `Mission.astro` — values | Three grammar fixes, same length |
| `Investors.astro` | Second sentence now lists AI agents; amounts untouched |

## Two bugs fixed along the way

**Duplicate H1** — the page shipped two: the hero and "Staying True to our Mission". The mission one is now an `<h2>`.

**Missing spaces in the trust block** — Astro strips the newline placed before a `<strong>`, so production was serving:

```
We believe that<strong>Kestra's potential is limitless</strong>
are eager to explore new<strong>opportunities</strong>
```

Visible as "thatKestra's" and "newopportunities" on the live page. The rewrite drops that `<strong>`/`<br />` soup, and the replacement markup keeps the space outside the tag. It also fixes "how Kestra **transform** the way".

## Deliberately not in this PR

- **Team list** — handled by #5436 (8 new faces, Elliot → Fernando). No overlap, no conflict: that PR touches the `teamMembers` array, this one touches the surrounding copy.
- **2.0 UI screenshot** — `Mission.astro` still shows `executions.png`, a 1.x dashboard. Candidates already exist in `src/components/twozero/assets/`; holding until we pick one.
- **Team photo and the Acxiom "Wizard of Oz" quote** — both dated. The offsite photos will be the moment for a deeper pass.

## Review

Please check the hero and mission wording against how we want to talk about 2.0, and the link anchor. Cloudflare preview once CI is green.