### PR TITLE
docs(assets): use the actual Table asset type name in the assets() examples

### DIFF
--- a/src/contents/blogs/release-1-2/index.md
+++ b/src/contents/blogs/release-1-2/index.md
@@ -115,7 +115,7 @@ namespace: company.team
 inputs:
   - id: assets
     type: MULTISELECT
-    expression: '{{ assets(type="io.kestra.core.models.assets.Table") | jq(".[].id") }}'
+    expression: '{{ assets(type="io.kestra.plugin.ee.assets.Table") | jq(".[].id") }}'
 
 tasks:
   - id: for_each

--- a/src/contents/docs/07.enterprise/02.governance/01.assets/index.md
+++ b/src/contents/docs/07.enterprise/02.governance/01.assets/index.md
@@ -701,7 +701,7 @@ namespace: company.team
 inputs:
   - id: assets
     type: MULTISELECT
-    expression: '{{ assets(type="io.kestra.core.models.assets.Table") | jq(".[].id") }}'
+    expression: '{{ assets(type="io.kestra.plugin.ee.assets.Table") | jq(".[].id") }}'
 
 tasks:
   - id: for_each
@@ -719,7 +719,7 @@ tasks:
 inputs:
   - id: staging_tables
     type: MULTISELECT
-    expression: '{{ assets(type="io.kestra.core.models.assets.Table", namespace="company.team") | jq(".[].id") }}'
+    expression: '{{ assets(type="io.kestra.plugin.ee.assets.Table", namespace="company.team") | jq(".[].id") }}'
 ```
 
 **Filter assets by metadata:**


### PR DESCRIPTION
Related to https://github.com/kestra-io/kestra-ee/issues/6508.

## What

The `assets()` function examples on the assets page (and in the 1.2 release blog post) filter on `io.kestra.core.models.assets.Table`, a class that never existed. The built-in table asset is `io.kestra.plugin.ee.assets.Table`, as the list of asset types further up on the same page says. The reporter of the issue above copied that name into a flow and got it underlined by the editor.

The editor-side part of the issue (a Pebble `namespace` and a free-form `type` being underlined) is fixed in `kestra` by the companion `PR` linked from the issue.