### PR TITLE
docs(ee): fix Elasticsearch LogExporter task type in Log Shipper page

### DIFF
--- a/src/contents/docs/07.enterprise/02.governance/logshipper/index.md
+++ b/src/contents/docs/07.enterprise/02.governance/logshipper/index.md
@@ -345,7 +345,7 @@ tasks:
     delete: false
     logExporters:
       - id: elasticsearch
-        type: io.kestra.plugin.elasticsearch.LogExporter
+        type: io.kestra.plugin.ee.elasticsearch.LogExporter
         indexName: kestra-logs
         connection:
           basicAuth:
@@ -667,7 +667,7 @@ tasks:
         apiKey: "{{ secret('DATADOG_API_KEY') }}"
 
       - id: elasticsearch
-        type: io.kestra.plugin.elasticsearch.LogExporter
+        type: io.kestra.plugin.ee.elasticsearch.LogExporter
         indexName: kestra-logs
         connection:
           basicAuth:


### PR DESCRIPTION
## What

Fixes the Elasticsearch `LogExporter` task type in two snippets on the Log Shipper enterprise governance page.

`src/contents/docs/07.enterprise/02.governance/logshipper/index.md` used:

```yaml
type: io.kestra.plugin.elasticsearch.LogExporter      # ❌ no such class in the OSS plugin
```

But `LogExporter` only exists in the **EE** plugin (`plugin-ee-elasticsearch`). Corrected both occurrences to:

```yaml
type: io.kestra.plugin.ee.elasticsearch.LogExporter   # ✅
```

## Why

Copy-pasting the previous snippets would fail — the OSS `plugin-elasticsearch` exposes no `LogExporter` (only `Bulk`/`Esql`/`Get`/`Load`/`Put`/`Request`/`Scroll`/`Search`). Every sibling exporter on the same page already uses the `io.kestra.plugin.ee.*` form (e.g. `io.kestra.plugin.ee.aws.cloudwatch.LogExporter`), so this aligns the Elasticsearch example with them.

Pre-existing typo, unrelated to any code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)