### PR TITLE
fix(docs): restore the "Available on" edition badges on docs pages

### DIFF
--- a/src/components/docs/FeatureScopeMarker.astro
+++ b/src/components/docs/FeatureScopeMarker.astro
@@ -1,0 +1,104 @@
+---
+/**
+ * "Available on:" edition pills above a docs body, from the page's `editions`
+ * frontmatter (see the `docs` collection schema in `src/content.config.ts`).
+ * Rendered by DocsLayout for every docs page; renders nothing without editions.
+ */
+import { editionLabelAndColorByPrefix } from "~/utils/badgeMaps.mjs"
+
+interface Props {
+    editions?: string[]
+}
+
+const editions = (Astro.props.editions ?? []).map((edition) => {
+    const info = Object.hasOwn(editionLabelAndColorByPrefix, edition)
+        ? editionLabelAndColorByPrefix[edition]
+        : undefined
+    return info
+        ? { label: info.label, href: info.link, tone: info.tone }
+        : { label: edition, href: undefined, tone: undefined }
+})
+---
+
+{
+    editions.length > 0 && (
+        <p class="feature-scope">
+            <span class="feature-scope-label">Available on:</span>
+            {editions.map((edition) => {
+                const Tag = edition.href ? "a" : "span"
+                return (
+                    <Tag
+                        class:list={[
+                            "feature-scope-pill",
+                            edition.tone && `tone-${edition.tone}`,
+                        ]}
+                        href={edition.href}
+                    >
+                        {edition.label}
+                    </Tag>
+                )
+            })}
+        </p>
+    )
+}
+
+<style lang="scss">
+    .feature-scope {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.5rem;
+        margin-bottom: 1.5rem;
+        color: var(--ks-content-primary);
+    }
+
+    .feature-scope-label {
+        font-weight: 600;
+        font-size: $font-size-sm;
+    }
+
+    // `&:hover` repeated so the pills outrank the markdown `.bd-content p a:hover`
+    // link color and keep their tag colors.
+    .feature-scope-pill {
+        &,
+        &:hover {
+            display: inline-flex;
+            align-items: center;
+            border-radius: 40px;
+            padding: 0.125rem 0.5rem;
+            font-size: $font-size-xs;
+            font-weight: 600;
+            line-height: 1.4;
+            white-space: nowrap;
+            text-decoration: none;
+            background: var(--ks-background-secondary);
+            color: var(--ks-content-primary);
+            border: 1px solid var(--ks-border-secondary);
+        }
+
+        &.tone-oss,
+        &.tone-oss:hover {
+            background: var(--ks-background-tag-success);
+            color: var(--ks-content-tag-success);
+            border-color: transparent;
+        }
+
+        &.tone-ee,
+        &.tone-ee:hover {
+            background: var(--ks-background-tag-EE);
+            color: var(--ks-content-tag-EE);
+            border-color: transparent;
+        }
+
+        &.tone-cloud,
+        &.tone-cloud:hover {
+            background: var(--ks-background-tag-category);
+            color: var(--ks-content-tag-category);
+            border-color: transparent;
+        }
+    }
+
+    a.feature-scope-pill:hover {
+        text-decoration: underline;
+    }
+</style>

--- a/src/components/docs/FeatureScopeMarker.astro
+++ b/src/components/docs/FeatureScopeMarker.astro
@@ -1,9 +1,4 @@
 ---
-/**
- * "Available on:" edition pills above a docs body, from the page's `editions`
- * frontmatter (see the `docs` collection schema in `src/content.config.ts`).
- * Rendered by DocsLayout for every docs page; renders nothing without editions.
- */
 import { editionLabelAndColorByPrefix } from "~/utils/badgeMaps.mjs"
 
 interface Props {
@@ -57,8 +52,6 @@ const editions = (Astro.props.editions ?? []).map((edition) => {
         font-size: $font-size-sm;
     }
 
-    // `&:hover` repeated so the pills outrank the markdown `.bd-content p a:hover`
-    // link color and keep their tag colors.
     .feature-scope-pill {
         &,
         &:hover {

--- a/src/components/layouts/DocsLayout.astro
+++ b/src/components/layouts/DocsLayout.astro
@@ -6,6 +6,7 @@ import { generatePageNames, recursivePages } from "~/utils/navigation"
 import { getDocsLatestVersion, getKnownDocVersions } from "~/utils/docVersionsFetch"
 import squaredGrid from "~/assets/squared-grid.svg"
 import type { NavigationItem } from "~/components/docs/RecursiveNavSidebar.vue"
+import FeatureScopeMarker from "~/components/docs/FeatureScopeMarker.astro"
 
 interface Props {
     title?: string
@@ -25,6 +26,8 @@ interface Props {
     noindex?: boolean
     /** Explicit breadcrumb trail, bypassing the slug-split default (the versioned docs page's version segment isn't a real page). */
     breadcrumbItems?: { label: string; href: string }[]
+    /** Frontmatter `editions` of the page, rendered as "Available on:" pills above the body. */
+    editions?: string[]
 }
 
 const props = Astro.props as Props
@@ -126,6 +129,7 @@ const techArticleSchema = {
             <div class="layout-docs">
                 <div class="bd-content">
                     <blockquote class="llms-directive">For the complete documentation index, see <a href="/llms.txt">llms.txt</a>. For a full content snapshot, see <a href="/llms-full.txt">llms-full.txt</a>. Append <code>.md</code> to any <code>kestra.io/docs/*</code> URL for plain Markdown.</blockquote>
+                    <FeatureScopeMarker editions={props.editions} />
                     <slot />
                 </div>
             </div>

--- a/src/pages/docs/[...docsPath].astro
+++ b/src/pages/docs/[...docsPath].astro
@@ -66,6 +66,7 @@ const editUrl = doc.filePath
     pageTitle={doc.data?.sidebarTitle ?? doc.data?.title}
     image={image.toString()}
     navigation={navigation}
+    editions={doc.data?.editions}
 >
     <h1 class="title" slot="title">
         {doc.data?.h1 ?? doc.data?.title}

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -23,6 +23,7 @@ const editUrl = doc.filePath
     title={doc.data?.title}
     description={doc.data?.description}
     navigation={navigation}
+    editions={doc.data?.editions}
 >
     <h1 slot="title" class="py-0 title">{doc.data?.h1 ?? doc.data?.title}</h1>
 

--- a/src/utils/badgeMaps.mjs
+++ b/src/utils/badgeMaps.mjs
@@ -1,10 +1,13 @@
 /**
- * Maps edition prefixes to their corresponding labels and colors.
- * @type {Record<string, {label: string, color: string}>}
+ * Maps edition prefixes to their labels, Bootstrap colors (used by the remark
+ * `::badge` directive and the versioned-doc renderer), the visual `tone` and
+ * marketing `link` used by the docs FeatureScopeMarker pills.
+ * @type {Record<string, {label: string, color: string, tone?: string, link?: string}>}
  */
 export const editionLabelAndColorByPrefix = {
-    OSS: { label: "Open Source Edition", color: "primary" },
-    EE: { label: "Enterprise Edition", color: "secondary" },
+    OSS: { label: "Open Source Edition", color: "primary", tone: "oss", link: "/features" },
+    EE: { label: "Enterprise Edition", color: "secondary", tone: "ee", link: "/enterprise" },
+    Cloud: { label: "Cloud", color: "secondary", tone: "cloud", link: "/cloud" },
     CLOUD_TEAM: { label: "Cloud Team plan", color: "success" },
     CLOUD_PRO: { label: "Cloud Pro plan", color: "info" },
 }


### PR DESCRIPTION
Restores the "Available on:" edition badges on docs pages. Reported by AJ: frontmatter like `editions: ["EE"]` was not appearing on pages such as https://kestra.io/docs/administrator-guide/log-data-store.

## Root cause

The `editions` field is declared in the content schema and set on 200+ pages, but nothing rendered it. The Nuxt-era `FeatureScopeMarker` was copied over during the Astro migration (3e0af2864) without being wired into the new docs template, then deleted as unused in 5f3d6d8f8.

## Changes

- New `FeatureScopeMarker.astro`: "Available on:" plus one pill per edition. OSS / EE / Cloud link to `/features`, `/enterprise`, `/cloud` and use the existing `--ks-*-tag-*` tokens.
- `DocsLayout.astro`: new optional `editions` prop, rendered above the body slot so every docs template gets the badges by default.
- `[...docsPath].astro` and `docs/index.astro` pass `doc.data.editions`.
- `badgeMaps.mjs`: adds `Cloud` and per-edition `tone` / `link`.

---