### PR TITLE
Add dynamic /.well-known/security.txt endpoint

### DIFF
--- a/src/pages/.well-known/security.txt.ts
+++ b/src/pages/.well-known/security.txt.ts
@@ -1,0 +1,22 @@
+import type { APIRoute } from "astro"
+
+export const GET: APIRoute = async () => {
+    const expires = new Date()
+    expires.setUTCFullYear(expires.getUTCFullYear() + 2, 7, 26)
+    expires.setUTCHours(0, 0, 0, 0)
+
+    const body = `Contact: https://github.com/kestra-io/kestra/security/advisories/new
+Expires: ${expires.toISOString()}
+Preferred-Languages: en
+Canonical: https://kestra.io/.well-known/security.txt
+Policy: https://kestra.io/docs/releases
+`
+
+    return new Response(body, {
+        status: 200,
+        headers: {
+            "Content-Type": "text/plain; charset=utf-8",
+            "Cache-Control": "public, max-age=3600",
+        },
+    })
+}


### PR DESCRIPTION
## Summary
- Adds a `security.txt` per [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) at `/.well-known/security.txt`, generated dynamically as an Astro API route rather than a static file
- `Expires` is computed at request time as "next Aug 26, 2 years out" so it never silently goes stale

## Test plan
- [ ] `npm run dev` and curl `/.well-known/security.txt` to confirm output and headers
- [ ] Confirm `Expires` recomputes correctly across the Aug 26 boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)