### PR TITLE
perf(about-us): load the hero image eagerly

### DIFF
--- a/src/components/company/Orchestrate.astro
+++ b/src/components/company/Orchestrate.astro
@@ -59,6 +59,8 @@ const CompanyLogos = [
                     class="image"
                     width={554}
                     height={414}
+                    loading="eager"
+                    fetchpriority="high"
                 />
             </div>
             <div class="content">


### PR DESCRIPTION
`/about-us` has been reporting two different LCPs across Lighthouse runs on comparable runners, around 1.6 s or around 2.7 s, with nothing else about the page moving. The score followed: 98 on some runs, 84 to 85 on others, which is most of the page's apparent instability now that the benchmark repeats it three times and takes the median.

## Cause

`src/components/company/Orchestrate.astro` renders the team photo as the hero, and it is the LCP element. Neither copy sets `loading`, so Astro's `<Image>` default applies: `loading="lazy" decoding="async"`. A lazy image is not fetched until layout has run and the intersection observer has resolved, so the request lands after the CSS and the font work rather than alongside it. Whether that lands before or after the paint depends on how the rest of the page schedules, which is exactly the bimodal split.

Every other hero in the tree already opts out: `twozero/Hero.astro:185`, `airflow-2-eol-whitepaper/Hero.astro:48`, `plugins/[...slug].astro:356`. This one was missed.

## Change

Two attributes on the visible image:

```diff
                 ``&lt;Image·                     src={TeamImage}·                     alt="The Kestra team"·                     class="image"·                     width={554}·                     height={414}·+                    loading="eager"·+                    fetchpriority="high"·                 /&gt;``
```

The decorative blurred copy above it keeps the default. It is the same `src` at the same dimensions, so Astro emits an identical optimised URL and the browser serves it from the one request; making it eager too would change nothing except the markup.

`fetchpriority="high"` is what stops the image queueing behind the stylesheet and font requests at the same `loading="eager"` priority, so it does the half of the work the `loading` attribute alone would not.

## Verifying

The next Lighthouse run on this branch reports `/about-us` as a median of 3. Expect LCP to settle near 1.6 s and the score near 98, with the 2.7 s mode gone rather than merely less frequent. The `lhr-reports` artifact carries `largest-contentful-paint-element` for the page if the element attribution needs confirming.

Not addressed here: `/about-us` also shows CLS 0.152 on some runs. Different element, different fix, and it needs the artifact to identify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5E2r1GCXnoUKpdqv389F9

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5E2r1GCXnoUKpdqv389F9)_