### PR TITLE
fix(plugins): fall back to the subgroup icon instead of a blank sheet

### DIFF
--- a/src/pages/icons/[cls].svg.ts
+++ b/src/pages/icons/[cls].svg.ts
@@ -4,9 +4,11 @@ export const prerender = false
 import { $fetchApiRawCached } from "~/utils/fetch.ts"
 import { optimizeSvgIcon } from "~/utils/svgo"
 
-// The API serves this blank-page outline for any type it cannot resolve. It resolves against the
-// running Kestra, so every class removed or renamed since the current release gets it, which on an
-// archived version page is a real task with an empty sheet where its icon should be.
+// Path from DEFAULT_ICON in api.kestra.io PluginController, the blank sheet it serves for any type
+// it cannot resolve. Icons resolve against the running Kestra, so anything renamed or removed since
+// the current release gets it, which on an archived page is a real task with no icon. The response
+// carries no other signal that it is a fallback, so matching the path is the only way to spot one.
+// If DEFAULT_ICON ever changes there, this stops matching and blanks come back.
 const PLACEHOLDER_PATH = "M288 32H0v448h384V128l-96-96z"
 
 async function fetchIcon(type: string): Promise<string | null> {

--- a/src/pages/icons/[cls].svg.ts
+++ b/src/pages/icons/[cls].svg.ts
@@ -4,16 +4,45 @@ export const prerender = false
 import { $fetchApiRawCached } from "~/utils/fetch.ts"
 import { optimizeSvgIcon } from "~/utils/svgo"
 
+// The API serves this blank-page outline for any type it cannot resolve. It resolves against the
+// running Kestra, so every class removed or renamed since the current release gets it, which on an
+// archived version page is a real task with an empty sheet where its icon should be.
+const PLACEHOLDER_PATH = "M288 32H0v448h384V128l-96-96z"
+
+async function fetchIcon(type: string): Promise<string | null> {
+    const response = await $fetchApiRawCached(`/plugins/icons/${type}`)
+    return response.ok ? await response.text() : null
+}
+
+/** "io.kestra.plugin.core.flow.ForEach" -> "io.kestra.plugin.core.flow", the subgroup. */
+function packageOf(cls: string): string | undefined {
+    const outer = cls.split("$")[0]
+    const lastDot = outer.lastIndexOf(".")
+    return lastDot < 0 ? undefined : outer.slice(0, lastDot)
+}
+
 export async function GET({ params }: { params: { cls: string } }) {
     const clsComplete = params.cls
     const [cls, modifier] = clsComplete.split("-")
-    const response = await $fetchApiRawCached(`/plugins/icons/${cls}`)
 
-    if (!response.ok) {
+    let icon = await fetchIcon(cls)
+
+    if (icon === null) {
         throw new Error("Failed to fetch icon")
     }
 
-    const svg = optimizeSvgIcon(await response.text(), "cls")
+    // Fall back to the subgroup so an archived page shows the Flow icon rather than a blank sheet.
+    let isPlaceholder = icon.includes(PLACEHOLDER_PATH)
+    if (isPlaceholder) {
+        const pkg = packageOf(cls)
+        const subGroupIcon = pkg ? await fetchIcon(pkg) : null
+        if (subGroupIcon && !subGroupIcon.includes(PLACEHOLDER_PATH)) {
+            icon = subGroupIcon
+            isPlaceholder = false
+        }
+    }
+
+    const svg = optimizeSvgIcon(icon, "cls")
 
     // replace all currentColor with the specified modifier if provided
     const modifiedSvg = modifier ? svg.replace(/currentColor/g, modifier) : svg
@@ -24,8 +53,12 @@ export async function GET({ params }: { params: { cls: string } }) {
             // Icons are keyed by a stable, per-plugin-class URL (a new plugin
             // gets a new URL, it never mutates an existing one), so they can be
             // cached "forever". This stops Googlebot from re-crawling the plugin
-            // SVGs on every visit — they were ~40% of the crawl budget at 24h.
-            "Cache-Control": "public, max-age=31536000, immutable",
+            // SVGs on every visit, they were ~40% of the crawl budget at 24h.
+            // A placeholder is the exception: it stops being the answer the moment
+            // the class resolves, so it must not be pinned for a year.
+            "Cache-Control": isPlaceholder
+                ? "public, max-age=3600"
+                : "public, max-age=31536000, immutable",
         },
     })
 }

--- a/src/pages/icons/[cls].svg.ts
+++ b/src/pages/icons/[cls].svg.ts
@@ -4,16 +4,25 @@ export const prerender = false
 import { $fetchApiRawCached } from "~/utils/fetch.ts"
 import { optimizeSvgIcon } from "~/utils/svgo"
 
-// Path from DEFAULT_ICON in api.kestra.io PluginController, the blank sheet it serves for any type
-// it cannot resolve. Icons resolve against the running Kestra, so anything renamed or removed since
-// the current release gets it, which on an archived page is a real task with no icon. The response
-// carries no other signal that it is a fallback, so matching the path is the only way to spot one.
-// If DEFAULT_ICON ever changes there, this stops matching and blanks come back.
-const PLACEHOLDER_PATH = "M288 32H0v448h384V128l-96-96z"
+// The API answers with a blank sheet for any type it cannot resolve, and gives no other signal that
+// it did. Icons resolve against the running Kestra, so anything renamed or removed since the current
+// release gets it, which on an archived page is a real task with no icon. Ask for a type that can
+// never exist to learn what that blank sheet is, rather than keeping a copy of it here.
+const UNRESOLVABLE_TYPE = "io.kestra.plugin.unresolvable"
 
 async function fetchIcon(type: string): Promise<string | null> {
     const response = await $fetchApiRawCached(`/plugins/icons/${type}`)
     return response.ok ? await response.text() : null
+}
+
+/** Memoised per isolate: the answer only changes when the API is redeployed. */
+let blankIcon: string | null | undefined
+
+async function fetchBlankIcon(): Promise<string | null> {
+    if (blankIcon === undefined) {
+        blankIcon = await fetchIcon(UNRESOLVABLE_TYPE)
+    }
+    return blankIcon
 }
 
 /** "io.kestra.plugin.core.flow.ForEach" -> "io.kestra.plugin.core.flow", the subgroup. */
@@ -34,11 +43,14 @@ export async function GET({ params }: { params: { cls: string } }) {
     }
 
     // Fall back to the subgroup so an archived page shows the Flow icon rather than a blank sheet.
-    if (icon.includes(PLACEHOLDER_PATH)) {
-        const pkg = packageOf(cls)
-        const subGroupIcon = pkg ? await fetchIcon(pkg) : null
-        if (subGroupIcon && !subGroupIcon.includes(PLACEHOLDER_PATH)) {
-            icon = subGroupIcon
+    const pkg = packageOf(cls)
+    if (pkg) {
+        const blank = await fetchBlankIcon()
+        if (blank !== null && icon === blank) {
+            const subGroupIcon = await fetchIcon(pkg)
+            if (subGroupIcon !== null && subGroupIcon !== blank) {
+                icon = subGroupIcon
+            }
         }
     }
 

--- a/src/pages/icons/[cls].svg.ts
+++ b/src/pages/icons/[cls].svg.ts
@@ -34,13 +34,11 @@ export async function GET({ params }: { params: { cls: string } }) {
     }
 
     // Fall back to the subgroup so an archived page shows the Flow icon rather than a blank sheet.
-    let isPlaceholder = icon.includes(PLACEHOLDER_PATH)
-    if (isPlaceholder) {
+    if (icon.includes(PLACEHOLDER_PATH)) {
         const pkg = packageOf(cls)
         const subGroupIcon = pkg ? await fetchIcon(pkg) : null
         if (subGroupIcon && !subGroupIcon.includes(PLACEHOLDER_PATH)) {
             icon = subGroupIcon
-            isPlaceholder = false
         }
     }
 
@@ -56,11 +54,7 @@ export async function GET({ params }: { params: { cls: string } }) {
             // gets a new URL, it never mutates an existing one), so they can be
             // cached "forever". This stops Googlebot from re-crawling the plugin
             // SVGs on every visit, they were ~40% of the crawl budget at 24h.
-            // A placeholder is the exception: it stops being the answer the moment
-            // the class resolves, so it must not be pinned for a year.
-            "Cache-Control": isPlaceholder
-                ? "public, max-age=3600"
-                : "public, max-age=31536000, immutable",
+            "Cache-Control": "public, max-age=31536000, immutable",
         },
     })
 }


### PR DESCRIPTION
`/plugins/core/v1.3.38/flow/...foreach` shows a blank sheet instead of an icon.

The API resolves icons against the running Kestra, so anything renamed or removed since (ForEach -> Loop in 2.0) gets its placeholder. Now retries with the class's package, which resolves.

Placeholders also stop being cached for a year, since they stop being correct once the class resolves. Resolved icons keep the immutable header.