### PR TITLE
fix(plugins): exclude pre-release versions from the version list

### DIFF
--- a/src/utils/plugins/compareVersions.test.ts
+++ b/src/utils/plugins/compareVersions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { compareVersionsDesc } from "~/utils/plugins/compareVersions"
+import { compareVersionsDesc, isStableVersion } from "~/utils/plugins/compareVersions"
 
 describe("compareVersionsDesc", () => {
     it("sorts descending by numeric semver, not lexically", () => {
@@ -19,5 +19,23 @@ describe("compareVersionsDesc", () => {
 
     it("returns 0 for equal versions", () => {
         expect(compareVersionsDesc("2.6.0", "2.6.0")).toBe(0)
+    })
+})
+
+describe("isStableVersion", () => {
+    it("rejects pre-releases", () => {
+        expect(isStableVersion("2.0.0-rc9")).toBe(false)
+        expect(isStableVersion("0.5.0-BETA")).toBe(false)
+    })
+
+    it("accepts releases", () => {
+        expect(isStableVersion("2.0.0")).toBe(true)
+    })
+
+    it("keeps an RC from tying with its release and stealing the latest slot", () => {
+        // 2.0.0-rc9 parses as [2,0,0], so a stable sort left it ahead of 2.0.0 and marked 2.0.0 archived
+        expect(compareVersionsDesc("2.0.0-rc9", "2.0.0")).toBe(0)
+        const sorted = ["2.0.0-rc9", "2.0.0", "1.3.38"].filter(isStableVersion).toSorted(compareVersionsDesc)
+        expect(sorted).toEqual(["2.0.0", "1.3.38"])
     })
 })

--- a/src/utils/plugins/compareVersions.ts
+++ b/src/utils/plugins/compareVersions.ts
@@ -16,3 +16,14 @@ export function compareVersionsDesc(a: string, b: string): number {
     }
     return 0
 }
+
+/**
+ * True for a release version, false for a pre-release ("2.0.0-rc9", "0.5.0-BETA").
+ *
+ * The version lists we build feed both the dropdown and "what is latest?", and pre-releases must be
+ * in neither: compareVersionsDesc parses "0-rc9" as 0, so "2.0.0-rc9" ties with "2.0.0" and a stable
+ * sort can leave the RC first, marking the real release archived.
+ */
+export function isStableVersion(version: string): boolean {
+    return !version.includes("-")
+}

--- a/src/utils/plugins/fetchPluginPageData.ts
+++ b/src/utils/plugins/fetchPluginPageData.ts
@@ -6,7 +6,7 @@ import { $fetchApiCached } from "~/utils/fetch"
 import loadBlogPostsMetadata from "~/utils/loadBlogPostsMetadata"
 import { nuxtBlocksFromJsonSchema } from "~/utils/plugins/nuxtBlocks"
 import { retrieveRepoReleases } from "~/utils/plugins/repoReleases"
-import { compareVersionsDesc } from "~/utils/plugins/compareVersions"
+import { compareVersionsDesc, isStableVersion } from "~/utils/plugins/compareVersions"
 import type { PluginPage } from "./types"
 
 const EE_RELEASES_PAGE_SIZE = 100
@@ -48,12 +48,14 @@ export async function fetchInitialPluginData(pluginName: string, githubReleaseRe
             }>(
                 `/plugins/artifacts/ee/releases?artifactId=${pluginName}&size=${EE_RELEASES_PAGE_SIZE}`,
             )
-            githubVersions.versions = eeData.results.map((r) => ({
-                version: r.version,
-                publishedAt: r.releaseDate,
-                minCoreCompatibilityVersion: r.kestraVersion,
-                releaseNotesUrl: `${API_URL}/plugins/artifacts/ee/release-notes/${githubReleaseRepo}?version=${r.version}`,
-            }))
+            githubVersions.versions = eeData.results
+                .filter((r) => isStableVersion(r.version))
+                .map((r) => ({
+                    version: r.version,
+                    publishedAt: r.releaseDate,
+                    minCoreCompatibilityVersion: r.kestraVersion,
+                    releaseNotesUrl: `${API_URL}/plugins/artifacts/ee/release-notes/${githubReleaseRepo}?version=${r.version}`,
+                }))
         } catch (e) {
             console.error("EE releases fetch failed", e)
         }
@@ -101,13 +103,13 @@ export async function fetchInitialPluginData(pluginName: string, githubReleaseRe
                 githubVersions.versions = coreVersions
                     .filter((v) => {
                         const major = parseInt(v.version.split(".")[0])
-                        return !isNaN(major) && major >= 1
+                        return !isNaN(major) && major >= 1 && isStableVersion(v.version)
                     })
                     .map((v) => ({ version: v.version, publishedAt: null }))
                     .toSorted((a, b) => compareVersionsDesc(a.version, b.version))
             } else {
                 githubVersions.versions = (Object.values(artifactsData).flat() as any[])
-                    .filter((a) => a?.version)
+                    .filter((a) => a?.version && isStableVersion(a.version))
                     .map((a) => ({
                         version: a.version,
                         publishedAt: a.publishedAt ?? null,

--- a/src/utils/plugins/repoReleases.ts
+++ b/src/utils/plugins/repoReleases.ts
@@ -1,10 +1,11 @@
 import { DISABLE_GITHUB } from "astro:env/server"
-import { compareVersionsDesc } from "~/utils/plugins/compareVersions"
+import { compareVersionsDesc, isStableVersion } from "~/utils/plugins/compareVersions"
 
 interface GitHubRelease {
     tag_name: string
     published_at: string | null
     draft: boolean
+    prerelease: boolean
 }
 
 export interface ReleaseInfo {
@@ -34,14 +35,17 @@ async function fetchRepoReleases(repo: string): Promise<{ versions: ReleaseInfo[
 
     const releases = (await response.json()) as GitHubRelease[]
     const versions: ReleaseInfo[] = releases
-        .filter((release) => !release.draft && !release.tag_name.includes("SNAPSHOT"))
+        .filter(
+            (release) =>
+                !release.draft && !release.prerelease && !release.tag_name.includes("SNAPSHOT"),
+        )
         .map((release) => ({
             version: release.tag_name.replace(/^v/, ""),
             publishedAt: release.published_at,
         }))
         .filter((v) => {
             const major = parseInt(v.version.split(".")[0])
-            return !isNaN(major) && major >= 1
+            return !isNaN(major) && major >= 1 && isStableVersion(v.version)
         })
         .toSorted((a, b) => compareVersionsDesc(a.version, b.version))
 


### PR DESCRIPTION
`/plugins/core` showed `2.0.0-rc9` as Latest and marked the real `2.0.0` as archived.

When the GitHub releases call comes back empty (rate limit), the core version list falls back to `api.kestra.io/v1/versions`, which includes `2.0.0-rc9`..`rc15`. `compareVersionsDesc` parses `"0-rc9"` as 0, so the RC ties with `2.0.0` and the stable sort leaves it at index 0, which is what drives both the Latest badge and the archived check.
