### PR TITLE
fix(build): cover shared styles/layouts in the incremental build cache key

### DIFF
--- a/src/utils/incrementalCacheKey.test.ts
+++ b/src/utils/incrementalCacheKey.test.ts
@@ -1,10 +1,21 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi, beforeEach } from "vitest"
 import {
     collectionContentDigest,
     collectionMetadataDigest,
     entryCacheKey,
+    fileContentsDigest,
     hashString,
 } from "~/utils/incrementalCacheKey"
+import { DOCS_LATEST_OVERRIDE } from "~/utils/versionedDocs"
+
+const { fetchMock } = vi.hoisted(() => ({ fetchMock: vi.fn() }))
+vi.mock("~/utils/fetch", () => ({ $fetchApiCached: fetchMock }))
+
+beforeEach(() => {
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue({ version: "2.9.0" })
+    vi.resetModules()
+})
 
 const entry = (id: string, digest: string, data: Record<string, unknown>) => ({
     id,
@@ -54,6 +65,41 @@ describe("collectionContentDigest", () => {
         expect(
             collectionContentDigest([collection[0], entry("b", "d9", { title: "B" })]),
         ).not.toBe(collectionContentDigest(collection))
+    })
+})
+
+describe("fileContentsDigest", () => {
+    it("ignores key order", () => {
+        expect(fileContentsDigest({ a: "1", b: "2" })).toBe(
+            fileContentsDigest({ b: "2", a: "1" }),
+        )
+    })
+
+    it("changes when a file's content changes, is added or removed", () => {
+        const base = fileContentsDigest({ a: "1", b: "2" })
+        expect(fileContentsDigest({ a: "1", b: "2 changed" })).not.toBe(base)
+        expect(fileContentsDigest({ a: "1", b: "2", c: "3" })).not.toBe(base)
+        expect(fileContentsDigest({ a: "1" })).not.toBe(base)
+    })
+
+    it("doesn't collide a path/content split across different files", () => {
+        expect(fileContentsDigest({ a: "b:c" })).not.toBe(fileContentsDigest({ "a:b": "c" }))
+    })
+})
+
+describe("layoutDigest", () => {
+    it("combines the docs version with a digest of the shared stylesheets", async () => {
+        const { layoutDigest } = await import("./incrementalCacheKey")
+        const [prefix, hex] = (await layoutDigest()).split("|")
+        expect(prefix).toBe(`l${DOCS_LATEST_OVERRIDE}`)
+        expect(hex).toMatch(/^[0-9a-f]{16}$/)
+    })
+
+    it("globs scss partials outside src/assets/styles too, since those also escape the module graph", async () => {
+        const { scssModules } = await import("./incrementalCacheKey")
+        expect(
+            Object.keys(scssModules).some((path) => path.endsWith("blueprints/_blueprintCard.scss")),
+        ).toBe(true)
     })
 })
 

--- a/src/utils/incrementalCacheKey.ts
+++ b/src/utils/incrementalCacheKey.ts
@@ -38,12 +38,36 @@ export function collectionContentDigest(entries: readonly KeyedEntry[]): string 
     return hashString(contents.join("\n"))
 }
 
+/** Digest of a set of file contents keyed by path, order-independent so glob
+ * iteration order doesn't matter. */
+export function fileContentsDigest(files: Record<string, string>): string {
+    const content = Object.keys(files)
+        .sort()
+        .map((path) => JSON.stringify([path, files[path]]))
+        .join("\n")
+    return hashString(content)
+}
+
+// A scss partial reached via `@use`/`@import` isn't a rollup module, so
+// Astro's own module-graph-based cache invalidation can't see it change.
+export const scssModules = import.meta.glob("~/**/*.scss", {
+    query: "?raw",
+    import: "default",
+    eager: true,
+}) as Record<string, string>
+
+if (Object.keys(scssModules).length === 0) {
+    throw new Error(
+        'layoutDigest: glob "~/**/*.scss" matched no files — shared style changes would silently stop invalidating the cache',
+    )
+}
+
 /** Build-time inputs the shared layout bakes into every page from outside the
- * module graph: today the latest docs version, fetched from the API. */
+ * module graph: the latest docs version, fetched from the API, and the
+ * shared stylesheets every cached route's chrome is built from. */
 export async function layoutDigest(): Promise<string> {
-    // Imported lazily so the pure helpers here stay importable outside a build.
     const { getDocsLatestVersion } = await import("~/utils/docVersionsFetch")
-    return `l${(await getDocsLatestVersion()) ?? "unknown"}`
+    return `l${(await getDocsLatestVersion()) ?? "unknown"}|${fileContentsDigest(scssModules)}`
 }
 
 /** Key for one entry, or undefined when the loader reports no digest, which


### PR DESCRIPTION
## Summary

`/docs/use-cases/data-pipelines` (and other untouched pages under `/docs/*`) was serving major broken styling — its `<link>` for the shared layout stylesheet pointed at a hashed CSS bundle that no longer exists on the CDN (404). `/docs` itself was unaffected.

Root cause: `experimental.incrementalBuild` skips re-rendering a static page when its `cacheKey` is unchanged since the last build. That key (`src/utils/incrementalCacheKey.ts`) covers the entry's own content digest plus sibling frontmatter/docs-version digests — but nothing in scope tracked the shared scss a scoped `<style>` block reaches via `@use`/`@import`. Those partials aren't rollup modules, so Astro's own module-graph-based invalidation can't see them change either. A page whose own markdown hasn't changed keeps its previous build's HTML forever, and that stale HTML references CSS asset hashes that get pruned on the next deploy.

This isn't docs-only: `[legal].astro`, `blogs/[...slug].astro`, `customers/[slug].astro`, `orchestration/[slug].astro`, `resources/[category]/[topic].astro`, and `vs/[slug].astro` all build their `cacheKey` scope from the same `layoutDigest()` helper and have the identical gap.

## Fix

- `layoutDigest()` now also folds in a content digest of every `**/*.scss` file under `src` (via `import.meta.glob`) — not just `src/assets/styles`, since component-local partials like `_blueprintCard.scss` have the same problem — so any shared style change invalidates the cache for every route that uses this helper.
- Guarded so the build fails loudly if the glob ever matches zero files, instead of silently going stale again.
- `fileContentsDigest` now hashes each path/content pair via `JSON.stringify` to avoid a delimiter collision between file boundaries.
- Cleared the already-poisoned production `astro-build-production-main-*` GitHub Actions cache directly (`gh cache delete`) so the next deploy on `main` does a clean rebuild instead of restoring the stale one.

(An earlier revision of this PR split `layoutDigest`/the glob into their own module to stop 3 markdown-only `.md.ts` routes from being invalidated by unrelated style edits — a real but minor build-efficiency point, not a correctness issue. Not worth two files for that, so it's back in `incrementalCacheKey.ts`.)

## Verification

- `npx vitest run` — 312/312 passing
- `npx astro check` — 0 errors
- `npx oxlint` on changed files — clean
- `npm run build` — full site build, exit 0
- Confirmed live 404 before the fix: `/docs/use-cases/data-pipelines` referenced `/_astro/layout.BZr939H_.css`, which 404s; `/docs` referenced a different, current hash.