### PR TITLE
ci(lighthouse): run the sample on four runners off one build

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -59,8 +59,21 @@ jobs:
 
       # dist is thousands of files, most of them images. One tarball moves in a
       # fraction of the time the artifact actions take over the tree itself.
+      #
+      # .wrangler/deploy/config.json travels with it: that redirect is what
+      # points wrangler at the generated dist/server/wrangler.json. Without it
+      # wrangler falls back to wrangler.jsonc and bundles the worker from src/,
+      # where the adapter's virtual modules do not resolve, so the dev server
+      # never serves. It is gitignored, so a shard only has it if it is packed.
       - name: Pack the build
-        run: tar -I 'zstd -1 -T0' -cf dist.tar.zst dist
+        run: |
+          test -f .wrangler/deploy/config.json || {
+            echo "::error::.wrangler/deploy/config.json missing after the build."
+            echo "::error::wrangler dev would bundle src/ instead of the build."
+            exit 1
+          }
+          cat .wrangler/deploy/config.json
+          tar -I 'zstd -1 -T0' -cf dist.tar.zst dist .wrangler/deploy/config.json
 
       - name: Upload the build
         uses: actions/upload-artifact@v7

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -18,6 +18,7 @@ jobs:
     name: Build site
     if: startsWith(github.repository, 'kestra-io/')
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
 
@@ -92,6 +93,7 @@ jobs:
     name: Lighthouse shard ${{ matrix.shard }}
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     strategy:
@@ -149,13 +151,19 @@ jobs:
         # the one in wrangler.jsonc): it blocks the worker from reaching the
         # fixture server on loopback, and it only affects same-zone routing,
         # which does not exist locally.
-        run: npx wrangler dev --local --compatibility-flags nodejs_compat &
+        # Output is captured: the process outlives this step, so whatever it
+        # prints while the next one waits is otherwise lost.
+        run: npx wrangler dev --local --compatibility-flags nodejs_compat > wrangler-dev.log 2>&1 &
 
       - name: Wait for dev server to be ready
+        # The dev proxy accepts connections while the worker is still compiling
+        # and holds the request until it is ready, so an unbounded curl blocks
+        # instead of retrying: without --max-time one hung probe is the job.
         run: |
           echo "Waiting for http://localhost:8787…"
           for i in $(seq 1 24); do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8787 || true)
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              --connect-timeout 2 --max-time 10 http://localhost:8787 || true)
             if [ "$STATUS" = "200" ]; then
               echo "Server is ready (HTTP 200)."
               exit 0
@@ -163,7 +171,11 @@ jobs:
             echo "  Attempt $i/24: HTTP $STATUS — retrying in 5 s…"
             sleep 5
           done
-          echo "Warning: server did not return 200 after 2 min; running Lighthouse anyway."
+          echo "::error::Dev server never returned 200. Measuring anyway would"
+          echo "::error::score a dead server, so this shard stops here."
+          echo "--- wrangler dev output ---"
+          cat wrangler-dev.log || echo "(no output captured)"
+          exit 1
 
       - name: Run Lighthouse benchmark
         run: node scripts/lighthouse-benchmark.mjs
@@ -233,6 +245,7 @@ jobs:
     needs: [build, lighthouse]
     if: ${{ !cancelled() && needs.build.result == 'success' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -11,13 +11,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lighthouse:
-    name: Lighthouse Benchmark
+  # The site is built once and handed to the shards as a tarball. Building in
+  # each of them instead would cost four times the runner minutes, and the
+  # measured pages have to come from one identical build to be comparable.
+  build:
+    name: Build site
     if: startsWith(github.repository, 'kestra-io/')
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -54,14 +56,91 @@ jobs:
           # the SSR pages read the API through the fixture server.
           API_URL: http://127.0.0.1:9001/v1
 
-      # The build itself calls the blueprint API, so the counters have to be
-      # snapshotted here for the check at the end to mean anything.
-      - name: Snapshot fixture server counters
-        run: curl -s http://127.0.0.1:9001/__fixtures/stats > fixtures-before.json
+      # dist is thousands of files, most of them images. One tarball moves in a
+      # fraction of the time the artifact actions take over the tree itself.
+      - name: Pack the build
+        run: tar -I 'zstd -1 -T0' -cf dist.tar.zst dist
+
+      - name: Upload the build
+        uses: actions/upload-artifact@v7
+        with:
+          name: lighthouse-dist
+          path: dist.tar.zst
+          retention-days: 1
+          compression-level: 0
+
+      - name: Count fixtures recorded during the build
+        id: fixtures
+        run: |
+          RECORDS=$(curl -s http://127.0.0.1:9001/__fixtures/stats | jq '.records')
+          echo "records=$RECORDS" >> "$GITHUB_OUTPUT"
+          echo "fixtures recorded during the build: $RECORDS"
+
+      # Only when the build asked for something not committed yet; commit these
+      # to freeze it. The shards read the committed set, not this artifact.
+      - name: Upload API fixtures artifact
+        if: ${{ !cancelled() && steps.fixtures.outputs.records != '0' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: api-fixtures-build
+          path: tests/fixtures/api/
+          retention-days: 30
+
+  # scripts/lighthouse-shared.mjs splits the page sample into SHARD_TOTAL slices
+  # of roughly equal measuring time, so the matrix length is the only knob.
+  lighthouse:
+    name: Lighthouse shard ${{ matrix.shard }}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    env:
+      SHARD_TOTAL: ${{ strategy.job-total }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      # wrangler compiles the worker from src/ at dev time, so the shards need
+      # the dependencies even though they never run the Astro build.
+      - name: Install dependencies
+        run: npm install
 
       - name: Install Lighthouse
         # Installed ad-hoc to keep package.json lean; ~100 MB only needed in CI.
         run: npm install --no-save lighthouse chrome-launcher
+
+      - name: Download the build
+        uses: actions/download-artifact@v7
+        with:
+          name: lighthouse-dist
+
+      - name: Unpack the build
+        run: tar -I zstd -xf dist.tar.zst && rm dist.tar.zst
+
+      - name: Start API fixture server
+        run: node scripts/api-fixture-server.mjs &
+
+      - name: Wait for the fixture server
+        run: |
+          for i in $(seq 1 10); do
+            curl -sf http://127.0.0.1:9001/__fixtures/stats > /dev/null && exit 0
+            sleep 1
+          done
+          echo "Fixture server did not come up on port 9001."
+          exit 1
+
+      - name: Snapshot fixture server counters
+        run: curl -s http://127.0.0.1:9001/__fixtures/stats > fixtures-before.json
 
       - name: Start local dev server
         # wrangler dev serves the built Workers bundle locally via Miniflare —
@@ -86,6 +165,102 @@ jobs:
           done
           echo "Warning: server did not return 200 after 2 min; running Lighthouse anyway."
 
+      - name: Run Lighthouse benchmark
+        run: node scripts/lighthouse-benchmark.mjs
+        env:
+          BASE_URL: http://localhost:8787
+          OUTPUT_FILE: lighthouse-results-shard-${{ matrix.shard }}.json
+          LHR_DIR: lhr-reports
+          SHARD_INDEX: ${{ matrix.shard }}
+
+      # The results are named per shard: the report job merges every shard
+      # artifact into one directory, so equal filenames would overwrite.
+      - name: Upload shard results
+        uses: actions/upload-artifact@v7
+        with:
+          name: lighthouse-results-shard-${{ matrix.shard }}
+          path: lighthouse-results-shard-${{ matrix.shard }}.json
+          retention-days: 30
+
+      # Per-page LHR JSONs — view any at https://googlechrome.github.io/lighthouse/viewer/.
+      - name: Upload LHR reports artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: lhr-reports-shard-${{ matrix.shard }}
+          path: lhr-reports/
+          retention-days: 30
+
+      # Only the shards holding a /blueprints page reach the fixture server, so
+      # the checks below run on those and are a no-op on the rest.
+      - name: Check what this shard measured
+        id: measured
+        run: |
+          BLUEPRINTS=$(jq '[.results[] | select(.path | startswith("/blueprints"))] | length' \
+            "lighthouse-results-shard-${{ matrix.shard }}.json")
+          RECORDS=$(curl -s http://127.0.0.1:9001/__fixtures/stats | jq '.records')
+          echo "blueprints=$BLUEPRINTS" >> "$GITHUB_OUTPUT"
+          echo "records=$RECORDS" >> "$GITHUB_OUTPUT"
+
+      - name: Upload API fixtures artifact
+        if: ${{ !cancelled() && steps.measured.outputs.records != '0' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: api-fixtures-shard-${{ matrix.shard }}
+          path: tests/fixtures/api/
+          retention-days: 30
+
+      # No new calls during the benchmark means the SSR blueprints page never
+      # reached the fixture server, so the page measured is not the page we
+      # think it is. Compared against the snapshot taken before the benchmark,
+      # since the warm-up requests hit the same API.
+      - name: Check the fixture server was used
+        if: steps.measured.outputs.blueprints != '0'
+        run: |
+          BEFORE=$(jq '.hits + .records' fixtures-before.json)
+          STATS=$(curl -s http://127.0.0.1:9001/__fixtures/stats)
+          AFTER=$(echo "$STATS" | jq '.hits + .records')
+          echo "$STATS"
+          echo "blueprint API calls during the benchmark: $((AFTER - BEFORE))"
+          if [ "$AFTER" -le "$BEFORE" ]; then
+            echo "::error::No blueprint API calls reached the fixture server during the benchmark."
+            exit 1
+          fi
+
+  # Runs even when a shard failed: the report marks the pages nobody measured
+  # rather than dropping the comment altogether.
+  report:
+    name: Lighthouse Benchmark
+    needs: [build, lighthouse]
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      # The report scripts have no dependencies beyond the page sample, so the
+      # 800 MB of content in the tree is dead weight here.
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github/actions
+            scripts
+            tests/fixtures/page-sample.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Download shard results
+        uses: actions/download-artifact@v7
+        with:
+          pattern: lighthouse-results-shard-*
+          merge-multiple: true
+          path: shard-results/
+
       # Only on PRs: fetch the latest baseline saved from main so the report
       # can show ▲/▼ deltas. Silently skipped if no baseline exists yet.
       - name: Download main branch baseline
@@ -105,10 +280,10 @@ jobs:
         id: public-url
         uses: ./.github/actions/preview-url
 
-      - name: Run Lighthouse benchmark
-        run: node scripts/lighthouse-benchmark.mjs
+      - name: Merge shards and build the report
+        run: node scripts/lighthouse-report.mjs
         env:
-          BASE_URL: http://localhost:8787
+          RESULTS_DIR: shard-results
           BASE_URL_OUTPUT: ${{ steps.public-url.outputs.url }}
           OUTPUT_FILE: lighthouse-results.json
           BASELINE_FILE: ${{ steps.baseline.outcome == 'success' && 'baseline/lighthouse-results.json' || '' }}
@@ -140,21 +315,13 @@ jobs:
           body-path: lighthouse-report.md
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # PRs: post scores as a PR comment and keep results for inspection.
+      # PRs: post scores as a PR comment and keep the merged results.
       - name: Upload PR results artifact
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: lighthouse-results
           path: lighthouse-results.json
-          retention-days: 30
-
-      # Per-page LHR JSONs — view any at https://googlechrome.github.io/lighthouse/viewer/.
-      - name: Upload LHR reports artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: lhr-reports
-          path: lhr-reports/
           retention-days: 30
 
       - name: Comment on PR
@@ -164,28 +331,3 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           title: 🔦 Lighthouse Benchmark
           template: ${{ steps.report.outputs.content }}
-
-      # First run records what /blueprints asks for; commit these to freeze it.
-      - name: Upload API fixtures artifact
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: api-fixtures
-          path: tests/fixtures/api/
-          retention-days: 30
-
-      # No new calls during the benchmark means the SSR blueprints page never
-      # reached the fixture server, so the page measured is not the page we
-      # think it is. Compared against the post-build snapshot, since the build
-      # calls the same API and would otherwise satisfy any absolute threshold.
-      - name: Check the fixture server was used
-        run: |
-          BEFORE=$(jq '.hits + .records' fixtures-before.json)
-          STATS=$(curl -s http://127.0.0.1:9001/__fixtures/stats)
-          AFTER=$(echo "$STATS" | jq '.hits + .records')
-          echo "$STATS"
-          echo "blueprint API calls during the benchmark: $((AFTER - BEFORE))"
-          if [ "$AFTER" -le "$BEFORE" ]; then
-            echo "::error::No blueprint API calls reached the fixture server during the benchmark."
-            exit 1
-          fi

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -239,14 +239,18 @@ jobs:
 
     steps:
       # The report scripts have no dependencies beyond the page sample, so the
-      # 800 MB of content in the tree is dead weight here.
+      # 800 MB of content in the tree is dead weight here. Non-cone mode takes
+      # these patterns and nothing else, so .nvmrc has to be asked for by name
+      # or setup-node has no file to read; the leading slashes anchor them, or
+      # `scripts` would drag src/scripts along too.
       - name: Checkout
         uses: actions/checkout@v6
         with:
           sparse-checkout: |
-            .github/actions
-            scripts
-            tests/fixtures/page-sample.mjs
+            /.github/actions/
+            /scripts/
+            /tests/fixtures/page-sample.mjs
+            /.nvmrc
           sparse-checkout-cone-mode: false
 
       - name: Set up Node

--- a/scripts/lighthouse-benchmark.mjs
+++ b/scripts/lighthouse-benchmark.mjs
@@ -2,38 +2,39 @@
 /**
  * Lighthouse performance benchmark script for kestra.io docs.
  *
- * Runs Lighthouse on a set of key pages, writes JSON results and a
- * Markdown report. Optionally compares against a baseline JSON file to
- * show score/metric deltas in the report (used for PR vs. main comparison).
+ * Measures one shard of the page sample and writes its scores as JSON, plus
+ * the per-page LHR dumps. scripts/lighthouse-report.mjs merges the shards and
+ * builds the Markdown report.
  *
  * Usage (environment variables):
  *   BASE_URL        – Root URL to benchmark, no trailing slash (required)
- *   BASE_URL_OUTPUT – Public root URL used for the report links, so they stay
- *                     clickable outside CI (default: BASE_URL)
  *   OUTPUT_FILE     – Path for JSON output  (default: lighthouse-results.json)
- *   BASELINE_FILE   – Path to baseline JSON (optional; omit to skip comparison)
- *   MARKDOWN_FILE   – Path for Markdown report (default: lighthouse-report.md)
  *   LHR_DIR         – Directory for per-page LHR JSON dumps (default: lhr-reports)
  *   MULTI_RUN_COUNT – Overrides the `runs` counts in the page sample
+ *   SHARD_INDEX     – 0-based shard to measure (default: 0)
+ *   SHARD_TOTAL     – Number of shards the sample is split across (default: 1)
  *   WARMUP_PATH     – Page warmed before measuring (default: /privacy-policy);
- *                     the sample's SSR pages are warmed after it
+ *                     the shard's SSR pages are warmed after it
  *
  * Exits with code 0 on success, 1 on fatal error.
  * Score regressions never cause a non-zero exit — output is informational only.
  */
 
-import { writeFileSync, readFileSync, existsSync, mkdirSync } from "node:fs"
+import { writeFileSync, mkdirSync } from "node:fs"
 import { PAGES } from "../tests/fixtures/page-sample.mjs"
+import {
+    METRIC_DEFS,
+    median,
+    runsFor as sampleRunsFor,
+    shardPages,
+} from "./lighthouse-shared.mjs"
 
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
 
 const BASE_URL = (process.env.BASE_URL ?? "").replace(/\/$/, "")
-const BASE_URL_OUTPUT = process.env.BASE_URL_OUTPUT ?? BASE_URL
 const OUTPUT_FILE = process.env.OUTPUT_FILE ?? "lighthouse-results.json"
-const BASELINE_FILE = process.env.BASELINE_FILE ?? ""
-const MARKDOWN_FILE = process.env.MARKDOWN_FILE ?? "lighthouse-report.md"
 const LHR_DIR = process.env.LHR_DIR ?? "lhr-reports"
 // Warm-up target: a prerendered page with almost no content of its own, so it
 // pulls the worker and the shared layout assets without touching the sample.
@@ -46,17 +47,29 @@ const MULTI_RUN_COUNT = Math.max(
     Math.trunc(Number(process.env.MULTI_RUN_COUNT ?? 0)) || 0,
 )
 
+const SHARD_TOTAL = Math.max(
+    1,
+    Math.trunc(Number(process.env.SHARD_TOTAL ?? 1)) || 1,
+)
+const SHARD_INDEX = Math.min(
+    SHARD_TOTAL - 1,
+    Math.max(0, Math.trunc(Number(process.env.SHARD_INDEX ?? 0)) || 0),
+)
+
+/** This shard's slice of the page sample. */
+const SHARD_PAGES = shardPages(SHARD_TOTAL, MULTI_RUN_COUNT)[SHARD_INDEX]
+
 /**
- * PAGES with the server-rendered ones hoisted to the front, order otherwise
- * preserved. They are measured while workerd is freshest, and the prerendered
- * pages, served from disk, care far less where they land.
+ * The shard's pages with the server-rendered ones hoisted to the front, order
+ * otherwise preserved. They are measured while workerd is freshest, and the
+ * prerendered pages, served from disk, care far less where they land.
  *
  * @returns {typeof PAGES}
  */
 function orderedPages() {
     return [
-        ...PAGES.filter((page) => page.ssr),
-        ...PAGES.filter((page) => !page.ssr),
+        ...SHARD_PAGES.filter((page) => page.ssr),
+        ...SHARD_PAGES.filter((page) => !page.ssr),
     ]
 }
 
@@ -67,8 +80,7 @@ function orderedPages() {
  * @returns {number}
  */
 function runsFor(page) {
-    if (!page.runs || page.runs < 2) return 1
-    return MULTI_RUN_COUNT || page.runs
+    return sampleRunsFor(page, MULTI_RUN_COUNT)
 }
 
 if (!BASE_URL) {
@@ -83,95 +95,11 @@ const LIGHTHOUSE_CATEGORIES = [
     "seo",
 ]
 
-/** Metrics extracted from the Lighthouse audit results. */
-const METRIC_DEFS = [
-    {
-        auditKey: "largest-contentful-paint",
-        key: "lcp",
-        label: "LCP",
-        unit: "s",
-        divisor: 1000,
-        decimals: 2,
-    },
-    {
-        auditKey: "first-contentful-paint",
-        key: "fcp",
-        label: "FCP",
-        unit: "s",
-        divisor: 1000,
-        decimals: 2,
-    },
-    {
-        auditKey: "total-blocking-time",
-        key: "tbt",
-        label: "TBT",
-        unit: "ms",
-        divisor: 1,
-        decimals: 0,
-    },
-    {
-        auditKey: "cumulative-layout-shift",
-        key: "cls",
-        label: "CLS",
-        unit: "",
-        divisor: 1,
-        decimals: 3,
-    },
-    {
-        auditKey: "speed-index",
-        key: "si",
-        label: "Speed Index",
-        unit: "s",
-        divisor: 1000,
-        decimals: 2,
-    },
-]
-
-// Score delta significance threshold (points).
-const SCORE_THRESHOLD = 10
-// Metric delta significance threshold (fraction of baseline value).
-const METRIC_THRESHOLD = 0.3
-// Relative benchmarkIndex gap above which baseline deltas are suppressed:
-// Lighthouse does not normalise host CPU, so a slower runner fakes regressions.
-const BENCHMARK_INDEX_THRESHOLD = 0.1
-
-// ---------------------------------------------------------------------------
-// Types (JSDoc)
-// ---------------------------------------------------------------------------
-
 /**
- * @typedef {{
- *   performance: number;
- *   accessibility: number;
- *   'best-practices': number;
- *   seo: number;
- * }} Scores
- *
- * @typedef {{
- *   lcp: number;
- *   fcp: number;
- *   tbt: number;
- *   cls: number;
- *   si: number;
- * }} Metrics
- *
- * @typedef {{
- *   path: string;
- *   label: string;
- *   scores: Scores;
- *   metrics: Metrics;
- *   benchmarkIndex: number;
- *   runs: number;
- *   perfScores?: number[];
- *   error?: string;
- * }} PageResult
- *
- * @typedef {{
- *   timestamp: string;
- *   baseUrl: string;
- *   benchmarkIndex: number;
- *   results: PageResult[];
- * }} BenchmarkOutput
+ * @typedef {import("./lighthouse-shared.mjs").Scores} Scores
+ * @typedef {import("./lighthouse-shared.mjs").Metrics} Metrics
+ * @typedef {import("./lighthouse-shared.mjs").PageResult} PageResult
+ * @typedef {import("./lighthouse-shared.mjs").BenchmarkOutput} BenchmarkOutput
  */
 
 // ---------------------------------------------------------------------------
@@ -304,18 +232,6 @@ function perfScore(lhr) {
 }
 
 /**
- * Median of a numeric list, lower-middle for even lengths.
- *
- * @param {number[]} values
- * @returns {number}
- */
-function median(values) {
-    if (values.length === 0) return 0
-    const sorted = [...values].sort((a, b) => a - b)
-    return sorted[Math.floor((sorted.length - 1) / 2)]
-}
-
-/**
  * Runs Lighthouse `runs` times and returns the run whose performance score is
  * the median, keeping every reported score and metric from one single trace.
  *
@@ -394,227 +310,6 @@ function extractResults(lhr) {
 }
 
 // ---------------------------------------------------------------------------
-// Delta helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Returns a display string for a score delta (higher is better).
- *
- * @param {number} current
- * @param {number | undefined} baseline
- * @returns {string}
- */
-function scoreDelta(current, baseline) {
-    if (baseline == null) return ""
-    const delta = Math.round(current - baseline)
-    if (delta >= SCORE_THRESHOLD) return ` 🟢 +${delta}`
-    if (delta <= -SCORE_THRESHOLD) return ` 🔻 ${delta}`
-    return ""
-}
-
-/**
- * Returns a display arrow for a metric delta (lower is better).
- *
- * @param {number} current
- * @param {number | undefined} baseline
- * @returns {string}
- */
-function metricDelta(current, baseline) {
-    if (baseline == null || baseline === 0) return ""
-    const pctChange = (current - baseline) / baseline
-    if (pctChange <= -METRIC_THRESHOLD) return " 🟢" // lower = better
-    if (pctChange >= METRIC_THRESHOLD) return " 🔻" // higher = worse
-    return ""
-}
-
-/**
- * Decides whether baseline deltas can be trusted. Lighthouse reports the host
- * CPU as benchmarkIndex; a runner much slower than the baseline's fakes drops.
- *
- * @param {number} current
- * @param {number | undefined} base
- * @returns {{ comparable: boolean; note: string }}
- */
-function compareBenchmarkIndex(current, base) {
-    if (!current || !base) {
-        return {
-            comparable: true,
-            note: "one side has no CPU index, deltas not CPU-checked",
-        }
-    }
-
-    const gap = Math.abs(current - base) / base
-    const pct = Math.round(gap * 100)
-    if (gap > BENCHMARK_INDEX_THRESHOLD) {
-        return {
-            comparable: false,
-            note: `runner CPU differs by ${pct}% from baseline, deltas hidden`,
-        }
-    }
-
-    return {
-        comparable: true,
-        note: `runner CPU within ${pct}% of baseline`,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Markdown report generation
-// ---------------------------------------------------------------------------
-
-const PAGE_ORDER = new Map(PAGES.map((page, index) => [page.path, index]))
-
-/**
- * Results back in page-sample order. Measurement runs the SSR pages first, but
- * the report should keep its rows where readers expect them run to run.
- *
- * @param {PageResult[]} results
- * @returns {PageResult[]}
- */
-function reportOrder(results) {
-    return [...results].sort(
-        (a, b) => (PAGE_ORDER.get(a.path) ?? 0) - (PAGE_ORDER.get(b.path) ?? 0),
-    )
-}
-
-/**
- * Formats a metric value for display.
- *
- * @param {number} value
- * @param {{ unit: string; decimals: number }} def
- * @returns {string}
- */
-function fmtMetric(value, def) {
-    const formatted = value.toFixed(def.decimals)
-    return def.unit ? `${formatted} ${def.unit}` : formatted
-}
-
-/**
- * Builds the Markdown report string.
- *
- * @param {BenchmarkOutput} output
- * @param {BenchmarkOutput | null} baseline
- * @returns {string}
- */
-function buildMarkdown(output, baseline) {
-    const testedAt =
-        new Date(output.timestamp)
-            .toISOString()
-            .replace("T", " ")
-            .slice(0, 16) + " UTC"
-    const cpu = baseline
-        ? compareBenchmarkIndex(output.benchmarkIndex, baseline.benchmarkIndex)
-        : null
-    // Deltas are dropped, not shown, when the runners differ too much.
-    const comparedBaseline = cpu && !cpu.comparable ? null : baseline
-
-    const baselineInfo = baseline
-        ? `Compared against \`main\` baseline from ${new Date(baseline.timestamp).toISOString().slice(0, 10)}`
-        : "No baseline available — scores will appear after the first merge to `main`"
-    const cpuInfo =
-        `Runner CPU index: ${output.benchmarkIndex || "unknown"}` +
-        (baseline
-            ? ` (baseline: ${baseline.benchmarkIndex || "unknown"}, ${cpu?.note})`
-            : "")
-
-    const lines = [
-        `> Tested on ${testedAt} &nbsp;·&nbsp; links point to \`${output.baseUrl}\`  `,
-        `> ${baselineInfo}  `,
-        `> ${cpuInfo}`,
-        "",
-        "### Scores (0–100, higher is better)",
-        "",
-        "| Page | Performance | Accessibility | Best Practices | SEO |",
-        "|------|-------------|---------------|----------------|-----|",
-    ]
-
-    for (const result of reportOrder(output.results)) {
-        if (result.error) {
-            lines.push(
-                `| [${result.label}](${output.baseUrl}${result.path}) | ❌ error | ❌ error | ❌ error | ❌ error |`,
-            )
-            continue
-        }
-        const base = comparedBaseline?.results.find(
-            (r) => r.path === result.path && !r.error,
-        )
-        const { scores } = result
-        const bs = base?.scores
-        lines.push(
-            `| [${result.label}](${output.baseUrl}${result.path}) ` +
-                `| ${scores.performance}${scoreDelta(scores.performance, bs?.performance)} ` +
-                `| ${scores.accessibility}${scoreDelta(scores.accessibility, bs?.accessibility)} ` +
-                `| ${scores["best-practices"]}${scoreDelta(scores["best-practices"], bs?.["best-practices"])} ` +
-                `| ${scores.seo}${scoreDelta(scores.seo, bs?.seo)} |`,
-        )
-    }
-
-    const failed = output.results.filter((r) => r.error)
-    if (failed.length > 0) {
-        lines.push("")
-        for (const result of failed) {
-            lines.push(`❌ \`${result.path}\` — ${result.error}  `)
-        }
-    }
-
-    lines.push("", "### Core Web Vitals (lower is better)", "")
-
-    // Build header from metric defs
-    const metricHeaders = METRIC_DEFS.map((d) => d.label).join(" | ")
-    const metricSep = METRIC_DEFS.map(() => "---").join(" | ")
-    lines.push(`| Page | ${metricHeaders} |`)
-    lines.push(`|------|${metricSep}|`)
-
-    for (const result of reportOrder(output.results)) {
-        if (result.error) {
-            const cells = METRIC_DEFS.map(() => "❌").join(" | ")
-            lines.push(
-                `| [${result.label}](${output.baseUrl}${result.path}) | ${cells} |`,
-            )
-            continue
-        }
-        const base = comparedBaseline?.results.find(
-            (r) => r.path === result.path && !r.error,
-        )
-        const cells = METRIC_DEFS.map((def) => {
-            const val = result.metrics[/** @type {keyof Metrics} */ (def.key)]
-            const bval = base?.metrics[/** @type {keyof Metrics} */ (def.key)]
-            return `${fmtMetric(val, def)}${metricDelta(val, bval)}`
-        }).join(" | ")
-        lines.push(
-            `| [${result.label}](${output.baseUrl}${result.path}) | ${cells} |`,
-        )
-    }
-
-    const multiRun = reportOrder(output.results).filter((r) => r.runs > 1)
-
-    lines.push(
-        "",
-        "<details><summary>Legend</summary>",
-        "",
-        "🟢 improved &nbsp;·&nbsp; 🔻 regressed &nbsp;·&nbsp; (blank) no significant change  ",
-        `Score threshold: ±${SCORE_THRESHOLD} pts &nbsp;·&nbsp; Metric threshold: ±${METRIC_THRESHOLD * 100}% of baseline`,
-        "",
-        multiRun.length
-            ? `Median of repeated runs: ${multiRun
-                  .map((r) => `${r.label} x${r.runs}`)
-                  .join(", ")}. A single run of these swings 20+ points between runners.  `
-            : "",
-        `Runner CPU index is Lighthouse's \`benchmarkIndex\`. Lighthouse does not normalise for host CPU, so deltas are hidden when the two runners differ by more than ${BENCHMARK_INDEX_THRESHOLD * 100}%.`,
-        "",
-        "</details>",
-        "",
-        "<details><summary>View full Lighthouse HTML report for a page</summary>",
-        "",
-        "Full per-page Lighthouse Results (LHR) are attached as the `lhr-reports` artifact on this run. Download and unzip it, then open <https://googlechrome.github.io/lighthouse/viewer/> and drop the `<page>-lhr.json` file into the page to see every audit, opportunity, and diagnostic.",
-        "",
-        "</details>",
-    )
-
-    return lines.join("\n")
-}
-
-// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -622,15 +317,17 @@ async function main() {
     // @ts-ignore - optional CI-only dependency, not in package.json
     const chromeLauncher = await import("chrome-launcher")
 
-    console.log(`\nLighthouse Benchmark`)
-    console.log(`Base URL : ${BASE_URL}`)
-    console.log(`Pages    : ${PAGES.length}`)
-    const runPlan = PAGES.filter((page) => runsFor(page) > 1)
+    const shardRuns = SHARD_PAGES.reduce((sum, page) => sum + runsFor(page), 0)
+    const runPlan = SHARD_PAGES.filter((page) => runsFor(page) > 1)
         .map((page) => `${page.path} x${runsFor(page)}`)
         .join(", ")
-    console.log(`Runs     : 1 per page, except ${runPlan}`)
+
+    console.log(`\nLighthouse Benchmark`)
+    console.log(`Base URL : ${BASE_URL}`)
+    console.log(`Shard    : ${SHARD_INDEX + 1} of ${SHARD_TOTAL}`)
+    console.log(`Pages    : ${SHARD_PAGES.length} of ${PAGES.length}`)
     console.log(
-        `Baseline : ${BASELINE_FILE && existsSync(BASELINE_FILE) ? BASELINE_FILE : "none"}\n`,
+        `Runs     : ${shardRuns}, 1 per page except ${runPlan || "none"}\n`,
     )
 
     // Launch Chrome once and reuse for all pages.
@@ -648,7 +345,9 @@ async function main() {
 
     // WARMUP_PATH covers the workerd compile and the shared layout assets. The
     // SSR routes each compile and render on their own first hit, so they follow.
-    const ssrPaths = PAGES.filter((page) => page.ssr).map((page) => page.path)
+    const ssrPaths = SHARD_PAGES.filter((page) => page.ssr).map(
+        (page) => page.path,
+    )
     process.stdout.write(
         `Warming up on ${WARMUP_PATH} and ${ssrPaths.length} SSR pages… `,
     )
@@ -683,6 +382,7 @@ async function main() {
                     metrics,
                     benchmarkIndex,
                     runs,
+                    shard: SHARD_INDEX,
                     perfScores,
                 })
                 const spread =
@@ -705,6 +405,7 @@ async function main() {
                     metrics: { lcp: 0, fcp: 0, tbt: 0, cls: 0, si: 0 },
                     benchmarkIndex: 0,
                     runs,
+                    shard: SHARD_INDEX,
                     error: message,
                 })
             }
@@ -722,37 +423,17 @@ async function main() {
     /** @type {BenchmarkOutput} */
     const output = {
         timestamp: new Date().toISOString(),
-        baseUrl: BASE_URL_OUTPUT,
+        baseUrl: BASE_URL,
         benchmarkIndex,
+        shard: SHARD_INDEX,
+        shardTotal: SHARD_TOTAL,
         results,
     }
 
     console.log(`\nRunner CPU index (median): ${benchmarkIndex || "unknown"}`)
 
-    // Write JSON output.
     writeFileSync(OUTPUT_FILE, JSON.stringify(output, null, 2))
-    console.log(`\nResults written to ${OUTPUT_FILE}`)
-
-    // Load baseline if provided and file exists.
-    /** @type {BenchmarkOutput | null} */
-    let baseline = null
-    if (BASELINE_FILE && existsSync(BASELINE_FILE)) {
-        try {
-            baseline = JSON.parse(readFileSync(BASELINE_FILE, "utf8"))
-            console.log(
-                `Baseline loaded from ${BASELINE_FILE} (${baseline?.timestamp?.slice(0, 10)})`,
-            )
-        } catch {
-            console.warn(
-                `Warning: Could not parse baseline file ${BASELINE_FILE}, skipping comparison.`,
-            )
-        }
-    }
-
-    // Write Markdown report.
-    const markdown = buildMarkdown(output, baseline)
-    writeFileSync(MARKDOWN_FILE, markdown)
-    console.log(`Report written to ${MARKDOWN_FILE}\n`)
+    console.log(`Results written to ${OUTPUT_FILE}\n`)
 }
 
 main().catch((err) => {

--- a/scripts/lighthouse-report.mjs
+++ b/scripts/lighthouse-report.mjs
@@ -1,0 +1,360 @@
+// @ts-check
+/**
+ * Merges the per-shard results written by scripts/lighthouse-benchmark.mjs into
+ * one result set, and renders the Markdown report posted on the PR or commit.
+ *
+ * Usage (environment variables):
+ *   RESULTS_DIR     – Directory of per-shard JSON results (default: shard-results)
+ *   BASE_URL_OUTPUT – Public root URL for the report links (required)
+ *   OUTPUT_FILE     – Path for the merged JSON (default: lighthouse-results.json)
+ *   BASELINE_FILE   – Path to baseline JSON (optional; omit to skip comparison)
+ *   MARKDOWN_FILE   – Path for Markdown report (default: lighthouse-report.md)
+ *
+ * Exits with code 0 on success, 1 when no shard result could be read.
+ * Score regressions never cause a non-zero exit — output is informational only.
+ */
+
+import { readFileSync, readdirSync, writeFileSync, existsSync } from "node:fs"
+import { join } from "node:path"
+import { PAGES } from "../tests/fixtures/page-sample.mjs"
+import {
+    BENCHMARK_INDEX_THRESHOLD,
+    METRIC_DEFS,
+    METRIC_THRESHOLD,
+    SCORE_THRESHOLD,
+    median,
+    reportOrder,
+} from "./lighthouse-shared.mjs"
+
+/**
+ * @typedef {import("./lighthouse-shared.mjs").Metrics} Metrics
+ * @typedef {import("./lighthouse-shared.mjs").PageResult} PageResult
+ * @typedef {import("./lighthouse-shared.mjs").BenchmarkOutput} BenchmarkOutput
+ */
+
+const RESULTS_DIR = process.env.RESULTS_DIR ?? "shard-results"
+const BASE_URL_OUTPUT = (process.env.BASE_URL_OUTPUT ?? "").replace(/\/$/, "")
+const OUTPUT_FILE = process.env.OUTPUT_FILE ?? "lighthouse-results.json"
+const BASELINE_FILE = process.env.BASELINE_FILE ?? ""
+const MARKDOWN_FILE = process.env.MARKDOWN_FILE ?? "lighthouse-report.md"
+
+// ---------------------------------------------------------------------------
+// Merge
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads every shard result in a directory, newest field wins on conflict.
+ *
+ * @param {string} dir
+ * @returns {BenchmarkOutput[]}
+ */
+function readShards(dir) {
+    if (!existsSync(dir)) return []
+
+    /** @type {BenchmarkOutput[]} */
+    const shards = []
+    for (const name of readdirSync(dir).sort()) {
+        if (!name.endsWith(".json")) continue
+        try {
+            shards.push(JSON.parse(readFileSync(join(dir, name), "utf8")))
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err)
+            console.warn(`Warning: could not parse ${name}: ${message}`)
+        }
+    }
+    return shards
+}
+
+/**
+ * Merges the shards into one result set. A page missing from every shard means
+ * its job never reported, which is an error row rather than a silent gap.
+ *
+ * @param {BenchmarkOutput[]} shards
+ * @returns {BenchmarkOutput}
+ */
+function mergeShards(shards) {
+    const results = reportOrder(shards.flatMap((shard) => shard.results))
+    const measured = new Set(results.map((result) => result.path))
+
+    for (const page of PAGES) {
+        if (measured.has(page.path)) continue
+        results.push({
+            path: page.path,
+            label: page.label,
+            scores: {
+                performance: 0,
+                accessibility: 0,
+                "best-practices": 0,
+                seo: 0,
+            },
+            metrics: { lcp: 0, fcp: 0, tbt: 0, cls: 0, si: 0 },
+            benchmarkIndex: 0,
+            runs: 0,
+            error: "no shard reported this page",
+        })
+    }
+
+    return {
+        timestamp: new Date().toISOString(),
+        baseUrl: BASE_URL_OUTPUT,
+        benchmarkIndex: median(
+            shards.map((shard) => shard.benchmarkIndex).filter(Boolean),
+        ),
+        shards: shards.map((shard) => ({
+            shard: shard.shard ?? 0,
+            benchmarkIndex: shard.benchmarkIndex,
+        })),
+        results: reportOrder(results),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Delta helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a display string for a score delta (higher is better).
+ *
+ * @param {number} current
+ * @param {number | undefined} baseline
+ * @returns {string}
+ */
+function scoreDelta(current, baseline) {
+    if (baseline == null) return ""
+    const delta = Math.round(current - baseline)
+    if (delta >= SCORE_THRESHOLD) return ` 🟢 +${delta}`
+    if (delta <= -SCORE_THRESHOLD) return ` 🔻 ${delta}`
+    return ""
+}
+
+/**
+ * Returns a display arrow for a metric delta (lower is better).
+ *
+ * @param {number} current
+ * @param {number | undefined} baseline
+ * @returns {string}
+ */
+function metricDelta(current, baseline) {
+    if (baseline == null || baseline === 0) return ""
+    const pctChange = (current - baseline) / baseline
+    if (pctChange <= -METRIC_THRESHOLD) return " 🟢" // lower = better
+    if (pctChange >= METRIC_THRESHOLD) return " 🔻" // higher = worse
+    return ""
+}
+
+/**
+ * Whether two runs are on close enough hardware to compare. Lighthouse reports
+ * the host CPU as benchmarkIndex and does not normalise for it.
+ *
+ * @param {number} current
+ * @param {number | undefined} base
+ * @returns {boolean}
+ */
+function comparableCpu(current, base) {
+    if (!current || !base) return true
+    return Math.abs(current - base) / base <= BENCHMARK_INDEX_THRESHOLD
+}
+
+/**
+ * The baseline row to compare a page against, or undefined when the two ran on
+ * hardware too far apart. Sharding puts pages on their own runner, so the check
+ * is per page rather than per run.
+ *
+ * @param {PageResult} result
+ * @param {BenchmarkOutput | null} baseline
+ * @returns {PageResult | undefined}
+ */
+function baselineFor(result, baseline) {
+    const base = baseline?.results.find(
+        (r) => r.path === result.path && !r.error,
+    )
+    if (!base) return undefined
+    return comparableCpu(result.benchmarkIndex, base.benchmarkIndex)
+        ? base
+        : undefined
+}
+
+// ---------------------------------------------------------------------------
+// Markdown report generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Formats a metric value for display.
+ *
+ * @param {number} value
+ * @param {{ unit: string; decimals: number }} def
+ * @returns {string}
+ */
+function fmtMetric(value, def) {
+    const formatted = value.toFixed(def.decimals)
+    return def.unit ? `${formatted} ${def.unit}` : formatted
+}
+
+/**
+ * Builds the Markdown report string.
+ *
+ * @param {BenchmarkOutput} output
+ * @param {BenchmarkOutput | null} baseline
+ * @returns {string}
+ */
+export function buildMarkdown(output, baseline) {
+    const testedAt =
+        new Date(output.timestamp)
+            .toISOString()
+            .replace("T", " ")
+            .slice(0, 16) + " UTC"
+
+    const scored = output.results.filter((result) => !result.error)
+    const hidden = baseline
+        ? scored.filter((result) => !baselineFor(result, baseline)).length
+        : 0
+
+    const baselineInfo = baseline
+        ? `Compared against \`main\` baseline from ${new Date(baseline.timestamp).toISOString().slice(0, 10)}`
+        : "No baseline available — scores will appear after the first merge to `main`"
+    const shardIndexes = (output.shards ?? [])
+        .map((shard) => shard.benchmarkIndex || "unknown")
+        .join(", ")
+    const cpuInfo =
+        `Runner CPU index per shard: ${shardIndexes || "unknown"}` +
+        (baseline
+            ? ` (baseline: ${baseline.benchmarkIndex || "unknown"}` +
+              (hidden ? `, deltas hidden on ${hidden} page(s)` : "") +
+              ")"
+            : "")
+
+    const lines = [
+        `> Tested on ${testedAt} &nbsp;·&nbsp; links point to \`${output.baseUrl}\`  `,
+        `> ${baselineInfo}  `,
+        `> ${cpuInfo}`,
+        "",
+        "### Scores (0–100, higher is better)",
+        "",
+        "| Page | Performance | Accessibility | Best Practices | SEO |",
+        "|------|-------------|---------------|----------------|-----|",
+    ]
+
+    for (const result of output.results) {
+        if (result.error) {
+            lines.push(
+                `| [${result.label}](${output.baseUrl}${result.path}) | ❌ error | ❌ error | ❌ error | ❌ error |`,
+            )
+            continue
+        }
+        const bs = baselineFor(result, baseline)?.scores
+        const { scores } = result
+        lines.push(
+            `| [${result.label}](${output.baseUrl}${result.path}) ` +
+                `| ${scores.performance}${scoreDelta(scores.performance, bs?.performance)} ` +
+                `| ${scores.accessibility}${scoreDelta(scores.accessibility, bs?.accessibility)} ` +
+                `| ${scores["best-practices"]}${scoreDelta(scores["best-practices"], bs?.["best-practices"])} ` +
+                `| ${scores.seo}${scoreDelta(scores.seo, bs?.seo)} |`,
+        )
+    }
+
+    const failed = output.results.filter((r) => r.error)
+    if (failed.length > 0) {
+        lines.push("")
+        for (const result of failed) {
+            lines.push(`❌ \`${result.path}\` — ${result.error}  `)
+        }
+    }
+
+    lines.push("", "### Core Web Vitals (lower is better)", "")
+
+    // Build header from metric defs
+    const metricHeaders = METRIC_DEFS.map((d) => d.label).join(" | ")
+    const metricSep = METRIC_DEFS.map(() => "---").join(" | ")
+    lines.push(`| Page | ${metricHeaders} |`)
+    lines.push(`|------|${metricSep}|`)
+
+    for (const result of output.results) {
+        if (result.error) {
+            const cells = METRIC_DEFS.map(() => "❌").join(" | ")
+            lines.push(
+                `| [${result.label}](${output.baseUrl}${result.path}) | ${cells} |`,
+            )
+            continue
+        }
+        const base = baselineFor(result, baseline)
+        const cells = METRIC_DEFS.map((def) => {
+            const val = result.metrics[/** @type {keyof Metrics} */ (def.key)]
+            const bval = base?.metrics[/** @type {keyof Metrics} */ (def.key)]
+            return `${fmtMetric(val, def)}${metricDelta(val, bval)}`
+        }).join(" | ")
+        lines.push(
+            `| [${result.label}](${output.baseUrl}${result.path}) | ${cells} |`,
+        )
+    }
+
+    const multiRun = output.results.filter((r) => r.runs > 1)
+
+    lines.push(
+        "",
+        "<details><summary>Legend</summary>",
+        "",
+        "🟢 improved &nbsp;·&nbsp; 🔻 regressed &nbsp;·&nbsp; (blank) no significant change  ",
+        `Score threshold: ±${SCORE_THRESHOLD} pts &nbsp;·&nbsp; Metric threshold: ±${METRIC_THRESHOLD * 100}% of baseline`,
+        "",
+        multiRun.length
+            ? `Median of repeated runs: ${multiRun
+                  .map((r) => `${r.label} x${r.runs}`)
+                  .join(
+                      ", ",
+                  )}. A single run of these swings 20+ points between runners.  `
+            : "",
+        `The sample is measured across ${output.shards?.length ?? 1} parallel runners, so each page carries its own CPU index (Lighthouse's \`benchmarkIndex\`). Lighthouse does not normalise for host CPU, so a page's deltas are hidden when its runner differs from the baseline's by more than ${BENCHMARK_INDEX_THRESHOLD * 100}%.`,
+        "",
+        "</details>",
+        "",
+        "<details><summary>View full Lighthouse HTML report for a page</summary>",
+        "",
+        "Full per-page Lighthouse Results (LHR) are attached as the `lhr-reports-shard-*` artifacts on this run. Download and unzip one, then open <https://googlechrome.github.io/lighthouse/viewer/> and drop the `<page>-lhr.json` file into the page to see every audit, opportunity, and diagnostic.",
+        "",
+        "</details>",
+    )
+
+    return lines.join("\n")
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+    const shards = readShards(RESULTS_DIR)
+    if (shards.length === 0) {
+        console.error(`ERROR: no shard results found in ${RESULTS_DIR}/`)
+        process.exit(1)
+    }
+
+    const output = mergeShards(shards)
+    const missing = output.results.filter((r) => r.error).length
+    console.log(
+        `Merged ${shards.length} shard(s), ${output.results.length} pages` +
+            (missing ? `, ${missing} without a score` : ""),
+    )
+
+    writeFileSync(OUTPUT_FILE, JSON.stringify(output, null, 2))
+    console.log(`Results written to ${OUTPUT_FILE}`)
+
+    /** @type {BenchmarkOutput | null} */
+    let baseline = null
+    if (BASELINE_FILE && existsSync(BASELINE_FILE)) {
+        try {
+            baseline = JSON.parse(readFileSync(BASELINE_FILE, "utf8"))
+            console.log(
+                `Baseline loaded from ${BASELINE_FILE} (${baseline?.timestamp?.slice(0, 10)})`,
+            )
+        } catch {
+            console.warn(
+                `Warning: Could not parse baseline file ${BASELINE_FILE}, skipping comparison.`,
+            )
+        }
+    }
+
+    writeFileSync(MARKDOWN_FILE, buildMarkdown(output, baseline))
+    console.log(`Report written to ${MARKDOWN_FILE}\n`)
+}
+
+main()

--- a/scripts/lighthouse-shared.mjs
+++ b/scripts/lighthouse-shared.mjs
@@ -1,0 +1,176 @@
+// @ts-check
+/**
+ * Shared between scripts/lighthouse-benchmark.mjs, which measures one shard of
+ * the page sample, and scripts/lighthouse-report.mjs, which merges the shards.
+ */
+
+import { PAGES } from "../tests/fixtures/page-sample.mjs"
+
+/** Metrics extracted from the Lighthouse audit results. */
+export const METRIC_DEFS = [
+    {
+        auditKey: "largest-contentful-paint",
+        key: "lcp",
+        label: "LCP",
+        unit: "s",
+        divisor: 1000,
+        decimals: 2,
+    },
+    {
+        auditKey: "first-contentful-paint",
+        key: "fcp",
+        label: "FCP",
+        unit: "s",
+        divisor: 1000,
+        decimals: 2,
+    },
+    {
+        auditKey: "total-blocking-time",
+        key: "tbt",
+        label: "TBT",
+        unit: "ms",
+        divisor: 1,
+        decimals: 0,
+    },
+    {
+        auditKey: "cumulative-layout-shift",
+        key: "cls",
+        label: "CLS",
+        unit: "",
+        divisor: 1,
+        decimals: 3,
+    },
+    {
+        auditKey: "speed-index",
+        key: "si",
+        label: "Speed Index",
+        unit: "s",
+        divisor: 1000,
+        decimals: 2,
+    },
+]
+
+// Score delta significance threshold (points).
+export const SCORE_THRESHOLD = 10
+// Metric delta significance threshold (fraction of baseline value).
+export const METRIC_THRESHOLD = 0.3
+// Relative benchmarkIndex gap above which baseline deltas are suppressed:
+// Lighthouse does not normalise host CPU, so a slower runner fakes regressions.
+export const BENCHMARK_INDEX_THRESHOLD = 0.1
+
+/**
+ * @typedef {{
+ *   performance: number;
+ *   accessibility: number;
+ *   'best-practices': number;
+ *   seo: number;
+ * }} Scores
+ *
+ * @typedef {{
+ *   lcp: number;
+ *   fcp: number;
+ *   tbt: number;
+ *   cls: number;
+ *   si: number;
+ * }} Metrics
+ *
+ * @typedef {{
+ *   path: string;
+ *   label: string;
+ *   scores: Scores;
+ *   metrics: Metrics;
+ *   benchmarkIndex: number;
+ *   runs: number;
+ *   shard?: number;
+ *   perfScores?: number[];
+ *   error?: string;
+ * }} PageResult
+ *
+ * @typedef {{
+ *   timestamp: string;
+ *   baseUrl: string;
+ *   benchmarkIndex: number;
+ *   shard?: number;
+ *   shardTotal?: number;
+ *   shards?: { shard: number; benchmarkIndex: number }[];
+ *   results: PageResult[];
+ * }} BenchmarkOutput
+ */
+
+/**
+ * Median of a numeric list, lower-middle for even lengths.
+ *
+ * @param {number[]} values
+ * @returns {number}
+ */
+export function median(values) {
+    if (values.length === 0) return 0
+    const sorted = [...values].sort((a, b) => a - b)
+    return sorted[Math.floor((sorted.length - 1) / 2)]
+}
+
+/**
+ * Runs to measure for a page: what the sample asks for, 1 by default.
+ *
+ * @param {typeof PAGES[number]} page
+ * @param {number} [override] Replaces every count above 1 when set.
+ * @returns {number}
+ */
+export function runsFor(page, override = 0) {
+    if (!page.runs || page.runs < 2) return 1
+    return override || page.runs
+}
+
+/**
+ * Splits the page sample into `total` shards of roughly equal measuring time.
+ *
+ * A page costs one Lighthouse run, or `runs` of them for the ones measured by
+ * median, so slicing by page count would leave one shard with half the work.
+ * Longest-processing-time first: heaviest page to the lightest shard so far,
+ * ties by sample order, which makes the assignment stable across shards.
+ *
+ * @param {number} total
+ * @param {number} [override] MULTI_RUN_COUNT, applied to every repeated page.
+ * @returns {(typeof PAGES)[]} One page list per shard, in sample order.
+ */
+export function shardPages(total, override = 0) {
+    /** @type {{ pages: typeof PAGES; load: number }[]} */
+    const shards = Array.from({ length: total }, () => ({
+        pages: [],
+        load: 0,
+    }))
+
+    const byWeight = PAGES.map((page, index) => ({ page, index })).sort(
+        (a, b) =>
+            runsFor(b.page, override) - runsFor(a.page, override) ||
+            a.index - b.index,
+    )
+
+    for (const { page } of byWeight) {
+        const target = shards.reduce((a, b) => (b.load < a.load ? b : a))
+        target.pages.push(page)
+        target.load += runsFor(page, override)
+    }
+
+    const order = new Map(PAGES.map((page, index) => [page.path, index]))
+    return shards.map((shard) =>
+        shard.pages.sort(
+            (a, b) => (order.get(a.path) ?? 0) - (order.get(b.path) ?? 0),
+        ),
+    )
+}
+
+const PAGE_ORDER = new Map(PAGES.map((page, index) => [page.path, index]))
+
+/**
+ * Results back in page-sample order. Shards measure disjoint slices and the SSR
+ * pages first, so rows only stay where readers expect them if sorted here.
+ *
+ * @param {PageResult[]} results
+ * @returns {PageResult[]}
+ */
+export function reportOrder(results) {
+    return [...results].sort(
+        (a, b) => (PAGE_ORDER.get(a.path) ?? 0) - (PAGE_ORDER.get(b.path) ?? 0),
+    )
+}


### PR DESCRIPTION
Stacked on #5572, which is where the fixture server, the warm-up and the median-of-3 come from. Merge that first.

## Why

The benchmark step took 9m56 as a single job on run 3750. Median-of-3 takes the sample to 34 page runs, so it was heading for half an hour on a docs PR.

## What

Three jobs: build once, measure in a 4-way matrix, merge and comment.

The shards get the build as a zstd tarball artifact instead of building their own. Four builds would cost four times the Astro minutes and, worse, put four different builds under measurement. `dist` is thousands of mostly-image files, so it is tarred before upload with `compression-level: 0`; the artifact actions walking the tree file by file is what makes that slow, not the bytes.

`SHARD_TOTAL` comes from `strategy.job-total`, so the matrix length is the only knob.

### Slicing is by measuring time, not page count

A page costs one run, or `runs` of them for the ones measured by median. Longest-processing-time first lands at 9/9/8/8 runs per shard. Round-robin by index would have put 15 of the 34 on one shard, and that shard would have set the wall clock.

### The CPU gate is now per page

`benchmarkIndex` is a property of the runner and there are four of them now, so one number for the whole run no longer describes it. Each `PageResult` already carried its own, so a page's deltas are hidden when its runner is more than 10% off the baseline's. On a single runner this is exactly what #5572 does today.

Tested against a synthetic slow shard: only that shard's four pages lose their deltas, and the header says how many.

### Script split

`scripts/lighthouse-report.mjs` is new and owns everything after the measuring: merge the shards, mark any page no shard reported rather than dropping the row, render the Markdown. `lighthouse-benchmark.mjs` is back to measuring one slice. `METRIC_DEFS`, the thresholds and the sharding live in `scripts/lighthouse-shared.mjs`.

### Smaller things

- the fixture-server check runs on the shards that measured `/blueprints`, which is where the SSR calls happen; the others never touch it
- the `api-fixtures` artifact uploads only when something was recorded, so it means "commit these" rather than appearing on every run
- the report job sparse-checks out and skips `npm install`: it needs the scripts and the page sample, not 800 MB of content or `node_modules`
- it keeps the name `Lighthouse Benchmark` so the existing status check still resolves

## Numbers

Roughly 17 min wall clock against ~32 serial, for about 46 runner minutes. Building in every shard would be quicker still (no serialized build job in front, ~13 min) at four times the build minutes and four builds under measurement, which defeats the point.

## What is not verified

The `dist` size and the shards' `wrangler dev` against an unpacked `dist` need CI to say. The 17-minute estimate assumes the download costs about a minute; the `Pack the build` step will report the real size on the first run. If it is much bigger than the ~5.1k assets in the deploy log suggest, building per shard is the better shape and this becomes the wrong trade.

Report merge, the missing-shard rows, the per-page CPU gate and the 9/9/8/8 split were verified locally against synthetic shard output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GEhSD6GqR4y8jL869sp9s

---
_Generated by [Claude Code](https://claude.ai/code/session_015GEhSD6GqR4y8jL869sp9s)_